### PR TITLE
Optional storage of DaqGeneric output channels

### DIFF
--- a/acq4/devices/DAQGeneric/AOChannelTemplate.py
+++ b/acq4/devices/DAQGeneric/AOChannelTemplate.py
@@ -2,8 +2,8 @@
 
 # Form implementation generated from reading ui file 'AOChannelTemplate.ui'
 #
-# Created: Sun Feb 22 13:29:01 2015
-#      by: PyQt4 UI code generator 4.10.4
+# Created: Fri Dec  1 15:06:51 2017
+#      by: PyQt4 UI code generator 4.11.3
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -26,7 +26,7 @@ except AttributeError:
 class Ui_Form(object):
     def setupUi(self, Form):
         Form.setObjectName(_fromUtf8("Form"))
-        Form.resize(529, 353)
+        Form.resize(321, 206)
         self.verticalLayout_3 = QtGui.QVBoxLayout(Form)
         self.verticalLayout_3.setSpacing(0)
         self.verticalLayout_3.setMargin(0)
@@ -36,6 +36,7 @@ class Ui_Form(object):
         font.setBold(True)
         font.setWeight(75)
         self.groupBox.setFont(font)
+        self.groupBox.setTitle(_fromUtf8(""))
         self.groupBox.setCheckable(False)
         self.groupBox.setObjectName(_fromUtf8("groupBox"))
         self.verticalLayout_2 = QtGui.QVBoxLayout(self.groupBox)
@@ -103,6 +104,14 @@ class Ui_Form(object):
         self.displayCheck.setChecked(True)
         self.displayCheck.setObjectName(_fromUtf8("displayCheck"))
         self.horizontalLayout.addWidget(self.displayCheck)
+        self.storeWaveCheck = QtGui.QCheckBox(self.frame)
+        font = QtGui.QFont()
+        font.setBold(False)
+        font.setWeight(50)
+        self.storeWaveCheck.setFont(font)
+        self.storeWaveCheck.setChecked(True)
+        self.storeWaveCheck.setObjectName(_fromUtf8("storeWaveCheck"))
+        self.horizontalLayout.addWidget(self.storeWaveCheck)
         self.verticalLayout.addLayout(self.horizontalLayout)
         self.waveGeneratorWidget = StimGenerator(self.frame)
         sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Expanding)
@@ -124,11 +133,11 @@ class Ui_Form(object):
 
     def retranslateUi(self, Form):
         Form.setWindowTitle(_translate("Form", "Form", None))
-        self.groupBox.setTitle(_translate("Form", "GroupBox", None))
         self.preSetCheck.setText(_translate("Form", "Pre-set", None))
         self.holdingCheck.setText(_translate("Form", "Holding", None))
         self.functionCheck.setText(_translate("Form", "Enable Function", None))
         self.displayCheck.setText(_translate("Form", "Display", None))
+        self.storeWaveCheck.setText(_translate("Form", "Store Waveform", None))
 
 from acq4.pyqtgraph import SpinBox, GroupBox
 from acq4.util.generator.StimGenerator import StimGenerator

--- a/acq4/devices/DAQGeneric/AOChannelTemplate.ui
+++ b/acq4/devices/DAQGeneric/AOChannelTemplate.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>529</width>
-    <height>353</height>
+    <width>321</width>
+    <height>206</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,7 +29,7 @@
       </font>
      </property>
      <property name="title">
-      <string>GroupBox</string>
+      <string/>
      </property>
      <property name="checkable">
       <bool>false</bool>
@@ -155,6 +155,22 @@
              </property>
              <property name="text">
               <string>Display</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="storeWaveCheck">
+             <property name="font">
+              <font>
+               <weight>50</weight>
+               <bold>false</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Store Waveform</string>
              </property>
              <property name="checked">
               <bool>true</bool>

--- a/acq4/devices/DAQGeneric/DAQGeneric.py
+++ b/acq4/devices/DAQGeneric/DAQGeneric.py
@@ -426,9 +426,10 @@ class DAQGenericTask(DeviceTask):
         ## Collect data and info for each channel in the command
         result = {}
         for ch in self.bufferedChannels:
-            result[ch] = self.daqTasks[ch].getData(self.dev._DGConfig[ch]['channel'])
-            result[ch]['data'] = self.mapping.mapFromDaq(ch, result[ch]['data']) ## scale/offset/invert
-            result[ch]['units'] = self.getChanUnits(ch)
+            if self._DAQCmd[ch].get('record', True):
+                result[ch] = self.daqTasks[ch].getData(self.dev._DGConfig[ch]['channel'])
+                result[ch]['data'] = self.mapping.mapFromDaq(ch, result[ch]['data']) ## scale/offset/invert
+                result[ch]['units'] = self.getChanUnits(ch)
         
         if len(result) > 0:
             meta = result[result.keys()[0]]['info']

