### PR TITLE
Turn on debug mode for Sensapex library

### DIFF
--- a/acq4/devices/Sensapex.py
+++ b/acq4/devices/Sensapex.py
@@ -28,8 +28,6 @@ class Sensapex(Stage):
         address = config.pop("address", None)
         address = None if address is None else address.encode()
         group = config.pop("group", None)
-        if man.config.get("drivers", {}).get("sensapex", {}).get("driverPath", None) is not None:
-            UMP.set_library_path(man.config["drivers"]["sensapex"]["driverPath"])
         ump = UMP.get_ump(address=address, group=group)
         # create handle to this manipulator
         self.dev = ump.get_device(self.devid)

--- a/acq4/devices/SensapexObjectiveChanger.py
+++ b/acq4/devices/SensapexObjectiveChanger.py
@@ -14,8 +14,6 @@ class SensapexObjectiveChanger(Device):
     def __init__(self, dm, config, name):
         Device.__init__(self, dm, config, name)
 
-        if dm.config.get("drivers", {}).get("sensapex", {}).get("driverPath", None) is not None:
-            UMP.set_library_path(dm.config["drivers"]["sensapex"]["driverPath"])
         address = config.pop('address', None)
         group = config.pop('group', None)
         ump = UMP.get_ump(address=address, group=group)

--- a/acq4/devices/SensapexPressureControl.py
+++ b/acq4/devices/SensapexPressureControl.py
@@ -24,8 +24,6 @@ class SensapexPressureControl(PressureControl):
 
     def __init__(self, manager, config, name):
         self.devId = config.get('deviceId')
-        if manager.config.get("drivers", {}).get("sensapex", {}).get("driverPath", None) is not None:
-            UMP.set_library_path(manager.config["drivers"]["sensapex"]["driverPath"])
         address = config.pop('address', None)
         group = config.pop('group', None)
         self._pollInterval = config.get('pollInterval', 1)

--- a/acq4/drivers/sensapex.py
+++ b/acq4/drivers/sensapex.py
@@ -1,3 +1,5 @@
+from .. import getManager
+
 try:
     from sensapex import UMP
 except ImportError as err:
@@ -6,3 +8,14 @@ except ImportError as err:
         err.args = (msg,)
     err.args = err.args + (msg,)
     raise
+
+
+def handle_config(conf):
+    for key, val in conf.items():
+        if key == "debug":
+            UMP.set_debug_mode(val)
+        elif key == "driverPath":
+            UMP.set_library_path(val)
+
+
+handle_config(getManager().config.get("drivers", {}).get("sensapex", {}))


### PR DESCRIPTION
Uses a top-level `drivers`->`sensapex`->`debug` configuration setting. This PR also centralizes the other global Sensapex config handling.