### PR TITLE
Add low-pass filters to plot options

### DIFF
--- a/acq4/Manager.py
+++ b/acq4/Manager.py
@@ -2,7 +2,7 @@
 """
 Manager.py -  Defines main Manager class for ACQ4
 Copyright 2010  Luke Campagnola
-Distributed under MIT/X11 license. See license.txt for more infomation.
+Distributed under MIT/X11 license. See license.txt for more information.
 
 This class must be invoked once to initialize the ACQ4 core system.
 The class is responsible for:
@@ -10,8 +10,6 @@ The class is responsible for:
     - Invoking/managing modules
     - Creating and executing acquisition tasks. 
 """
-from __future__ import print_function
-
 import atexit
 import gc
 import getopt
@@ -22,21 +20,20 @@ import weakref
 from collections import OrderedDict
 
 import six
+from six.moves import map
 
 import pyqtgraph as pg
 import pyqtgraph.reload as reload
+from pyqtgraph import configfile
+from pyqtgraph.debug import printExc, Profiler
+from pyqtgraph.util.mutex import Mutex
 from . import __version__
 from . import devices, modules
 from .Interfaces import InterfaceDirectory
 from .devices.Device import Device, DeviceTask
-from pyqtgraph.debug import printExc, Profiler
-from pyqtgraph import configfile
-from pyqtgraph.util.mutex import Mutex
 from .util import DataManager, ptime, Qt
 from .util.HelpfulException import HelpfulException
-
-from .util.debug import logMsg, createLogWindow, logExc # logExc needed by debug
-from six.moves import map
+from .util.debug import logMsg, createLogWindow  # logExc needed by debug
 
 
 def __reload__(old):

--- a/acq4/__init__.py
+++ b/acq4/__init__.py
@@ -1,5 +1,6 @@
-from __future__ import print_function
-import os, sys
+import os
+import sys
+from .util import pg_setup
 
 __version__ = '0.9.3'
 

--- a/acq4/util/pg_setup.py
+++ b/acq4/util/pg_setup.py
@@ -1,0 +1,25 @@
+from scipy.signal import butter, lfilter, sosfilt
+
+import pyqtgraph as pg
+
+
+def butter_transform(x, y, order, cutoff):
+    sample_rate = (len(x) - 1) / (x[-1] - x[0])
+    sos = butter(order, cutoff, fs=sample_rate, btype="low", analog=False, output="sos")
+    return x, sosfilt(sos, y)
+
+
+if hasattr(pg.PlotItem, "addDefaultDataTransformOption"):
+    pg.PlotItem.addDefaultDataTransformOption(
+        "Butter Low-pass",
+        butter_transform,
+        params=[
+            {"name": "cutoff", "type": "float", "siPrefix": True, "suffix": "Hz", "min": 0, "value": 5000},
+            {"name": "order", "type": "int", "min": 1, "value": 5},
+        ],
+    )
+    pg.PlotItem.addDefaultDataTransformOption(
+        "Gaussian Low-pass",
+        lambda _x, _y, sigma: (_x, pg.gaussianFilter(_y, sigma)),
+        params=[{"name": "sigma", "type": "float", "suffix": "", "min": 0, "value": 5}],
+    )


### PR DESCRIPTION
This adds a Gaussian and a Butterworth low-pass filter to the plot options on every plot in the app. This also alters the MultiPatch saveState behavior to also include all the plot options, thus preserving them between invocations. This depends on https://github.com/pyqtgraph/pyqtgraph/pull/2326 to function, but is gated to not error if that code is not present.