--- a/acq4/devices/DAQGeneric/DOChannelTemplate.py
+++ b/acq4/devices/DAQGeneric/DOChannelTemplate.py
@@ -2,8 +2,8 @@
 
 # Form implementation generated from reading ui file 'DOChannelTemplate.ui'
 #
-# Created: Sun Feb 22 13:29:09 2015
-#      by: PyQt4 UI code generator 4.10.4
+# Created: Fri Dec  1 15:18:39 2017
+#      by: PyQt4 UI code generator 4.11.3
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -26,7 +26,7 @@ except AttributeError:
 class Ui_Form(object):
     def setupUi(self, Form):
         Form.setObjectName(_fromUtf8("Form"))
-        Form.resize(400, 300)
+        Form.resize(321, 218)
         self.verticalLayout_3 = QtGui.QVBoxLayout(Form)
         self.verticalLayout_3.setSpacing(0)
         self.verticalLayout_3.setMargin(0)
@@ -36,6 +36,7 @@ class Ui_Form(object):
         font.setBold(True)
         font.setWeight(75)
         self.groupBox.setFont(font)
+        self.groupBox.setTitle(_fromUtf8(""))
         self.groupBox.setCheckable(False)
         self.groupBox.setObjectName(_fromUtf8("groupBox"))
         self.verticalLayout_2 = QtGui.QVBoxLayout(self.groupBox)
@@ -101,6 +102,14 @@ class Ui_Form(object):
         self.displayCheck.setChecked(True)
         self.displayCheck.setObjectName(_fromUtf8("displayCheck"))
         self.horizontalLayout.addWidget(self.displayCheck)
+        self.storeWaveCheck = QtGui.QCheckBox(self.frame)
+        font = QtGui.QFont()
+        font.setBold(False)
+        font.setWeight(50)
+        self.storeWaveCheck.setFont(font)
+        self.storeWaveCheck.setChecked(True)
+        self.storeWaveCheck.setObjectName(_fromUtf8("storeWaveCheck"))
+        self.horizontalLayout.addWidget(self.storeWaveCheck)
         self.verticalLayout.addLayout(self.horizontalLayout)
         self.waveGeneratorWidget = StimGenerator(self.frame)
         sizePolicy = QtGui.QSizePolicy(QtGui.QSizePolicy.Preferred, QtGui.QSizePolicy.Expanding)
@@ -122,11 +131,11 @@ class Ui_Form(object):
 
     def retranslateUi(self, Form):
         Form.setWindowTitle(_translate("Form", "Form", None))
-        self.groupBox.setTitle(_translate("Form", "GroupBox", None))
         self.preSetCheck.setText(_translate("Form", "Pre-set", None))
         self.holdingCheck.setText(_translate("Form", "Holding", None))
         self.functionCheck.setText(_translate("Form", "Enable Function", None))
         self.displayCheck.setText(_translate("Form", "Display", None))
+        self.storeWaveCheck.setText(_translate("Form", "Store Waveform", None))
 
 from acq4.pyqtgraph import GroupBox
 from acq4.util.generator.StimGenerator import StimGenerator

--- a/acq4/devices/DAQGeneric/DOChannelTemplate.ui
+++ b/acq4/devices/DAQGeneric/DOChannelTemplate.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>321</width>
+    <height>218</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,7 +29,7 @@
       </font>
      </property>
      <property name="title">
-      <string>GroupBox</string>
+      <string/>
      </property>
      <property name="checkable">
       <bool>false</bool>
@@ -149,6 +149,22 @@
              </property>
              <property name="text">
               <string>Display</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="storeWaveCheck">
+             <property name="font">
+              <font>
+               <weight>50</weight>
+               <bold>false</bold>
+              </font>
+             </property>
+             <property name="text">
+              <string>Store Waveform</string>
              </property>
              <property name="checked">
               <bool>true</bool>

--- a/acq4/devices/DAQGeneric/DaqChannelGui.py
+++ b/acq4/devices/DAQGeneric/DaqChannelGui.py
@@ -199,6 +199,8 @@ class OutputChannelGui(DaqChannelGui):
             prot['holding'] = state['holdingSpin']
         if state['functionCheck']:
             prot['command'] = self.getSingleWave(params)
+        if not state['storeWaveCheck']:
+            prot['record'] = False
             
         return prot
     


### PR DESCRIPTION
Allow user to decide whether to store waveforms for DaqGeneric outputchannels.

Added a "Store Waveform" checkBox to guis. Default is checked.
Then, when handling the result, the output arrays are added to the
result to be stored if the 'record' key in the task command is not
set to False.