### PR TITLE
Python3 manislab: 

### DIFF
--- a/acq4/analysis/dataModels/PatchEPhys/PatchEPhys.py
+++ b/acq4/analysis/dataModels/PatchEPhys/PatchEPhys.py
@@ -753,7 +753,7 @@ class GetClamps():
             if len(sequence_values) > 0:
                 self.values.append(sequence_values[i])
             else:
-                self.values.append(cmd[len(cmd) / 2])
+                self.values.append(cmd[int(len(cmd) / 2)])
         if traces is None or len(traces) == 0:
             print("PatchEPhys/GetClamps: No data found in this run...")
             return None

--- a/acq4/analysis/modules/IVCurve/IVCurve.py
+++ b/acq4/analysis/modules/IVCurve/IVCurve.py
@@ -1063,7 +1063,7 @@ class IVCurve(AnalysisModule):
         dt = self.Clamps.sample_interval
         rgnindx = [int((rgnpk[1]-0.005)/dt), int((rgnpk[1])/dt)]
         rmps = self.ivbaseline
-        vmeans = np.mean(self.Clamps.traces[:, rgnindx[0]:rgnindx[1]], axis=1) - self.ivbaseline
+        vmeans = np.mean(self.Clamps.traces[:, rgnindx[0]:rgnindx[1]].view(np.ndarray), axis=1) - self.ivbaseline
         indxs = np.where(np.logical_and((vrange[0]*1e-3 >= vmeans[ineg]), 
                          (vmeans[ineg] >= vrange[1]*1e-3)))
         indxs = list(indxs[0])

--- a/acq4/devices/MultiClamp/taskGUI.py
+++ b/acq4/devices/MultiClamp/taskGUI.py
@@ -344,6 +344,10 @@ class MultiClampTaskGui(TaskGui):
     def quit(self):
         TaskGui.quit(self)
         if not sip.isdeleted(self.daqUI):
-            Qt.QObject.disconnect(self.daqUI, Qt.SIGNAL('changed'), self.daqChanged)
+            # Qt.QObject.disconnect(self.daqUI, Qt.SIGNAL('changed'), self.daqChanged)
+            try:
+                self.daqUI.sigChange.disconnect(self.daqChanged)
+            except TypeError:
+                pass
         self.ui.topPlotWidget.close()
         self.ui.bottomPlotWidget.close()

--- a/acq4/devices/MultiClamp/taskGUI.py
+++ b/acq4/devices/MultiClamp/taskGUI.py
@@ -346,7 +346,7 @@ class MultiClampTaskGui(TaskGui):
         if not sip.isdeleted(self.daqUI):
             # Qt.QObject.disconnect(self.daqUI, Qt.SIGNAL('changed'), self.daqChanged)
             try:
-                self.daqUI.sigChange.disconnect(self.daqChanged)
+                self.daqUI.sigChanged.disconnect(self.daqChanged)
             except TypeError:
                 pass
         self.ui.topPlotWidget.close()

--- a/acq4/devices/PVCam/PVCam.py
+++ b/acq4/devices/PVCam/PVCam.py
@@ -121,7 +121,7 @@ class PVCam(Camera):
         
         ## Determine how many new frames have arrived since last check
         if self.lastIndex is not None:
-            diff = (index - self.lastIndex) % self.ringSize
+            diff = int((index - self.lastIndex) % self.ringSize)
             if diff > (self.ringSize / 2):
                 print("Image acquisition buffer is at least half full (possible dropped frames)")
         else:
@@ -131,7 +131,7 @@ class PVCam(Camera):
         dt = (now - self.lastFrameTime) / diff
         frames = []
         for i in range(diff):
-            fInd = (i+self.lastIndex+1) % self.ringSize
+            fInd = int((i+self.lastIndex+1) % self.ringSize)
             frame = {}
             frame['time'] = self.lastFrameTime + (dt * (i+1))
             frame['id'] = self.frameId

--- a/acq4/devices/SutterMPC200/SutterMPC200.py
+++ b/acq4/devices/SutterMPC200/SutterMPC200.py
@@ -62,6 +62,12 @@ class SutterMPC200(Stage):
             SutterMPC200._monitor = MonitorThread(self)
             SutterMPC200._monitor.start()
 
+    def axes(self):
+        if 'axes' in self.config:
+            return self.config['axes']
+        else:
+            return ('x', 'y')
+
     def capabilities(self):
         """Return a structure describing the capabilities of this device"""
         if 'capabilities' in self.config:

--- a/acq4/devices/SutterMPC200/SutterMPC200.py
+++ b/acq4/devices/SutterMPC200/SutterMPC200.py
@@ -124,7 +124,8 @@ class SutterMPC200(Stage):
             return self._lastMove.targetPos
 
     def quit(self):
-        self._monitor.stop()
+        SutterMPC200._monitor.stop()  # only one thread for all
+        # self._monitor.stop()  # this was never set to anything but None
         Stage.quit(self)
 
     def _move(self, abs, rel, speed, linear):

--- a/acq4/drivers/MultiClamp/multiclamp.py
+++ b/acq4/drivers/MultiClamp/multiclamp.py
@@ -58,7 +58,6 @@ def getAxlib(libPath=None):
             libPath = find_lib('AxMultiClampMsg.dll', paths=searchPaths)
         if not os.path.isfile(libPath):
             raise ValueError('MultiClamp DLL file "%s" does not exist' % libPath)
-        print("Using MultiClamp DLL at ", libPath)
 
         axlib = CLibrary(ctypes.windll.LoadLibrary(libPath), axonDefs, prefix='MCCMSG_')
         initializeGlobals()

