### PR TITLE
Profiling tools

### DIFF
--- a/acq4/modules/Profiler.py
+++ b/acq4/modules/Profiler.py
@@ -1,0 +1,343 @@
+"""
+Profiling module for monitoring acq4 performance and identifying bottlenecks
+Uses yappi profiler to collect thread-aware performance statistics with UI for control and display
+"""
+import yappi
+import time
+import re
+from datetime import datetime
+from acq4.modules.Module import Module
+from acq4.util import Qt
+from acq4.util.codeEditor import invokeCodeEditor
+from pyqtgraph import TableWidget
+
+
+class ProfileResult:
+    """Container for a single profiling session result"""
+    
+    def __init__(self, name, start_time, func_stats, thread_stats):
+        self.name = name
+        self.start_time = start_time
+        self.end_time = datetime.now()
+        self.func_stats = func_stats
+        self.thread_stats = thread_stats
+        self.duration = (self.end_time - self.start_time).total_seconds()
+
+
+class Profiler(Module):
+    """Performance profiling module for acq4
+    
+    Provides UI controls for starting/stopping profiling sessions and displaying
+    results in both flat and hierarchical views organized by thread.
+    """
+    moduleDisplayName = "Profiler"
+    moduleCategory = "Utilities"
+
+    # Column definitions: (header, attribute, format_func)
+    COLUMNS = [
+        ('Function/Thread', 'name', str),
+        ('Calls', 'ncall', str),
+        ('Total Time', 'ttot', lambda x: f"{x:.6f}"),
+        ('Sub Time', 'tsub', lambda x: f"{x:.6f}"),
+        ('Avg Time', 'tavg', lambda x: f"{x:.6f}"),
+        ('Location', 'full_name', str),
+    ]
+
+    def __init__(self, manager, name, config):
+        Module.__init__(self, manager, name, config)
+        self.manager = manager
+        self.is_profiling = False
+        self.current_session_start = None
+        self.profile_results = []
+        
+        self._setupUI()
+
+    def _setItemColumns(self, item, data_obj=None, **custom_values):
+        """Set item column values using COLUMNS definition"""
+        for i, (header, attr, format_func) in enumerate(self.COLUMNS):
+            if header in custom_values:
+                value = custom_values[header]
+            elif data_obj and hasattr(data_obj, attr):
+                value = format_func(getattr(data_obj, attr))
+            else:
+                value = ""
+            item.setText(i, value)
+
+    def _setupUI(self):
+        """Initialize the user interface"""
+        self.win = Qt.QMainWindow()
+        self.win.setWindowTitle('Profiler')
+        self.win.resize(1000, 800)
+        
+        # Central widget with splitter
+        central_widget = Qt.QWidget()
+        self.win.setCentralWidget(central_widget)
+        layout = Qt.QVBoxLayout(central_widget)
+        
+        # Control panel - fixed size, don't expand
+        control_panel = self._createControlPanel()
+        layout.addWidget(control_panel, 0)  # 0 stretch factor
+        
+        # Main splitter for results list and profile display
+        splitter = Qt.QSplitter(Qt.Qt.Horizontal)
+        layout.addWidget(splitter)
+        
+        # Left side: Profile results list
+        self.results_list = Qt.QListWidget()
+        self.results_list.itemSelectionChanged.connect(self._onResultSelected)
+        splitter.addWidget(self.results_list)
+        
+        # Right side: Profile data display
+        self.profile_display = Qt.QTreeWidget()
+        self.profile_display.setHeaderLabels([col[0] for col in self.COLUMNS])
+        self.profile_display.setSortingEnabled(True)
+        self.profile_display.sortByColumn(2, Qt.Qt.DescendingOrder)  # Sort by total time by default
+        self.profile_display.setExpandsOnDoubleClick(False)  # Disable expand/collapse on double-click
+        self.profile_display.itemDoubleClicked.connect(self._onItemDoubleClicked)
+        splitter.addWidget(self.profile_display)
+        
+        # Set splitter proportions
+        splitter.setSizes([200, 600])
+        
+        self.win.show()
+
+    def _createControlPanel(self):
+        """Create the control panel with start/stop and view controls"""
+        panel = Qt.QGroupBox("Profile Controls")
+        panel.setSizePolicy(Qt.QSizePolicy.Preferred, Qt.QSizePolicy.Fixed)
+        layout = Qt.QHBoxLayout(panel)
+        
+        # Start/Stop button
+        self.start_stop_btn = Qt.QPushButton("Start Profiling")
+        self.start_stop_btn.clicked.connect(self._toggleProfiling)
+        layout.addWidget(self.start_stop_btn)
+        
+        # Session name input
+        layout.addWidget(Qt.QLabel("Session Name:"))
+        self.session_name_edit = Qt.QLineEdit()
+        self.session_name_edit.setText(f"Profile_{len(self.profile_results) + 1}")
+        layout.addWidget(self.session_name_edit)
+        
+        # View mode selector
+        layout.addWidget(Qt.QLabel("View:"))
+        self.view_mode_combo = Qt.QComboBox()
+        self.view_mode_combo.addItems(["Grouped by Thread", "Combined Threads"])
+        self.view_mode_combo.currentTextChanged.connect(self._onViewModeChanged)
+        layout.addWidget(self.view_mode_combo)
+        
+        # Clock type selector
+        layout.addWidget(Qt.QLabel("Clock:"))
+        self.clock_type_combo = Qt.QComboBox()
+        self.clock_type_combo.addItems(["CPU Time", "Wall Time"])
+        layout.addWidget(self.clock_type_combo)
+        
+        layout.addStretch()
+        
+        return panel
+
+    def _toggleProfiling(self):
+        """Start or stop profiling session"""
+        if self.is_profiling:
+            self._stopProfiling()
+        else:
+            self._startProfiling()
+
+    def _startProfiling(self):
+        """Begin a new profiling session"""
+        yappi.clear_stats()
+        
+        # Set clock type based on user selection
+        clock_type = 'cpu' if self.clock_type_combo.currentText() == "CPU Time" else 'wall'
+        yappi.set_clock_type(clock_type)
+        
+        yappi.start()
+        
+        self.is_profiling = True
+        self.current_session_start = datetime.now()
+        
+        self.start_stop_btn.setText("Stop Profiling")
+        self.start_stop_btn.setStyleSheet("background-color: #ff4444;")
+
+    def _stopProfiling(self):
+        """End current profiling session and store results"""
+        if not self.is_profiling:
+            return
+            
+        yappi.stop()
+        
+        # Collect profiling data
+        func_stats = yappi.get_func_stats()
+        thread_stats = yappi.get_thread_stats()
+        
+        # Create result object
+        session_name = self.session_name_edit.text() or f"Profile_{len(self.profile_results) + 1}"
+        result = ProfileResult(session_name, self.current_session_start, func_stats, thread_stats)
+        self.profile_results.append(result)
+        
+        # Update UI
+        self._addResultToList(result)
+        self.is_profiling = False
+        self.current_session_start = None
+        
+        self.start_stop_btn.setText("Start Profiling")
+        self.start_stop_btn.setStyleSheet("")
+        
+        # Update session name for next run
+        self.session_name_edit.setText(f"Profile_{len(self.profile_results) + 1}")
+
+    def _addResultToList(self, result):
+        """Add a profile result to the results list"""
+        item_text = f"{result.name} ({result.start_time.strftime('%H:%M:%S')}) - {result.duration:.2f}s"
+        item = Qt.QListWidgetItem(item_text)
+        item.setData(Qt.Qt.UserRole, result)
+        self.results_list.addItem(item)
+
+    def _onResultSelected(self):
+        """Handle selection change in results list"""
+        current_item = self.results_list.currentItem()
+        if current_item is None:
+            return
+            
+        self.current_result = current_item.data(Qt.Qt.UserRole)
+        self._displayProfileResult(self.current_result)
+
+    def _displayProfileResult(self, result):
+        """Display profile result in the tree widget"""
+        self.profile_display.clear()
+        
+        view_mode = self.view_mode_combo.currentText()
+        
+        if view_mode == "Grouped by Thread":
+            self._displayGroupedByThread(result)
+        else:  # Combined Threads
+            self._displayCombinedThreads(result)
+        
+        # Auto-resize columns to fit content
+        for i in range(self.profile_display.columnCount()):
+            self.profile_display.resizeColumnToContents(i)
+
+    def _onViewModeChanged(self):
+        """Handle view mode change"""
+        current_item = self.results_list.currentItem()
+        if current_item is not None:
+            result = current_item.data(Qt.Qt.UserRole)
+            self._displayProfileResult(result)
+
+    def _displayGroupedByThread(self, result):
+        """Display profile data grouped by thread with per-thread function breakdown"""
+        # Display thread statistics first
+        thread_stats_item = Qt.QTreeWidgetItem(self.profile_display)
+        self._setItemColumns(thread_stats_item, **{'Function/Thread': f"Thread Statistics ({len(result.thread_stats)} threads)"})
+        
+        for thread_stat in result.thread_stats:
+            if thread_stat.ttot > 0.000001:  # Skip empty threads
+                thread_item = Qt.QTreeWidgetItem(thread_stats_item)
+                thread_name = getattr(thread_stat, 'name', f"Thread {thread_stat.id}")
+                self._setItemColumns(thread_item, thread_stat, **{'Function/Thread': thread_name})
+        
+        # Display functions grouped by thread
+        for thread_stat in result.thread_stats:
+            thread_funcs = [fs for fs in result.func_stats if getattr(fs, 'ctx_id', 0) == thread_stat.id]
+            if len(thread_funcs) > 0:
+                thread_name = getattr(thread_stat, 'name', f"Thread {thread_stat.id}")
+                thread_func_item = Qt.QTreeWidgetItem(self.profile_display)
+                self._setItemColumns(thread_func_item, **{'Function/Thread': f"{thread_name} Functions ({len(thread_funcs)})"})
+                
+                for func_stat in sorted(thread_funcs, key=lambda x: x.ttot, reverse=True):
+                    self._addFunctionItem(thread_func_item, func_stat, result.func_stats)
+
+    def _displayCombinedThreads(self, result):
+        """Display thread stats and combined function stats separately"""
+        # Display thread statistics
+        thread_stats_item = Qt.QTreeWidgetItem(self.profile_display)
+        self._setItemColumns(thread_stats_item, **{'Function/Thread': f"Thread Statistics ({len(result.thread_stats)} threads)"})
+        
+        for thread_stat in result.thread_stats:
+            if thread_stat.ttot > 0.000001:  # Skip empty threads
+                thread_item = Qt.QTreeWidgetItem(thread_stats_item)
+                thread_name = getattr(thread_stat, 'name', f"Thread {thread_stat.id}")
+                self._setItemColumns(thread_item, thread_stat, **{'Function/Thread': thread_name})
+        
+        # Display combined function statistics
+        func_stats_item = Qt.QTreeWidgetItem(self.profile_display)
+        self._setItemColumns(func_stats_item, **{'Function/Thread': f"Function Statistics ({len(result.func_stats)} functions)"})
+        
+        for func_stat in sorted(result.func_stats, key=lambda x: x.ttot, reverse=True):
+            self._addFunctionItem(func_stats_item, func_stat, result.func_stats)
+
+    def _addFunctionItem(self, parent_item, func_stat, all_func_stats):
+        """Add a function item with subcalls and callers"""
+        # Main function item
+        func_item = Qt.QTreeWidgetItem(parent_item)
+        self._setItemColumns(func_item, func_stat)
+        func_item.func_stat = func_stat
+        func_item.item_type = 'function'
+        
+        # Subcalls (children) section
+        if hasattr(func_stat, 'children') and func_stat.children:
+            subcalls_item = Qt.QTreeWidgetItem(func_item)
+            self._setItemColumns(subcalls_item, **{'Function/Thread': f"Subcalls ({len(func_stat.children)})"})
+            
+            for child in sorted(func_stat.children, key=lambda x: x.ttot, reverse=True):
+                child_item = Qt.QTreeWidgetItem(subcalls_item)
+                self._setItemColumns(child_item, child)
+                child_item.link_target = child.name
+                child_item.item_type = 'link'
+        
+        # Callers section - find all functions that call this one
+        callers = self._findCallers(func_stat.name, all_func_stats)
+        if callers:
+            callers_item = Qt.QTreeWidgetItem(func_item)
+            self._setItemColumns(callers_item, **{'Function/Thread': f"Callers ({len(callers)})"})
+            
+            for caller_stat, child_stat in callers:
+                caller_item = Qt.QTreeWidgetItem(callers_item)
+                self._setItemColumns(caller_item, child_stat, **{'Function/Thread': caller_stat.name})
+                caller_item.link_target = caller_stat.name
+                caller_item.item_type = 'link'
+
+    def _findCallers(self, func_name, all_func_stats):
+        """Find all functions that call the specified function"""
+        callers = []
+        for stat in all_func_stats:
+            if hasattr(stat, 'children'):
+                for child in stat.children:
+                    if child.name == func_name:
+                        callers.append((stat, child))
+        return callers
+
+    def _onItemDoubleClicked(self, item, column):
+        """Handle double-click on tree items to navigate to linked functions or open editor"""
+        if hasattr(item, 'item_type'):
+            if item.item_type == 'link':
+                self._scrollToFunction(item.link_target)
+            elif item.item_type == 'function':
+                # Double-clicked on a function item - open in editor
+                self._openInEditor(item.func_stat)
+
+    def _scrollToFunction(self, func_name):
+        """Scroll to and select the specified function in the tree"""
+        # Find the function item in the tree
+        iterator = Qt.QTreeWidgetItemIterator(self.profile_display)
+        while iterator.value():
+            item = iterator.value()
+            if (hasattr(item, 'item_type') and item.item_type == 'function' and 
+                hasattr(item, 'func_stat') and item.func_stat.name == func_name):
+                self.profile_display.scrollToItem(item)
+                self.profile_display.setCurrentItem(item)
+                item.setExpanded(True)
+                break
+            iterator += 1
+
+    def _openInEditor(self, func_stat):
+        """Open function in code editor using module and lineno attributes"""
+        if not (hasattr(func_stat, 'module') and hasattr(func_stat, 'lineno')):
+            return
+        
+        file_path = func_stat.module
+        line_num = func_stat.lineno
+        
+        try:
+            invokeCodeEditor(file_path, line_num)
+        except Exception as e:
+            print(f"Failed to open editor for {file_path}:{line_num}: {e}")

