### PR TITLE
optimization: rate limit Sensapex position updates inline

### DIFF
--- a/acq4/devices/Sensapex.py
+++ b/acq4/devices/Sensapex.py
@@ -216,7 +216,6 @@ class Sensapex(Stage):
         Sensapex.devices.pop(self.devid, None)
         if len(Sensapex.devices) == 0:
             UMP.get_ump().close()
-        self._positionWatcher.join()
 
     def _move(self, pos, speed, linear, name=None, **kwds):
         if self._force_linear_movement:


### PR DESCRIPTION
the update timer was seemingly out of control. this change assumes incidental UMP position updates are happening constantly at the <100nm level, and so no explicit timer is needed to ensure the position update will be revisited in a timely fashion.