### PR TITLE
µManager binning-roi scaling

### DIFF
--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -258,28 +258,27 @@ class MicroManagerCamera(Camera):
             p('start')
         
         needRestart = False
-        return (newVals, needRestart)
+        return newVals, needRestart
 
     def setParam(self, param, value, autoCorrect=True, autoRestart=True):
         return self.setParams({param: value}, autoCorrect=autoCorrect, autoRestart=autoRestart)
 
     def _setParam(self, param, value, autoCorrect=True):
-        if param == 'region':
-            value = (value[0], value[1], value[2], value[3])
-            self.mmc.setCameraDevice(self.camName)
-            self.mmc.setROI(*value)
-            return
-
         if param.startswith('region'):
-            rgn = list(self.mmc.getROI(self.camName))
-            if param[-1] == 'X':
-                rgn[0] = value
-            elif param[-1] == 'Y':
-                rgn[1] = value
-            elif param[-1] == 'W':
-                rgn[2] = value
-            elif param[-1] == 'H':
-                rgn[3] = value
+            if param == 'region':
+                rgn = (value[0], value[1], value[2], value[3])
+            else:
+                rgn = list(self.mmc.getROI(self.camName))
+                if param[-1] == 'X':
+                    rgn[0] = value
+                elif param[-1] == 'Y':
+                    rgn[1] = value
+                elif param[-1] == 'W':
+                    rgn[2] = value
+                elif param[-1] == 'H':
+                    rgn[3] = value
+            rgn[2] /= self.getParam('binningX')
+            rgn[3] /= self.getParam('binningY')
             self.mmc.setCameraDevice(self.camName)
             self.mmc.setROI(*rgn)
             return

--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -277,8 +277,8 @@ class MicroManagerCamera(Camera):
                     rgn[2] = value
                 elif param[-1] == 'H':
                     rgn[3] = value
-            rgn[2] /= self.getParam('binningX')
-            rgn[3] /= self.getParam('binningY')
+            rgn[2] = int(rgn[2] / self.getParam('binningX'))
+            rgn[3] = int(rgn[3] / self.getParam('binningY'))
             self.mmc.setCameraDevice(self.camName)
             self.mmc.setROI(*rgn)
             return

--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -266,7 +266,7 @@ class MicroManagerCamera(Camera):
     def _setParam(self, param, value, autoCorrect=True):
         if param.startswith('region'):
             if param == 'region':
-                rgn = (value[0], value[1], value[2], value[3])
+                rgn = [value[0], value[1], value[2], value[3]]
             else:
                 rgn = list(self.mmc.getROI(self.camName))
                 if param[-1] == 'X':

--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -187,7 +187,7 @@ class MicroManagerCamera(Camera):
             bin = '1' if self._binningMode == 'x' else '1x1'
             self.mmc.setProperty(self.camName, 'Binning', bin)
             self.mmc.clearROI()