--- a/acq4/drivers/SutterMPC200/mpc200.py
+++ b/acq4/drivers/SutterMPC200/mpc200.py
@@ -95,7 +95,6 @@ class SutterMPC200(SerialDevice):
 
     def __init__(self, port):
         port = SerialDevice.normalizePortName(port)
-        print("***** PORT ****  ", port)
         if port in SutterMPC200.DEVICES:
             raise Exception("The port %s is already accessed by another instance of this class. Use getDevice(port) instead.")
         SutterMPC200.DEVICES[port] = self
@@ -109,7 +108,7 @@ class SutterMPC200(SerialDevice):
     def setDrive(self, drive):
         """Set the current drive (1-4)"""
         cmd = 'I' + chr(drive)
-        cmd = cmd.encode('utf8')  # turn into bytes 
+        cmd = cmd.encode('utf8')  # turn into bytes
         self.write(cmd)
         ret = self.read(2, term=b'\r')
         if ord(ret) == drive:

--- a/acq4/drivers/pvcam/pvcam.py
+++ b/acq4/drivers/pvcam/pvcam.py
@@ -347,9 +347,9 @@ class _CameraClass:
             self.isOpen = False
             
     def call(self, fn, *args, **kargs):
-        # ret = LIB('functions', fn)(*args, **kargs)
-        # return ret
-        return self.pvcam.call(fn, *args, **kargs)
+        ret = LIB('functions', fn)(*args, **kargs)
+        return ret
+        #return self.pvcam.call(fn, *args, **kargs)
 
     def initCam(self, params=None):
         buf = create_string_buffer(b'\0' * LIB.CCD_NAME_LEN)
@@ -672,12 +672,14 @@ class _CameraClass:
         self.buf = numpy.ascontiguousarray(numpy.empty((ringSize, rgn.height, rgn.width), dtype=numpy.uint16))
         
         res = self.call('pl_exp_setup_cont', self.hCam, 1, rgn, expMode, exp, buffer_mode=LIB.CIRC_OVERWRITE)
-        #res = LIB.pl_exp_setup_cont(self.hCam, 1, rgn, expMode, exp, buffer_mode=LIB.CIRC_OVERWRITE)
+        # res = LIB.pl_exp_setup_cont(self.hCam, 1, rgn, expMode, exp, buffer_mode=LIB.CIRC_OVERWRITE)
         ssize = res[5]
         ssize = ssize*ringSize
         #print "   done"
-        if len(self.buf.data) != ssize:
-            raise Exception('Created wrong size buffer! (%d != %d) Error: %s' %(len(self.buf.data), ssize, self.pvcam.error()))
+        bufsize = 2*numpy.prod(self.buf.data.shape)
+        if bufsize != ssize:
+            raise Exception('Created wrong size buffer! (%d != %d) Error: %s'
+                     % bufsize, ssize, self.pvcam.error())
         self.call('pl_exp_start_cont', self.hCam, self.buf.ctypes.data, ssize)   ## Warning: this memory is not locked, may cause errors if the system starts swapping.
 
         self.mode = 2

--- a/acq4/modules/Patch/PatchWindow.py
+++ b/acq4/modules/Patch/PatchWindow.py
@@ -701,9 +701,9 @@ class PatchThread(Thread):
             iStep = iPulse.mean() - iBase.mean()
             
             if iStep >= 0:
-                vStep = np.max(1e-5, -fitAmp)
+                vStep = np.max((1e-5, -fitAmp))
             else:
-                vStep = np.min(-1e-5, -fitAmp)
+                vStep = np.min((-1e-5, -fitAmp))
             #sign = [-1, 1][iStep >= 0]
             #vStep = sign * max(1e-5, sign * (vPulseEnd.mean() - vBase.mean()))
             #vStep = sign * max(1e-5, sign * fitAmp)

--- a/acq4/util/SequenceRunner.py
+++ b/acq4/util/SequenceRunner.py
@@ -177,6 +177,8 @@ class SequenceRunner:
 
             if not isinstance(params, Iterable):
                 params = [params]
+            elif isinstance(params, range):
+                params = list(params)  # force generator
             self._paramSpace[i] = params
 
     def buildReturnArray(self, ret):
@@ -196,6 +198,7 @@ class SequenceRunner:
             dtype = object
 
         info = [{'name': p, 'values': self._paramSpace[p]} for p in self._order]
+
         self._return = MetaArray(np.zeros(shape + shapeExtra, dtype=dtype), info=info)
         self._runMask = MetaArray(np.zeros(shape, dtype=bool), info=info)
 


### PR DESCRIPTION
A set of small cumulative fixes to get MultiClamp 700B, PVCam cameras, and NIDAQ support working under Python3. Also minor changes to TaskRunner/SequenceRunner for Python3.

- commit #2c1f556 handles arguments/order for nidaq/pydaqmx. Solves  Issue (closed now) raised in December.
- commit #3d8616 fixes ring buffer size calculation in PVCam.py device, and pvcam.py driver. It also corrects call to LIB rather than pvcam.call (longstanding issue often manually corrected).
- commit #26127ac changes MultiClamp TaskGUI quit call to be PyQt5 compatible, and to be consistent with other calls.
- commit 613b5ab util/SequenceRunner.py : forces generation of the range values, rather than returning the generator (python 2 vs python 3)
- commit #d24d88b PatchWindow: update for numpy.min/max: requires array-like (so cast to tuple)
- commit #3a0da18 Removes a lagging print statement in drivers/Multiclamp/multiclamp.py (may not exist upstream)
- commit #c7c40a2  Fixes a signal name in MultiClamp TaskGUI (related to #26127ac)

Tested with MC700B, Retiga R1 in a basic configuration. Issue #114 regarding TaskRunner dock behavior is not addressed by these changes.