### PR TITLE
Imaging fixes

### DIFF
--- a/acq4/devices/Laser/Laser.py
+++ b/acq4/devices/Laser/Laser.py
@@ -569,6 +569,8 @@ class Laser(DAQGeneric, OptomechDevice):
                     else:
                         power = self.params['currentPower']
                     transmission = self.params['scopeTransmission']
+                    if transmission is None:
+                        raise Exception('Power transmission has not been calibrated for "%s" with the current optics and wavelength.' % self.name())
                     #transmission = 0.1
                 powerCmd = cmd['switchWaveform']*power*transmission
             else:


### PR DESCRIPTION
Minor change to allow testing a minimal imaging setup:
* Allow imager to operate when laser has no pockels cell
* Option to set/disable imager power monitoring 
* Minor cleanup -- removed an unused imager configuration option, added an error message

Should be tested on an imaging system before merge.