### PR TITLE
MultiPatch pipette control ui updates

### DIFF
--- a/acq4/devices/AxoPatch200/AxoPatch200.py
+++ b/acq4/devices/AxoPatch200/AxoPatch200.py
@@ -168,8 +168,6 @@ class AxoPatch200(DAQGeneric):
         self.sigShowModeDialog.connect(self.showModeDialog)
         self.sigHideModeDialog.connect(self.hideModeDialog)
         
-        
-        
         try:
             self.setHolding()
         except:
@@ -210,7 +208,7 @@ class AxoPatch200(DAQGeneric):
                 ## (we may be about to switch modes)
                 DAQGeneric.setChanHolding(self, 'command', value, mapping=mapping)
            
-            self.sigHoldingChanged.emit('primary', self.holding.copy())
+            self.sigHoldingChanged.emit(self, self.holding.copy())
             
     def setChanHolding(self, chan, value=None):
         if chan == 'command':

--- a/acq4/devices/MockClamp/MockClamp.py
+++ b/acq4/devices/MockClamp/MockClamp.py
@@ -58,7 +58,9 @@ class MockClamp(PatchClamp):
         if config['simulator'] == 'builtin':
             self.simulator = self.process._import('hhSim')
         elif config['simulator'] == 'neuron':
-            self.simulator = self.process._import('neuronSim')
+            self.simulator = self.process._import('acq4.devices.MockClamp.neuronSim')
+        elif config['simulator'] == 'neuroanalysis':
+            self.simulator = self.process._import('acq4.devices.MockClamp.neuroanalysisSim')
 
         dm.declareInterface(name, ['clamp'], self)
 

--- a/acq4/devices/MockClamp/MockClamp.py
+++ b/acq4/devices/MockClamp/MockClamp.py
@@ -79,18 +79,16 @@ class MockClamp(PatchClamp):
                 mode = currentMode
             ivMode = ivModes[mode]  ## determine vc/ic
 
-            if value is None:
-                value = self.holding[ivMode]
-            else:
+            if value is not None:
                 self.holding[ivMode] = value
 
-            if ivMode == ivModes[currentMode] or force:
+            # if ivMode == ivModes[currentMode] or force:
                 # gain = self.getCmdGain(mode)
                 ## override the scale since getChanScale won't necessarily give the correct value
                 ## (we may be about to switch modes)
                 # DAQGeneric.setChanHolding(self, 'command', value, scale=gain)
-                pass
-            self.sigHoldingChanged.emit('primary', self.holding.copy())
+                # pass
+            self.sigHoldingChanged.emit(ivMode, value)
 
     def setChanHolding(self, chan, value=None):
         if chan == 'command':
@@ -104,7 +102,7 @@ class MockClamp(PatchClamp):
         else:
             return self.daqDev.getChanHolding(chan)
 
-    def getHolding(self, mode=None):
+    def getHolding(self, mode: str = None):
         global ivModes
         with self.devLock:
             if mode is None:
@@ -410,13 +408,14 @@ class MockClampDevGui(Qt.QWidget):
         self.ui.vcHoldingSpin.setValue(vcHold)
         self.ui.icHoldingSpin.setValue(icHold)
 
-    def devHoldingChanged(self, chan, hval):
-        if isinstance(hval, dict):
+    def devHoldingChanged(self, mode, val):
+        if mode == "VC":
             self.ui.vcHoldingSpin.blockSignals(True)
-            self.ui.icHoldingSpin.blockSignals(True)
-            self.ui.vcHoldingSpin.setValue(hval['VC'])
-            self.ui.icHoldingSpin.setValue(hval['IC'])
+            self.ui.vcHoldingSpin.setValue(val)
             self.ui.vcHoldingSpin.blockSignals(False)
+        else:
+            self.ui.icHoldingSpin.blockSignals(True)
+            self.ui.icHoldingSpin.setValue(val)
             self.ui.icHoldingSpin.blockSignals(False)
 
     def devStateChanged(self):

--- a/acq4/devices/MockClamp/MockClamp.py
+++ b/acq4/devices/MockClamp/MockClamp.py
@@ -198,7 +198,7 @@ class MockClampTask(DAQGenericTask):
             if 'holding' in cmd:
                 daqP['command'] = {'command': cmd['command'], 'holding': cmd['holding']}
             else:
-                daqP['command'] = {'command': cmd['command']}
+                daqP['command'] = {'command': cmd['command'], 'holding': dev.getHolding(cmd['mode'])}
         daqP['command']['lowLevelConf'] = {'mockFunc': self.write}
 
         cmd['daqProtocol']['primary'] = {'record': True, 'lowLevelConf': {'mockFunc': self.read}}

--- a/acq4/devices/MockClamp/neuroanalysisSim.py
+++ b/acq4/devices/MockClamp/neuroanalysisSim.py
@@ -1,0 +1,30 @@
+from neuroanalysis.neuronsim.model_cell import ModelCell
+from neuroanalysis.data import TSeries
+import numpy as np
+
+
+model_cell = ModelCell()
+model_cell.enable_mechs(['leak', 'lgkfast', 'lgkslow', 'lgkna'])
+
+model_cell.clamp.ra = 10e6
+model_cell.clamp.cpip = 3e-12
+model_cell.soma.cap = 100e-12
+
+
+def run(cmd):
+    """
+    Accept command like 
+    
+        {
+            'dt': 1e-4,
+            'mode': 'ic',
+            'data': np.array([...]),
+        }
+        
+    Return array of Vm or Im values.        
+    """
+    global model_cell
+    mode = cmd['mode'].lower()
+    cmd_ts = TSeries(cmd['data'], dt=cmd['dt'])
+    result = model_cell.test(cmd_ts, mode)
+    return result['primary'].data

--- a/acq4/devices/MockClamp/neuronSim.py
+++ b/acq4/devices/MockClamp/neuronSim.py
@@ -6,11 +6,11 @@ import numpy as np
 import sys, os
 
 # Try standard locations to find neuron library
-for nrnpath in ['/usr/local/nrn/lib/python']:
-    if os.path.isdir(nrnpath):
-        sys.path.append(nrnpath)
-from .neuron import h
-from . import neuron
+# for nrnpath in ['/usr/local/nrn/lib/python']:
+#     if os.path.isdir(nrnpath):
+#         sys.path.append(nrnpath)
+from neuron import h
+import neuron
 
 # try to load extra mechanisms
 for name in ('i386', 'x86_64'):
@@ -67,14 +67,14 @@ def run(cmd):
 
     #times = h.Vector(np.linspace(h.t, h.t+len(data)*dt, len(data)))
     #print "times:", times.min(), times.max()
-    if mode == 'ic':
+    if mode == 'IC':
         #ic.delay = h.t
         ic.delay = 0
         vc.rs = 1e9
         im = h.Vector(data * 1e9)
         im.play(ic._ref_amp, dt)
 
-    elif mode == 'vc':
+    elif mode == 'VC':
         #vc.amp1 = data[0]
         vc.rs = vcrs
         ic.delay = 1e9
@@ -89,8 +89,7 @@ def run(cmd):
         #syn.i --- nA
         
     else:
-        sys.stderr.write("Unknown mode '%s'" % sys.argv[1])
-        raise Exception("Unknown mode '%s'" % sys.argv[1])
+        raise Exception("Unknown mode '%s'" % mode)
 
     #t2 = t + dt * (len(data)+2)
     #print "run until:", t2
