### PR TITLE
fix: ensure Linux installer has feature parity with Windows installer

### DIFF
--- a/tools/installer/install_linux.sh
+++ b/tools/installer/install_linux.sh
@@ -166,8 +166,19 @@ ensure_installer_env() {
         fi
         rm -f "${create_log}"
     fi
+
+    log "Verifying Python is available in installer environment..."
+    if ! "${conda_exe}" run -n "${INSTALLER_ENV_NAME}" python --version >/dev/null 2>&1; then
+        log "ERROR: Python not found in installer environment '${INSTALLER_ENV_NAME}'"
+        log "Try running: conda env remove -n '${INSTALLER_ENV_NAME}' and then re-run this script"
+        exit 1
+    fi
+    log "Python verified successfully"
+
+    log "Installing dependencies in installer environment..."
     "${conda_exe}" run -n "${INSTALLER_ENV_NAME}" python -m pip install --quiet --upgrade \
-        "${QT_PACKAGE}" "${TOML_PARSER_PACKAGE}"
+        "${QT_PACKAGE}" "${TOML_PARSER_PACKAGE}" --index-url=https://pypi.org/simple/
+    log "Dependencies installed successfully"
 }
 
 check_conda_version() {

--- a/tools/installer/install_windows.bat
+++ b/tools/installer/install_windows.bat
@@ -12,7 +12,7 @@ if exist "%~f0" (
 )
 set "DOWNLOADED_INSTALLER="
 set "RESULT=0"
-set "INSTALLER_URL=https://raw.githubusercontent.com/AllenInstitute/acq4/ivscc-rc/tools/installer/installer.py"
+set "INSTALLER_URL=https://raw.githubusercontent.com/acq4/acq4/main/tools/installer/installer.py"
 set "INSTALLER_ENV_NAME=_acq4_installer"
 set "PYTHON_VERSION=3.12"
 set "QT_PACKAGE=pyqt6"


### PR DESCRIPTION
- Add Python verification step before installing dependencies in Linux installer
- Add --index-url flag to pip install in Linux installer
- Fix incorrect INSTALLER_URL in Windows installer (was pointing to AllenInstitute/ivscc-rc)

🤖 Generated with [Claude Code](https://claude.ai/code)