### PR TITLE
Scanner laser control

### DIFF
--- a/acq4/devices/Scanner/TaskGui.py
+++ b/acq4/devices/Scanner/TaskGui.py
@@ -83,8 +83,9 @@ class ScannerTaskGui(TaskGui):
         
         self.scanProgram = ScanProgram()
         self.scanProgram.setDevices(scanner=self.dev)
+        self.scanProgram.sigProgramChanged.connect(self.scanProgramChanged)
         self.ui.programTree.setParameters(self.scanProgram.ctrlParameter(), showTop=False)
-        generator.waveforms.setDataSource(self.dev.name() + '_laserMask', self.scanProgram.generateLaserMask)
+        generator.setDataSource(self.dev.name() + '_laserMask', self.scanProgram.generateLaserMask)
 
         ## Set up SpinBoxes
         self.ui.minTimeSpin.setOpts(dec=True, step=1, minStep=1e-3, siPrefix=True, suffix='s', bounds=[0, 50])
@@ -157,6 +158,10 @@ class ScannerTaskGui(TaskGui):
     def enableScanProgToggled(self, b):
         self.ui.scanProgramGroup.setVisible(b)
         self.updateVisibility()
+
+    def scanProgramChanged(self, prog, comp):
+        # reset laser mask source just to kick any generators that may depend on this key
+        generator.setDataSource(self.dev.name() + '_laserMask', self.scanProgram.generateLaserMask)
 
     def showPosCtrls(self, b):
         self.updateVisibility()
@@ -560,7 +565,7 @@ class ScannerTaskGui(TaskGui):
             s.removeItem(self.testTarget)
             s.removeItem(self.spotMarker)
         self.scanProgram.close()
-        generator.waveforms.setDataSource(self.dev.name() + '_laserMask', None)
+        generator.setDataSource(self.dev.name() + '_laserMask', None)
 
 
 class TargetPoint(pg.EllipseROI):

--- a/acq4/devices/Scanner/TaskGui.py
+++ b/acq4/devices/Scanner/TaskGui.py
@@ -12,6 +12,7 @@ from acq4.util.debug import Profiler
 from acq4.util.HelpfulException import HelpfulException
 import acq4.pyqtgraph.parametertree.parameterTypes as pTypes
 from acq4.pyqtgraph.parametertree import Parameter, ParameterTree, ParameterItem, registerParameterType
+from acq4.util import generator
 
 from TaskTemplate import Ui_Form
 from .scan_program import ScanProgram, ScanProgramPreview
@@ -83,6 +84,7 @@ class ScannerTaskGui(TaskGui):
         self.scanProgram = ScanProgram()
         self.scanProgram.setDevices(scanner=self.dev)
         self.ui.programTree.setParameters(self.scanProgram.ctrlParameter(), showTop=False)
+        generator.waveforms.setDataSource(self.dev.name() + '_laserMask', self.scanProgram.generateLaserMask)
 
         ## Set up SpinBoxes
         self.ui.minTimeSpin.setOpts(dec=True, step=1, minStep=1e-3, siPrefix=True, suffix='s', bounds=[0, 50])
@@ -558,6 +560,7 @@ class ScannerTaskGui(TaskGui):
             s.removeItem(self.testTarget)
             s.removeItem(self.spotMarker)
         self.scanProgram.close()
+        generator.waveforms.setDataSource(self.dev.name() + '_laserMask', None)
 
 
 class TargetPoint(pg.EllipseROI):

--- a/acq4/devices/Scanner/scan_program/component.py
+++ b/acq4/devices/Scanner/scan_program/component.py
@@ -2,7 +2,7 @@ from PyQt4 import QtGui, QtCore
 import weakref
 
 
-class ScanProgramComponent(object):
+class ScanProgramComponent(QtCore.QObject):
     """
     Base class for all components that make up a scan program.
     
@@ -17,9 +17,12 @@ class ScanProgramComponent(object):
     
     """
     
+    sigChanged = QtCore.Signal(object)  # self
+    
     type = None  # String identifying the type of this scan component.
                  
     def __init__(self, scanProgram):
+        QtCore.QObject.__init__(self)
         self._laser = None
         self.params = None
         self.program = weakref.ref(scanProgram)
