### PR TITLE
bugfix against logging changes

### DIFF
--- a/acq4/util/debug.py
+++ b/acq4/util/debug.py
@@ -29,6 +29,7 @@ def createLogWindow(manager):
     global LOG_UI
     assert LOG_UI is None
     LOG_UI = LogWindow(manager)
+    return LOG_UI
 
 
 def printExc(msg='', indent=4, prefix='|', msgType='error'):


### PR DESCRIPTION
This change lets avoids the following start up error:

`=== Setting base directory: f:\data\junk ===
[16:49:45]  Error in ACQ4 configuration:

    |==============================>>
    |    File "C:\Anaconda64\lib\runpy.py", line 162, in _run_module_as_main
    |      "__main__", fname, loader, pkg_name)
    |    File "C:\Anaconda64\lib\runpy.py", line 72, in _run_code
    |      exec code in run_globals
    |    File "C:\Users\Experimenters\acq4\acq4\__main__.py", line 48, in <module>
    |      man = Manager(argv=sys.argv[1:])
    |    File "acq4\Manager.py", line 146, in __init__
    |      self.readConfig(configFile)
    |    File "acq4\Manager.py", line 232, in readConfig
    |      self.configure(cfg)
    |    File "acq4\Manager.py", line 329, in configure
    |      printExc("Error in ACQ4 configuration:")
    |    File "acq4\util\debug.py", line 37, in printExc
    |      pgdebug.printExc(msg, indent, prefix)
    |    ---- exception caught ---->
    |    File "acq4\Manager.py", line 272, in configure
    |      self.setBaseDir(cfg['storageDir'])
    |    File "acq4\Manager.py", line 682, in setBaseDir
    |      self.setCurrentDir(self.baseDir)
    |    File "acq4\Manager.py", line 638, in setCurrentDir
    |      logDir = self.logWindow.getLogDir()
    |  AttributeError: 'NoneType' object has no attribute 'getLogDir'
    |==============================<<

============= Manager configuration complete =================`

by setting self.logWindow to a LogWindow instead of to None in line 85 of acq4/Manager.py.

This seems like an odd thing to leave though. Is there a new configuration setting or something that I'm missing? 
