### PR TITLE
various bugfixes for fallout from recalibrating axes

### DIFF
--- a/acq4/devices/Pipette/pipette.py
+++ b/acq4/devices/Pipette/pipette.py
@@ -108,6 +108,7 @@ class Pipette(Device, OptomechDevice):
             raise Exception(
                 f"Pipette device requires some type of translation stage as its parentDevice (got {parent}).")
 
+        parent.sigOrientationChanged.connect(self.clearSavedOffsets)
         # may add items here to implement per-pipette custom motion planning
         self.motionPlanners = {}
         self.currentMotionPlanner = None
@@ -314,6 +315,13 @@ class Pipette(Device, OptomechDevice):
         cal['offset'] = list(self.offset)
         cal['offset history'] = [cal['offset']]
         self.writeConfigFile(cal, 'calibration')
+
+    def clearSavedOffsets(self, parent):
+        """Clear the saved offsets if the parent manipulator's axes are re-calibrated."""
+        cal = self.readConfigFile('calibration')
+        if 'offset history' in cal:
+            del cal['offset history']
+            self.writeConfigFile(cal, 'calibration')
 
     def setTipOffset(self, pos):
         """Given a global position, set the offset such that the pipette tip is located at that position."""

--- a/acq4/devices/Stage/Stage.py
+++ b/acq4/devices/Stage/Stage.py
@@ -613,7 +613,6 @@ class Stage(Device, OptomechDevice):
         locations = self.readConfigFile('stored_locations')
         locations[name] = list(pos)
         self.writeConfigFile(locations, 'stored_locations')
-        self.checkRangeOfMotion(pos)
 
     def clearStoredLocation(self, name):
         locations = self.readConfigFile('stored_locations')

--- a/acq4/devices/Stage/Stage.py
+++ b/acq4/devices/Stage/Stage.py
@@ -566,7 +566,7 @@ class Stage(Device, OptomechDevice):
         bad_axes = []
         for axis in (0, 1, 2):
             try:
-                bound = pos[:]
+                bound = pos.copy()
                 bound[axis] -= tolerance
                 self.checkLimits(self.mapGlobalToDevicePosition(bound))
                 bound[axis] += 2 * tolerance
@@ -576,14 +576,14 @@ class Stage(Device, OptomechDevice):
         if bad_axes:
             axis_names = {0: 'x', 1: 'y', 2: 'z'}
             axes = ', '.join(axis_names[axis] for axis in bad_axes)
-            pos = self.mapGlobalToDevicePosition(pos)
+            stage_pos = self.mapGlobalToDevicePosition(pos)
             possible_problem = "pipette pull consistency" if self.isManipulator else "hardware reliability"
             raise HelpfulException(
                 f"The specified position is within ±{siFormat(tolerance, suffix='m')} of the {axes} limit(s) of "
                 f"{self.name()} and may not always be accessible, depending on your {possible_problem}.",
                 reasons=[
                     f"Manipulator limits: {self.getLimits()}",
-                    f"Position: ({pos[0]:f}, {pos[1]:f}, {pos[2]:f})",
+                    f"Position: ({stage_pos[0]:f}, {stage_pos[1]:f}, {stage_pos[2]:f})",
                 ],
             )
 

--- a/acq4/modules/AutomationDebug/AutomationDebug.py
+++ b/acq4/modules/AutomationDebug/AutomationDebug.py
@@ -301,7 +301,7 @@ class AutomationDebugWindow(Qt.QWidget):
             ).getResult()
             depth -= 50 * µm
             self.cameraDevice.setFocusDepth(depth)
-            neurons = _future.waitFor(self._detectNeuronsZStack()).getResult()
+            neurons = _future.waitFor(self._detectNeuronsZStack(), timeout=600).getResult()
             runInGuiThread(self._displayBoundingBoxes, neurons)
         centers = [(start + end) / 2 for start, end in np.array(neurons)]
         target = next(
@@ -311,7 +311,7 @@ class AutomationDebugWindow(Qt.QWidget):
         if target is None:
             if possibly_stale:
                 runInGuiThread(self.clearBoundingBoxes)
-                return self.waitFor(self._autoTarget()).getResult()
+                return self.waitFor(self._autoTarget(), timeout=None).getResult()
             else:
                 raise RuntimeError("No valid target found")
         self._previousTargets.append(target)


### PR DESCRIPTION
* allow offset history to be reset for any outlier calibration
* clear offset history on axes recalibration
* "set home" need not warn about manipulator boundaries
* pos variable was being modified (`[:]` no longer copies numpy arrays)