### PR TITLE
Microscope device bugfix

### DIFF
--- a/acq4/devices/Microscope/Microscope.py
+++ b/acq4/devices/Microscope/Microscope.py
@@ -35,7 +35,7 @@ class Microscope(Device, OptomechDevice):
         self.currentObjective = None
         self._focusDevice = None
         self._positionDevice = None
-        self._surfaceDepth = None
+        self._surfaceDepth = 0.0
         
         self.objectives = collections.OrderedDict()
         ## Format of self.objectives is:


### PR DESCRIPTION
Bugfix. Previously if there was not yet a Microscope device config file (config/devices/Microscope_config/calibration) attempting to open the Camera module would cause this exception and fail:

> Loading module "Camera" as "Camera"...
> ===== 2017.11.01 14:11:50 =====
> Traceback (most recent call last):
>   File "acq4\modules\Manager\Manager.py", line 91, in loadModule
>            self.manager.loadDefinedModule(mod)
>   File "acq4\Manager.py", line 579, in loadDefinedModule
>            mod = self.loadModule(mod, mName, config, forceReload=forceReload)
>   File "acq4\Manager.py", line 512, in loadModule
>            mod = modclass(self, name, config)
>   File "acq4\modules\Camera\Camera.py", line 10, in __init__
>            self.ui = CameraWindow(self)
>   File "acq4\modules\Camera\CameraWindow.py", line 64, in __init__
>            ifaces = OrderedDict([(dev.name(), dev.cameraModuleInterface(self)) for dev in devices if hasattr(dev, 'cameraModuleInterface')])
>   File "acq4\devices\Microscope\Microscope.py", line 163, in cameraModuleInterface
>            return ScopeCameraModInterface(self, mod)
>   File "acq4\devices\Microscope\Microscope.py", line 477, in __init__
>            self.transformChanged()
>   File "acq4\devices\Microscope\Microscope.py", line 502, in transformChanged
>            depth = fpos[2] - self.getDevice().getSurfaceDepth()
> TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'

Changing self._surfaceDepth to initialize to 0.0 instead of None resolves this.