@@ -45,6 +48,10 @@ class ScanProgramComponent(object):
         changed.
         """
         pass
+
+    def changed(self):
+        # Called when the output of this component has changed
+        self.sigChanged.emit(self)
         
     def isActive(self):
         """Return True if this component is currently active.

--- a/acq4/devices/Scanner/scan_program/program.py
+++ b/acq4/devices/Scanner/scan_program/program.py
@@ -24,7 +24,7 @@ for cType in ['step', 'line', 'rect', 'loop', 'ellipse', 'spiral']:
 
 
 
-class ScanProgram:
+class ScanProgram(QtCore.QObject):
     """
     ScanProgram encapsulates one or more laser scanning operations that are
     executed in sequence. 
@@ -43,7 +43,12 @@ class ScanProgram:
     the COMPONENTS global variable, which may be used to install new component
     types at runtime.
     """
+    
+    sigProgramChanged = QtCore.Signal(object, object)  # self, component
+    
     def __init__(self):
+        QtCore.QObject.__init__(self)
+        
         self.components = []
         
         self.canvas = None  # used to display graphical controls for components
@@ -79,13 +84,19 @@ class ScanProgram:
             for item in component.graphicsItems():
                 self.canvas.addItem(item, None, [1, 1], 10000)
         self.components.append(component)
+        component.sigChanged.connect(self.componentChanged)
+        
         return component
 
     def removeComponent(self, component):
         """Remove a component from this program.
         """
         self.components.remove(component)
+        component.sigChanged.disconnect(self.componentChanged)
         self.clearGraphicsItems(component)
+        
+    def componentChanged(self, component):
+        self.sigProgramChanged.emit(self, component)
         
     def ctrlParameter(self):
         """Return the control Parameter for this scan program. 

--- a/acq4/devices/Scanner/scan_program/rect.py
+++ b/acq4/devices/Scanner/scan_program/rect.py
@@ -21,6 +21,7 @@ class RectScanComponent(ScanProgramComponent):
     def __init__(self, scanProgram=None):
         ScanProgramComponent.__init__(self, scanProgram)
         self.ctrl = RectScanControl(self)
+        self.ctrl.sigStateChanged.connect(self.changed)
         
     def samplingChanged(self):
         self.ctrl.update()
@@ -170,6 +171,8 @@ class RectScanControl(QtCore.QObject):
         finally:
             if reconnect:
                 self.params.sigTreeStateChanged.connect(self.paramsChanged)
+                
+        self.sigStateChanged.emit(self)
     
     def roiChanged(self):
         """ read the ROI rectangle width and height and repost

--- a/acq4/util/generator/StimGenerator.py
+++ b/acq4/util/generator/StimGenerator.py
@@ -578,6 +578,10 @@ class DataSources(QtCore.QObject):
         else:
             return data()
         
+    def keys(self):
+        """All data keys available in this instance.
+        """
+        return self.data.keys()
 
 
 DATA_SOURCES = DataSources()

--- a/acq4/util/generator/StimGenerator.py
+++ b/acq4/util/generator/StimGenerator.py
@@ -89,6 +89,8 @@ class StimGenerator(QtGui.QWidget):
         self.ui.advancedBtn.toggled.connect(self.updateWidgets)
         self.ui.forceAdvancedBtn.clicked.connect(self.forceAdvancedClicked)
         self.ui.forceSimpleBtn.clicked.connect(self.forceSimpleClicked)
+        
+        DATA_SOURCES.sigSourceChanged.connect(self.dataSourceChanged)
 
     def setEvalNames(self, **kargs):
         """Make variables accessible for use by evaluated functions."""
@@ -397,6 +399,10 @@ class StimGenerator(QtGui.QWidget):
             obj = getattr(waveforms, i)
             if type(obj) is types.FunctionType:
                 ns[i] = self.makeWaveFunction(i, arg)
+                
+        # Add global data sources
+        ns['globalData'] = DATA_SOURCES
+        ns['getArray'] = DATA_SOURCES.getArray
         
         ## add current sequence parameter values into namespace
         seq = self.paramSpace() # -- this is where the Laser bug was happening -- seq becomes 'Pulse_sum', but params was {'power.Pulse_sum': x}, so the default value is always used instead (fixed by removing 'power.' before the params are sent to stimGenerator, but perhaps there is a better place to fix this)