--- a/tools/system_monitor.py
+++ b/tools/system_monitor.py
@@ -1,0 +1,369 @@
+# System resource monitoring utility that logs and plots CPU/memory usage over time
+#Displays real-time graphs and top process lists with historical timeline selection
+
+import argparse
+import sys
+import time
+import json
+import os
+import psutil
+from datetime import datetime
+
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtCore, QtGui, QtWidgets
+
+
+class SystemMonitor(QtWidgets.QWidget):
+    def __init__(self, poll_interval=20, load_file=None):
+        super().__init__()
+        self.poll_interval = poll_interval
+        self.is_polling = False
+        self.loaded_from_file = load_file is not None
+        self.current_log_file = None
+        
+        # Data storage
+        self.timestamps = []
+        self.cpu_data = []
+        self.memory_data = []
+        self.process_history = []  # List of dicts with timestamp and process data
+        
+        self.setup_ui()
+        
+        # Set up polling timer
+        self.timer = QtCore.QTimer()
+        self.timer.timeout.connect(self.poll_system_resources)
+        
+        # Load data if file provided, otherwise create new log file and start polling  
+        if load_file:
+            self.load_data(load_file)
+            self.stop_polling()  # Sets correct button text for non-polling state
+        else:
+            self.create_new_log_file()
+            self.start_polling()
+        
+    def setup_ui(self):
+        """Set up the user interface"""
+        self.setWindowTitle('System Resource Monitor')
+        self.setGeometry(100, 100, 1200, 600)
+        
+        # Main layout with splitter
+        main_layout = QtWidgets.QHBoxLayout()
+        self.setLayout(main_layout)
+        
+        splitter = QtWidgets.QSplitter(QtCore.Qt.Horizontal)
+        main_layout.addWidget(splitter)
+        main_layout.setContentsMargins(0, 0, 0, 0)
+        
+        # Left side - plot widget
+        plot_widget = QtWidgets.QWidget()
+        plot_layout = QtWidgets.QVBoxLayout()
+        plot_layout.setContentsMargins(0, 0, 0, 0)
+        plot_widget.setLayout(plot_layout)
+        splitter.addWidget(plot_widget)
+        
+        # Plot widget
+        self.plot_widget = pg.PlotWidget(title="System Resource Usage")
+        self.plot_widget.setLabel('left', 'Usage %')
+        self.plot_widget.setLabel('bottom', 'Time')
+        self.plot_widget.showGrid(True, True)
+        self.plot_widget.setYRange(0, 100)
+        
+        # Plot curves
+        self.cpu_curve = self.plot_widget.plot(pen=pg.mkPen(color='red', width=2), name='CPU %')
+        self.memory_curve = self.plot_widget.plot(pen=pg.mkPen(color='blue', width=2), name='Memory %')
+        self.plot_widget.addLegend()
+        
+        # Timeline selection line
+        self.timeline_line = pg.InfiniteLine(angle=90, movable=True, pen=pg.mkPen(color='green', width=2))
+        self.timeline_line.sigPositionChanged.connect(self.on_timeline_changed)
+        self.plot_widget.addItem(self.timeline_line)
+        self.timeline_line.setVisible(False)  # Hide until we have data
+        
+        plot_layout.addWidget(self.plot_widget)
+        
+        # Control buttons
+        button_layout = QtWidgets.QHBoxLayout()
+        self.start_stop_btn = QtWidgets.QPushButton('')  # Text will be set by start/stop methods
+        self.start_stop_btn.clicked.connect(self.toggle_polling)
+        button_layout.addWidget(self.start_stop_btn)
+        
+        self.load_btn = QtWidgets.QPushButton('Load File')
+        self.load_btn.clicked.connect(self.load_file_dialog)
+        button_layout.addWidget(self.load_btn)
+        
+        status_label = QtWidgets.QLabel(f'Poll Interval: {self.poll_interval}s')
+        button_layout.addWidget(status_label)
+        button_layout.addStretch()
+        
+        plot_layout.addLayout(button_layout)
+        
+        # Right side - process tables widget
+        tables_widget = QtWidgets.QWidget()
+        tables_layout = QtWidgets.QVBoxLayout()
+        tables_layout.setContentsMargins(0, 0, 0, 0)
+        tables_widget.setLayout(tables_layout)
+        splitter.addWidget(tables_widget)
+        
+        # Set splitter proportions (2:1 ratio)
+        splitter.setSizes([500, 700])
+        
+        # CPU processes table
+        cpu_label = QtWidgets.QLabel('Top 10 CPU Processes')
+        tables_layout.addWidget(cpu_label)
+        
+        self.cpu_table = QtWidgets.QTableWidget(10, 3)
+        self.cpu_table.setHorizontalHeaderLabels(['PID', 'CPU %', 'Command'])
+        self.cpu_table.horizontalHeader().setStretchLastSection(True)
+        tables_layout.addWidget(self.cpu_table)
+        
+        # Memory processes table  
+        memory_label = QtWidgets.QLabel('Top 10 Memory Processes')
+        tables_layout.addWidget(memory_label)
+        
+        self.memory_table = QtWidgets.QTableWidget(10, 3)
+        self.memory_table.setHorizontalHeaderLabels(['PID', 'Mem %', 'Command'])
+        self.memory_table.horizontalHeader().setStretchLastSection(True)
+        tables_layout.addWidget(self.memory_table)
+        
+    def update_title(self):
+        """Update window title with current log file"""
+        base_title = 'System Resource Monitor'
+        if self.current_log_file:
+            filename = os.path.basename(self.current_log_file)
+            self.setWindowTitle(f'{base_title} - {filename}')
+        else:
+            self.setWindowTitle(base_title)
+            
+    def create_new_log_file(self):
+        """Create a new timestamped log file"""
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        self.current_log_file = f"system_monitor_{timestamp}.json"
+        self.update_title()
+        
+    def save_current_data(self):
+        """Save current data to the log file"""
+        if not self.current_log_file:
+            return
+            
+        data = {
+            'poll_interval': self.poll_interval,
+            'timestamps': self.timestamps,
+            'cpu_data': self.cpu_data,
+            'memory_data': self.memory_data,
+            'process_history': self.process_history
+        }
+        
+        try:
+            with open(self.current_log_file, 'w') as f:
+                json.dump(data, f, indent=2)
+        except Exception as e:
+            QtWidgets.QMessageBox.warning(self, 'Save Error', f'Failed to save data: {str(e)}')
+            
+    def load_data(self, filename):
+        """Load data from a JSON file"""
+        try:
+            with open(filename, 'r') as f:
+                data = json.load(f)
+                
+            self.timestamps = data.get('timestamps', [])
+            self.cpu_data = data.get('cpu_data', [])
+            self.memory_data = data.get('memory_data', [])
+            self.process_history = data.get('process_history', [])
+            
+            # Update displays
+            if len(self.timestamps) > 0:
+                self.update_plot()
+                if self.process_history:
+                    self.update_process_tables(self.process_history[-1]['processes'])
+                    
+                # Show timeline line
+                if len(self.timestamps) > 1:
+                    self.timeline_line.setVisible(True)
+                    start_time = self.timestamps[0]
+                    latest_time = (self.timestamps[-1] - start_time) / 60.0
+                    self.timeline_line.setPos(latest_time)
+                    
+            self.current_log_file = filename
+            self.update_title()
+            
+        except Exception as e:
+            QtWidgets.QMessageBox.critical(self, 'Load Error', f'Failed to load file: {str(e)}')
+            
+    def load_file_dialog(self):
+        """Open file dialog to load a saved log file"""
+        filename, _ = QtWidgets.QFileDialog.getOpenFileName(
+            self, 'Load System Monitor Log', '', 'JSON files (*.json);;All files (*.*)')
+        
+        if filename:
+            self.load_data(filename)
+            self.loaded_from_file = True
+            
+    def start_polling(self):
+        """Start the polling timer and update button"""
+        self.timer.start(self.poll_interval * 1000)
+        self.is_polling = True
+        self.start_stop_btn.setText('Stop Polling')
+        
+    def stop_polling(self):
+        """Stop the polling timer and update button"""
+        self.timer.stop()
+        self.is_polling = False
+        self.start_stop_btn.setText('Start Polling')
+        self.save_current_data()
+            
+    def toggle_polling(self):
+        """Start or stop the polling"""
+        if self.is_polling:
+            self.stop_polling()
+        else:
+            # If we loaded from file, ask user what to do
+            if self.loaded_from_file and len(self.timestamps) > 0:
+                filename = os.path.basename(self.current_log_file) if self.current_log_file else "loaded file"
+                reply = QtWidgets.QMessageBox.question(
+                    self, 'Start Polling',
+                    f'Do you want to append to the loaded log file "{filename}"?\n\n'
+                    'Click Yes to append new data, No to start a new log file.',
+                    QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No | QtWidgets.QMessageBox.Cancel)
+                
+                if reply == QtWidgets.QMessageBox.Cancel:
+                    return
+                elif reply == QtWidgets.QMessageBox.No:
+                    # Start new file
+                    self.create_new_log_file()
+                    self.timestamps.clear()
+                    self.cpu_data.clear()
+                    self.memory_data.clear()
+                    self.process_history.clear()
+                    self.update_plot()
+                    self.cpu_table.clearContents()
+                    self.memory_table.clearContents()
+                # If Yes (append), just continue with existing data
+                
+            self.start_polling()
+            
+    def poll_system_resources(self):
+        """Poll system resources and update displays"""
+        # Get current timestamp
+        timestamp = time.time()
+        
+        # Get CPU and memory usage
+        cpu_percent = psutil.cpu_percent()
+        memory_percent = psutil.virtual_memory().percent
+        
+        # Store data
+        self.timestamps.append(timestamp)
+        self.cpu_data.append(cpu_percent)
+        self.memory_data.append(memory_percent)
+        
+        # Get process information
+        processes = []
+        for proc in psutil.process_iter(['pid', 'name', 'cmdline', 'cpu_percent', 'memory_percent']):
+            try:
+                info = proc.info
+                if info['cpu_percent'] is not None and info['memory_percent'] is not None:
+                    # Get full command line
+                    cmdline = ' '.join(info['cmdline']) if info['cmdline'] else info['name']
+                    processes.append({
+                        'pid': info['pid'],
+                        'cpu_percent': info['cpu_percent'],
+                        'memory_percent': info['memory_percent'],
+                        'cmdline': cmdline[:50]  # Truncate long command lines
+                    })
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+                
+        # Store process data with timestamp
+        self.process_history.append({
+            'timestamp': timestamp,
+            'processes': processes
+        })
+        
+        # Update displays
+        self.update_plot()
+        self.update_process_tables(processes)
+        
+        # Show timeline line if we have data and it's not visible yet
+        if len(self.timestamps) > 1 and not self.timeline_line.isVisible():
+            self.timeline_line.setVisible(True)
+            
+        # Always move timeline to latest data point on new updates
+        if len(self.timestamps) > 0:
+            start_time = self.timestamps[0]
+            latest_time = (self.timestamps[-1] - start_time) / 60.0
+            self.timeline_line.setPos(latest_time)
+            
+        # Auto-save data periodically
+        self.save_current_data()
+        
+    def update_plot(self):
+        """Update the plot with new data"""
+        if len(self.timestamps) > 0:
+            # Convert timestamps to relative time in minutes
+            start_time = self.timestamps[0]
+            relative_times = [(t - start_time) / 60.0 for t in self.timestamps]
+            
+            self.cpu_curve.setData(relative_times, self.cpu_data)
+            self.memory_curve.setData(relative_times, self.memory_data)
+            
+    def update_process_tables(self, processes):
+        """Update the process tables with current data"""
+        # Sort by CPU usage
+        cpu_processes = sorted(processes, key=lambda x: x['cpu_percent'], reverse=True)[:10]
+        
+        for i, proc in enumerate(cpu_processes):
+            self.cpu_table.setItem(i, 0, QtWidgets.QTableWidgetItem(str(proc['pid'])))
+            self.cpu_table.setItem(i, 1, QtWidgets.QTableWidgetItem(f"{proc['cpu_percent']:.1f}"))
+            self.cpu_table.setItem(i, 2, QtWidgets.QTableWidgetItem(proc['cmdline']))
+            
+        # Sort by memory usage
+        memory_processes = sorted(processes, key=lambda x: x['memory_percent'], reverse=True)[:10]
+        
+        for i, proc in enumerate(memory_processes):
+            self.memory_table.setItem(i, 0, QtWidgets.QTableWidgetItem(str(proc['pid'])))
+            self.memory_table.setItem(i, 1, QtWidgets.QTableWidgetItem(f"{proc['memory_percent']:.1f}"))
+            self.memory_table.setItem(i, 2, QtWidgets.QTableWidgetItem(proc['cmdline']))
+            
+    def on_timeline_changed(self):
+        """Handle timeline selection changes"""
+        if len(self.process_history) == 0:
+            return
+            
+        # Get selected time in minutes from plot
+        selected_time_minutes = self.timeline_line.getPos()[0]
+        
+        # Convert to absolute timestamp
+        start_time = self.timestamps[0]
+        selected_timestamp = start_time + (selected_time_minutes * 60.0)
+        
+        # Find closest process data point
+        closest_data = None
+        min_diff = float('inf')
+        
+        for data_point in self.process_history:
+            diff = abs(data_point['timestamp'] - selected_timestamp)
+            if diff < min_diff:
+                min_diff = diff
+                closest_data = data_point
+                
+        if closest_data:
+            self.update_process_tables(closest_data['processes'])
+
+
+def main():
+    parser = argparse.ArgumentParser(description='System Resource Monitor')
+    parser.add_argument('--poll-interval', '-i', type=int, default=20,
+                       help='Polling interval in seconds (default: 20)')
+    parser.add_argument('--load', '-l', type=str, default=None,
+                       help='Load data from a saved JSON log file')
+    
+    args = parser.parse_args()
+    
+    app = QtWidgets.QApplication(sys.argv)
+    monitor = SystemMonitor(poll_interval=args.poll_interval, load_file=args.load)
+    monitor.show()
+    
+    sys.exit(app.exec_())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds:
- an acq4 module for collecting and inspecting profiles
- a script in tools/ that is for logging and plotting cpu/memory usage over time, good for tracking bad bahavior in long tests.

Note that the profiler uses yappi, which appears to have a bug that misnames some of the functions (but the actual module/lineno appears to be correct)