### PR TITLE
Bugfix: Zeiss filter turret moves error when used as task

### DIFF
--- a/acq4/devices/zeiss/ZeissTurret.py
+++ b/acq4/devices/zeiss/ZeissTurret.py
@@ -79,11 +79,11 @@ class ZeissFilterWheelFuture(FilterWheelFuture):
             return True
 
     def _atTarget(self):
-        # sometimes we transiently return 0 at the end of a move; just wait a little longer
+        # sometimes we transiently return 0 (converted to None) at the end of a move; just wait a little longer
         start = ptime.time()
         while True:
-            pos = self.dev._getPosition()
-            if pos != 0 or ptime.time() - start > 1.0:
+            pos = self.dev.getPosition()
+            if pos is not None or ptime.time() - start > 1.0:
                 break
 
         return pos == self.position


### PR DESCRIPTION
I think it's this line, but I lack the hardware to test it.