### PR TITLE
Micromanager fixes

### DIFF
--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -42,7 +42,9 @@ class MicroManagerCamera(Camera):
                 raise
             # MM does not install itself to standard path. User should take care of this,
             # but we can make a guess..
-            sys.path.append('C:\\Program Files\\Micro-Manager-1.4')
+            path = config.get('path', 'C:\\Program Files\\Micro-Manager-1.4')
+            sys.path.append(path)
+            os.environ['PATH'] = os.environ['PATH'] + ';' + path
             try:
                 import MMCorePy
             finally:

--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -12,6 +12,19 @@ from acq4.util.Mutex import Mutex
 from acq4.util.debug import *
 
 
+# Micromanager does not standardize trigger modes across cameras,
+# so we use this dict to translate the modes of various cameras back
+# to the standard ACQ4 modes:
+#   Normal: Camera starts by software and acquires frames on its own clock
+#   TriggerStart: Camera starts by trigger and acquires frames on its own clock
+#   Strobe: Camera acquires one frame of a predefined exposure time for every trigger pulse
+#   Bulb: Camera exposes one frame for the duration of each trigger pulse
+
+triggerModes = {
+    'TriggerType': {'FreeRun': 'Normal'},  # QImaging 
+    'Trigger': {'NORMAL': 'Normal', 'START': 'TriggerStart'},  # Hamamatsu
+}
+
 
 class MicroManagerCamera(Camera):
     """Camera device that uses MicroManager to provide imaging.
@@ -153,9 +166,10 @@ class MicroManagerCamera(Camera):
                     params['binningX'] = ([int(v[0]) for v in vals], not readonly, True, [])
                     params['binningY'] = ([int(v[1]) for v in vals], not readonly, True, [])
                     continue
-                elif prop == 'Trigger':
+                elif prop in triggerModes:
+                    modes = triggerModes[prop]
                     prop = 'triggerMode'
-                    vals = [{'NORMAL': 'Normal', 'START': 'TriggerStart'}[v] for v in vals]
+                    vals = [modes[v] for v in vals]
                 elif prop == 'PixelType':
                     prop = 'bitDepth'
                     vals = [int(bd.rstrip('bit')) for bd in vals]

--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -278,6 +278,10 @@ class MicroManagerCamera(Camera):
             value = self._triggerModes[1][value]
             param = self._triggerProp
 
+        elif param == 'bitDepth':
+            param = 'PixelType'
+            value = '%dbit' % value
+
         with self.camLock:
             self.mmc.setProperty(self.camName, str(param), str(value))
 


### PR DESCRIPTION
Make the MicroManager camera implementation more tolerant of variations between cameras:

* Some cameras have binning modes like "1x1", and others use just "1" (and some have no binning support at all). These should now be correctly translated.
* Added support for cameras with no trigger modes
* Corrected the PixelType issue