### PR TITLE
c library fixes

### DIFF
--- a/acq4/Manager.py
+++ b/acq4/Manager.py
@@ -111,7 +111,7 @@ class Manager(Qt.QObject):
                     print(str(err))
                     print("""
     Valid options are:
-        -x --exit-on-error Whether to exit immidiately on the first exception
+        -x --exit-on-error Whether to exit immidiately on the first exception during initial Manager setup
         -c --config=       Configuration file to load
         -a --config-name=  Named configuration to load
         -m --module=       Module name to load

--- a/acq4/drivers/MultiClamp/MultiClampTelegraph.py
+++ b/acq4/drivers/MultiClamp/MultiClampTelegraph.py
@@ -159,13 +159,13 @@ class MultiClampTelegraph:
     def createWindow(self):
         if self.debug:
             print("MultiClampTelegraph.createWindow called.")
-        self.wndClass = wmlib.WNDCLASSA(0, wmlib.WNDPROC(self.wndProc), 0, 0, wmlib.HWND_MESSAGE, 0, 0, 0, "", "AxTelegraphWin")
+        self.wndClass = wmlib.WNDCLASSA(0, wmlib.WNDPROC(self.wndProc), 0, 0, wmlib.HWND_MESSAGE, 0, 0, 0, b"", b"AxTelegraphWin")
         ret = wmlib.RegisterClassA(self.wndClass)
         #print "Register class:", ret()
         if ret() == 0:
             raise Exception("Error registering window class.")
         cwret = wmlib.CreateWindowExA(
-            0, self.wndClass.lpszClassName, "title", 
+            0, self.wndClass.lpszClassName, b"title",
             wmlib.WS_OVERLAPPEDWINDOW,
             wmlib.CW_USEDEFAULT,
             wmlib.CW_USEDEFAULT,
@@ -274,8 +274,8 @@ class MultiClampTelegraph:
             print("MultiClampTelegraph.registerMessages called.")
         self.msgIds = {}
         for m in ['OPEN', 'CLOSE', 'REQUEST', 'BROADCAST', 'RECONNECT', 'ID']:
-            self.msgIds[m] = wmlib.RegisterWindowMessageA(wmlib('values', 'MCTG_' + m + '_MESSAGE_STR'))()
-        self.msgIds['COMMAND'] = wmlib.RegisterWindowMessageA(wmlib('values', 'MC_COMMAND_MESSAGE_STR'))()
+            self.msgIds[m] = wmlib.RegisterWindowMessageA(wmlib("values", "MCTG_" + m + "_MESSAGE_STR").encode("ascii"))()
+        self.msgIds["COMMAND"] = wmlib.RegisterWindowMessageA(wmlib("values", "MC_COMMAND_MESSAGE_STR").encode("ascii"))()
 
     def post(self, msg, val):
         if self.debug:

--- a/acq4/drivers/nidaq/nidaq.py
+++ b/acq4/drivers/nidaq/nidaq.py
@@ -141,7 +141,7 @@ class _NIDAQ:
         if errCode is None:
             err = self.GetExtendedErrorInfo()
         else:
-            err = self.GetErrorString(errCode)
+            err = self.GetErrorString(errCode).decode('ascii')
         err.replace('\\n', '\n')
         return err
 

--- a/acq4/drivers/nidaq/nidaq.py
+++ b/acq4/drivers/nidaq/nidaq.py
@@ -139,7 +139,7 @@ class _NIDAQ:
     def error(self, errCode=None):
         """Return a string with error information. If errCode is None, then the currently 'active' error will be used."""
         if errCode is None:
-            err = self.GetExtendedErrorInfo()
+            err = self.GetExtendedErrorInfo().decode('ascii')
         else:
             err = self.GetErrorString(errCode).decode('ascii')
         err.replace('\\n', '\n')

--- a/acq4/util/clibrary/CLibrary.py
+++ b/acq4/util/clibrary/CLibrary.py
@@ -267,13 +267,13 @@ class CLibrary:
                     if m[0] == '*' or m[0] == '&':
                         for i in m:
                             cls = POINTER(cls)
-                elif type(m) is list:          ## array
+                elif isinstance(m, list) and isinstance(m[0], int):          ## array
                     for i in m:
                         if i == -1:            ## -1 indicates an 'incomplete type' like "int variable[]"
                             cls = POINTER(cls) ## which we should interpret like "int *variable"
                         else:
                             cls = cls * i
-                elif type(m) is tuple:   ## Probably a function pointer
+                elif isinstance(m, (list, tuple)) and not isinstance(m[0], int):   ## Probably a function pointer
                     ## Find pointer and calling convention
                     isPtr = False
                     conv = '__cdecl'

--- a/acq4/util/clibrary/CLibrary.py
+++ b/acq4/util/clibrary/CLibrary.py
@@ -302,7 +302,7 @@ class CLibrary:
                     cls = mkfn(cls, *args)
                             
                 else:
-                    raise Exception("Not sure what to do with this type modifier: '%s'" % str(p))
+                    raise Exception("Not sure what to do with this type modifier: '%s'" % (m,))
             return cls
         except:
             print("Error while processing type", typ)

--- a/acq4/util/imaging/frame_display.py
+++ b/acq4/util/imaging/frame_display.py
@@ -8,6 +8,10 @@ from .bg_subtract_ctrl import BgSubtractCtrl
 from .contrast_ctrl import ContrastCtrl
 
 
+MAX_FRAMES_PER_SECOND = 30
+S_PER_FRAME = 1.0 / MAX_FRAMES_PER_SECOND
+MS_PER_FRAME = int(S_PER_FRAME * 1000)
+
 class FrameDisplay(Qt.QObject):
     """Used with live imaging to hold the most recently acquired frame and allow
     user control of contrast, gain, and background subtraction.
@@ -46,7 +50,7 @@ class FrameDisplay(Qt.QObject):
         # 60fps.
         self.frameTimer = Qt.QTimer()
         self.frameTimer.timeout.connect(self.drawFrame)
-        self.frameTimer.start(30)  # draw frames no faster than 60Hz
+        self.frameTimer.start(MS_PER_FRAME)  # draw frames no faster than 60Hz
         # Qt.QTimer.singleShot(1, self.drawFrame)
         # avoiding possible singleShot-induced crashes
 
@@ -96,7 +100,7 @@ class FrameDisplay(Qt.QObject):
         try:
             # If we last drew a frame < 1/30s ago, return.
             t = pg.ptime.time()
-            if (self.lastDrawTime is not None) and (t - self.lastDrawTime < 0.03):
+            if (self.lastDrawTime is not None) and (t - self.lastDrawTime < S_PER_FRAME):
                 return
             # if there is no new frame and no controls have changed, just exit
             if not self._updateFrame and self.nextFrame is None:


### PR DESCRIPTION
3 unrelated updates are included here.

clibrary fixes: the changes are mostly the same as what @campagnola figured out with me the other day. The new cache format doesn't deserialize with tuples (maybe it should include an explicit type somewhere, eventually). Multiclamp code needs bytes instead of strings.

`--exit-on-error` flag to make reading errors easier.

Refactor of how frames-per-second limits are written in the code.