### PR TITLE
Change to TimeoutError

### DIFF
--- a/acq4/drivers/Scientifica/scientifica.py
+++ b/acq4/drivers/Scientifica/scientifica.py
@@ -130,7 +130,7 @@ class Scientifica(SerialDevice):
                 SerialDevice.__init__(self, port=self.port, baudrate=baudrate)
                 try:
                     sci = self.send('scientifica', timeout=0.2)
-                except RuntimeError:
+                except TimeoutError:
                     # try again because prior communication at a different baud rate may have garbled serial communication.
                     sci = self.send('scientifica', timeout=1.0)
 


### PR DESCRIPTION
sci = self.send('scientifica', timeout=0.2) (line 132) will lead to a TimeoutError, not RunetimeError. If want to try again need to catch TimeoutError.