### PR TITLE
Don't copy config 'misc' keys to top level

### DIFF
--- a/acq4/Manager.py
+++ b/acq4/Manager.py
@@ -82,6 +82,7 @@ class Manager(Qt.QObject):
         self.disableAllDevs = False
         self.alreadyQuit = False
         self.taskLock = Mutex(Qt.QMutex.Recursive)
+        self._folderTypes = None
 
         try:
             if Manager.CREATED:
@@ -347,6 +348,9 @@ class Manager(Qt.QObject):
                     print("=== Setting default HDF5 compression: %s ===" % comp)
                     import pyqtgraph.metaarray as ma
                     ma.MetaArray.defaultCompression = comp
+
+                elif key == 'folderTypes':
+                    self._folderTypes = val
 
                 ## load stylesheet
                 elif key == 'stylesheet':
@@ -813,12 +817,7 @@ class Manager(Qt.QObject):
         return fields
 
     def _folderTypesConfig(self):
-        # handle folder types appearing in two different places
-        # (the correct place is in the config top-level)
-        if 'folderTypes' in self.config:
-            return self.config['folderTypes']
-        elif 'misc' in self.config and 'folderTypes' in self.config['misc']:
-            return self.config['misc']['folderTypes']
+        return self._folderTypes
 
     def showDocumentation(self, label=None):
         self.documentation.show(label)

--- a/acq4/Manager.py
+++ b/acq4/Manager.py
@@ -381,17 +381,6 @@ class Manager(Qt.QObject):
                     # Let's start moving things out of the top level, but stay backwards compatible
                     self._loadConfig(cfg[key])
 
-                ## Copy in any other configurations.
-                ## dicts are extended, all others are overwritten.
-                else:
-                    if isinstance(cfg[key], dict):
-                        if key not in self.config:
-                            self.config[key] = {}
-                        for key2 in cfg[key]:
-                            self.config[key][key2] = cfg[key][key2]
-                    else:
-                        self.config[key] = cfg[key]
-
             except:
                 printExc("Error in ACQ4 configuration:")
                 if self.exitOnError:
@@ -812,8 +801,9 @@ class Manager(Qt.QObject):
                 if 'dirType' in info:
                     # infoKeys.remove('dirType')
                     dt = info['dirType']
-                    if dt in self.config['folderTypes']:
-                        fields = self.config['folderTypes'][dt]['info']
+                    folderTypesConfig = self._foldlerTypesConfig()
+                    if dt in folderTypesConfig:
+                        fields = folderTypesConfig[dt]['info']
 
         if 'notes' not in fields:
             fields['notes'] = 'text', 5
@@ -821,6 +811,14 @@ class Manager(Qt.QObject):
             fields['important'] = 'bool'
 
         return fields
+
+    def _folderTypesConfig(self):
+        # handle folder types appearing in two different places
+        # (the correct place is in the config top-level)
+        if 'folderTypes' in self.config:
+            return self.config['folderTypes']
+        elif 'misc' in self.config and 'folderTypes' in self.config['misc']:
+            return self.config['misc']['folderTypes']
 
     def showDocumentation(self, label=None):
         self.documentation.show(label)

--- a/acq4/modules/DataManager/DataManagerModule.py
+++ b/acq4/modules/DataManager/DataManagerModule.py
@@ -85,8 +85,7 @@ class DataManager(Module):
 
     def updateNewFolderList(self):
         self.ui.newFolderList.clear()
-        conf = self.manager.config['folderTypes']
-        # print "folderTypes:", self.manager.config['folderTypes'].keys()
+        conf = self.manager._folderTypesConfig()
         self.ui.newFolderList.clear()
         self.ui.newFolderList.addItems(['New...', 'Folder'] + list(conf.keys()))
 
@@ -203,7 +202,7 @@ class DataManager(Module):
             # item = self.model.handleIndex(nd)
             self.ui.fileTreeWidget.editItem(nd)
         else:
-            spec = self.manager.config['folderTypes'][ftype]
+            spec = self.manager._folderTypesConfig()[ftype]
             name = time.strftime(spec['name'])
 
             ## Determine where to put the new directory

--- a/acq4/util/cuda.py
+++ b/acq4/util/cuda.py
@@ -22,7 +22,13 @@ except Exception as exc:
 
 @lru_cache()
 def shouldUseCuda():
-    if getManager().config.get("cudaImageProcessing", False) is not True:
+    config = getManager().config.copy()
+    config.update(config.get('misc', {}))  # cudaImageProcessing could appear in top-level or under 'misc' depending on config version
+    if "cudaImageProcessing" not in config:
+        print("CUDA acceleration disabled by default (to enable set misc: cudaImageProcessing=True in config)")
+        return False
+
+    if config.get('cudaImageProcessing', False) is not True:
         print("CUDA acceleration disabled by config key (cudaImageProcessing)")
         return False
 


### PR DESCRIPTION
The `storageDir` and `defaultCompression` keys already support being in either location.
Fixup usage of `folderTypes` and `cupyImageProcessing` to support these keys being present in either location.