### PR TITLE
position needs to be set after adding the ellipse to the window

### DIFF
--- a/acq4/devices/RecordingChamber.py
+++ b/acq4/devices/RecordingChamber.py
@@ -41,9 +41,8 @@ class RecordingChamberCameraInterface(CameraModuleInterface):
         self.boundingEllipse = Qt.QGraphicsEllipseItem(-1, -1, 2, 2)
         self.boundingEllipse.setPen(pg.mkPen("y"))
         self.boundingEllipse.setScale(radius)
-        self.boundingEllipse.setPos(x, y)
-
         mod.window().addItem(self.boundingEllipse, ignoreBounds=True)
+        self.boundingEllipse.setPos(x, y)
 
     def boundingRect(self):
         return None


### PR DESCRIPTION
I don't know what change precipitated this bug; some Qt thing or another, maybe? I don't have an environment where this change doesn't work, but it might need to be tested on an older install.