@@ -104,9 +103,10 @@ def run(cmd):
     #print len(out), out
     #out = np.array(out)[:len(data)]
 
-    if mode == 'ic':
+    out = None
+    if mode == 'IC':
         out = np.array(icRec)[:len(data)] * 1e-3 + np.random.normal(size=len(data), scale=0.3e-3)
-    elif mode == 'vc':
+    elif mode == 'VC':
         out = np.array(vcRec)[:len(data)] * 1e-9 + np.random.normal(size=len(data), scale=3.e-12)
     return out
 

--- a/acq4/devices/MultiClamp/DeviceGui.py
+++ b/acq4/devices/MultiClamp/DeviceGui.py
@@ -63,13 +63,12 @@ class MCDeviceGui(Qt.QWidget):
         finally:
             self.state.sigChanged.connect(self.uiStateChanged)
 
-    def devHoldingChanged(self, dev, mode):
+    def devHoldingChanged(self, mode, val):
         with pg.SignalBlock(self.state.sigChanged, self.uiStateChanged):
-            state = self.dev.getLastState(mode)
             if mode == 'VC':
-                self.ui.vcHoldingSpin.setValue(state['holding'])
-            elif mode == 'IC':
-                self.ui.icHoldingSpin.setValue(state['holding'])
+                self.ui.vcHoldingSpin.setValue(val)
+            else:
+                self.ui.icHoldingSpin.setValue(val)
 
     def uiStateChanged(self, name=None, value=None):
         if name == 'icRadio' and value is True:

--- a/acq4/devices/MultiClamp/multiclamp.py
+++ b/acq4/devices/MultiClamp/multiclamp.py
@@ -374,8 +374,6 @@ class MultiClampTask(DeviceTask):
 
     def configure(self):
         """Sets the state of a remote multiclamp to prepare for a program run."""
-        #print "mc configure"
-        
         #from debug import Profiler
         #prof = Profiler()
         ## Set state of clamp
@@ -431,7 +429,6 @@ class MultiClampTask(DeviceTask):
                 
         self.holdingVal = self.dev.getHolding(self.cmd['mode'])
         
-        #print "mc configure complete"
         #prof.mark('    Multiclamp: set holding')
                 
     def getUsedChannels(self):

--- a/acq4/devices/MultiClamp/multiclamp.py
+++ b/acq4/devices/MultiClamp/multiclamp.py
@@ -236,8 +236,8 @@ class MultiClamp(PatchClamp):
                 if mode == 'I=0':  ## ..and if the current mode is I=0, do nothing.
                     return
             if mode == 'I=0':
-                raise Exception("Can't set holding value for I=0 mode.")
-            
+                raise ValueError("Can't set holding value for I=0 mode.")
+
             ## Update stored holding value if value is supplied
             if value is not None:
                 if self.holding[mode] == value:
@@ -247,14 +247,14 @@ class MultiClamp(PatchClamp):
                 state['holding'] = value
                 if mode == currentMode:
                     self.sigStateChanged.emit(state)
-                self.sigHoldingChanged.emit(self, mode)
-                
+                self.sigHoldingChanged.emit(mode, value)
+
             ## We only want to set the actual DAQ channel if:
-            ##   - currently in I=0, or 
+            ##   - currently in I=0, or
             ##   - currently in the mode that was changed
             if mode != currentMode and currentMode != 'I=0':
                 return
-            
+
             holding = self.holding[mode]
             daq = self.getDAQName('command')
             chan = self.config['commandChannel']['channel']
@@ -264,7 +264,7 @@ class MultiClamp(PatchClamp):
                 if holding == 0.0:
                     s = 1.0
                 else:
-                    raise Exception('Can not set holding value for multiclamp--external command sensitivity is disabled by commander.')
+                    raise ValueError('Can not set holding value for multiclamp--external command sensitivity is disabled by commander.')
             scale = 1.0 / s
             daqDev.setChannelValue(chan, holding*scale, block=False)
 

--- a/acq4/devices/MultiClamp/taskGUI.py
+++ b/acq4/devices/MultiClamp/taskGUI.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import print_function
-
 import numpy
 import sip
 from pyqtgraph import mkPen, disconnect
@@ -103,12 +100,11 @@ class MultiClampTaskGui(TaskGui):
             ssig = state['secondarySignal']
         self.setSignals(psig, ssig)
 
-    def devHoldingChanged(self, dev, mode):
+    def devHoldingChanged(self, mode, val):
         if mode != self.getMode():
             return
         if not self.ui.holdingSpin.isEnabled():
-            state = self.dev.getLastState(mode)
-            self.ui.holdingSpin.setValue(state['holding'])
+            self.ui.holdingSpin.setValue(val)
 
     def saveState(self):
         state = self.stateGroup.state().copy()
@@ -126,7 +122,7 @@ class MultiClampTaskGui(TaskGui):
                 self.setSignals(state['primarySignal'], state['secondarySignal'])
             self.stateGroup.setState(state)
             self.devStateChanged()
-        except:
+        except Exception:
             printExc('Error while restoring MultiClamp task GUI state:')
         finally:
             self._block_update = block

--- a/acq4/devices/PatchClamp/patchclamp.py
+++ b/acq4/devices/PatchClamp/patchclamp.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import print_function
-
 from acq4.devices.Device import Device
 from acq4.util import Qt
 