-            rgn = self.mmc.getROI(self.camName)
+            rgn = self.getROI()
             self._sensorSize = rgn[2:]
 
             params.update({
@@ -205,6 +205,15 @@ class MicroManagerCamera(Camera):
                 params['binningY'] = [[1], False, True, []]
 
             self._allParams = params
+
+    def getROI(self):
+        cam_region = self.mmc.getROI(self.camName)
+        return [
+            cam_region[0],
+            cam_region[1],
+            cam_region[2] * self.getParam("binningX"),
+            cam_region[3] * self.getParam("binningY"),
+        ]
 
     def listParams(self, params=None):
         """List properties of specified parameters, or of all parameters if None"""
@@ -230,7 +239,7 @@ class MicroManagerCamera(Camera):
         regionKeys = ['regionX', 'regionY', 'regionW', 'regionH']
         nRegionKeys = len([k for k in regionKeys if k in params])
         if nRegionKeys > 1:
-            rgn = list(self.mmc.getROI(self.camName))
+            rgn = list(self.getROI())
             for k in regionKeys:
                 if k not in params:
                     continue
@@ -268,7 +277,7 @@ class MicroManagerCamera(Camera):
             if param == 'region':
                 rgn = [value[0], value[1], value[2], value[3]]
             else:
-                rgn = list(self.mmc.getROI(self.camName))
+                rgn = list(self.getROI())
                 if param[-1] == 'X':
                     rgn[0] = value
                 elif param[-1] == 'Y':
@@ -355,7 +364,7 @@ class MicroManagerCamera(Camera):
         if param == 'sensorSize':
             return self._sensorSize
         elif param.startswith('region'):
-            rgn = self.mmc.getROI(self.camName)
+            rgn = self.getROI()
             if param == 'region':
                 return rgn
             i = ['regionX', 'regionY', 'regionW', 'regionH'].index(param)

--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -216,14 +216,16 @@ class MicroManagerCamera(Camera):
             xAdjustment = 1
             yAdjustment = 1
         return [
-            cam_region[0],
-            cam_region[1],
+            cam_region[0] * xAdjustment,
+            cam_region[1] * yAdjustment,
             cam_region[2] * xAdjustment,
             cam_region[3] * yAdjustment,
         ]
 
     def setROI(self, rgn):
         if self._useBinnedPixelsForROI:
+            rgn[0] = int(rgn[0] / self.getParam('binningX'))
+            rgn[1] = int(rgn[1] / self.getParam('binningY'))
             rgn[2] = int(rgn[2] / self.getParam('binningX'))
             rgn[3] = int(rgn[3] / self.getParam('binningY'))
         self.mmc.setROI(*rgn)

--- a/acq4/devices/MicroManagerCamera/mmcamera.py
+++ b/acq4/devices/MicroManagerCamera/mmcamera.py
@@ -208,7 +208,7 @@ class MicroManagerCamera(Camera):
             self._allParams = params
 
     def getROI(self):
-        cam_region = self.mmc.getROI(self.camName)
+        camRegion = self.mmc.getROI(self.camName)
         if self._useBinnedPixelsForROI:
             xAdjustment = self.getParam("binningX")
             yAdjustment = self.getParam("binningY")
@@ -216,10 +216,10 @@ class MicroManagerCamera(Camera):
             xAdjustment = 1
             yAdjustment = 1
         return [
-            cam_region[0] * xAdjustment,
-            cam_region[1] * yAdjustment,
-            cam_region[2] * xAdjustment,
-            cam_region[3] * yAdjustment,
+            camRegion[0] * xAdjustment,
+            camRegion[1] * yAdjustment,
+            camRegion[2] * xAdjustment,
+            camRegion[3] * yAdjustment,
         ]
 
     def setROI(self, rgn):

--- a/acq4/util/micromanager.py
+++ b/acq4/util/micromanager.py
@@ -11,20 +11,25 @@ microManagerPath = 'C:\\Program Files\\Micro-Manager-1.4'
 microManagerPath = 'C:\\Program Files\\Micro-Manager-2.0gamma'
 
 
+USES_PYMMCORE = False
+USES_MMCOREPY = False
+
+
 def getMMCorePy(path=None):
     """Return a singleton MMCorePy instance that is shared by all devices for accessing micromanager.
     """
-    global _mmc
+    global _mmc, USES_MMCOREPY, USES_PYMMCORE
     if _mmc is None:
         try:
             import pymmcore
+            USES_PYMMCORE = True
             _mmc = pymmcore.CMMCore()
             _mmc.setDeviceAdapterSearchPaths([microManagerPath])
         except ImportError:
 
             try:
-                global MMCorePy
                 import MMCorePy
+                USES_MMCOREPY = True
             except ImportError:
                 if sys.platform != 'win32':
                     raise
@@ -36,6 +41,7 @@ def getMMCorePy(path=None):
                 os.environ['PATH'] = os.environ['PATH'] + ';' + path
                 try:
                     import MMCorePy
+                    USES_MMCOREPY = True
                 finally:
                     sys.path.pop()
 

--- a/acq4/util/micromanager.py
+++ b/acq4/util/micromanager.py
@@ -7,29 +7,23 @@ from acq4.util.Mutex import Mutex
 _mmc = None
 
 # default location to search for micromanager
-microManagerPath = 'C:\\Program Files\\Micro-Manager-1.4'
+# microManagerPath = 'C:\\Program Files\\Micro-Manager-1.4'
 microManagerPath = 'C:\\Program Files\\Micro-Manager-2.0gamma'
-
-
-USES_PYMMCORE = False
-USES_MMCOREPY = False
 
 
 def getMMCorePy(path=None):
     """Return a singleton MMCorePy instance that is shared by all devices for accessing micromanager.
     """
-    global _mmc, USES_MMCOREPY, USES_PYMMCORE
+    global _mmc
     if _mmc is None:
         try:
             import pymmcore
-            USES_PYMMCORE = True
             _mmc = pymmcore.CMMCore()
             _mmc.setDeviceAdapterSearchPaths([microManagerPath])
         except ImportError:
 
             try:
                 import MMCorePy
-                USES_MMCOREPY = True
             except ImportError:
                 if sys.platform != 'win32':
                     raise
@@ -41,7 +35,6 @@ def getMMCorePy(path=None):
                 os.environ['PATH'] = os.environ['PATH'] + ';' + path
                 try:
                     import MMCorePy
-                    USES_MMCOREPY = True
                 finally:
                     sys.path.pop()
 


### PR DESCRIPTION
This behavior first shows up in MMCore version 7.0.2 (distributed as MicroManager 1.4.21). For all versions after that (including 2.0), use binned pixel units in ROI operations.