### PR TITLE
PyQtGraph missing function name fix

### DIFF
--- a/acq4/pyqtgraph/functions.py
+++ b/acq4/pyqtgraph/functions.py
@@ -16,6 +16,7 @@ from .Qt import QtGui, QtCore, USE_PYSIDE
 from .metaarray import MetaArray
 from . import getConfigOption, setConfigOptions
 from . import debug
+from .reload import getPreviousVersion
 
 
 


### PR DESCRIPTION
added missing import statement. 

getPreviousVersion is called in disconnect, but was not defined in the file or imported, so I added a statement to import it from reload.py