@@ -17,7 +14,7 @@ class PatchClamp(Device):
     """
 
     sigStateChanged = Qt.Signal(object)  # state
-    sigHoldingChanged = Qt.Signal(object, object)  # self, mode
+    sigHoldingChanged = Qt.Signal(object, object)  # mode, value
 
     def __init__(self, deviceManager, config, name):
         Device.__init__(self, deviceManager, config, name)

--- a/acq4/devices/PatchPipette/patchpipette.py
+++ b/acq4/devices/PatchPipette/patchpipette.py
@@ -15,6 +15,7 @@ from ..Device import Device
 from ..Pipette import Pipette
 from ..PressureControl import PressureControl
 from ...util.json_encoder import ACQ4JSONEncoder
+from acq4.devices.PatchClamp.patchclamp import PatchClamp
 
 
 class PatchPipette(Device):
@@ -60,7 +61,7 @@ class PatchPipette(Device):
 
         clampName = config.pop('clampDevice', None)
         if clampName is None:
-            self.clampDevice = None
+            self.clampDevice: PatchClamp = None
         else:
             self.clampDevice = deviceManager.getDevice(clampName)
             self.clampDevice.sigStateChanged.connect(self.clampStateChanged)

--- a/acq4/devices/PatchPipette/patchpipette.py
+++ b/acq4/devices/PatchPipette/patchpipette.py
@@ -57,7 +57,11 @@ class PatchPipette(Device):
         self.pipetteDevice: Pipette = deviceManager.getDevice(pipName)
 
         clampName = config.pop('clampDevice', None)
-        self.clampDevice = None if clampName is None else deviceManager.getDevice(clampName)
+        if clampName is None:
+            self.clampDevice = None
+        else:
+            self.clampDevice = deviceManager.getDevice(clampName)
+            self.clampDevice.sigStateChanged.connect(self.clampStateChanged)
 
         Device.__init__(self, deviceManager, config, name)
         self._eventLog = []  # chronological record of events 
@@ -381,9 +385,8 @@ class PatchPipette(Device):
         self.sigAutoBiasChanged.emit(self, enabled, v)
         self.emitNewEvent('auto_bias_target_changed', OrderedDict([('enabled', enabled), ('target', v)]))
 
-    def setHolding(self, mode, value):
-        self.clampDevice.setHolding(mode, value)
-        self.emitNewEvent('holding_changed', {'mode': mode, 'value': value})
+    def clampStateChanged(self, state):
+        self.emitNewEvent('clamp_state_change', state)
 
     def autoBiasTarget(self):
         return self._testPulseThread.getParameter('autoBiasTarget')

--- a/acq4/devices/PatchPipette/patchpipette.py
+++ b/acq4/devices/PatchPipette/patchpipette.py
@@ -381,6 +381,10 @@ class PatchPipette(Device):
         self.sigAutoBiasChanged.emit(self, enabled, v)
         self.emitNewEvent('auto_bias_target_changed', OrderedDict([('enabled', enabled), ('target', v)]))
 
+    def setHolding(self, mode, value):
+        self.clampDevice.setHolding(mode, value)
+        self.emitNewEvent('holding_changed', {'mode': mode, 'value': value})
+
     def autoBiasTarget(self):
         return self._testPulseThread.getParameter('autoBiasTarget')
 

--- a/acq4/devices/PatchPipette/patchpipette.py
+++ b/acq4/devices/PatchPipette/patchpipette.py
@@ -1,7 +1,8 @@
+import json
 from collections import OrderedDict
+from typing import Optional
 
 import numpy as np
-from typing import Optional
 
 from acq4.util import Qt
 from acq4.util import ptime
@@ -13,6 +14,7 @@ from ..Camera import Camera
 from ..Device import Device
 from ..Pipette import Pipette
 from ..PressureControl import PressureControl
+from ...util.json_encoder import ACQ4JSONEncoder
 
 
 class PatchPipette(Device):
@@ -434,6 +436,7 @@ class PatchPipette(Device):
         ])
         if eventData is not None:
             newEv.update(eventData)
+        json.dumps(newEv, cls=ACQ4JSONEncoder)  # make sure it's serializable without the event system blowing our stack
         self.sigNewEvent.emit(self, newEv)
 
         self._eventLog.append(newEv)

--- a/acq4/devices/PatchPipette/states.py
+++ b/acq4/devices/PatchPipette/states.py
@@ -828,7 +828,7 @@ class SealState(PatchPipetteState):
 
             if not holdingSet and ssr > config['holdingThreshold']:
                 self.setState(f'enable holding potential {config["holdingPotential"] * 1000:0.1f} mV')
-                dev.clampDevice.setHolding(mode=None, value=config['holdingPotential'])
+                dev.setHolding(mode="VC", value=config['holdingPotential'])
                 holdingSet = True
 
             # seal detected? 

--- a/acq4/devices/PatchPipette/states.py
+++ b/acq4/devices/PatchPipette/states.py
@@ -158,7 +158,6 @@ class PatchPipetteState(Future):
                 cdev.setHolding(mode=mode, value=holding)
             if tpParams is None:
                 tpParams = {}
-            tpParams.setdefault('clampMode', mode)
 
         # enable test pulse if config requests it AND the device is "active"
         if tp is not None:

--- a/acq4/devices/PatchPipette/states.py
+++ b/acq4/devices/PatchPipette/states.py
@@ -561,10 +561,10 @@ class CellDetectState(PatchPipetteState):
             self.checkStop()
 
             if config['autoAdvance']:
-                self.setState("cell detection: advance pipette")
                 if config['advanceContinuous']:
                     # Start continuous move if needed
                     if self.contAdvanceFuture is None:
+                        self.setState("cell detection: continuous pipette advance")
                         self.startContinuousMove()
                     if self.contAdvanceFuture.isDone():
                         self.contAdvanceFuture.wait()  # check for move errors
@@ -572,6 +572,7 @@ class CellDetectState(PatchPipetteState):
                 else:
                     # advance to next position if stepping
                     if self.advanceSteps is None:
+                        self.setState("cell detection: stepping pipette")
                         self.advanceSteps = self.getAdvanceSteps()
                         print(len(self.advanceSteps))
                         print(self.advanceSteps)

--- a/acq4/devices/PatchPipette/states.py
+++ b/acq4/devices/PatchPipette/states.py
@@ -794,13 +794,13 @@ class SealState(PatchPipetteState):
             config['pressureChangeRates'] = eval(config['pressureChangeRates'], units.__dict__)
 
         mode = config['pressureMode']
-        self.setState('beginning seal (mode: %r)' % mode)
+        self.setState(f'beginning seal (mode: {mode!r})')
         if mode == 'user':
             dev.pressureDevice.setPressure(source='user', pressure=0)
         elif mode == 'auto':
             dev.pressureDevice.setPressure(source='atmosphere', pressure=pressure)
         else:
-            raise ValueError(f"pressureMode must be 'auto' or 'user' (got {mode}')")
+            raise ValueError(f"pressureMode must be 'auto' or 'user' (got '{mode}')")
 
         dev.setTipClean(False)
 
@@ -827,7 +827,7 @@ class SealState(PatchPipetteState):
             patchrec['capacitanceBeforeBreakin'] = cap
 
             if not holdingSet and ssr > config['holdingThreshold']:
-                self.setState('enable holding potential %0.1f mV' % (config['holdingPotential']*1000))
+                self.setState(f'enable holding potential {config["holdingPotential"] * 1000:0.1f} mV')
                 dev.clampDevice.setHolding(mode=None, value=config['holdingPotential'])
                 holdingSet = True
 
@@ -858,7 +858,7 @@ class SealState(PatchPipetteState):
 
                 if dt > config['autoSealTimeout']:
                     patchrec['sealSuccessful'] = False
-                    self._taskDone(interrupted=True, error="Seal failed after %f seconds" % dt)
+                    self._taskDone(interrupted=True, error=f"Seal failed after {dt:f} seconds")
                     return
 
                 # update pressure
@@ -882,7 +882,7 @@ class SealState(PatchPipetteState):
                     dev.pressureDevice.setPressure(source='regulator', pressure=pressure)
                     continue
 
-                self.setState('Rpip slope: %g MOhm/sec   Pressure: %g Pa' % (slope/1e6, pressure))
+                self.setState(f'Rpip slope: {slope / 1e6:g} MOhm/sec   Pressure: {pressure:g} Pa')
                 dev.pressureDevice.setPressure(source='regulator', pressure=pressure)
 
     def cleanup(self):

--- a/acq4/devices/PatchPipette/states.py
+++ b/acq4/devices/PatchPipette/states.py
@@ -798,7 +798,7 @@ class SealState(PatchPipetteState):
         if mode == 'user':
             dev.pressureDevice.setPressure(source='user', pressure=0)
         elif mode == 'auto':
-            dev.pressureDevice.setPressure(source='atmosphere', pressure=pressure)
+            dev.pressureDevice.setPressure(source='regulator', pressure=pressure)
         else:
             raise ValueError(f"pressureMode must be 'auto' or 'user' (got '{mode}')")
 

--- a/acq4/devices/PatchPipette/states.py
+++ b/acq4/devices/PatchPipette/states.py
@@ -825,7 +825,7 @@ class SealState(PatchPipetteState):
 
             if ssr > config['holdingThreshold'] and not holdingSet:
                 self.setState(f'enable holding potential {config["holdingPotential"] * 1000:0.1f} mV')
-                dev.setHolding(mode="VC", value=config['holdingPotential'])
+                dev.clampDevice.setHolding(mode="VC", value=config['holdingPotential'])
                 holdingSet = True
 
             # seal detected? 

--- a/acq4/devices/PatchPipette/states.py
+++ b/acq4/devices/PatchPipette/states.py
@@ -774,7 +774,7 @@ class SealState(PatchPipetteState):
     def run(self):
         self.monitorTestPulse()
         config = self.config
-        dev = self.dev
+        dev: "PatchPipette" = self.dev
 
         recentTestPulses = deque(maxlen=config['nSlopeSamples'])
         while True:
@@ -819,14 +819,11 @@ class SealState(PatchPipetteState):
 
             ssr = tp.analysis()['steadyStateResistance']
             cap = tp.analysis()['capacitance']
-            # if cap > config['breakInThreshold']:
-            #     patchrec['spontaneousBreakin'] = True
-            #     return 'break in'
 
             patchrec['resistanceBeforeBreakin'] = ssr
             patchrec['capacitanceBeforeBreakin'] = cap
 
-            if not holdingSet and ssr > config['holdingThreshold']:
+            if ssr > config['holdingThreshold'] and not holdingSet:
                 self.setState(f'enable holding potential {config["holdingPotential"] * 1000:0.1f} mV')
                 dev.setHolding(mode="VC", value=config['holdingPotential'])
                 holdingSet = True

--- a/acq4/devices/PatchPipette/states.py
+++ b/acq4/devices/PatchPipette/states.py
@@ -798,7 +798,7 @@ class SealState(PatchPipetteState):
         if mode == 'user':
             dev.pressureDevice.setPressure(source='user', pressure=0)
         elif mode == 'auto':
-            dev.pressureDevice.setPressure(source='atmosphere', pressure=0)
+            dev.pressureDevice.setPressure(source='atmosphere', pressure=pressure)
         else:
             raise ValueError(f"pressureMode must be 'auto' or 'user' (got {mode}')")
 
@@ -873,11 +873,12 @@ class SealState(PatchPipetteState):
                         pressure += change
                         break
                 
-                # here, if the pressureLimit has been achieved and we are still sealing, cycle back to 0 and redo the pressure change
+                # here, if the pressureLimit has been achieved and we are still sealing, cycle back to starting
+                # pressure and redo the pressure change
                 if pressure <= config['pressureLimit']:
                     dev.pressureDevice.setPressure(source='atmosphere', pressure=0)
                     self.sleep(config['resetDelay'])
-                    pressure = 0
+                    pressure = config['startingPressure']
                     dev.pressureDevice.setPressure(source='regulator', pressure=pressure)
                     continue
 

--- a/acq4/devices/PatchPipette/states.py
+++ b/acq4/devices/PatchPipette/states.py
@@ -856,7 +856,7 @@ class SealState(PatchPipetteState):
                 if dt > config['autoSealTimeout']:
                     patchrec['sealSuccessful'] = False
                     self._taskDone(interrupted=True, error=f"Seal failed after {dt:f} seconds")
-                    return
+                    return config['fallbackState']
 
                 # update pressure
                 res = np.array([tp.analysis()['steadyStateResistance'] for tp in recentTestPulses])

--- a/acq4/filetypes/MultiPatchLog.py
+++ b/acq4/filetypes/MultiPatchLog.py
@@ -274,10 +274,11 @@ class MultiPatchLogData(object):
             ),
             # TODO save field of view dimensions to show stage (camera) position
             # TODO save objective
+            # TODO save current patch profile and any changes thereof
+            # TODO save pressure measurements, maybe?
             # TODO save lighting
             # TODO save clamp mode changes, holding voltage, current
             # TODO save entire test pulse
-            # 'move_request': is currently ignored
             'test_pulse': np.zeros(
                 count_for_use('test_pulse'),
                 dtype=TEST_PULSE_NUMPY_DTYPE,
@@ -287,6 +288,8 @@ class MultiPatchLogData(object):
     @staticmethod
     def _prepare_event_for_use(event: dict, use: str) -> tuple[Any, ...]:
         event_time = float(event['event_time'])
+        # TODO 'move_request'
+        # TODO 'init'
         if use == 'event':
             return event_time, event['event'], event['is_true']
         if use == 'position':

--- a/acq4/filetypes/MultiPatchLog.py
+++ b/acq4/filetypes/MultiPatchLog.py
@@ -277,8 +277,8 @@ class MultiPatchLogData(object):
             # TODO save current patch profile and any changes thereof
             # TODO save pressure measurements, maybe?
             # TODO save lighting
-            # TODO save clamp mode changes, holding voltage, current
-            # TODO save entire test pulse
+            # TODO handle clamp_state_change, holding value
+            # 'move_request': is currently ignored
             'test_pulse': np.zeros(
                 count_for_use('test_pulse'),
                 dtype=TEST_PULSE_NUMPY_DTYPE,

--- a/acq4/modules/Camera/CameraWindow.py
+++ b/acq4/modules/Camera/CameraWindow.py
@@ -126,7 +126,7 @@ class CameraWindow(Qt.QMainWindow):
 
         self.gv.scene().sigMouseMoved.connect(self.updateMouse)
 
-    def addInterface(self, name, iface):
+    def addInterface(self, name, iface: "CameraModuleInterface"):
         """Display a new user interface in the camera module.
         """
         assert name not in self.interfaces

--- a/acq4/modules/MultiPatch/mockPatch.py
+++ b/acq4/modules/MultiPatch/mockPatch.py
@@ -88,7 +88,17 @@ class MockPatch(object):
 
         i = (holding - self.membranePotential) / ssr
 
-        return {'baselinePotential': holding, 'baselineCurrent': i, 'peakResistance': pr, 'steadyStateResistance': ssr, 'capacitance': cap}
+        return {
+            'baselinePotential': holding,
+            'baselineCurrent': i,
+            'peakResistance': pr,
+            'steadyStateResistance': ssr,
+            'capacitance': cap,
+            'fitExpAmp': 0,
+            'fitExpTau': cap * ssr,
+            'fitExpYOffset': 0,
+            'fitExpXOffset': 0,
+        }
 
 
 class MockPatchUI(Qt.QWidget):

--- a/acq4/modules/MultiPatch/multipatch.py
+++ b/acq4/modules/MultiPatch/multipatch.py
@@ -13,6 +13,7 @@ from acq4.util import Qt, ptime
 from .mockPatch import MockPatch
 from .pipetteControl import PipetteControl
 from ...devices.PatchPipette.statemanager import PatchPipetteStateManager
+from ...util.json_encoder import ACQ4JSONEncoder
 
 Ui_MultiPatch = Qt.importTemplate('.multipatchTemplate')
 
@@ -579,5 +580,5 @@ class MultiPatchWindow(Qt.QWidget):
         if self.storageFile is None:
             return
         for rec in recs:
-            self.storageFile.write(json.dumps(rec).encode("utf8") + b",\n")
+            self.storageFile.write(json.dumps(rec, cls=ACQ4JSONEncoder).encode("utf8") + b",\n")
         self.storageFile.flush()

--- a/acq4/modules/MultiPatch/pipetteControl.py
+++ b/acq4/modules/MultiPatch/pipetteControl.py
@@ -188,7 +188,7 @@ class PipetteControl(Qt.QWidget):
         if mode == 'VC' or (mode == 'IC' and self.pip.autoBiasEnabled()):
             self.pip.setAutoBiasTarget(val)
         if not (mode == 'IC' and self.pip.autoBiasEnabled()):
-            self.pip.setHolding(mode, val)
+            self.pip.clampDevice.setHolding(mode, val)
 
     def clampMode(self):
         """Return the currently displayed clamp mode (not necessarily the same as the device clamp mode)