@@ -465,7 +471,11 @@ class StimGenerator(QtGui.QWidget):
         obj = getattr(waveforms, name)
         return lambda *args, **kwargs: obj(arg, *args, **kwargs)
         
-
+    def dataSourceChanged(self, name):
+        self.clearCache()
+        if self.test():
+            self.autoUpdate()
+        self.sigStateChanged.emit()
 
 
 ## Old sequence parsing functions for backward compatibility:
@@ -536,3 +546,43 @@ def seqParse(seqStr):
         'log spacing': 'l' in opts, 'randomize': 'r' in opts
     }
     #return (name, single, seq)
+
+
+class DataSources(QtCore.QObject):
+    
+    sigSourceChanged = QtCore.Signal(object)  # name
+    
+    def __init__(self):
+        QtCore.QObject.__init__(self)
+        self.data = {}
+        
+    def setDataSource(self, name, data):
+        """Assign a global array or callable to be used by other generators.
+        """
+        if data is None:
+            del self.data[name]
+        else:
+            self.data[name] = data
+
+        self.sigSourceChanged.emit(name)
+
+    def __getitem__(self, name):
+        if name not in self.data:
+            raise Exception("No data source named '%s'. Options are: %s" % (name, str(list(self.data.keys()))))
+        return self.data[name]
+
+    def getArray(self, name):
+        data = self[name]
+        if isinstance(data, np.ndarray):
+            return data
+        else:
+            return data()
+        
+
+
+DATA_SOURCES = DataSources()
+
+def setDataSource(name, data):
+    """Set a global data source that may be used from inside function generators.
+    """
+    return DATA_SOURCES.setDataSource(name, data)

--- a/acq4/util/generator/StimParamSet.py
+++ b/acq4/util/generator/StimParamSet.py
@@ -309,7 +309,7 @@ class PulseTrainParameter(PulseParameter):
         
     def setState(self, state):
         # for backward compatibility
-    	if 'interpulse_length' in state:
+        if 'interpulse_length' in state:
             state['period'] = state['interpulse_length']
             del state['interpulse_length']
         return PulseParameter.setState(self, state)

--- a/acq4/util/generator/__init__.py
+++ b/acq4/util/generator/__init__.py
@@ -1,0 +1,2 @@
+from StimGenerator import StimGenerator, setDataSource, DATA_SOURCES
+import waveforms

--- a/acq4/util/generator/waveforms.py
+++ b/acq4/util/generator/waveforms.py
@@ -314,3 +314,23 @@ def noise(params, mean, sigma, start=0.0, stop=None):
 
     d[start:stop] = numpy.random.normal(size=stop-start, loc=mean, scale=sigma)
     return d
+    
+
+_global_data = {}
+def setDataSource(name, data):
+    """Assign a global array or callable to be used by other generators.
+    """
+    if data is None:
+        del _global_data[name]
+    else:
+        _global_data[name] = data
+
+def getArray(params, name):
+    if name not in _global_data:
+        raise Exception("No data source named '%s'. Options are: %s" % (name, str(list(_global_data.keys()))))
+    
+    data = _global_data[name]
+    if isinstance(data, numpy.ndarray):
+        return data
+    else:
+        return data()

--- a/acq4/util/generator/waveforms.py
+++ b/acq4/util/generator/waveforms.py
@@ -314,23 +314,3 @@ def noise(params, mean, sigma, start=0.0, stop=None):
 
     d[start:stop] = numpy.random.normal(size=stop-start, loc=mean, scale=sigma)
     return d
-    
-
-_global_data = {}
-def setDataSource(name, data):
-    """Assign a global array or callable to be used by other generators.
-    """
-    if data is None:
-        del _global_data[name]
-    else:
-        _global_data[name] = data
-
-def getArray(params, name):
-    if name not in _global_data:
-        raise Exception("No data source named '%s'. Options are: %s" % (name, str(list(_global_data.keys()))))
-    
-    data = _global_data[name]
-    if isinstance(data, numpy.ndarray):
-        return data
-    else:
-        return data()


### PR DESCRIPTION
Adds a simple way to share waveforms between devices in the task runner. 
Use case: scanner generates a mask that tells the laser when it should be active, and the laser pulls this in by using `globalData['Scanner_laserMask']()` in its waveform code.
