### PR TITLE
FileLoader Improvement

### DIFF
--- a/acq4/util/FileLoader/FileLoader.py
+++ b/acq4/util/FileLoader/FileLoader.py
@@ -8,7 +8,8 @@ from acq4.Manager import logMsg, logExc, getManager
 class FileLoader(QtGui.QWidget):
     """Interface for 1) displaying directory tree and 2) loading a file from the tree.
     You must call setHost, and the widget will call host.loadFileRequested whenever 
-    the user requests to load a file."""
+    the user requests to load a file and host.clearFilesRequested whenever the user 
+    clicks the clear button."""
     
     
     sigFileLoaded = QtCore.Signal(object)
@@ -26,9 +27,14 @@ class FileLoader(QtGui.QWidget):
         
         self.ui.setDirBtn.clicked.connect(self.setBaseClicked)
         self.ui.loadBtn.clicked.connect(self.loadClicked)
+        self.ui.clearBtn.clicked.connect(self.clearClicked)
         self.ui.dirTree.currentItemChanged.connect(self.updateNotes) ## self.ui.dirTree is a DirTreeWidget
         self.ui.dirTree.itemDoubleClicked.connect(self.doubleClickEvent)
         self.ui.fileTree.currentItemChanged.connect(self.selectedFileChanged)
+
+        ### disable clearBtn if host does not have a clearFilesRequested function
+        if not hasattr(host, 'clearFilesRequested') and self.host is not None:
+            self.ui.clearBtn.setEnabled(False)
         
         self.ui.fileTree.setVisible(showFileTree)
         self.ui.notesTextEdit.setReadOnly(True)
@@ -81,6 +87,13 @@ class FileLoader(QtGui.QWidget):
             #self.emit(QtCore.SIGNAL('fileLoaded'), fh)
         finally:
             QtGui.QApplication.restoreOverrideCursor()
+
+    def clearClicked(self):
+        if self.host is not None:
+            self.host.clearFilesRequested()
+        self.ui.fileTree.clear()
+        self.loaded = []
+
             
     def selectedFileChanged(self):
         self.sigSelectedFileChanged.emit(self.ui.fileTree.currentItem())

--- a/acq4/util/FileLoader/FileLoader.py
+++ b/acq4/util/FileLoader/FileLoader.py
@@ -15,7 +15,7 @@ class FileLoader(QtGui.QWidget):
     sigFileLoaded = QtCore.Signal(object)
     sigBaseChanged = QtCore.Signal(object)
     sigSelectedFileChanged = QtCore.Signal(object)
-    sigClearRequested = QtCore.Signal(object)
+    sigClearRequested = QtCore.Signal()
     
     def __init__(self, dataManager, host=None, showFileTree=True):
         self._baseDir = None
@@ -87,8 +87,8 @@ class FileLoader(QtGui.QWidget):
     def clearClicked(self):
         """Remove all loaded data. User will be asked whether they really want to clear."""
         ## double-check with user to avoid accidental button presses
-        if len(self.items) > 0:
-            response = QtGui.QMessageBox.question(self.clearBtn, "Warning", "Really clear all items?", 
+        if len(self.loaded) > 0:
+            response = QtGui.QMessageBox.question(self.ui.clearBtn, "Warning", "Really clear all items?", 
                 QtGui.QMessageBox.Ok|QtGui.QMessageBox.Cancel)
             if response != QtGui.QMessageBox.Ok:
                 return

--- a/acq4/util/FileLoader/FileLoader.py
+++ b/acq4/util/FileLoader/FileLoader.py
@@ -89,11 +89,21 @@ class FileLoader(QtGui.QWidget):
             QtGui.QApplication.restoreOverrideCursor()
 
     def clearClicked(self):
+        """Remove all loaded data. User will be asked whether they really want to clear."""
+        ## double-check with user to avoid accidental button presses
+        if len(self.items) > 0:
+            response = QtGui.QMessageBox.question(self.clearBtn, "Warning", "Really clear all items?", 
+                QtGui.QMessageBox.Ok|QtGui.QMessageBox.Cancel)
+            if response != QtGui.QMessageBox.Ok:
+                return
+        else:
+            return
+
+        ## clear the data
         if self.host is not None:
             self.host.clearFilesRequested()
         self.ui.fileTree.clear()
         self.loaded = []
-
             
     def selectedFileChanged(self):
         self.sigSelectedFileChanged.emit(self.ui.fileTree.currentItem())

--- a/acq4/util/FileLoader/FileLoader.py
+++ b/acq4/util/FileLoader/FileLoader.py
@@ -15,6 +15,7 @@ class FileLoader(QtGui.QWidget):
     sigFileLoaded = QtCore.Signal(object)
     sigBaseChanged = QtCore.Signal(object)
     sigSelectedFileChanged = QtCore.Signal(object)
+    sigClearRequested = QtCore.Signal(object)
     
     def __init__(self, dataManager, host=None, showFileTree=True):
         self._baseDir = None
@@ -31,10 +32,6 @@ class FileLoader(QtGui.QWidget):
         self.ui.dirTree.currentItemChanged.connect(self.updateNotes) ## self.ui.dirTree is a DirTreeWidget
         self.ui.dirTree.itemDoubleClicked.connect(self.doubleClickEvent)
         self.ui.fileTree.currentItemChanged.connect(self.selectedFileChanged)
-
-        ### disable clearBtn if host does not have a clearFilesRequested function
-        if not hasattr(host, 'clearFilesRequested') and self.host is not None:
-            self.ui.clearBtn.setEnabled(False)
         
         self.ui.fileTree.setVisible(showFileTree)
         self.ui.notesTextEdit.setReadOnly(True)
@@ -84,7 +81,6 @@ class FileLoader(QtGui.QWidget):
                     self.ui.fileTree.addTopLevelItem(item)
                     self.sigFileLoaded.emit(fh)
                     self.loaded.append(fh)
-            #self.emit(QtCore.SIGNAL('fileLoaded'), fh)
         finally:
             QtGui.QApplication.restoreOverrideCursor()
 
@@ -100,8 +96,7 @@ class FileLoader(QtGui.QWidget):
             return
 
         ## clear the data
-        if self.host is not None:
-            self.host.clearFilesRequested()
+        self.sigClearRequested.emit()
         self.ui.fileTree.clear()
         self.loaded = []
             
@@ -131,16 +126,11 @@ class FileLoader(QtGui.QWidget):
 
         
     def updateNotes(self, current, previous):
-        #sFile = self.ui.dirTree.selectedFile()
         fh = current
         if fh is None:
             return
-        
         notes = fh.handle.info().get('notes', ' ')
-        
         self.ui.notesTextEdit.setPlainText(notes)
-        #print fh
-        #print fh.info()
         
     def loadedFiles(self):
         """Return a list of loaded file handles"""

--- a/acq4/util/FileLoader/template.py
+++ b/acq4/util/FileLoader/template.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file './acq4/util/FileLoader/template.ui'
+# Form implementation generated from reading ui file 'acq4/util/FileLoader/template.ui'
 #
-# Created: Tue Dec 24 01:49:17 2013
-#      by: PyQt4 UI code generator 4.10
+# Created: Tue Dec 13 15:21:33 2016
+#      by: PyQt4 UI code generator 4.10.4
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -26,7 +26,7 @@ except AttributeError:
 class Ui_Form(object):
     def setupUi(self, Form):
         Form.setObjectName(_fromUtf8("Form"))
-        Form.resize(361, 557)
+        Form.resize(238, 433)
         self.gridLayout = QtGui.QGridLayout(Form)
         self.gridLayout.setMargin(0)
         self.gridLayout.setSpacing(0)
@@ -49,20 +49,23 @@ class Ui_Form(object):
         self.dirTree.setObjectName(_fromUtf8("dirTree"))
         self.dirTree.headerItem().setText(0, _fromUtf8("1"))
         self.verticalLayout.addWidget(self.dirTree)
+        self.loadBtn = QtGui.QPushButton(self.layoutWidget)
+        self.loadBtn.setObjectName(_fromUtf8("loadBtn"))
+        self.verticalLayout.addWidget(self.loadBtn)
         self.layoutWidget1 = QtGui.QWidget(self.splitter)
         self.layoutWidget1.setObjectName(_fromUtf8("layoutWidget1"))
         self.verticalLayout_2 = QtGui.QVBoxLayout(self.layoutWidget1)
         self.verticalLayout_2.setSpacing(0)
         self.verticalLayout_2.setMargin(0)
         self.verticalLayout_2.setObjectName(_fromUtf8("verticalLayout_2"))
-        self.loadBtn = QtGui.QPushButton(self.layoutWidget1)
-        self.loadBtn.setObjectName(_fromUtf8("loadBtn"))
-        self.verticalLayout_2.addWidget(self.loadBtn)
         self.fileTree = QtGui.QTreeWidget(self.layoutWidget1)
         self.fileTree.setHeaderHidden(True)
         self.fileTree.setObjectName(_fromUtf8("fileTree"))
         self.fileTree.headerItem().setText(0, _fromUtf8("1"))
         self.verticalLayout_2.addWidget(self.fileTree)
+        self.clearBtn = QtGui.QPushButton(self.layoutWidget1)
+        self.clearBtn.setObjectName(_fromUtf8("clearBtn"))
+        self.verticalLayout_2.addWidget(self.clearBtn)
         self.label = QtGui.QLabel(self.layoutWidget1)
         self.label.setObjectName(_fromUtf8("label"))
         self.verticalLayout_2.addWidget(self.label)
@@ -78,6 +81,7 @@ class Ui_Form(object):
         Form.setWindowTitle(_translate("Form", "Form", None))
         self.setDirBtn.setText(_translate("Form", "Set Base Dir ->", None))
         self.loadBtn.setText(_translate("Form", "Load File ->", None))
+        self.clearBtn.setText(_translate("Form", "Clear", None))
         self.label.setText(_translate("Form", "Notes:", None))
 
 from acq4.util.DirTreeWidget import DirTreeWidget

--- a/acq4/util/FileLoader/template.py
+++ b/acq4/util/FileLoader/template.py
@@ -2,8 +2,7 @@
 
 # Form implementation generated from reading ui file 'acq4/util/FileLoader/template.ui'
 #
-# Created: Tue Dec 13 15:21:33 2016
-#      by: PyQt4 UI code generator 4.10.4
+# Created by: PyQt4 UI code generator 4.11.4
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -38,7 +37,6 @@ class Ui_Form(object):
         self.layoutWidget.setObjectName(_fromUtf8("layoutWidget"))
         self.verticalLayout = QtGui.QVBoxLayout(self.layoutWidget)
         self.verticalLayout.setSpacing(0)
-        self.verticalLayout.setMargin(0)
         self.verticalLayout.setObjectName(_fromUtf8("verticalLayout"))
         self.setDirBtn = QtGui.QPushButton(self.layoutWidget)
         self.setDirBtn.setObjectName(_fromUtf8("setDirBtn"))
@@ -52,20 +50,19 @@ class Ui_Form(object):
         self.loadBtn = QtGui.QPushButton(self.layoutWidget)
         self.loadBtn.setObjectName(_fromUtf8("loadBtn"))
         self.verticalLayout.addWidget(self.loadBtn)
+        self.clearBtn = QtGui.QPushButton(self.layoutWidget)
+        self.clearBtn.setObjectName(_fromUtf8("clearBtn"))
+        self.verticalLayout.addWidget(self.clearBtn)
         self.layoutWidget1 = QtGui.QWidget(self.splitter)
         self.layoutWidget1.setObjectName(_fromUtf8("layoutWidget1"))
         self.verticalLayout_2 = QtGui.QVBoxLayout(self.layoutWidget1)
         self.verticalLayout_2.setSpacing(0)
-        self.verticalLayout_2.setMargin(0)
         self.verticalLayout_2.setObjectName(_fromUtf8("verticalLayout_2"))
         self.fileTree = QtGui.QTreeWidget(self.layoutWidget1)
         self.fileTree.setHeaderHidden(True)
         self.fileTree.setObjectName(_fromUtf8("fileTree"))
         self.fileTree.headerItem().setText(0, _fromUtf8("1"))
         self.verticalLayout_2.addWidget(self.fileTree)
-        self.clearBtn = QtGui.QPushButton(self.layoutWidget1)
-        self.clearBtn.setObjectName(_fromUtf8("clearBtn"))
-        self.verticalLayout_2.addWidget(self.clearBtn)
         self.label = QtGui.QLabel(self.layoutWidget1)
         self.label.setObjectName(_fromUtf8("label"))
         self.verticalLayout_2.addWidget(self.label)

--- a/acq4/util/FileLoader/template.ui
+++ b/acq4/util/FileLoader/template.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>361</width>
-    <height>557</height>
+    <width>238</width>
+    <height>433</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -52,13 +52,6 @@
          </column>
         </widget>
        </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="layoutWidget">
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="spacing">
-        <number>0</number>
-       </property>
        <item>
         <widget class="QPushButton" name="loadBtn">
          <property name="text">
@@ -66,6 +59,13 @@
          </property>
         </widget>
        </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="layoutWidget">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="spacing">
+        <number>0</number>
+       </property>
        <item>
         <widget class="QTreeWidget" name="fileTree">
          <property name="headerHidden">
@@ -76,6 +76,13 @@
            <string notr="true">1</string>
           </property>
          </column>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="clearBtn">
+         <property name="text">
+          <string>Clear</string>
+         </property>
         </widget>
        </item>
        <item>

--- a/acq4/util/FileLoader/template.ui
+++ b/acq4/util/FileLoader/template.ui
@@ -59,6 +59,13 @@
          </property>
         </widget>
        </item>
+       <item>
+        <widget class="QPushButton" name="clearBtn">
+         <property name="text">
+          <string>Clear</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="layoutWidget">
@@ -76,13 +83,6 @@
            <string notr="true">1</string>
           </property>
          </column>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="clearBtn">
-         <property name="text">
-          <string>Clear</string>
-         </property>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
Adds a clear button to the file loader. Clicking the clear button calls host.clearFilesRequested; for backwards compatibility the clear button is disabled if host doesn't have a clearFilesRequested method.

Also moves the LoadFile button to above the splitter so that the user can hide the loadedFiles list and notes field while still having access to the LoadFile button.