--- a/acq4/modules/MultiPatch/pipetteControl.py
+++ b/acq4/modules/MultiPatch/pipetteControl.py
@@ -31,7 +31,7 @@ class PipetteControl(Qt.QWidget):
     sigLockChanged = Qt.Signal(object, object)
     sigPlotModesChanged = Qt.Signal(object)  # mode list
 
-    def __init__(self, pipette, mainWin, parent=None):
+    def __init__(self, pipette: PatchPipette, mainWin, parent=None):
         Qt.QWidget.__init__(self, parent)
         self.pip = pipette
         self.mainWin = mainWin
@@ -48,24 +48,23 @@ class PipetteControl(Qt.QWidget):
             self.pip.sigTipCleanChanged.connect(self.tipCleanChanged)
             self.pip.sigTipBrokenChanged.connect(self.tipBrokenChanged)
 
-        self.ui.holdingSpin.setOpts(
+        self.ui.vcHoldingSpin.setOpts(
             bounds=[None, None],
             decimals=0,
             siPrefix=True,
             format='{scaledValue:.3g} {siPrefix:s}{suffix:s}',
             **_vc_mode_opts,
         )
+        self.ui.icHoldingSpin.setOpts(
+            bounds=[None, None],
+            decimals=0,
+            siPrefix=True,
+            format='{scaledValue:.3g} {siPrefix:s}{suffix:s}',
+            **_ic_mode_opts,
+        )
         self.ui.autoOffsetBtn.clicked.connect(self.autoOffsetRequested)
         self.ui.autoPipCapBtn.clicked.connect(self.autoPipCapRequested)
-
-        self.displayWidgets = [
-            self.ui.stateText,
-            self.ui.modeText,
-            self.ui.holdingSpin,
-            self.ui.pressureWidget.pressureSpin,
-        ]
-        for w in self.displayWidgets:
-            w.setFixedHeight(20)
+        self.ui.autoBridgeBalanceBtn.clicked.connect(self.autoBridgeBalanceRequested)
 
         n = re.sub(r'[^\d]+', '', pipette.name())
         self.ui.activeBtn.setText(n)
@@ -75,8 +74,18 @@ class PipetteControl(Qt.QWidget):
         self.ui.lockBtn.clicked.connect(self.lockClicked)
         self.ui.tipBtn.clicked.connect(self.focusTipBtnClicked)
         self.ui.targetBtn.clicked.connect(self.focusTargetBtnClicked)
+
+        self.modeGroup = Qt.QButtonGroup()
+        self.modeGroup.addButton(self.ui.vcBtn, 0)
+        self.modeGroup.addButton(self.ui.icBtn, 1)
+        self.modeGroup.addButton(self.ui.i0Btn, 2)
+        self.modeGroup.idClicked.connect(self.modeBtnClicked)
+
         self.ui.autoBiasBtn.clicked.connect(self.autoBiasClicked)
-        self.ui.holdingSpin.valueChanged.connect(self.holdingSpinChanged)
+        self.ui.vcHoldingSpin.valueChanged.connect(self.vcHoldingSpinChanged)
+        self.ui.icHoldingSpin.valueChanged.connect(self.icHoldingSpinChanged)
+        self.ui.autoBiasTargetSpin.valueChanged.connect(self.autoBiasSpinChanged)
+
         self.ui.newPipetteBtn.clicked.connect(self.newPipetteClicked)
         self.ui.fouledCheck.stateChanged.connect(self.fouledCheckChanged)
         self.ui.brokenCheck.stateChanged.connect(self.brokenCheckChanged)
@@ -87,7 +96,6 @@ class PipetteControl(Qt.QWidget):
                 self.stateMenu.addAction(state, self.stateActionClicked)
 
         self._pc1 = MousePressCatch(self.ui.stateText, self.stateTextClicked)
-        self._pc2 = MousePressCatch(self.ui.modeText, self.modeTextClicked)
 
         self.plots = [
             PlotWidget(mode='test pulse'), 
@@ -157,16 +165,8 @@ class PipetteControl(Qt.QWidget):
         state = pipette.getState()
         self.ui.stateText.setText(state.stateName)
 
-    def clampStateChanged(self, state):
-        if self.clampMode() != state['mode']:
-            self.ui.modeText.setText(state['mode'])
-            self.updateHoldingInfo(mode=state['mode'])
-
     def clampHoldingChanged(self, mode, val):
-        currentMode = str(self.ui.modeText.text()).upper()
-        if mode != currentMode:
-            return
-        self.updateHoldingInfo(mode=mode)
+        self._setHoldingSpin(mode, val)
 
     def autoBiasChanged(self, pip, enabled, target):
         self.updateAutoBiasSpin()
@@ -174,61 +174,75 @@ class PipetteControl(Qt.QWidget):
             self.ui.autoBiasBtn.setChecked(enabled)
 
     def updateAutoBiasSpin(self):
-        if self.pip.autoBiasEnabled() and self.clampMode() == 'IC':
+        if self.pip.autoBiasEnabled() and self.selectedClampMode() == 'IC':
             biasTarget = self.pip.autoBiasTarget()
             self._setHoldingSpin(biasTarget, 'V')
 
-    def holdingSpinChanged(self):
+    def vcHoldingSpinChanged(self, value):
         # NOTE: The spin emits a delayed signal when the user changes its value. 
         # That means if we are not careful, some other signal could reset the value
         # of the spin before it has even emitted the change signal, causing the user's
         # requested change to be cancelled.
-        val = self.ui.holdingSpin.value()
-        mode = self.clampMode()
-        if mode == 'VC' or (mode == 'IC' and self.pip.autoBiasEnabled()):
-            self.pip.setAutoBiasTarget(val)
-        if not (mode == 'IC' and self.pip.autoBiasEnabled()):
-            self.pip.clampDevice.setHolding(mode, val)
+        self.pip.clampDevice.setHolding('VC', value)
 
-    def clampMode(self):
+    def icHoldingSpinChanged(self, value):
+        self.pip.clampDevice.setHolding('IC', value)
+
+    def autoBiasSpinChanged(self, value):
+        self.pip.setAutoBiasTarget(value)
+        
+    def selectedClampMode(self):
         """Return the currently displayed clamp mode (not necessarily the same as the device clamp mode)
         """
-        return str(self.ui.modeText.text()).upper()
+        return [None, 'VC', 'IC', 'I=0'][self.modeGroup.checkedId() + 1]
 
-    def updateHoldingInfo(self, mode=None):
-        clamp = self.pip.clampDevice
-        if mode is None:
-            mode = clamp.getMode()
-        hval = clamp.getHolding(mode)
+    def modeBtnClicked(self, btnId):
+        mode = self.selectedClampMode()
+        self.pip.clampDevice.setMode(mode)
 
-        if self.pip.autoBiasEnabled():
-            if mode == 'VC':
-                spinVal = hval
-                self.ui.autoBiasBtn.setText('bias: vc')
-            else:
-                biasTarget = self.pip.autoBiasTarget()
-                spinVal = biasTarget
-                self.ui.autoBiasBtn.setText(f'bias: {int(hval * 1e12):d}pA')
-            units = 'V'
-            self.ui.autoBiasBtn.setChecked(True)
-        else:
-            if mode == 'VC':
-                units = 'V'
-            else:
-                units = 'A'
-            spinVal = hval
-            self.ui.autoBiasBtn.setChecked(False)
-            self.ui.autoBiasBtn.setText('bias: off')
+    def clampStateChanged(self, state):
+        mode = self.selectedClampMode()
+        if mode != state['mode']:
+            btnId = {'VC': 0, 'IC': 1, 'I=0': 2}[state['mode']]
+            with pg.SignalBlock(self.modeGroup.idClicked, self.modeBtnClicked):
+                self.modeGroup.button(btnId).setChecked(True)
+            # self.pip.setTestPulseParameters(clampMode=state['mode'])
+            # self.updateHoldingInfo(mode=state['mode'])
 
-        self._setHoldingSpin(spinVal, units)
+    # def updateHoldingInfo(self, mode=None):
+    #     clamp = self.pip.clampDevice
+    #     if mode is None:
+    #         mode = clamp.getMode()
+    #     hval = clamp.getHolding(mode)
 
-    def _setHoldingSpin(self, value, units):
-        with pg.SignalBlock(self.ui.holdingSpin.valueChanged, self.holdingSpinChanged):
-            self.ui.holdingSpin.setValue(value)
-            if units == 'V':
-                self.ui.holdingSpin.setOpts(**_vc_mode_opts)
-            else:
-                self.ui.holdingSpin.setOpts(**_ic_mode_opts)
+    #     if self.pip.autoBiasEnabled():
+    #         if mode == 'VC':
+    #             spinVal = hval
+    #             self.ui.autoBiasBtn.setText('bias: vc')
+    #         else:
+    #             biasTarget = self.pip.autoBiasTarget()
+    #             spinVal = biasTarget
+    #             self.ui.autoBiasBtn.setText(f'bias: {int(hval * 1e12):d}pA')
+    #         units = 'V'
+    #         self.ui.autoBiasBtn.setChecked(True)
+    #     else:
+    #         if mode == 'VC':
+    #             units = 'V'
+    #         else:
+    #             units = 'A'
+    #         spinVal = hval
+    #         self.ui.autoBiasBtn.setChecked(False)
+    #         self.ui.autoBiasBtn.setText('bias: off')
+
+    #     self._setHoldingSpin(spinVal, units)
+
+    def _setHoldingSpin(self, mode, value):
+        if mode == 'VC':
+            with pg.SignalBlock(self.ui.vcHoldingSpin.valueChanged, self.vcHoldingSpinChanged):
+                self.ui.vcHoldingSpin.setValue(value)
+        elif mode == 'IC':
+            with pg.SignalBlock(self.ui.icHoldingSpin.valueChanged, self.icHoldingSpinChanged):
+                self.ui.icHoldingSpin.setValue(value)
 
     def stateActionClicked(self):
         state = str(self.sender().text())
@@ -240,19 +254,6 @@ class PipetteControl(Qt.QWidget):
 
     def stateTextClicked(self, sender, event):
         self.stateMenu.popup(sender.mapToGlobal(event.pos()))
-
-    def modeTextClicked(self, sender, event):
-        if self.clampMode() == 'VC':
-            self.pip.clampDevice.setMode('IC')
-            self.pip.setTestPulseParameters(clampMode='IC')
-            if self.pip.autoBiasEnabled():
-                self.ui.holdingSpin.setOpts(**_vc_mode_opts)
-            else:
-                self.ui.holdingSpin.setOpts(**_ic_mode_opts)
-        else:
-            self.pip.clampDevice.setMode('VC')
-            self.pip.setTestPulseParameters(clampMode='VC')
-            self.ui.holdingSpin.setOpts(**_vc_mode_opts)
 
     def focusTipBtnClicked(self, state):
         speed = self.mainWin.selectedSpeed(default='fast')
@@ -299,6 +300,9 @@ class PipetteControl(Qt.QWidget):
 
     def autoPipCapRequested(self):
         self.pip.clampDevice.autoCapComp()
+
+    def autoBridgeBalanceRequested(self):
+        self.pip.clampDevice.autoBridgeBalance()
 
     def brokenCheckChanged(self, checked):
         self.pip.setTipBroken(self.ui.brokenCheck.isChecked())

--- a/acq4/modules/MultiPatch/pipetteControl.py
+++ b/acq4/modules/MultiPatch/pipetteControl.py
@@ -284,12 +284,12 @@ class PipetteControl(Qt.QWidget):
     def autoBiasVcClicked(self, enabled):
         if enabled:
             self.pip.setAutoBiasTarget(None)
-            self.ui.autoBiasTargetSpin.setEnabled(False)
             self.ui.autoBiasTargetSpin.setValue(self.ui.vcHoldingSpin.value())
         else:
             self.pip.setAutoBiasTarget(self.ui.autoBiasTargetSpin.value())
             self.ui.autoBiasTargetSpin.setEnabled(True)
             self.ui.autoBiasTargetSpin.setValue(self.ui.vcHoldingSpin.value())
+        self._updateAutoBiasUi()
 
     def _updateAutoBiasUi(self):
         # auto bias changed elsewhere; update UI to reflect new state
@@ -298,6 +298,11 @@ class PipetteControl(Qt.QWidget):
         with pg.SignalBlock(self.ui.autoBiasVcBtn.clicked, self.autoBiasVcClicked):
             self.ui.autoBiasVcBtn.setChecked(self.pip.autoBiasTarget() is None)
         self._updateActiveHoldingUi()
+
+        if self.pip.autoBiasTarget() is None:
+            self.ui.autoBiasTargetSpin.setEnabled(False)
+        else:
+            self.ui.autoBiasTargetSpin.setEnabled(True)
 
     def newPipetteRequested(self):
         self.ui.newPipetteBtn.setStyleSheet("QPushButton {border: 2px solid #F00;}")

--- a/acq4/modules/MultiPatch/pipetteTemplate.ui
+++ b/acq4/modules/MultiPatch/pipetteTemplate.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1004</width>
-    <height>176</height>
+    <height>184</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -372,7 +372,7 @@
    </item>
    <item row="0" column="4" rowspan="2">
     <widget class="QWidget" name="widget_6" native="true">
-     <layout class="QGridLayout" name="gridLayout_4">
+     <layout class="QGridLayout" name="gridLayout_2">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -388,96 +388,6 @@
       <property name="spacing">
        <number>0</number>
       </property>
-      <item row="2" column="4">
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>5</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="3" column="0">
-       <widget class="QPushButton" name="i0Btn">
-        <property name="maximumSize">
-         <size>
-          <width>40</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>I=0</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="5">
-       <widget class="QPushButton" name="autoPipCapBtn">
-        <property name="maximumSize">
-         <size>
-          <width>70</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>pip cap.</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="3">
-       <widget class="SpinBox" name="autoBiasTargetSpin">
-        <property name="maximumSize">
-         <size>
-          <width>50</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <property name="buttonSymbols">
-         <enum>QAbstractSpinBox::NoButtons</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="5">
-       <widget class="QPushButton" name="autoOffsetBtn">
-        <property name="maximumSize">
-         <size>
-          <width>70</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>pip offset</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="5">
-       <widget class="QLabel" name="label_9">
-        <property name="text">
-         <string>auto</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="label_8">
         <property name="maximumSize">
@@ -494,8 +404,50 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="2" colspan="2">
-       <widget class="SpinBox" name="icHoldingSpin">
+      <item row="0" column="2" colspan="2">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>holding</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="6">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>auto</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="vcBtn">
+        <property name="maximumSize">
+         <size>
+          <width>40</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>VC</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2" colspan="3">
+       <widget class="SpinBox" name="vcHoldingSpin">
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="maximumSize">
          <size>
           <width>100</width>
@@ -516,8 +468,8 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="5">
-       <widget class="QPushButton" name="autoBridgeBalanceBtn">
+      <item row="1" column="6">
+       <widget class="QPushButton" name="autoOffsetBtn">
         <property name="maximumSize">
          <size>
           <width>70</width>
@@ -525,7 +477,7 @@
          </size>
         </property>
         <property name="text">
-         <string>bridge bal.</string>
+         <string>pip offset</string>
         </property>
        </widget>
       </item>
@@ -539,56 +491,6 @@
         </property>
         <property name="text">
          <string>IC</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2" colspan="2">
-       <widget class="SpinBox" name="vcHoldingSpin">
-        <property name="maximumSize">
-         <size>
-          <width>100</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <property name="buttonSymbols">
-         <enum>QAbstractSpinBox::NoButtons</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QPushButton" name="autoBiasBtn">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>40</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>40</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="text">
-         <string>bias</string>
         </property>
         <property name="checkable">
          <bool>true</bool>
@@ -611,8 +513,65 @@
         </property>
        </spacer>
       </item>
-      <item row="1" column="0">
-       <widget class="QPushButton" name="vcBtn">
+      <item row="2" column="2" colspan="3">
+       <widget class="SpinBox" name="icHoldingSpin">
+        <property name="minimumSize">
+         <size>
+          <width>120</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>100</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="buttonSymbols">
+         <enum>QAbstractSpinBox::NoButtons</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="5">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>5</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="6">
+       <widget class="QPushButton" name="autoPipCapBtn">
+        <property name="maximumSize">
+         <size>
+          <width>70</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>pip cap.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QPushButton" name="i0Btn">
         <property name="maximumSize">
          <size>
           <width>40</width>
@@ -620,14 +579,105 @@
          </size>
         </property>
         <property name="text">
-         <string>VC</string>
+         <string>I=0</string>
         </property>
         <property name="checkable">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="4" column="2">
+      <item row="3" column="2">
+       <widget class="QPushButton" name="autoBiasBtn">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>30</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>30</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>bias</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="SpinBox" name="autoBiasTargetSpin">
+        <property name="minimumSize">
+         <size>
+          <width>70</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>70</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="buttonSymbols">
+         <enum>QAbstractSpinBox::NoButtons</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="4">
+       <widget class="QPushButton" name="autoBiasVcBtn">
+        <property name="minimumSize">
+         <size>
+          <width>20</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>20</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>vc</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="6">
+       <widget class="QPushButton" name="autoBridgeBalanceBtn">
+        <property name="maximumSize">
+         <size>
+          <width>70</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>bridge bal.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
        <spacer name="verticalSpacer_2">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -639,16 +689,6 @@
          </size>
         </property>
        </spacer>
-      </item>
-      <item row="0" column="2" colspan="2">
-       <widget class="QLabel" name="label_7">
-        <property name="text">
-         <string>holding</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>

--- a/acq4/modules/MultiPatch/pipetteTemplate.ui
+++ b/acq4/modules/MultiPatch/pipetteTemplate.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1004</width>
-    <height>133</height>
+    <height>176</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,97 +20,22 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="horizontalSpacing">
+   <property name="leftMargin">
     <number>2</number>
    </property>
-   <property name="margin">
-    <number>0</number>
+   <property name="topMargin">
+    <number>2</number>
    </property>
-   <item row="0" column="5">
-    <widget class="QLabel" name="label_4">
-     <property name="maximumSize">
-      <size>
-       <width>65</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Pressure</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>Enab.</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="4">
-    <widget class="QLabel" name="label_3">
-     <property name="maximumSize">
-      <size>
-       <width>65</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Holding</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QLabel" name="label">
-     <property name="maximumSize">
-      <size>
-       <width>65</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>State</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="3">
-    <widget class="QLabel" name="label_2">
-     <property name="maximumSize">
-      <size>
-       <width>65</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="text">
-      <string>Clamp Mode</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLabel" name="label_6">
-     <property name="text">
-      <string>Sel.</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
+   <property name="rightMargin">
+    <number>2</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
+   </property>
+   <property name="spacing">
+    <number>2</number>
+   </property>
+   <item row="1" column="0" rowspan="2">
     <widget class="QPushButton" name="activeBtn">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
@@ -145,188 +70,20 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="selectBtn">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="0" column="5" rowspan="2">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>30</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>30</width>
-       <height>16777215</height>
-      </size>
-     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>&gt;</string>
+      <string>Enab.</string>
      </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="3">
-    <widget class="QWidget" name="widget_2" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>65</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>65</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_2">
-      <property name="spacing">
-       <number>2</number>
-      </property>
-      <property name="margin">
-       <number>2</number>
-      </property>
-      <item>
-       <widget class="QLineEdit" name="modeText">
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="text">
-         <string>VC</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <property name="readOnly">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="autoOffsetBtn">
-        <property name="text">
-         <string>auto offs.</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="autoPipCapBtn">
-        <property name="text">
-         <string>pip. cap.</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="fouledCheck">
-        <property name="text">
-         <string>fouled</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="4">
-    <widget class="QWidget" name="widget_3" native="true">
-     <property name="minimumSize">
-      <size>
-       <width>65</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>65</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <property name="spacing">
-       <number>2</number>
-      </property>
-      <property name="margin">
-       <number>2</number>
-      </property>
-      <item>
-       <widget class="SpinBox" name="holdingSpin">
-        <property name="font">
-         <font>
-          <weight>75</weight>
-          <bold>true</bold>
-         </font>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
-        </property>
-        <property name="buttonSymbols">
-         <enum>QAbstractSpinBox::NoButtons</enum>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="autoBiasBtn">
-        <property name="text">
-         <string>bias: off</string>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>20</width>
-          <height>40</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="brokenCheck">
-        <property name="text">
-         <string>broken</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="5">
-    <widget class="PressureControlWidget" name="pressureWidget" native="true">
-     <property name="maximumSize">
-       <size>
-         <width>65</width>
-         <height>16777215</height>
-       </size>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
     </widget>
    </item>
@@ -348,8 +105,17 @@
       <property name="spacing">
        <number>2</number>
       </property>
-      <property name="margin">
+      <property name="leftMargin">
        <number>2</number>
+      </property>
+      <property name="topMargin">
+       <number>2</number>
+      </property>
+      <property name="rightMargin">
+       <number>2</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
       </property>
       <item>
        <widget class="QLineEdit" name="stateText">
@@ -385,6 +151,19 @@
          <bool>true</bool>
         </property>
        </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
       </item>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
@@ -432,17 +211,20 @@
         </property>
        </spacer>
       </item>
-      <item>
-       <widget class="QPushButton" name="newPipetteBtn">
-        <property name="text">
-         <string>new pip.</string>
-        </property>
-       </widget>
-      </item>
      </layout>
     </widget>
    </item>
-   <item row="0" column="6" rowspan="2">
+   <item row="0" column="1">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Sel.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="7" rowspan="2">
     <widget class="QWidget" name="plotLayoutWidget" native="true">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -454,9 +236,420 @@
       <property name="spacing">
        <number>0</number>
       </property>
-      <property name="margin">
+      <property name="leftMargin">
        <number>0</number>
       </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="1" rowspan="2">
+    <widget class="QPushButton" name="selectBtn">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>30</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>30</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>&gt;</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2" colspan="3">
+    <widget class="QWidget" name="widget_5" native="true">
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="spacing">
+       <number>2</number>
+      </property>
+      <property name="leftMargin">
+       <number>2</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>2</number>
+      </property>
+      <property name="bottomMargin">
+       <number>2</number>
+      </property>
+      <item>
+       <widget class="QPushButton" name="newPipetteBtn">
+        <property name="text">
+         <string>new pip.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="fouledCheck">
+        <property name="text">
+         <string>fouled</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="brokenCheck">
+        <property name="text">
+         <string>broken</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="3" rowspan="2">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="6">
+    <widget class="QLabel" name="label_4">
+     <property name="maximumSize">
+      <size>
+       <width>65</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Pressure</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="6">
+    <widget class="PressureControlWidget" name="pressureWidget" native="true">
+     <property name="maximumSize">
+      <size>
+       <width>65</width>
+       <height>16777215</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QLabel" name="label">
+     <property name="maximumSize">
+      <size>
+       <width>65</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>State</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="4" rowspan="2">
+    <widget class="QWidget" name="widget_6" native="true">
+     <layout class="QGridLayout" name="gridLayout_4">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <item row="2" column="4">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>5</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="3" column="0">
+       <widget class="QPushButton" name="i0Btn">
+        <property name="maximumSize">
+         <size>
+          <width>40</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>I=0</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="5">
+       <widget class="QPushButton" name="autoPipCapBtn">
+        <property name="maximumSize">
+         <size>
+          <width>70</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>pip cap.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="SpinBox" name="autoBiasTargetSpin">
+        <property name="maximumSize">
+         <size>
+          <width>50</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="buttonSymbols">
+         <enum>QAbstractSpinBox::NoButtons</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="5">
+       <widget class="QPushButton" name="autoOffsetBtn">
+        <property name="maximumSize">
+         <size>
+          <width>70</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>pip offset</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <widget class="QLabel" name="label_9">
+        <property name="text">
+         <string>auto</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_8">
+        <property name="maximumSize">
+         <size>
+          <width>65</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Clamp</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2" colspan="2">
+       <widget class="SpinBox" name="icHoldingSpin">
+        <property name="maximumSize">
+         <size>
+          <width>100</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="buttonSymbols">
+         <enum>QAbstractSpinBox::NoButtons</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="5">
+       <widget class="QPushButton" name="autoBridgeBalanceBtn">
+        <property name="maximumSize">
+         <size>
+          <width>70</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>bridge bal.</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QPushButton" name="icBtn">
+        <property name="maximumSize">
+         <size>
+          <width>40</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>IC</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2" colspan="2">
+       <widget class="SpinBox" name="vcHoldingSpin">
+        <property name="maximumSize">
+         <size>
+          <width>100</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="font">
+         <font>
+          <weight>75</weight>
+          <bold>true</bold>
+         </font>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="buttonSymbols">
+         <enum>QAbstractSpinBox::NoButtons</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QPushButton" name="autoBiasBtn">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>40</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>40</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>bias</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>5</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="0">
+       <widget class="QPushButton" name="vcBtn">
+        <property name="maximumSize">
+         <size>
+          <width>40</width>
+          <height>16777215</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>VC</string>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="2">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="2" colspan="2">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>holding</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/acq4/util/LogWindow.py
+++ b/acq4/util/LogWindow.py
@@ -14,6 +14,8 @@ import six
 from six.moves import map
 from six.moves import range
 
+from acq4.util.json_encoder import ACQ4JSONEncoder
+
 if __name__ == "__main__":
     libdir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     sys.path = [os.path.join(libdir, "lib", "util")] + sys.path + [libdir]
@@ -329,7 +331,7 @@ class LogWindow(Qt.QMainWindow):
                 self.saveEntries(temp)
 
         self.logMsg(f"Moved log storage from {oldfName} to {self.fileName()}.")
-        self.logMsg(f"Current configuration: {json.dumps(self.manager.config)}")
+        self.logMsg(f"Current configuration: {json.dumps(self.manager.config, cls=ACQ4JSONEncoder)}")
         self.wid.ui.dirLabel.setText("Current Storage Directory: " + self.fileName())
         self.manager.sigLogDirChanged.emit(dh)
 

--- a/acq4/util/igorpro.py
+++ b/acq4/util/igorpro.py
@@ -13,6 +13,9 @@ import zmq
 
 import os
 from six.moves import range
+
+from acq4.util.json_encoder import ACQ4JSONEncoder
+
 sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
 from acq4.util import Qt
 from pyqtgraph.util.mutex import Mutex
@@ -268,7 +271,7 @@ class ZMQIgorBridge(object):
                     "name": cmd,
                     "params": params}
                 }
