### PR TITLE
Sensapex pressure controller v0.915

### DIFF
--- a/acq4/devices/SensapexPressureControl/pressurecontrol.py
+++ b/acq4/devices/SensapexPressureControl/pressurecontrol.py
@@ -33,14 +33,14 @@ class SensapexPressureControl(PressureControl):
             if match:
                 self.source = source
                 break
-        self.pressure = self.dev.get_pressure(self.pressureChannel)
+        self.pressure = self.dev.get_pressure(self.pressureChannel) * 1000
 
     def _setPressure(self, p):
         """Set the regulated output pressure (in Pascals) to the pipette.
 
         Note: this does _not_ change the configuration of any values.
         """
-        self.dev.set_pressure(self.pressureChannel, p)
+        self.dev.set_pressure(self.pressureChannel, p / 1000.)
         self.pressure = p
 
     def _setSource(self, source):

--- a/acq4/devices/SensapexPressureControl/pressurecontrol.py
+++ b/acq4/devices/SensapexPressureControl/pressurecontrol.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
-from acq4.util import Qt
-from acq4.drivers.sensapex import SensapexDevice, UMP, UMPError
+
+from acq4.drivers.sensapex import SensapexDevice, UMP
 from ..PressureControl import PressureControl
 
 

--- a/acq4/devices/SensapexPressureControl/pressurecontrol.py
+++ b/acq4/devices/SensapexPressureControl/pressurecontrol.py
@@ -21,8 +21,6 @@ class SensapexPressureControl(PressureControl):
         PressureControl.__init__(self, manager, config, name)
 
         self.pressureChannel = config.pop('pressureChannel')
-        self.pressureScale = config.pop('pressureScale') * 1e6
-        self.voltageOffset = config.pop('voltageOffset') * 1e6
         self.sources = config.pop('sources')
 
         # try to infer current source from channel state
@@ -35,14 +33,14 @@ class SensapexPressureControl(PressureControl):
             if match:
                 self.source = source
                 break
-        self.pressure = (self.dev.get_pressure(self.pressureChannel) - self.voltageOffset) / self.pressureScale
+        self.pressure = self.dev.get_pressure(self.pressureChannel)
 
     def _setPressure(self, p):
         """Set the regulated output pressure (in Pascals) to the pipette.
 
         Note: this does _not_ change the configuration of any values.
         """
-        self.dev.set_pressure(self.pressureChannel, p * self.pressureScale + self.voltageOffset)
+        self.dev.set_pressure(self.pressureChannel, p)
         self.pressure = p
 
     def _setSource(self, source):

--- a/acq4/drivers/sensapex/sensapex.py
+++ b/acq4/drivers/sensapex/sensapex.py
@@ -600,13 +600,19 @@ class SensapexDevice(object):
 
     def set_pressure(self, channel, value):
         """
-        @param value: pressure in kPa
+        Parameters
+        ----------
+        value : float
+            pressure in kPa
         """
         return self.ump.set_pressure(self.devid, int(channel), float(value))
 
     def get_pressure(self, channel):
         """
-        @return: pressure in kPa
+        Returns
+        -------
+        float
+            pressure in kPa
         """
         return self.ump.get_pressure(self.devid, int(channel))
 

--- a/acq4/drivers/sensapex/sensapex.py
+++ b/acq4/drivers/sensapex/sensapex.py
@@ -441,7 +441,7 @@ class UMP(object):
         self.call('um_cu_set_active', dev, int(active))
 
     def set_pressure(self, dev, channel, value):
-        return self.call('umc_set_pressure_setting', dev, int(channel), float(value))
+        return self.call('umc_set_pressure_setting', dev, int(channel), c_float(value))
 
     def get_pressure(self, dev, channel):
         p = c_float()

--- a/acq4/drivers/sensapex/sensapex.py
+++ b/acq4/drivers/sensapex/sensapex.py
@@ -3,7 +3,7 @@ import os, sys, ctypes, atexit, time, threading, platform
 import numpy as np
 from ctypes import (c_int, c_uint, c_ulong, c_short, c_ushort,
                     c_byte, c_void_p, c_char, c_char_p, c_longlong,
-                    byref, POINTER, pointer, Structure)
+                    byref, POINTER, pointer, Structure, c_float)
 from timeit import default_timer
 from six.moves import map
 from six.moves import range
@@ -444,7 +444,9 @@ class UMP(object):
         return self.call('umc_set_pressure_setting', dev, int(channel), float(value))
 
     def get_pressure(self, dev, channel):
-        return self.call('umc_get_pressure_setting', dev, int(channel))
+        p = c_float()
+        self.call('umc_get_pressure_setting', dev, int(channel), byref(p))
+        return p.value
 
     def set_valve(self, dev, channel, value):
         return self.call('umv_set_valve', dev, int(channel), int (value))

--- a/acq4/drivers/sensapex/sensapex.py
+++ b/acq4/drivers/sensapex/sensapex.py
@@ -441,10 +441,10 @@ class UMP(object):
         self.call('um_cu_set_active', dev, int(active))
 
     def set_pressure(self, dev, channel, value):
-        return self.call('umv_set_pressure', dev, int(channel), int (value))
+        return self.call('umc_set_pressure_setting', dev, int(channel), float(value))
 
     def get_pressure(self, dev, channel):
-        return self.call('umv_get_pressure', dev, int(channel))
+        return self.call('umc_get_pressure_setting', dev, int(channel))
 
     def set_valve(self, dev, channel, value):
         return self.call('umv_set_valve', dev, int(channel), int (value))
@@ -597,9 +597,15 @@ class SensapexDevice(object):
             self.callback(self, new_pos, old_pos)
 
     def set_pressure(self, channel, value):
-        return self.ump.set_pressure(self.devid, int(channel), int (value))
+        """
+        @param value: pressure in kPa
+        """
+        return self.ump.set_pressure(self.devid, int(channel), float(value))
 
     def get_pressure(self, channel):
+        """
+        @return: pressure in kPa
+        """
         return self.ump.get_pressure(self.devid, int(channel))
 
     def set_valve(self, channel, value):


### PR DESCRIPTION
I couldn't come up with a way to test that I am converting kPa to Pa correctly, so double-check my logic there.

Note: the sdk offers two `get_pressure` functions, one for the setting, and one for an actual measurement. I picked the "setting" one. We only ever check the pressure when we init the `SensapexPressureControl`.