-        msg = [b"", json.dumps(call).encode()]
+        msg = [b"", json.dumps(call, cls=ACQ4JSONEncoder).encode()]
         return msg
 
     def parseReply(self, reply):

--- a/acq4/util/json_encoder.py
+++ b/acq4/util/json_encoder.py
@@ -1,0 +1,12 @@
+import json
+
+import numpy as np
+
+
+class ACQ4JSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.floating):
+            return float(obj)
+        return json.JSONEncoder.default(self, obj)

--- a/config/example/devices.cfg
+++ b/config/example/devices.cfg
@@ -41,8 +41,9 @@ DaqDevice:
 # a "real" system.
 Clamp1:
     driver: 'MockClamp'
-    simulator: 'builtin'  # Also supports 'neuron' if you have neuron+python
-                            # installed. See lib/devices/MockClamp/neuronSim.py.
+    simulator: 'neuroanalysis'  # Also supports 'neuron' if you have neuron+python
+                                # installed. See lib/devices/MockClamp/neuronSim.py,
+                                # or 'builtin' if neither neuron nor neuroanalysis is available
                             
     # Define two connections to the DAQ:
     Command:


### PR DESCRIPTION
Allow better control over clamp mode, holding, and auto bias.
- Change holding values regardless of current clamp mode
- Enable/disable bias regardless of mode
- Optionally lock bias to VC
- Easily disable bias by changing holding current
- Controls illuminate to show currently active control

Bonus: add a mock clamp simulator based on neuroanalysis, fix NEURON simulator