### PR TITLE
refactor: migrate OptomechDevice transforms to coorx and add adapter-based Visualize3D integration

### DIFF
--- a/acq4/Manager.py
+++ b/acq4/Manager.py
@@ -24,15 +24,13 @@ from pyqtgraph.util.mutex import Mutex
 from . import __version__
 from . import devices, modules
 from .Interfaces import InterfaceDirectory
-from .devices.Device import Device, DeviceTask
-from .logging_config import get_logger, setup_logging, HistoricLogRecord
+from .devices.Device import Device, DeviceTask, DeviceLocker
+from .logging_config import get_logger, set_log_file, setup_logging, HistoricLogRecord
 from .util import DataManager, ptime, Qt
 from .util.DataManager import DirHandle
 from .util.HelpfulException import HelpfulException
 from .util.LogWindow import get_log_window, get_error_dialog
 
-TEMP_LOG = "temp_log.json"
-setup_logging(TEMP_LOG, gui=False, console_level=logging.DEBUG)
 logger = get_logger()
 
 
@@ -71,8 +69,6 @@ class Manager(Qt.QObject):
         parser.add_argument("--module", "-m", help="Module name to load", action="append")
         parser.add_argument("--base-dir", "-b", help="Base directory to use")
         parser.add_argument("--storage-dir", "-s", help="Storage directory to use")
-        parser.add_argument("--log-level", action="store", help="Set the console log level", default="WARNING")
-        parser.add_argument("--root-log-level", action="store", help="Set the root log level", default="DEBUG")
         parser.add_argument("--disable", "-d", help="Disable the device specified", action="append")
         parser.add_argument("--disable-all", "-D", help="Disable all devices", action="store_true")
         parser.add_argument("--exit-on-error", "-x", help="Whether to exit immidiately on the first exception during initial Manager setup", action="store_true")
@@ -105,8 +101,6 @@ class Manager(Qt.QObject):
         self.taskLock = Mutex(Qt.QMutex.Recursive)
         self._folderTypes = None
         self._logFile = None
-        self._consoleLogLevel = logging.WARNING
-        self._rootLogLevel = logging.DEBUG
 
         try:
             if Manager.CREATED:
@@ -141,8 +135,6 @@ class Manager(Qt.QObject):
         self.exitOnError = args.exit_on_error
         self.disableDevs = args.disable or []
         self.disableAllDevs = args.disable_all
-        self._consoleLogLevel = getattr(logging, args.log_level.upper(), logging.WARNING)
-        self._rootLogLevel = getattr(logging, args.root_log_level.upper(), logging.DEBUG)
 
         self.configDir = os.path.dirname(args.config)
         self.readConfig(args.config)
@@ -170,9 +162,6 @@ class Manager(Qt.QObject):
                         # we have to show it now, otherwise we'll have no windows
                         self.showGUI()
                     raise
-            setup_logging(
-                TEMP_LOG, acq4_level=self._rootLogLevel, console_level=self._consoleLogLevel
-            )
 
         except Exception:
             if self.exitOnError:
@@ -452,18 +441,28 @@ class Manager(Qt.QObject):
         """
         return self.listInterfaces('device')
 
-    def reserveDevices(self, devices, timeout=10.0):
+    def reserveDevices(self, devices, timeout=10.0, reserver: str = None):
         """Return a DeviceLocker that can be used to reserve multiple devices simultaneously::
 
-            with manager.reserveDevices(['Camera', 'Clamp1', 'Stage']):
+            with manager.reserveDevices(['Camera', 'Clamp1', 'Stage'], reserver='MySubsystem'):
                 # .. do stuff
 
+        Parameters
+        ----------
+        reserver : str
+            Name identifying the caller reserving these devices. Required for deadlock diagnostics.
         """
-        devices = [self.getDevice(d) if isinstance(d, str) else d for d in devices]
-        return DeviceLocker(self, devices, timeout=timeout)
+        return DeviceLocker(self, devices, timeout=timeout, reserver=reserver)
+
+    def getOrLoadModule(self, name):
+        if name in self.modules:
+            return self.getModule(name)
+        if name in self.definedModules:
+            return self.loadDefinedModule(name)
+        return self.loadModule(name)
 
     def loadModule(self, moduleClassName, name=None, config=None, forceReload=False, importMod=None, execPath=None):
-        """Create a new instance of an user interface module.
+        """Create a new instance of a user interface module.
 
         Parameters
         ----------
@@ -602,7 +601,11 @@ class Manager(Qt.QObject):
         try:
             sh = Qt.QShortcut(Qt.QKeySequence(keys), win)
             sh.setContext(Qt.Qt.ApplicationShortcut)
-            sh.activated.connect(lambda *args: win.raise_())
+            def raiseWindow(*rargs):
+                win.setWindowState(win.windowState() & ~Qt.QtCore.Qt.WindowMinimized)
+                win.raise_()
+                win.activateWindow()
+            sh.activated.connect(raiseWindow)
         except:
             if self.exitOnError:
                 raise
@@ -668,28 +671,11 @@ class Manager(Qt.QObject):
         """
         Set the directory to which log messages are stored.
         """
-        was_temp = self._logFile is None
-        self._logFile = d["log.json"]
-        file_handler = setup_logging(
-            self._logFile.name(),
-            acq4_level=self._rootLogLevel,
-            console_level=self._consoleLogLevel,
-        )
+        # start a new log file in the new directory
+        # also migrates any temporary log messages to the new file
+        set_log_file(d["log.json"].name())
+
         self.sigLogDirChanged.emit(d)
-        if was_temp:
-            try:
-                with open(TEMP_LOG, 'r') as f:
-                    for line in f:
-                        file_handler.emit(HistoricLogRecord(**(json.loads(line))))
-            finally:
-                os.remove(TEMP_LOG)
-            log_win = get_log_window()
-            with open(self._logFile.name(), 'r') as f:
-                for i, line in enumerate(f):
-                    log_win.new_record(HistoricLogRecord(**(json.loads(line))), sort=False)
-                    if i % 20 == 0:
-                        Qt.QApplication.processEvents()
-            log_win.ensure_chronological_sorting()
 
     def setCurrentDir(self, d):
         """
@@ -812,23 +798,22 @@ class Manager(Qt.QObject):
             with pg.ProgressDialog("Shutting down..", 0, lm + ld, cancelText=None, wait=0) as dlg:
                 self.documentation.quit()
 
-                logger.debug("Requesting all modules shut down..")
-                logger.info("Shutting Down.")
+                logger.info("Requesting all modules shut down..")
                 while len(self.modules) > 0:  ## Modules may disappear from self.modules as we ask them to quit
                     m = list(self.modules.keys())[0]
-                    logger.debug(f"    {m}")
+                    logger.info(f"    Closing {m}")
 
                     self.unloadModule(m)
                     dlg.setValue(lm - len(self.modules))
 
-                logger.debug("Requesting all devices shut down..")
+                logger.info("Requesting all devices shut down..")
                 devs = Device._deviceCreationOrder[::-1]
                 for d in devs:  # shut down in reverse order
                     d = d()
                     if d is None:
                         # device was already deleted
                         continue
-                    logger.debug(f"    {d}")
+                    logger.info(f"    Closing {d}")
                     try:
                         d.quit()
                     except:
@@ -836,10 +821,10 @@ class Manager(Qt.QObject):
 
                     dlg.setValue(lm + ld - len(devs))
 
-                logger.debug("Closing windows..")
+                logger.info("Closing windows..")
                 Qt.QApplication.instance().closeAllWindows()
                 Qt.QApplication.instance().processEvents()
-            logger.debug("\n    ciao.")
+            logger.info("\n    ciao.")
         Qt.QApplication.quit()
 
 
@@ -848,51 +833,6 @@ def getManager() -> Manager:
     if Manager.single is None:
         raise RuntimeError("No manager created yet")
     return Manager.single
-
-
-class DeviceLocker(object):
-    def __init__(self, manager, devices, timeout=10.0):
-        # make sure we lock devices in a predictable order; this is what prevents deadlocks
-        self.devices = sorted(devices, key=lambda d: d.name())
-        self.locked = []
-        self.timeout = timeout
-        self.lockErr = None
-
-    def tryLock(self, timeout=None):
-        try:
-            for device in self.devices:
-                devLocked = device.reserve(block=True, timeout=timeout)
-                if not devLocked:
-                    self.lockErr = "Timed out waiting for %s" % device.name()
-                    self.unlock()
-                    return False
-                self.locked.append(device)
-
-            return True
-        except Exception:
-            self.unlock()
-            raise
-
-    def lock(self):
-        locked = self.tryLock(timeout=self.timeout)
-        if not locked:
-            self.unlock()
-            raise RuntimeError("Failed to lock devices: %s" % self.lockErr)
-
-    def unlock(self):
-        for device in self.locked:
-            try:
-                device.release()
-            except:
-                pass
-        self.locked = []
-
-    def __enter__(self):
-        self.lock()
-        return self
-
-    def __exit__(self, *args):
-        self.unlock()
 
 
 class Task:
@@ -1011,7 +951,7 @@ class Task:
             try:
 
                 ## Reserve all hardware
-                self.reserveDevices()
+                self.reserveDevices(reserver=f"Task[{self.id}].execute")
 
                 prof.mark('reserve')
 
@@ -1199,10 +1139,12 @@ class Task:
             self.stop()
             return self.result
 
-    def reserveDevices(self):
+    def reserveDevices(self, reserver: str = None):
+        if reserver is None:
+            reserver = f"Task[{self.id}]"
         if self.deviceLock is None:
             try:
-                self.deviceLock = self.dm.reserveDevices(list(self.tasks.keys()))
+                self.deviceLock = self.dm.reserveDevices(list(self.tasks.keys()), reserver=reserver)
                 self.deviceLock.lock()
             except Exception:
                 self.deviceLock = None

--- a/acq4/devices/OptomechDevice.py
+++ b/acq4/devices/OptomechDevice.py
@@ -6,11 +6,31 @@ import numpy as np
 
 import pyqtgraph as pg
 from acq4.Interfaces import InterfaceMixin
+from acq4.modules.Visualize3D import Visualize3D
 from acq4.util import Qt
 from acq4.util.Mutex import Mutex
-from acq4.util.geometry import Geometry
+from acq4.util.geometry import Plane, Geometry, load_transform_from_anything
+from coorx import SRT3DTransform, Transform
+from pyqtgraph import opengl as gl
+from pyqtgraph.parametertree import Parameter
 
-TransformCache = "int | None | pg.SRTTransform3D"
+
+def map_through_transform(
+    obj: tuple | list | Qt.QPointF | Qt.QVector3D | np.ndarray, tr: Transform
+):
+    """Map an object through a transform."""
+    if not isinstance(tr, Transform):
+        raise TypeError(f"Transform must be a coorx Transform, not {type(tr)}")
+
+    # handle special types
+    if isinstance(obj, Qt.QPointF):
+        return tr.map([obj.x(), obj.y()])
+    elif isinstance(obj, Qt.QVector3D):
+        return tr.map([obj.x(), obj.y(), obj.z()])
+    elif isinstance(obj[0], (Qt.QPointF, Qt.QVector3D)):
+        return [map_through_transform(o, tr) for o in obj]
+
+    return tr.map(obj)
 
 
 class OptomechDevice(InterfaceMixin):
@@ -29,7 +49,8 @@ class OptomechDevice(InterfaceMixin):
     physical location.
 
     In most cases, the transformation will be in the form of an affine matrix multiplication.
-    Devices are free, however, to define an arbitrary transformation as well.
+    Devices are free, however, to define an arbitrary transformation as well using custom subclasses of
+    coorx.Transform.
 
     Devices may also have selectable sub-devices, providing a set of interchangeable transforms.
     For example, a microscope with multiple objectives may define one sub-device per objective.
@@ -93,7 +114,9 @@ class OptomechDevice(InterfaceMixin):
         # Emitted when this device changes its current subdevice
         sigSubdeviceChanged = Qt.Signal(object, object, object)  # self, new subdev, old subdev
         # Emitted when this device or any (grand)parent changes its current subdevice
-        sigGlobalSubdeviceChanged = Qt.Signal(object, object, object, object)  # self, dev, new subdev, old subdev
+        sigGlobalSubdeviceChanged = Qt.Signal(
+            object, object, object, object
+        )  # self, dev, new subdev, old subdev
 
         # Emitted when this device changes its list of available subdevices
         sigSubdeviceListChanged = Qt.Signal(object)  # self
@@ -119,8 +142,9 @@ class OptomechDevice(InterfaceMixin):
         self.sigGlobalSubdeviceListChanged = self.__sigProxy.sigGlobalSubdeviceListChanged
         self.sigGeometryChanged = self.__sigProxy.sigGeometryChanged
 
+        # Redundant: Device also saves these
         self.__devManager = dm
-        self._omconfig = config  # Redundant: Device also saves this
+        self.__config = config
         self.__name = name
 
         # __ports is a list of port names to which devices may be attached.
@@ -140,13 +164,10 @@ class OptomechDevice(InterfaceMixin):
 
         # and might not be cacheable.
         # Transformation from this device to its parent (or to global if there is no parent)
-        self.__transform: pg.SRTTransform3D = pg.SRTTransform3D()
-        # 0 indicates the cache is invalid. None indicates the transform is non-affine,
-        self.__inverseTransform: TransformCache = 0
-        self.__globalTransform: TransformCache = 0
-        self.__inverseGlobalTransform: TransformCache = 0
-        self.__globalPhysicalTransform: TransformCache = 0
-        self.__inverseGlobalPhysicalTransform: TransformCache = 0
+        self.__transform: SRT3DTransform = SRT3DTransform(dims=(3, 3))
+        # None indicates the cache is invalid
+        self.__globalTransform: None | Transform = None
+        self.__globalPhysicalTransform: None | Transform = None
 
         # Contains {port: [list of optics]} describing the optics (usually filters) for each port
         self.__optics = {}
@@ -157,11 +178,19 @@ class OptomechDevice(InterfaceMixin):
 
         self.__lock = Mutex(recursive=True, debug=False)
 
-        self.sigTransformChanged.connect(self.__emitGlobalTransformChanged, type=Qt.Qt.DirectConnection)
-        self.sigSubdeviceTransformChanged.connect(self.__emitGlobalSubdeviceTransformChanged, type=Qt.Qt.DirectConnection)
+        self.sigTransformChanged.connect(
+            self.__emitGlobalTransformChanged, type=Qt.Qt.DirectConnection
+        )
+        self.sigSubdeviceTransformChanged.connect(
+            self.__emitGlobalSubdeviceTransformChanged, type=Qt.Qt.DirectConnection
+        )
         self.sigOpticsChanged.connect(self.__emitGlobalOpticsChanged, type=Qt.Qt.DirectConnection)
-        self.sigSubdeviceChanged.connect(self.__emitGlobalSubdeviceChanged, type=Qt.Qt.DirectConnection)
-        self.sigSubdeviceListChanged.connect(self.__emitGlobalSubdeviceListChanged, type=Qt.Qt.DirectConnection)
+        self.sigSubdeviceChanged.connect(
+            self.__emitGlobalSubdeviceChanged, type=Qt.Qt.DirectConnection
+        )
+        self.sigSubdeviceListChanged.connect(
+            self.__emitGlobalSubdeviceListChanged, type=Qt.Qt.DirectConnection
+        )
 
         if config is not None:
             if "parentDevice" in config:
@@ -177,7 +206,9 @@ class OptomechDevice(InterfaceMixin):
                 except Exception as ex:
                     if "No device named" not in ex.args[0]:
                         raise
-                    print(f"Cannot set parent device {config['parentDevice']!r}; no device by that name.")
+                    print(
+                        f"Cannot set parent device {config['parentDevice']!r}; no device by that name."
+                    )
                     print("Available devices:", dm.listDevices())
             if "transform" in config:
                 self.setDeviceTransform(config["transform"])
@@ -189,13 +220,17 @@ class OptomechDevice(InterfaceMixin):
 
         # declare that this device supports the OptomechDevice API
         self.addInterface("OptomechDevice")
-        dm.declareInterface(name, ["OptomechDevice"], self)
+        self.addInterface(Visualize3D.interfaceName)
+        dm.declareInterface(name, ["OptomechDevice", Visualize3D.interfaceName], self)
+
+    def visualize3DAdapter(self, win):
+        return OptomechDeviceVisualizerAdapter(self, win)
 
     def getGeometry(self, name=None) -> Geometry | None:
-        if "geometry" in self._omconfig:
+        if "geometry" in self.__config:
             name = self.geometryCacheKey if name is None else name
             return Geometry(
-                config=self._omconfig["geometry"],
+                config=self.__config["geometry"],
                 name=f"[primary geometry of {name}]",
                 parent_name=name,
             )
@@ -238,11 +273,17 @@ class OptomechDevice(InterfaceMixin):
         with self.__lock:
             # disconnect from previous parent if needed
             if self.__parent is not None:
-                self.__parent.sigGlobalTransformChanged.disconnect(self.__parentDeviceTransformChanged)
-                self.__parent.sigGlobalSubdeviceTransformChanged.disconnect(self.__parentSubdeviceTransformChanged)
+                self.__parent.sigGlobalTransformChanged.disconnect(
+                    self.__parentDeviceTransformChanged
+                )
+                self.__parent.sigGlobalSubdeviceTransformChanged.disconnect(
+                    self.__parentSubdeviceTransformChanged
+                )
                 self.__parent.sigGlobalOpticsChanged.disconnect(self.__parentOpticsChanged)
                 self.__parent.sigGlobalSubdeviceChanged.disconnect(self.__parentSubdeviceChanged)
-                self.__parent.sigGlobalSubdeviceListChanged.disconnect(self.__parentSubdeviceListChanged)
+                self.__parent.sigGlobalSubdeviceListChanged.disconnect(
+                    self.__parentSubdeviceListChanged
+                )
                 self.__parent.__children.remove(self)
 
             # look up device from its name
@@ -257,14 +298,25 @@ class OptomechDevice(InterfaceMixin):
 
             if port not in parent.ports():
                 raise ValueError(
-                    "Cannot connect to port %r on device %r; available ports are: %r" % (port, parent, parent.ports())
+                    "Cannot connect to port %r on device %r; available ports are: %r"
+                    % (port, parent, parent.ports())
                 )
 
-            parent.sigGlobalTransformChanged.connect(self.__parentDeviceTransformChanged, type=Qt.Qt.DirectConnection)
-            parent.sigGlobalSubdeviceTransformChanged.connect(self.__parentSubdeviceTransformChanged, type=Qt.Qt.DirectConnection)
-            parent.sigGlobalOpticsChanged.connect(self.__parentOpticsChanged, type=Qt.Qt.DirectConnection)
-            parent.sigGlobalSubdeviceChanged.connect(self.__parentSubdeviceChanged, type=Qt.Qt.DirectConnection)
-            parent.sigGlobalSubdeviceListChanged.connect(self.__parentSubdeviceListChanged, type=Qt.Qt.DirectConnection)
+            parent.sigGlobalTransformChanged.connect(
+                self.__parentDeviceTransformChanged, type=Qt.Qt.DirectConnection
+            )
+            parent.sigGlobalSubdeviceTransformChanged.connect(
+                self.__parentSubdeviceTransformChanged, type=Qt.Qt.DirectConnection
+            )
+            parent.sigGlobalOpticsChanged.connect(
+                self.__parentOpticsChanged, type=Qt.Qt.DirectConnection
+            )
+            parent.sigGlobalSubdeviceChanged.connect(
+                self.__parentSubdeviceChanged, type=Qt.Qt.DirectConnection
+            )
+            parent.sigGlobalSubdeviceListChanged.connect(
+                self.__parentSubdeviceListChanged, type=Qt.Qt.DirectConnection
+            )
             parent.__children.append(self)
             self.__parent = parent
             self.__parentPort = port
@@ -272,23 +324,12 @@ class OptomechDevice(InterfaceMixin):
     def mapToParentDevice(self, obj, subdev=None):
         """Map from local coordinates to the parent device (or to global if there is no parent)"""
         tr = self.deviceTransform(subdev)
-        if tr is None:
-            raise ValueError("Cannot map--device classes with no affine transform must override map methods.")
-        return self._mapTransform(obj, tr)
+        return map_through_transform(obj, tr)
 
     def mapToGlobal(self, obj, subdev=None):
         """Map *obj* from local coordinates to global."""
         tr = self.globalTransform(subdev)
-        if tr is not None:
-            return self._mapTransform(obj, tr)
-        # If our transformation is nonlinear, then the local mapping step must be done separately.
-        subdev = self._subdevDict(subdev)
-        o2 = self.mapToParentDevice(obj, subdev)
-        parent = self.parentDevice()
-        if parent is None:
-            return o2
-        else:
-            return parent.mapToGlobal(o2, subdev)
+        return map_through_transform(obj, tr)
 
     def mapToDevice(self, device, obj, subdev=None):
         """Map *obj* from local coordinates to *device*'s coordinate system."""
@@ -298,29 +339,12 @@ class OptomechDevice(InterfaceMixin):
     def mapFromParentDevice(self, obj, subdev=None):
         """Map *obj* from parent coordinates (or from global if there is no parent) to local coordinates."""
         tr = self.inverseDeviceTransform(subdev)
-        if tr is None:
-            raise ValueError("Cannot map--device classes with no affine transform must override map methods.")
-        return self._mapTransform(obj, tr)
+        return map_through_transform(obj, tr)
 
     def mapFromGlobal(self, obj, subdev=None):
         """Map *obj* from global to local coordinates."""
         tr = self.inverseGlobalTransform(subdev)
-        if tr is not None:
-            return self._mapTransform(obj, tr)
-
-        # If our transformation is nonlinear, then the local mapping step must be done separately.
-        raise NotImplementedError("The rest of this method has never been tested.")
-        # subdev = self._subdevDict(subdev)
-        # parent = self.parentDevice()
-        # if parent is not None:
-        #     obj = parent.mapFromGlobal(obj, subdev)
-        # return self.mapFromParentDevice(obj, subdev)
-
-    def mapFromDevice(self, device, obj, subdev=None):
-        """Map *obj* from the coordinate system of the specified *device* to local coordinates."""
-        raise NotImplementedError("This method has never been tested.")
-        # subdev = self._subdevDict(subdev)
-        # return self.mapFromGlobal(device.mapToGlobal(obj, subdev), subdev)
+        return map_through_transform(obj, tr)
 
     def mapGlobalToParent(self, obj, subdev=None):
         """Map *obj* from global coordinates to the parent device coordinates.
@@ -340,44 +364,6 @@ class OptomechDevice(InterfaceMixin):
         else:
             return self.parentDevice().mapToGlobal(obj, subdev)
 
-    def _mapTransform(self, obj, tr):
-        """Map an object through a transform.
-
-        *obj* may be tuple, list, QPointF, QVector3D, or ndarray.
-        Mapping multiple points at once is only supported with ndarray.
-        """
-        # convert to a type that can be mapped
-        retType = None
-        if isinstance(obj, (tuple, list)):
-            retType = type(obj)
-            if np.isscalar(obj[0]):
-                if len(obj) == 2:
-                    obj = Qt.QPointF(*obj)
-                elif len(obj) == 3:
-                    obj = Qt.QVector3D(*obj)
-                else:
-                    raise TypeError(f"Cannot map {type(obj).__name__} of length {len(obj)}.")
-            elif isinstance(obj[0], np.ndarray):
-                obj = np.concatenate([x[np.newaxis, ...] for x in obj])
-            else:
-                raise TypeError(f"Cannot map--object of type {type(obj[0])}")
-
-        if isinstance(obj, Qt.QPointF):
-            ret = tr.map(obj)
-            if retType is not None:
-                return retType([ret.x(), ret.y()])
-            return ret
-        elif isinstance(obj, Qt.QVector3D):
-            ret = tr.map(obj)
-            if retType is not None:
-                return retType([ret.x(), ret.y(), ret.z()])
-            return ret
-
-        elif isinstance(obj, np.ndarray):
-            return pg.transformCoordinates(tr, obj)
-        else:
-            raise TypeError(f"Cannot map--object of type {type(obj)}")
-
     def deviceTransform(self, subdev=None):
         """
         Return this device's affine transformation matrix.
@@ -396,104 +382,54 @@ class OptomechDevice(InterfaceMixin):
 
             # if a subdevice is specified, multiply by the subdevice's transform before returning
             dev = self.getSubdevice(subdev)
-            if dev is None:
-                return tr * 1  # *1 makes a copy
-            else:
+            if dev is not None:
                 return tr * dev.deviceTransform()
+            return tr
 
     def inverseDeviceTransform(self, subdev=None):
         """
         See deviceTransform; this method returns the inverse.
         """
-        invtr = self.__inverseTransform
-        if invtr == 0:
-            tr = self.__transform * 1  # *1 makes a copy
-            if tr is None:
-                invtr = None
-            else:
-                inv, invertible = tr.inverted()
-                if not invertible:
-                    raise Exception("Transform is not invertible.")
-                invtr = inv
-            self.__inverseTransform = invtr
-        tr = Qt.QMatrix4x4(invtr)
-        if subdev == 0:  # indicates we should skip any subdevices
-            return tr
-        # if a subdevice is specified, multiply by the subdevice's transform before returning
-        dev = self.getSubdevice(subdev)
-        if dev is None:
-            return tr
-        else:
-            return dev.inverseDeviceTransform() * tr
+        return self.deviceTransform(subdev).inverse
 
     def setDeviceTransform(self, tr):
-        if isinstance(tr, dict):
-            allowed = {"pos", "scale", "angle", "axis"}
-            if len(set(tr.keys()) - allowed) > 0:
-                raise ValueError(f"Illegal args while creating a transform ({tr})")
+        tr = load_transform_from_anything(tr)
         with self.__lock:
-            self.__transform = pg.SRTTransform3D(tr)
+            self.__transform = tr
             self.invalidateCachedTransforms()
 
         self.sigTransformChanged.emit(self)
 
-    def globalTransform(self, subdev=None) -> pg.SRTTransform3D:
+    def globalTransform(self, subdev=None) -> SRT3DTransform | None:
         """
         Return the transform mapping from local device coordinates to global coordinates.
-        If the resulting transform is non-affine, then None is returned and the mapTo/mapFrom
-        methods must be used instead.
 
         If *subdev* is given, it must be a dictionary of {deviceName: subdevice} or
         {deviceName: subdeviceName} pairs specifying the state to compute.
         """
         if subdev is not None:
             return self.__computeGlobalTransform(subdev)
-        if self.__globalTransform == 0:
+        if self.__globalTransform is None:
             self.__globalTransform = self.__computeGlobalTransform()
-        return self.__globalTransform * 1  # *1 makes a copy
+        return self.__globalTransform
 
-    def __computeGlobalTransform(self, subdev=None, inverse=False):
-        # subdev must be a dict
+    def __computeGlobalTransform(self, subdev: dict | None = None):
         parent = self.parentDevice()
         if parent is None:
-            parentTr = pg.SRTTransform3D()
-        else:
-            parentTr = parent.globalTransform(subdev)
-        if parentTr is None:
-            return None
-        deviceTr = self.deviceTransform(subdev)
-        if deviceTr is None:
-            return None
-        transform = (parentTr * 1) * deviceTr
-
-        if not inverse:
-            return transform
-        inv, invertible = transform.inverted()
-        if not invertible:
-            raise ValueError("Transform is not invertible.")
-        return inv
+            return self.deviceTransform(subdev)
+        return parent.globalTransform(subdev) * self.deviceTransform(subdev)
 
     def inverseGlobalTransform(self, subdev=None):
         """
         See globalTransform; this method returns the inverse.
         """
-        if subdev is not None:
-            return self.__computeGlobalTransform(subdev, inverse=True)
-        if self.__inverseGlobalTransform == 0:
-            tr = self.globalTransform()
-            if tr is None:
-                self.__inverseGlobalTransform = None
-            else:
-                inv, invertible = tr.inverted()
-                if not invertible:
-                    raise ValueError("Transform is not invertible.")
-                self.__inverseGlobalTransform = inv
-        return self.__inverseGlobalTransform * 1  # *1 makes a copy
+        return self.globalTransform(subdev).inverse
 
     def physicalTransform(self, subdev=None):
         """
-        Return the transform mapping from local device coordinates to physical coordinates.
-        This is the same as deviceTransform. Override this if your device has optical transformations.
+        Return the transform mapping from local device coordinates to parent physical coordinates,
+        much the same as deviceTransform. Override this if your device can distinguish optical
+        transformations from physical ones.
         """
         return self.deviceTransform(subdev)
 
@@ -501,53 +437,32 @@ class OptomechDevice(InterfaceMixin):
         """
         See physicalTransform; this method returns the inverse.
         """
-        return self.inverseDeviceTransform(subdev)
+        return self.physicalTransform(subdev).inverse
 
     def globalPhysicalTransform(self, subdev=None):
         """
         Return the transform mapping from local device coordinates to global physical coordinates.
         This is the same as globalTransform, except that the transform is not affected by the
-        current subdevice selection.
+        optical properties of any devices in the hierarchy.
         """
         if subdev is not None:
             return self.__computeGlobalPhysicalTransform(subdev)
-        if self.__globalPhysicalTransform == 0:
+        if self.__globalPhysicalTransform is None:
             self.__globalPhysicalTransform = self.__computeGlobalPhysicalTransform()
-        return self.__globalPhysicalTransform * 1  # *1 makes a copy
+        return self.__globalPhysicalTransform
 
     def inverseGlobalPhysicalTransform(self, subdev=None):
         """
         See globalPhysicalTransform; this method returns the inverse.
         """
-        if subdev is not None:
-            return self.__computeGlobalPhysicalTransform(subdev, inverse=True)
-        if self.__inverseGlobalPhysicalTransform == 0:
-            tr = self.globalPhysicalTransform()
-            inv, invertible = tr.inverted()
-            if not invertible:
-                raise ValueError("Transform is not invertible.")
-            self.__inverseGlobalPhysicalTransform = inv
-        return self.__inverseGlobalPhysicalTransform * 1
+        return self.globalPhysicalTransform(subdev).inverse
 
-    def __computeGlobalPhysicalTransform(self, subdev=None, inverse=False):
+    def __computeGlobalPhysicalTransform(self, subdev=None):
         parent = self.parentDevice()
         if parent is None:
-            parentTr = pg.SRTTransform3D()
-        else:
-            parentTr = parent.globalPhysicalTransform(subdev)
-        if parentTr is None:
-            return None
-        deviceTr = self.physicalTransform(subdev)
-        if deviceTr is None:
-            return None
-        transform = parentTr * deviceTr
+            return self.physicalTransform(subdev)
 
-        if not inverse:
-            return transform
-        inv, invertible = transform.inverted()
-        if not invertible:
-            raise ValueError("Transform is not invertible.")
-        return inv
+        return parent.globalPhysicalTransform(subdev) * self.physicalTransform(subdev)
 
     def listOptics(self, port="default"):
         """Return a list of Optics this device adds to the optical
@@ -645,12 +560,8 @@ class OptomechDevice(InterfaceMixin):
 
     def invalidateCachedTransforms(self, invalidateLocal=True):
         with self.__lock:
-            if invalidateLocal:
-                self.__inverseTransform = 0
-            self.__globalTransform = 0
-            self.__inverseGlobalTransform = 0
-            self.__globalPhysicalTransform = 0
-            self.__inverseGlobalPhysicalTransform = 0
+            self.__globalTransform = None
+            self.__globalPhysicalTransform = None
 
         # child global transforms must also be invalidated before any change signals are emitted
         for ch in self.__children:
@@ -659,7 +570,9 @@ class OptomechDevice(InterfaceMixin):
     def addSubdevice(self, subdev):
         subdev.setParentDevice(self)
         self.invalidateCachedTransforms()
-        subdev.sigTransformChanged.connect(self.__subdeviceTransformChanged, type=Qt.Qt.DirectConnection)
+        subdev.sigTransformChanged.connect(
+            self.__subdeviceTransformChanged, type=Qt.Qt.DirectConnection
+        )
         subdev.sigOpticsChanged.connect(self.__subdeviceOpticsChanged, type=Qt.Qt.DirectConnection)
         with self.__lock:
             self.__subdevices[subdev.name()] = subdev
@@ -762,14 +675,14 @@ class OptomechDevice(InterfaceMixin):
         """Return the Z position of this device's origin, mapped to the global coordinate system."""
         return self.mapToGlobal([0, 0, 0])[2]
 
-    def setFocusDepth(self, depth, speed="slow"):
+    def setFocusDepth(self, depth, speed="slow", name=None):
         """Set microscope focus such that this device's origin is moved to the specified global Z position."""
         dev = self.getFocusDevice()
         if dev is None:
             raise ValueError(f"Device {dev} is not connected to a focus controller.")
         dz = depth - self.getFocusDepth()
         dpos = dev.globalPosition()
-        return dev.moveToGlobal([dpos[0], dpos[1], dpos[2] + dz], speed)
+        return dev.moveToGlobal([dpos[0], dpos[1], dpos[2] + dz], speed, name=name)
 
     def getFocusDevice(self):
         """Return the device that provides focus capabilities for this device."""
@@ -816,17 +729,17 @@ class DeviceTreeItemGroup(pg.ItemGroup):
         """Construct a QGraphicsItemGroup for the specified device/subdevice.
         This is a good method to extend in subclasses."""
         newGroup = Qt.QGraphicsItemGroup()
-        newGroup.setTransform(pg.SRTTransform(dev.deviceTransform(subdev)))
+        newGroup.setTransform(dev.deviceTransform(subdev).as_pyqtgraph().as2D())
         return newGroup
 
     def transformChanged(self, sender, device):
         for subdev, items in self.groups[device].items():
-            tr = pg.SRTTransform(device.deviceTransform(subdev))
+            tr = device.deviceTransform(subdev).as_pyqtgraph().as2D()
             for item in items:
                 item.setTransform(tr)
 
     def subdevTransformChanged(self, sender, device, subdev):
-        tr = pg.SRTTransform(device.deviceTransform(subdev))
+        tr = device.deviceTransform(subdev).as_pyqtgraph().as2D()
         for item in self.groups[device][subdev]:
             item.setTransform(tr)
 
@@ -887,3 +800,128 @@ class DeviceTreeItemGroup(pg.ItemGroup):
         for subdev, items in self.groups[device].items():
             groups.extend(items)
         return groups
+
+
+class OptomechDeviceVisualizerAdapter(Qt.QObject):
+    def __init__(self, dev: OptomechDevice, win: "VisualizerWindow"):
+        super().__init__()
+        self.device = dev
+        self.win = win
+        self._param = None
+        self._limits = None
+        self._mesh = None
+
+        dev.sigGeometryChanged.connect(self.handleGeometryChange)
+        self._geometry = dev.getGeometry()
+        if self._geometry is None:
+            return
+
+        self._mesh = self._geometry.glMesh()
+
+        # Add geometry to the scene
+        self.win.add3DItem(self._mesh)
+        dev.sigGlobalTransformChanged.connect(self.handleTransformUpdate)
+        self.handleTransformUpdate(dev, dev)
+
+        if bounds := dev.getBoundaries():
+            self._limits = self.createBounds(bounds, False)
+
+        self._param = self._buildControlParam()
+        self.win.addControls(self._param)
+
+    def _buildControlParam(self):
+        children = [
+            dict(name='Geometry', type='bool', value=True),
+            dict(name='Center View', type='action'),
+        ]
+        if self._limits is not None:
+            children.append(dict(name='Range of Motion', type='bool', value=False))
+
+        param = Parameter.create(name=self.device.name(), type='bool', value=True, children=children)
+        param.sigValueChanged.connect(self._handleDeviceToggle)
+        param.child('Geometry').sigValueChanged.connect(self._handleGeometryVisible)
+        param.child('Center View').sigActivated.connect(self._handleCenterView)
+        if self._limits is not None:
+            param.child('Range of Motion').sigValueChanged.connect(self._handleLimitsVisible)
+        return param
+
+    def _handleCenterView(self) -> None:
+        pos = self.device.globalPhysicalTransform().map((0, 0, 0))
+        self.win.centerOnPosition(pos)
+
+    def _handleDeviceToggle(self, param, value):
+        for child in param.children():
+            child.setOpts(enabled=value)
+        self._updateMeshVisibility()
+        self._updateLimitsVisibility()
+
+    def _handleGeometryVisible(self, param, value):
+        self._updateMeshVisibility()
+
+    def _handleLimitsVisible(self, param, value):
+        self._updateLimitsVisibility()
+
+    def _updateMeshVisibility(self):
+        if self._mesh is None or self._param is None:
+            return
+        self._mesh.setVisible(
+            self._param.value() and self._param.child('Geometry').value()
+        )
+
+    def _updateLimitsVisibility(self):
+        if self._limits is None or self._param is None:
+            return
+        try:
+            limits_on = self._param.child('Range of Motion').value()
+        except KeyError:
+            return
+        self._limits.setVisible(self._param.value() and limits_on)
+
+    def handleTransformUpdate(self, moved_device: "OptomechDevice", cause_device: "OptomechDevice"):
+        geom = self._geometry
+        if geom is None:
+            return
+        xform = moved_device.globalPhysicalTransform() * geom.transform
+        self.setMeshTransform(moved_device, xform.as_pyqtgraph())
+
+    def handleGeometryChange(self, dev: "OptomechDevice"):
+        if self._mesh is not None:
+            self.win.remove3DItem(self._mesh)
+        self._mesh = None
+
+        self._geometry = dev.getGeometry()
+        if self._geometry is not None:
+            self._mesh = self._geometry.glMesh()
+            self.win.add3DItem(self._mesh)
+            self._updateMeshVisibility()
+            self.handleTransformUpdate(dev, dev)
+
+    def setMeshTransform(self, dev, xform):
+        self._mesh.setTransform(xform)
+
+    def createBounds(self, bounds, visible):
+        edges = []
+        for a, b in Plane.wireframe(*bounds):
+            for bound in bounds:
+                if not (bound.allows_point(a) and bound.allows_point(b)):
+                    continue
+            if np.linalg.norm(a - b) > 0.1:
+                # being far away happens with not-quite-parallel planes; we can just pretend they're parallel
+                continue
+            edge = [a, b]
+            edges.extend(edge)
+        plot = gl.GLLinePlotItem(pos=np.array(edges), color=(1, 0, 0, 0.2), width=4, mode="lines")
+        plot.setVisible(visible)
+        self.win.add3DItem(plot)
+        return plot
+
+    def clear(self):
+        if self._mesh is not None:
+            self.win.remove3DItem(self._mesh)
+            self._mesh = None
+        if self._limits is not None:
+            self.win.remove3DItem(self._limits)
+            self._limits = None
+        if self._param is not None:
+            self.win.removeControls(self._param)
+            self._param = None

--- a/acq4/devices/Pipette/pipette.py
+++ b/acq4/devices/Pipette/pipette.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import contextlib
 import json
 import os
+import time
 import weakref
 from typing import List
 
@@ -17,12 +18,14 @@ from acq4.modules.Camera import CameraModuleInterface
 from acq4.util import Qt, ptime
 from acq4.util.future import future_wrap, Future
 from acq4.util.target import Target
+from coorx import AffineTransform
 from pyqtgraph import Point, siFormat
 from .planners import PipettePathGenerator
 from .planners import defaultMotionPlanners
 from .tracker import ResnetPipetteTracker
 from ..Camera import Camera
-from ..RecordingChamber import RecordingChamber
+from ...modules.Visualize3D.travelers_proxy import MovePathException
+from ..InteractionSite import InteractionSite
 from ...util.PromptUser import prompt
 from ...util.geometry import Plane
 from ...util.imaging.sequencer import run_image_sequence
@@ -250,7 +253,7 @@ class Pipette(Device, OptomechDevice):
             pos = self.globalPosition()
         manip_pos = self._solveGlobalStagePosition(pos)
         manip: Stage = self.parentStage
-        manip.checkLimits(manip.mapGlobalToDevicePosition(manip_pos))
+        manip.checkRangeOfMotion(manip_pos, name, tolerance=0)
 
         cache = self.readConfigFile('stored_positions')
         cache[name] = list(pos)
@@ -283,8 +286,8 @@ class Pipette(Device, OptomechDevice):
                     name = cams[0]
                 else:
                     raise Exception(
-                        "Pipette requires either a single imaging device available (found %d) or 'imagingDevice' specified in its configuration."
-                        % len(cams)
+                        "Pipette requires either a single imaging device available "
+                        f"(found {len(cams)}) or 'imagingDevice' specified in its configuration."
                     )
             self._imagingDev = man.getDevice(name)
         return self._imagingDev
@@ -293,7 +296,9 @@ class Pipette(Device, OptomechDevice):
         pass
 
     def stop(self):
-        self.keepOnStepping = False  # thread safety? if a user starts a new stepwise movement simultaneous with stopping, they deserve to have to stop a second or even third time.
+        # thread safety? if a user starts a new stepwise movement simultaneous with stopping, they
+        # deserve to have to stop a second or even third time.
+        self.keepOnStepping = False
         cmp = self.currentMotionPlanner
         if cmp is not None:
             cmp.stop()
@@ -302,10 +307,14 @@ class Pipette(Device, OptomechDevice):
         """Return a widget with a UI to put in the device rack"""
         return PipetteDeviceGui(self, win)
 
-    def cameraModuleInterface(self, mod):
-        iface = PipetteCamModInterface(self, mod, showUi=self._opts['showCameraModuleUI'])
+    def cameraModuleInterface(self, win):
+        iface = PipetteCamModInterface(self, win, showUi=self._opts['showCameraModuleUI'])
         self._camInterfaces[iface] = None
         return iface
+
+    def visualize3DAdapter(self, win):
+        from .visualization import PipetteVisualizerAdapter
+        return PipetteVisualizerAdapter(self, win)
 
     def tipOffsetIsReasonable(self, pos) -> bool:
         dist = np.linalg.norm(np.array(self.mapToGlobal((0, 0, 0))) - pos)
@@ -416,24 +425,34 @@ class Pipette(Device, OptomechDevice):
         path = self.dm.configFileName(path)
         path = self.dm.dirHandle(path, create=True)
 
+        pip_info = {
+            "tip position": self.globalPosition(),
+            "axis yaw": self.yawAngle(),
+            "axis pitch": self.pitchAngle(),
+        }
+
         cam: Camera = self.imagingDevice()
         with cam.ensureRunning():
             img = _future.waitFor(cam.acquireFrames(n=1, ensureFreshFrames=True)).getResult()[0]
-        img.addInfo({"tip position": self.globalPosition()})
+        img.addInfo(pip_info)
+        timestamp = time.strftime("%Y%m%d-%H%M%S")
         path.writeFile(
             img.data(),
-            "manual-calibration.ma",
+            f"manual-calibration-{timestamp}.ma",
             info=img.info(),
             autoIncrement=True,
         )
         if stack:
             depth = cam.getFocusDepth()
             is_below_surface = depth <= self.scopeDevice().getSurfaceDepth()
-            scan_dist = np.random.randint(2, 40 if is_below_surface else 100) * 1e-6
-            step = scan_dist / 2
+            scan_dist = (2 + (np.random.random()**2) * (100 if is_below_surface else 100)) * 1e-6
+            step = max(1e-6, scan_dist / 4)
             try:
                 seq_future = run_image_sequence(
-                    cam, z_stack=(depth - scan_dist, depth + scan_dist, step), storage_dir=path
+                    cam,
+                    z_stack=(depth - scan_dist, depth + scan_dist, step),
+                    storage_dir=path,
+                    name="manual calibration stack",
                 )
                 _future.waitFor(seq_future)
             finally:
@@ -441,7 +460,7 @@ class Pipette(Device, OptomechDevice):
             fh = seq_future.imagesSavedIn
             info = {
                 **fh.info(),
-                "tip position": self.globalPosition(),
+                **pip_info,
             }
             fh.setInfo(info)
 
@@ -450,8 +469,8 @@ class Pipette(Device, OptomechDevice):
 
         This method is for recalibration; it does not physically move the device.
         """
-        lpos = np.array(self.mapFromGlobal(pos))
-        self.setOffset(self.offset + lpos)
+        pos = self.mapGlobalToParent(np.array(pos))  # put the offset into our manipulator's coordinates
+        self.setOffset(pos)  # then that becomes our translation offset
 
     def setOffset(self, offset):
         self.offset = np.array(offset)
@@ -459,23 +478,17 @@ class Pipette(Device, OptomechDevice):
         self.sigCalibrationChanged.emit(self)
 
     def _updateTransform(self):
-        # matrix mapping from local to parent
         x = self.globalDirection()
         x[2] = 0
         x = x / np.linalg.norm(x)
         z = np.array([0, 0, 1])
-        y = np.cross(x, z)
+        y = np.cross(z, x)  # +y points left when looking down +x
         y = y / np.linalg.norm(y)
-        m = np.array(
-            [
-                [x[0], y[0], z[0], 0],
-                [x[1], y[1], z[1], 0],
-                [x[2], y[2], z[2], 0],
-                [0, 0, 0, 1],
-            ]
+        tr = AffineTransform(dims=(3, 3))
+        tr.set_mapping(
+            np.asarray([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 1]]),  # local
+            np.asarray([[0, 0, 0], x, y, z]) + self.offset,  # parent
         )
-        tr = pg.Transform3D(m)
-        tr.translate(*self.offset)
         self.setDeviceTransform(tr)
 
     def _directionChanged(self):
@@ -567,7 +580,7 @@ class Pipette(Device, OptomechDevice):
         WARNING: This method does _not_ implement any motion planning.
         """
 
-        self.sigMoveRequested.emit(self, path[-1][0], None, {'path': path})
+        self.sigMoveRequested.emit(self, path[-1][0], None, {'path': path, 'name': name})
         stagePath = []
         for pos, speed, linear, explanation in path:
             stagePos = self._solveGlobalStagePosition(pos)
@@ -581,7 +594,13 @@ class Pipette(Device, OptomechDevice):
             )
 
         stage = self.parentStage
-        return stage.movePath(stagePath, name=name)
+        try:
+            return stage.movePath(stagePath, name=name)
+        except MovePathException as e:
+            e.offset_points(self.offset)
+            adapter = self.dm.getOrLoadModule("Visualize3D").window().findAdapter(lambda a: a.device == self)
+            e.visualize(adapter)
+            raise e
 
     def approachDepth(self):
         """Return the global depth where the electrode should move to when starting approach mode.
@@ -649,7 +668,7 @@ class Pipette(Device, OptomechDevice):
         depth = self.globalPosition()[2]
         appDepth = self.approachDepth()
         if depth < appDepth:
-            return self.advance(appDepth, speed=speed)
+            return self.advance(appDepth, speed=speed, name='retract from surface')
         return Future.immediate()
 
     @future_wrap
@@ -660,6 +679,7 @@ class Pipette(Device, OptomechDevice):
         speed: float = 10e-6,
         interval: float = 5,
         step: float = 1e-6,
+        name: str | None = None,
         _future=None,
     ):
         """Retract/advance in small steps, allowing for manual user movements.
@@ -693,7 +713,7 @@ class Pipette(Device, OptomechDevice):
                 break  # overshot
             distance = np.linalg.norm(direction)
             next_pos = pos + step * direction / distance
-            _future.waitFor(self._moveToGlobal(next_pos, speed=speed, linear=True))
+            _future.waitFor(self._moveToGlobal(next_pos, speed=speed, linear=True, name=name))
             if distance <= step:
                 break
             _future.sleep(interval)
@@ -716,7 +736,7 @@ class Pipette(Device, OptomechDevice):
 
         pos = np.array(self.globalPosition())
         prev_dir = random_wiggle_direction()
-        for _ in range(repetitions):
+        for step_i in range(repetitions):
             with contextlib.ExitStack() as stack:
                 if extra is not None:
                     stack.enter_context(extra())
@@ -724,18 +744,18 @@ class Pipette(Device, OptomechDevice):
                 while ptime.time() - start < duration:
                     while np.dot(direction := random_wiggle_direction(), prev_dir) > 0:
                         pass  # ensure different direction from previous
-                    _future.waitFor(self._moveToGlobal(pos=pos + radius * direction, speed=speed))
+                    _future.waitFor(self._moveToGlobal(pos=pos + radius * direction, speed=speed, name=f"wiggle step {step_i}"))
                     prev_dir = direction
-                _future.waitFor(self._moveToGlobal(pos=pos, speed=speed))
+                _future.waitFor(self._moveToGlobal(pos=pos, speed=speed, name=f"wiggle return {step_i}"))
 
     def globalPosition(self):
         """Return the position of the electrode tip in global coordinates.
 
         Note: the position in local coordinates is always [0, 0, 0].
         """
-        return self.mapToGlobal([0, 0, 0])
+        return self.mapToGlobal(np.array([0, 0, 0]))
 
-    def _moveToGlobal(self, pos, speed, **kwds):
+    def _moveToGlobal(self, pos, speed, name=None, **kwds):
         """Move the electrode tip directly to the given position in global coordinates.
         WARNING: This method does _not_ implement any motion planning.
         """
@@ -743,10 +763,16 @@ class Pipette(Device, OptomechDevice):
         stagePos = self._solveGlobalStagePosition(pos)
         stage: Stage = self.parentStage
         try:
-            return stage.moveToGlobal(stagePos, speed, **kwds)
+            adapter = self.dm.getOrLoadModule("Visualize3D").window().findAdapter(lambda a: a.device == self)
+            if adapter is not None:
+                adapter.setPath([self.globalPosition(), pos])
+        except Exception:
+            self.logger.exception("Error visualizing pipette move path")
+        try:
+            return stage.moveToGlobal(stagePos, speed, name=name, **kwds)
         except Exception as exc:
             exc.add_note(
-                f"Moving {self} to global position {pos!r} (name={kwds.get('name', None)})"
+                f"Moving {self} to global position {pos!r} (name={name})"
             )
             raise exc
 
@@ -762,11 +788,11 @@ class Pipette(Device, OptomechDevice):
         dif = np.asarray(pos) - np.asarray(self.parentStage.globalPosition())
         return np.asarray(self.globalPosition()) + dif
 
-    def _moveToLocal(self, pos, speed, linear=False):
+    def _moveToLocal(self, pos, speed, linear=False, **kwds):
         """Move the electrode tip directly to the given position in local coordinates.
         WARNING: This method does _not_ implement any motion planning.
         """
-        return self._moveToGlobal(self.mapToGlobal(pos), speed, linear=linear)
+        return self._moveToGlobal(self.mapToGlobal(pos), speed, linear=linear, **kwds)
 
     def setTarget(self, target):
         self.target = np.array(target)
@@ -784,7 +810,7 @@ class Pipette(Device, OptomechDevice):
 
     def focusTip(self, speed='fast', raiseErrors=False):
         pos = self.globalPosition()
-        future = self.scopeDevice().setGlobalPosition(
+        future = self.imagingDevice().moveCenterToGlobal(
             pos, speed=speed, name=f"focus on {self.name()}"
         )
         if raiseErrors:
@@ -793,7 +819,7 @@ class Pipette(Device, OptomechDevice):
 
     def focusTarget(self, speed='fast', raiseErrors=False):
         pos = self.targetPosition()
-        future = self.scopeDevice().setGlobalPosition(
+        future = self.imagingDevice().moveCenterToGlobal(
             pos, speed=speed, name=f"focus on target for {self.name()}"
         )
         if raiseErrors:
@@ -813,14 +839,14 @@ class Pipette(Device, OptomechDevice):
         self.moving = False
         self.sigMoveFinished.emit(self, self.globalPosition())
 
-    def getRecordingChambers(self) -> List[RecordingChamber]:
+    def getRecordingChambers(self) -> List[InteractionSite]:
         """Return a list of RecordingChamber instances that are associated with this Pipette (see
         'recordingChambers' config option).
         """
         man = getManager()
         return [man.getDevice(d) for d in self.config.get('recordingChambers', [])]
 
-    def getCleaningWell(self) -> RecordingChamber | None:
+    def getCleaningWell(self) -> InteractionSite | None:
         """Return the RecordingChamber instance that is associated with this Pipette for cleaning
         (see 'cleaningWell' config option).
         """
@@ -829,9 +855,90 @@ class Pipette(Device, OptomechDevice):
             return None
         return self.dm.getDevice(name)
 
+    def getNucleusDepositionWell(self) -> InteractionSite | None:
+        """Return the RecordingChamber instance that is associated with this Pipette for nucleus expulsion
+        (see 'nucleusExpulsionWell' config option).
+        """
+        name = self.config.get('nucleusExpulsionWell', None)
+        if name is None:
+            return None
+        return self.dm.getDevice(name)
+
+    def getElectrodeSolutionWell(self) -> InteractionSite | None:
+        """Return the RecordingChamber instance that is associated with this Pipette for electrode solution
+        (see 'electrodeSolutionWell' config option).
+        """
+        name = self.config.get('electrodeSolutionWell', None)
+        if name is None:
+            return None
+        return self.dm.getDevice(name)
+
     def startRecording(self):
         """Return an object that records all motion updates from this pipette"""
         return PipetteRecorder(self)
+
+    @future_wrap
+    def iterativelyFindTip(self, max_reps=10, found_threshold=3e-6, delay_after_move=0.4, 
+                           max_allowed_offset=None, delay_after_update=0, reserve_devices=True,
+                           go_to_tip_first=False, _future=None):
+        """Iteratively refine the tip position by finding the tip in frame and focusing, until convergence.
+        
+        Returns if convergence is reached (tip position changes less than *found_threshold* between iterations) or after *max_reps* iterations.
+        Otherwise, raises an exception.
+
+        Parameters
+        ----------
+        max_reps : int
+            Maximum number of iterations to perform.
+            If exceeded before convergence, TimeoutError is raised.
+        found_threshold : float
+            Distance threshold (meters) for convergence.
+        delay_after_move : float
+            Time to wait (seconds) after each move before finding the tip again.
+        max_allowed_offset : float
+            Maximum allowed tip offset distance (meters).
+            If exceeded, ValueError is raised.
+        delay_after_update : float
+            Time to wait (seconds) after updating the tip position before the next iteration.
+            Default is 0; this is used to allow visual confirmation of the update before moving on.
+        reserve_devices : bool
+            If True, then devices will be reserved for the duration of this method.
+        go_to_tip_first : bool
+            If True, then the pipette will first move to the current tip position before starting the
+            iterative process.
+        """
+        imgr = self.imagingDevice()
+        manager = getManager()
+
+        with contextlib.ExitStack() as stack:
+            if reserve_devices:
+                stack.enter_context(manager.reserveDevices([self] + imgr.devicesToReserve(), timeout=30.0, reserver="Pipette.refineTipPosition"))
+            try:
+                last_pos = None
+                start_pos = self.globalPosition()
+                if go_to_tip_first:
+                    _future.waitFor(self.focusTip())
+                    _future.sleep(delay_after_move)
+                for _ in range(max_reps):
+                    pos = self.tracker.findTipInFrame()
+                    _future.waitFor(self.setTipOffsetIfAcceptable(pos), timeout=None)
+                    converged = last_pos is not None and np.linalg.norm(np.array(pos) - np.array(last_pos)) < found_threshold
+                    _future.sleep(delay_after_update)
+                    if converged:
+                        diff = np.linalg.norm(np.array(pos) - np.array(start_pos))
+                        if max_allowed_offset is not None and diff > max_allowed_offset:
+                            raise ValueError(f"Tip offset exceeded maximum allowed distance: {diff} > {max_allowed_offset}")
+                        return
+
+                    last_pos = pos
+                    _future.waitFor(self.focusTip())
+                    _future.sleep(delay_after_move)
+                raise TimeoutError(f"Iterative tip finding did not converge after {max_reps} iterations.")
+            except Exception as exc:
+                # reset position to start if we fail, to avoid leaving the pipette in a bad position
+                self.setTipOffset(start_pos)
+                raise exc
+        
 
     def findNewPipette(self):
         from acq4.devices.Pipette.calibration import findNewPipette
@@ -901,8 +1008,8 @@ class PipetteCamModInterface(CameraModuleInterface):
 
     canImage = False
 
-    def __init__(self, dev: "Pipette", mod, showUi=True):
-        CameraModuleInterface.__init__(self, dev, mod)
+    def __init__(self, dev: Pipette, win, showUi=True):
+        CameraModuleInterface.__init__(self, dev, win)
         self._haveTarget = False
         self._showUi = showUi
 
@@ -912,16 +1019,16 @@ class PipetteCamModInterface(CameraModuleInterface):
 
         self.calibrateAxis = Axis([0, 0], 0, inverty=False)
         self.calibrateAxis.setZValue(5000)
-        mod.addItem(self.calibrateAxis)
+        win.addItem(self.calibrateAxis)
         self.calibrateAxis.setVisible(False)
 
         self.centerArrow = pg.ArrowItem()
         self.centerArrow.setZValue(5000)
-        mod.addItem(self.centerArrow)
+        win.addItem(self.centerArrow)
 
         self.target = Target()
         self.target.setZValue(5000)
-        mod.addItem(self.target)
+        win.addItem(self.target)
         self.target.setVisible(False)
 
         # decide how / whether to add a label for the target
@@ -940,17 +1047,17 @@ class PipetteCamModInterface(CameraModuleInterface):
             self._updateTargetLabel()
 
         self.depthTarget = Target(movable=False)
-        mod.getDepthView().addItem(self.depthTarget)
+        win.getDepthView().addItem(self.depthTarget)
         self.depthTarget.setVisible(False)
 
         self.depthArrow = pg.ArrowItem(angle=180 - dev.yawAngle())
-        mod.getDepthView().addItem(self.depthArrow)
+        win.getDepthView().addItem(self.depthArrow)
 
         # self.ui.setOrientationBtn.toggled.connect(self.setOrientationToggled)
         self.ui.setOrientationBtn.setEnabled(False)
-        mod.window().getView().scene().sigMouseClicked.connect(self.sceneMouseClicked)
+        win.getView().scene().sigMouseClicked.connect(self.sceneMouseClicked)
         dev.sigGlobalTransformChanged.connect(self.transformChanged)
-        dev.scopeDevice().sigGlobalTransformChanged.connect(self.focusChanged)
+        dev.imagingDevice().sigGlobalTransformChanged.connect(self.focusChanged)
         dev.sigTargetChanged.connect(self.targetChanged)
         self.calibrateAxis.sigRegionChangeFinished.connect(self.calibrateAxisChanged)
         self.calibrateAxis.sigRegionChanged.connect(self.calibrateAxisChanging)
@@ -991,12 +1098,12 @@ class PipetteCamModInterface(CameraModuleInterface):
 
         if self.ui.setCenterBtn.isChecked():
             self.ui.setCenterBtn.setChecked(False)
-            pos = self.mod().getView().mapSceneToView(ev.scenePos())
+            pos = self.win().getView().mapSceneToView(ev.scenePos())
             self.calibrateAxis.setPos(pos)
 
         elif self.ui.setTargetBtn.isChecked():
-            pos = self.mod().getView().mapSceneToView(ev.scenePos())
-            z = self.getDevice().scopeDevice().getFocusDepth()
+            pos = self.win().getView().mapSceneToView(ev.scenePos())
+            z = self.getDevice().imagingDevice().getFocusDepth()
             self.setTargetPos(pos, z)
             self.target.setFocusDepth(z)
 
@@ -1016,7 +1123,7 @@ class PipetteCamModInterface(CameraModuleInterface):
         self.focusChanged()
 
     def targetDragged(self):
-        z = self.getDevice().scopeDevice().getFocusDepth()
+        z = self.getDevice().imagingDevice().getFocusDepth()
         self.setTargetPos(self.target.pos(), z)
         self.target.setFocusDepth(z)
 
@@ -1064,7 +1171,7 @@ class PipetteCamModInterface(CameraModuleInterface):
             tdepth = self.dev().targetPosition()[2]
         except RuntimeError:
             return
-        fdepth = self.dev().scopeDevice().getFocusDepth()
+        fdepth = self.dev().imagingDevice().getFocusDepth()
         self.target.setFocusDepth(fdepth)
 
     def calibrateAxisChanging(self):
@@ -1079,7 +1186,7 @@ class PipetteCamModInterface(CameraModuleInterface):
         angle = self.calibrateAxis.angle()
         size = self.calibrateAxis.size()
         dev = self.getDevice()
-        z = dev.scopeDevice().getFocusDepth()
+        z = dev.imagingDevice().getFocusDepth()
 
         # first orient the parent stage
         dev.setCalibratedOrientation(yaw=angle)

--- a/acq4/devices/Pipette/planners.py
+++ b/acq4/devices/Pipette/planners.py
@@ -94,10 +94,14 @@ class PipettePathGenerator:
 
         The returned path does _not_ include the starting position.
         """
+        man = getManager()
+        mod = man.getOrLoadModule("Visualize3D")
+        # grab the visualizer for visualizing errors
+        adapter = mod.window().findAdapter(lambda a: a.device == self.pip)
         explanation = explanation or MOVE_TO_DESTINATION
         globalStart = np.asarray(globalStart)
         globalStop = np.asarray(globalStop)
-        path = [(globalStart,)]
+        path = [(globalStart, "", False, "")]
 
         # retract first if we are doing a lateral movement inside the sample
         lateralDist = np.linalg.norm(globalStop[1:] - globalStart[1:])
@@ -123,6 +127,8 @@ class PipettePathGenerator:
         # consider two possible waypoints, pick the one closer to the inner position
         pitch = self.pip.pitchRadians()
         localDirection = np.array([np.cos(pitch), 0, -np.sin(pitch)])
+        if localDirection[0] == 0 or localDirection[2] == 0:
+            raise ValueError(f"Invalid pipette pitch {pitch}; cannot compute approach waypoints.")
         waypoint1 = innerPos - localDirection * abs((diff[0] / localDirection[0]))
         waypoint2 = innerPos - localDirection * abs((diff[2] / localDirection[2]))
         dist1 = np.linalg.norm(waypoint1 - innerPos)
@@ -139,16 +145,19 @@ class PipettePathGenerator:
 
         path = path[1:]  # trim off the start position
         for globalPos, speed, linear, stepName in path:
+            if not np.isfinite(globalPos).all():
+                raise ValueError(f"Invalid position {globalPos} for step '{stepName}' in path from {globalStart} to {globalStop}")
             try:
-                assert np.isfinite(globalPos).all()
                 # what global position should we ask the stage to move to in order for the pipette tip to reach globalPos
                 manipulatorGlobalPos = self.pip._solveGlobalStagePosition(globalPos)
                 # ask the stage to check whether this position is reachable
-                self.manipulator.checkGlobalLimits(manipulatorGlobalPos)
+                self.manipulator.checkGlobalLimits(manipulatorGlobalPos, linear)
             except Exception as e:
+                adapter.setPathError([globalStart] + [p[0] for p in path], failed_at=globalPos)
                 raise ValueError(
                     f"Moving {self.pip} to '{stepName}' would be beyond the limits of its manipulator: {e}"
                 ) from e
+        adapter.setPath([globalStart] + [p[0] for p in path])
         return path
 
     def enforceSafeSpeed(self, start, stop, speed, explanation, linear):
@@ -219,7 +228,7 @@ class GeometryAwarePathGenerator(PipettePathGenerator):
                 continue
             geom = dev.getGeometry()
             if geom is not None:
-                pg_xform = pg.SRTTransform3D(dev.globalPhysicalTransform())
+                pg_xform = dev.globalPhysicalTransform().as_pyqtgraph()
                 physical_xform = SRT3DTransform.from_pyqtgraph(
                     pg_xform,
                     from_cs=dev.geometryCacheKey,
@@ -227,7 +236,7 @@ class GeometryAwarePathGenerator(PipettePathGenerator):
                 )
                 geometries[geom] = physical_xform
         planner = GeometryMotionPlanner(geometries)
-        pg_xform = pg.SRTTransform3D(self.pip.globalPhysicalTransform())
+        pg_xform = self.pip.globalPhysicalTransform().as_pyqtgraph()
         from_pip_to_global = SRT3DTransform.from_pyqtgraph(
             pg_xform,
             from_cs=self.pip.geometryCacheKey,
@@ -241,10 +250,10 @@ class GeometryAwarePathGenerator(PipettePathGenerator):
             man = getManager()
             while not man.isReady.wait(0.05):
                 _future.checkStop()
-            mod = man.getModule("Visualize3D")
+            mod = man.getOrLoadModule("Visualize3D")
             while not mod.isReady.wait(0.05):
                 _future.checkStop()
-            viz = mod.window().pathPlanVisualizer(self.pip)
+            viz = mod.window().findAdapter(lambda a: a.device == self.pip).pathSearchVisualizer()
             planner, from_pip_to_global = self._getPlanningContext()
             planner.make_convolved_obstacles(self.pip.getGeometry(), from_pip_to_global, viz)
             print(f"cache primed for {self.pip.name()}")
@@ -275,7 +284,8 @@ class GeometryAwarePathGenerator(PipettePathGenerator):
             explanation = WAYPOINT_TO_AVOID_SAMPLE_TEAR
             globalStop = final_waypoint
 
-        viz = getManager().getModule("Visualize3D").window().pathPlanVisualizer(self.pip)
+        win = getManager().getOrLoadModule("Visualize3D").window()
+        viz = win.findAdapter(lambda a: a.device == self.pip).pathSearchVisualizer()
         planner, from_pip_to_global = self._getPlanningContext()
         try:
             path = planner.find_path(
@@ -315,11 +325,15 @@ class PipetteMotionPlanner:
         self.position = position
         self.speed = speed
         self.kwds = kwds
+        self.name = kwds.get("name", self._default_name())
 
         self.future = None
 
         # wrap safePath for convenience
         self.safePath = self.pip.pathGenerator.safePath
+
+    def _default_name(self):
+        return "move"
 
     def move(self):
         """Move the pipette to the requested named position and return a Future"""
@@ -334,7 +348,7 @@ class PipetteMotionPlanner:
             self.future.stop()
 
     def _move(self):
-        return self.pip._movePath(self.path(), name=f"{self.pip.name()} {type(self).__name__} path")
+        return self.pip._movePath(self.path(), name=f"{self.pip.name()} {self.name} path")
 
     def path(self):
         startPosGlobal = self.pip.globalPosition()
@@ -348,6 +362,9 @@ class PipetteMotionPlanner:
 class SavedPositionMotionPlanner(PipetteMotionPlanner):
     """Move to a saved position"""
 
+    def _default_name(self):
+        return f"move to {self.position}"
+
     def path(self):
         startPosGlobal = self.pip.globalPosition()
         endPosGlobal = self.pip.loadPosition(self.position)
@@ -355,6 +372,9 @@ class SavedPositionMotionPlanner(PipetteMotionPlanner):
 
 
 class CleanMotionPlanner(SavedPositionMotionPlanner):
+    def _default_name(self):
+        return f"move to {self.position}ing well"
+
     def path(self):
         if isinstance(self.pip.pathGenerator, GeometryAwarePathGenerator):
             return super().path()
@@ -396,6 +416,9 @@ class CleanMotionPlanner(SavedPositionMotionPlanner):
 class HomeMotionPlanner(PipetteMotionPlanner):
     """Extract pipette tip diagonally, then move to home position."""
 
+    def _default_name(self):
+        return "move to home"
+
     def path(self):
         manipulator = self.pip.parentDevice()
         manipulatorHome = manipulator.homePosition()
@@ -421,6 +444,9 @@ class SearchMotionPlanner(PipetteMotionPlanner):
     Negative values move the pipette past the center of the microscope to improve the
     probability of seeing the tip immediately.
     """
+
+    def _default_name(self):
+        return "search"
 
     @future_wrap
     def _move(self, _future):
@@ -459,6 +485,9 @@ class SearchMotionPlanner(PipetteMotionPlanner):
 
 
 class ApproachMotionPlanner(PipetteMotionPlanner):
+    def _default_name(self):
+        return "approach target"
+
     def path(self):
         pip = self.pip
         approachDepth = pip.approachDepth()
@@ -467,6 +496,9 @@ class ApproachMotionPlanner(PipetteMotionPlanner):
 
 
 class TargetMotionPlanner(PipetteMotionPlanner):
+    def _default_name(self):
+        return "move to target"
+
     def path(self):
         start = self.pip.globalPosition()
         stop = self.pip.targetPosition()
@@ -481,6 +513,9 @@ class AboveTargetMotionPlanner(PipetteMotionPlanner):
     nucleus extraction.
     """
 
+    def _default_name(self):
+        return "move above target"
+
     @future_wrap
     def _move(self, _future):
         pip = self.pip
@@ -489,7 +524,7 @@ class AboveTargetMotionPlanner(PipetteMotionPlanner):
         waypoint1, waypoint2 = self.aboveTargetPath()
 
         path = self.safePath(pip.globalPosition(), waypoint1, speed, APPROACH_TO_CORRECT_FOR_HYSTERESIS)
-        _future.waitFor(pip._movePath(path + [(waypoint2, "fast", True, "Above target")]))
+        _future.waitFor(pip._movePath(path + [(waypoint2, "fast", True, "Above target")], name=f"{pip.name()} above target path"))
         move_scope = scope.setGlobalPosition(waypoint2, name=f"move scope for {self.pip.name()} above target")
         _future.waitFor(move_scope)  # TODO act simultaneously once we can handle motion planning around moving objects
 

--- a/acq4/devices/Pipette/visualization.py
+++ b/acq4/devices/Pipette/visualization.py
@@ -1,0 +1,271 @@
+import collections
+import numpy as np
+from acq4.util import ptime
+from coorx import TTransform
+from pyqtgraph import opengl as gl
+from acq4.util import Qt
+from acq4.devices.Pipette.pipette import Pipette
+from acq4.devices.OptomechDevice import OptomechDeviceVisualizerAdapter
+from acq4.modules.Visualize3D import VisualizePathSearch
+
+
+class PipetteVisualizerAdapter(OptomechDeviceVisualizerAdapter):
+    sigPathUpdate = Qt.Signal(object, bool, object)  # path, is_error, failed_at
+
+    def __init__(self, dev: Pipette, win):
+        self._obstacles = {}
+        self._history = []  # list of (position, time) tuples for target history visualization
+        super().__init__(dev, win)
+        self._target = win.target()
+        self._path = win.path(color=[0.5, 0, 1, 1])
+        self._actual_path = win.path(color=[1, 0.6, 0, 0.8])  # orange: actual motion
+        self._error = win.target(color=[1, 0.2, 0.2, 0.6])
+        # Path history: deque of (seq_id, path, is_error, failed_at) tuples
+        self._path_history = collections.deque(maxlen=10)
+        self._next_seq = 0
+        # _pinned_seq: None = follow latest; int = pinned to that seq_id
+        self._pinned_seq = None
+        # _error_pinned: True when pinned due to an error path (highest priority)
+        self._error_pinned = False
+        # Guard flag to suppress slider signals during programmatic updates
+        self._updating_slider = False
+        if dev.target is not None:
+            self.handleTargetChanged(dev, dev.targetPosition())
+        # TODO obstacles and voxels
+        # TODO signal connections for obstacle and voxel updates
+        # TODO tie in with prime caches?
+
+        dev.sigCalibrationChanged.connect(self.handleCalibrationUpdate)
+        dev.sigTargetChanged.connect(self.handleTargetChanged)
+        dev.sigGlobalTransformChanged.connect(self.deviceMoved)
+        self.sigPathUpdate.connect(self._handlePathUpdate)
+
+    def deviceMoved(self, dev, transform):
+        pos = self.device.globalPosition()
+        now = ptime.time()
+        self._history.append((pos, now))
+
+    def _buildControlParam(self):
+        from pyqtgraph.parametertree import Parameter
+
+        param = super()._buildControlParam()
+
+        path_param = Parameter.create(
+            name='Path plan',
+            type='bool',
+            value=False,
+            children=[
+                dict(name='History', type='slider', value=0, limits=[0, 0], step=1),
+            ],
+        )
+        path_param.sigValueChanged.connect(self._handlePathVisible)
+        path_param.child('History').sigValueChanged.connect(self._handleHistorySliderMoved)
+        param.addChild(path_param)
+
+        target_param = Parameter.create(name='Target', type='bool', value=False)
+        param.addChild(target_param)
+        target_param.sigValueChanged.connect(self._handleTargetVisible)
+
+        # TODO figure all the geometry-aware stuff out
+        # obstacle_devices = [d for d in getManager().listInterfaces("OptomechDevice") if d != self.device.name()]
+        obstacle_devices = []
+        for other_dev in obstacle_devices:
+            other_dev_param = Parameter.create(
+                name=f"{other_dev} obstacles",
+                type='bool',
+                value=False,
+                children=[
+                    dict(name='Obstacle', type='bool', value=True),
+                    dict(name='Raw Obstacle Voxels', type='bool', value=False),
+                ],
+            )
+            param.addChild(other_dev_param)
+            self._obstacles[other_dev] = {
+                "device param": other_dev_param,
+                "obstacle param": other_dev_param.child('Obstacle'),
+                "voxels param": other_dev_param.child('Raw Obstacle Voxels'),
+            }
+
+        return param
+
+    def _handleDeviceToggle(self, param, value):
+        super()._handleDeviceToggle(param, value)
+        self._updateTargetVisibility()
+        self._updatePathVisibility()
+
+    def _handleTargetVisible(self, param, value):
+        self._updateTargetVisibility()
+
+    def _handlePathVisible(self, param, value):
+        self._updatePathVisibility()
+
+    def _updateTargetVisibility(self):
+        visible = self._param.value() and self._param.child('Target').value()
+        self._target.setVisible(visible)
+
+    def _updatePathVisibility(self):
+        visible = self._param.value() and self._param.child('Path plan').value()
+        self._path.setVisible(visible)
+        self._actual_path.setVisible(visible)
+        self._error.setVisible(visible)
+
+    def handleCalibrationUpdate(self, dev):
+        if bounds := dev.getBoundaries():
+            if self._limits is not None:
+                self.win.remove3DItem(self._limits)
+            self._limits = self.createBounds(bounds, False)
+            self._updateLimitsVisibility()
+        self.handleTransformUpdate(dev, dev)
+
+    def handleTargetChanged(self, dev, pos):
+        self._target.setData(pos=np.asarray([pos]))
+
+    def pathSearchVisualizer(self):
+        return VisualizePathSearch(self)
+
+    def setPathError(self, path, failed_at=None):
+        self.sigPathUpdate.emit(path, True, failed_at)
+
+    def setPath(self, path):
+        self.sigPathUpdate.emit(path, False, None)
+
+    def _handlePathUpdate(self, path, is_error, failed_at):
+        seq = self._next_seq
+        self._next_seq += 1
+        self._path_history.append((seq, path, is_error, failed_at, ptime.time()))
+
+        if is_error:
+            # Error paths have highest priority: always pin to them
+            self._pinned_seq = seq
+            self._error_pinned = True
+            if self._param is not None:
+                self._param.child('Path plan').setValue(True)
+            self.win.focus()
+        elif self._pinned_seq is not None:
+            # Check if the pinned entry is still in history (may have fallen off)
+            seqs = {entry[0] for entry in self._path_history}
+            if self._pinned_seq not in seqs:
+                self._pinned_seq = None
+                self._error_pinned = False
+
+        self._syncSlider()
+
+    def _syncSlider(self):
+        """Update the history slider range and position, then render the selected path."""
+        if self._param is None:
+            return
+        n = len(self._path_history)
+        if n == 0:
+            return
+
+        slider_param = self._param.child('Path plan').child('History')
+        self._updating_slider = True
+        try:
+            slider_param.setLimits([0, n - 1])
+            if self._pinned_seq is not None:
+                seqs = [entry[0] for entry in self._path_history]
+                try:
+                    idx = seqs.index(self._pinned_seq)
+                except ValueError:
+                    idx = n - 1
+            else:
+                idx = n - 1
+            slider_param.setValue(idx)
+        finally:
+            self._updating_slider = False
+
+        idx = int(slider_param.value())
+        _, path, is_error, failed_at, _ = self._path_history[idx]
+        self._displayPath(path, is_error, failed_at, idx)
+
+    def _displayPath(self, path, is_error, failed_at, path_idx=None):
+        """Render path and error marker for the given history entry."""
+        self._path.setData(pos=np.asarray(path))
+        if failed_at is None:
+            self._error.setData(pos=np.empty((0, 3)))
+        else:
+            self._error.setData(pos=np.asarray([failed_at]))
+        if path_idx is not None:
+            self._actual_path.setData(pos=self._getActualPath(path_idx))
+        else:
+            self._actual_path.setData(pos=np.empty((0, 3)))
+
+    def _getActualPath(self, path_idx):
+        """Return actual pipette positions spanning the time window of path_history[path_idx].
+
+        Includes the last known position before the move started and the first
+        position after it ended, with all positions in between.
+        """
+        if not self._history:
+            return np.empty((0, 3))
+
+        _, _, _, _, t_start = self._path_history[path_idx]
+
+        if path_idx + 1 < len(self._path_history):
+            _, _, _, _, t_end = self._path_history[path_idx + 1]
+        else:
+            t_end = None
+
+        times = [t for _, t in self._history]
+        positions = [p for p, _ in self._history]
+
+        # Last index with time <= t_start (last position before move)
+        i_start = 0
+        for i, t in enumerate(times):
+            if t <= t_start:
+                i_start = i
+
+        # First index with time >= t_end (first position after move)
+        if t_end is not None:
+            i_end = len(times) - 1
+            for i, t in enumerate(times):
+                if t >= t_end:
+                    i_end = i
+                    break
+        else:
+            i_end = len(times) - 1
+
+        pts = positions[i_start:i_end + 1]
+        if len(pts) < 2:
+            return np.empty((0, 3))
+        return np.array(pts)
+
+    def _handleHistorySliderMoved(self, param, value):
+        """Handle manual slider movement to navigate path history."""
+        if self._updating_slider:
+            return
+        n = len(self._path_history)
+        if n == 0:
+            return
+        idx = max(0, min(int(value), n - 1))
+        # Clear error pin on any manual move
+        self._error_pinned = False
+        if idx >= n - 1:
+            # At the latest position: switch back to follow-latest mode
+            self._pinned_seq = None
+        else:
+            self._pinned_seq = self._path_history[idx][0]
+        _, path, is_error, failed_at, _ = self._path_history[idx]
+        self._displayPath(path, is_error, failed_at, idx)
+
+    def createBounds(self, bounds, visible):
+        limits = self.device.parentDevice().getLimits()
+        local_to_global = (
+            TTransform(offset=self.device.offset) * self.device.parentDevice().axisTransform()
+        )
+        edges = set()
+        ndim = len(limits)
+        vertices = list(np.ndindex(tuple([2] * ndim)))
+        vertices = [tuple(limits[i][v] for i, v in enumerate(vertex)) for vertex in vertices]
+        # find every edge between vertices that differ in exactly one coordinate
+        for v1 in vertices:
+            for v2 in vertices:
+                if sum(a != b for a, b in zip(v1, v2)) == 1:
+                    # dedup by sorting
+                    edge = tuple(sorted((v1, v2)))
+                    edges.add(edge)
+        edges = [local_to_global.map(v) for edge in edges for v in edge]
+        plot = gl.GLLinePlotItem(pos=np.array(edges), color=(1, 0, 0, 0.2), width=4, mode="lines")
+        plot.setVisible(False)
+        self.win.add3DItem(plot)
+        return plot

--- a/acq4/modules/Visualize3D/__init__.py
+++ b/acq4/modules/Visualize3D/__init__.py
@@ -1,3 +1,3 @@
-from .travelers_proxy import VisualizePathPlan
+from .travelers_proxy import VisualizePathSearch
 from .module import Visualize3D
 from .gui import VisualizerWindow

--- a/acq4/modules/Visualize3D/gui.py
+++ b/acq4/modules/Visualize3D/gui.py
@@ -1,29 +1,27 @@
 import os
-from typing import Union
+from typing import Callable
 
-import numpy as np
-
-from acq4.devices.Device import Device
-from acq4.modules.Visualize3D import VisualizePathPlan
+import pyqtgraph as pg
 from acq4.util import Qt
-from acq4.util.geometry import Plane, Geometry
 from pyqtgraph import opengl as gl
+from pyqtgraph.parametertree import Parameter, ParameterTree
 
 
 class VisualizerWindow(Qt.QMainWindow):
-    newDeviceSignal = Qt.pyqtSignal(object)
     focusEvent = Qt.pyqtSignal()
 
-    def __init__(self, expectedDevices=0, testing=False):
+    def __init__(self, expectedAdapters=0, testing=False):
         super().__init__(None)
         self.testing = testing
-        self._devicesBeingAdded = expectedDevices
-        self._itemsByDevice = {}  # Maps devices to their visualization components
+        self._adaptersBeingAdded = expectedAdapters
+        self._adapters = []
         self._moduleReadyEvent = None
 
         self.setWindowTitle("3D Visualization of all Optomech Devices")
         self.setGeometry(50, 50, 1000, 600)
-        self.setWindowIcon(Qt.QIcon(os.path.join(os.path.dirname(os.path.dirname(__file__)), "icons.svg")))
+        self.setWindowIcon(
+            Qt.QIcon(os.path.join(os.path.dirname(os.path.dirname(__file__)), "icons.svg"))
+        )
 
         # Main layout is a horizontal splitter
         self.splitter = Qt.QSplitter(Qt.Qt.Horizontal)
@@ -46,25 +44,29 @@ class VisualizerWindow(Qt.QMainWindow):
         axes.setSize(0.1, 0.1, 0.1)
         self.view.addItem(axes)
 
-        # Right side: Tree widget for device controls
-        self.controlWidget = Qt.QWidget()
-        self.controlLayout = Qt.QVBoxLayout()
-        self.controlWidget.setLayout(self.controlLayout)
-        self.splitter.addWidget(self.controlWidget)
-
-        # Create tree widget for hierarchical device display
-        self.deviceTree = Qt.QTreeWidget()
-        self.deviceTree.setHeaderLabel("Devices")
-        self.deviceTree.setMinimumWidth(250)
-        self.deviceTree.itemChanged.connect(self.toggleVisibility)
-        self.controlLayout.addWidget(self.deviceTree)
+        # Right side: ParameterTree for all device controls
+        self._rootParam = Parameter.create(name='devices', type='group', children=[])
+        self.paramTree = ParameterTree()
+        self.paramTree.setParameters(self._rootParam, showTop=False)
+        self.splitter.addWidget(self.paramTree)
 
         # Set splitter sizes
         self.splitter.setSizes([700, 300])
 
         # Connect signals
-        self.newDeviceSignal.connect(self._addDevice)
         self.focusEvent.connect(self._focus)
+
+    def addControls(self, param: Parameter):
+        self._rootParam.addChild(param)
+
+    def removeControls(self, param: Parameter):
+        self._rootParam.removeChild(param)
+
+    def add3DItem(self, item):
+        self.view.addItem(item)
+
+    def remove3DItem(self, item):
+        self.view.removeItem(item)
 
     def target(self, visible=False, color=(0, 0, 1, 1)):
         target = gl.GLScatterPlotItem(pos=[], color=color, size=10, pxMode=True)
@@ -78,10 +80,9 @@ class VisualizerWindow(Qt.QMainWindow):
         self.view.addItem(path)
         return path
 
-    def clear(self):
-        for dev in list(self._itemsByDevice.keys()):
-            self._removeDevice(dev)
-        self._itemsByDevice = {}
+    def centerOnPosition(self, pos: tuple[float, float, float]) -> None:
+        """Center the 3D camera on the given (x, y, z) position."""
+        self.view.setCameraPosition(pos=pg.Vector(*pos))
 
     def focus(self):
         self.focusEvent.emit()
@@ -91,204 +92,23 @@ class VisualizerWindow(Qt.QMainWindow):
         self.activateWindow()
         self.raise_()
 
-    def addDevice(self, dev: "OptomechDevice", ready_event=None):
-        self._moduleReadyEvent = ready_event
-        self.newDeviceSignal.emit(dev)
-
-    def _addDevice(self, dev: Union[Device, "OptomechDevice"]):
+    def addAdapter(self, adapter, ready_event=None):
         try:
-            dev.sigGeometryChanged.connect(self.handleGeometryChange)
-            if (geom := dev.getGeometry()) is None:
-                return
-
-            # Create device entry in data structure
-            self._itemsByDevice[dev] = {"checkboxes": {}}
-
-            # Add geometry to the scene
-            self.addGeometry(geom, dev)
-            dev.sigGlobalTransformChanged.connect(self.handleTransformUpdate)
-            self.handleTransformUpdate(dev, dev)
-
-            # Create tree item for this device
-            deviceItem = Qt.QTreeWidgetItem(self.deviceTree)
-            deviceItem.setText(0, dev.name())
-            deviceItem.setFlags(deviceItem.flags() | Qt.Qt.ItemIsUserCheckable)
-            deviceItem.setCheckState(0, Qt.Qt.Checked)
-            deviceItem.setData(0, Qt.Qt.UserRole, dev)
-            self._itemsByDevice[dev]["checkbox root"] = deviceItem
-
-            # Create geometry sub-item
-            geomItem = Qt.QTreeWidgetItem(deviceItem)
-            geomItem.setText(0, "Geometry")
-            geomItem.setFlags(geomItem.flags() | Qt.Qt.ItemIsUserCheckable)
-            geomItem.setCheckState(0, Qt.Qt.Checked)
-            geomItem.setData(0, Qt.Qt.UserRole, "geometry")
-            self._itemsByDevice[dev]["checkboxes"]["geometry"] = geomItem
-
-            # Add boundaries if available
-            if bounds := dev.getBoundaries():
-                self._itemsByDevice[dev]["limits"] = self.createBounds(bounds, False)
-
-                # Create limits sub-item
-                limitsItem = Qt.QTreeWidgetItem(deviceItem)
-                limitsItem.setText(0, "Range of Motion")
-                limitsItem.setFlags(limitsItem.flags() | Qt.Qt.ItemIsUserCheckable)
-                limitsItem.setCheckState(0, Qt.Qt.Unchecked)
-                limitsItem.setData(0, Qt.Qt.UserRole, "limits")
-                self._itemsByDevice[dev]["checkboxes"]["limits"] = limitsItem
-
-                if hasattr(dev, "sigCalibrationChanged"):
-                    dev.sigCalibrationChanged.connect(self.handleGeometryChange)
-
-            obstacleItem = Qt.QTreeWidgetItem(deviceItem)
-            obstacleItem.setText(0, "Obstacle")
-            obstacleItem.setFlags(obstacleItem.flags() | Qt.Qt.ItemIsUserCheckable)
-            obstacleItem.setCheckState(0, Qt.Qt.Unchecked)
-            obstacleItem.setData(0, Qt.Qt.UserRole, "obstacle")
-            self._itemsByDevice[dev]["checkboxes"]["obstacle"] = obstacleItem
-
-            voxelsItem = Qt.QTreeWidgetItem(deviceItem)
-            voxelsItem.setText(0, "Raw Obstacle Voxels")
-            voxelsItem.setFlags(voxelsItem.flags() | Qt.Qt.ItemIsUserCheckable)
-            voxelsItem.setCheckState(0, Qt.Qt.Unchecked)
-            voxelsItem.setData(0, Qt.Qt.UserRole, "voxels")
-            self._itemsByDevice[dev]["checkboxes"]["voxels"] = voxelsItem
+            self._moduleReadyEvent = ready_event
+            self._adapters.append(adapter)
         finally:
-            self._devicesBeingAdded -= 1
-            if self._moduleReadyEvent is not None and self._devicesBeingAdded == 0:
+            self._adaptersBeingAdded -= 1
+            if self._moduleReadyEvent is not None and self._adaptersBeingAdded == 0:
                 self._moduleReadyEvent.set()
                 self._moduleReadyEvent = None
 
-    def ensurePathTogglerExists(self, device):
-        """Make sure the device has a toggle for showing its path plan. Returns whether that toggle is on."""
-        toggles = self._itemsByDevice[device]["checkboxes"]
-        generally_visible = self._itemsByDevice[device]["checkbox root"].checkState(0) == Qt.Qt.Checked
-        if "path" not in toggles:
-            path_item = Qt.QTreeWidgetItem(self._itemsByDevice[device]["checkbox root"])
-            path_item.setText(0, "Path plan")
-            path_item.setFlags(path_item.flags() | Qt.Qt.ItemIsUserCheckable)
-            path_item.setCheckState(0, Qt.Qt.Checked)
-            path_item.setDisabled(not generally_visible)
-            path_item.setData(0, Qt.Qt.UserRole, "path")
-            toggles["path"] = path_item
-        return generally_visible and toggles["path"].checkState(0) == Qt.Qt.Checked
+    def removeAdapter(self, adapter):
+        if adapter in self._adapters:
+            self._adapters.remove(adapter)
+            adapter.clear()
 
-    def getDeviceCheckboxes(self, name: str):
-        """This is an ugly code path. The `name` here is not an exact match; it's the coordinate system name for the
-        geometry associated with a device. Further, some devices will have subdevices, and so their name won't even be
-        uniquely present in only one geometry even if all devices had completely unique names."""
-        # TODO handle subdevices
-        device = next((dev for dev in self._itemsByDevice if dev.name() in name), None)
-        if device is None:
-            raise ValueError(f"Could not find device associated with '{name}'")
-        return self._itemsByDevice[device]["checkboxes"]
-
-    def toggleVisibility(self, item: Qt.QTreeWidgetItem, column):
-        parentItem = item.parent()
-        visible = item.checkState(0) == Qt.Qt.Checked
-
-        # A top-level device item
-        if parentItem is None:
-            dev = item.data(0, Qt.Qt.UserRole)
-
-            if dev not in self._itemsByDevice:
-                return
-
-            for ch in range(item.childCount()):
-                child = item.child(ch)
-                child.setDisabled(not visible)
-                self.toggleVisibility(child, None)  # let each child decide if it's really visible
-
-        else:  # This is a component item
-            dev = parentItem.data(0, Qt.Qt.UserRole)
-            visible = visible and parentItem.checkState(0) == Qt.Qt.Checked
-            componentType = item.data(0, Qt.Qt.UserRole)
-
-            if dev not in self._itemsByDevice:
-                return
-
-            if componentType in self._itemsByDevice[dev]:
-                self._itemsByDevice[dev][componentType].setVisible(visible)
-            elif componentType in ["obstacle", "voxels"]:
-                for items in self._itemsByDevice.values():
-                    if "path" in items:
-                        items["path"].toggleDeviceVisibility(componentType, dev, visible)
-
-    def pathPlanVisualizer(self, traveler) -> VisualizePathPlan:
-        if traveler not in self._itemsByDevice:
-            raise ValueError(f"{traveler.name()} is not known to the Visualizer")
-        if "path" not in self._itemsByDevice[traveler]:
-            self._itemsByDevice[traveler]["path"] = VisualizePathPlan(self, traveler)
-        return self._itemsByDevice[traveler]["path"]
-
-    def createBounds(self, bounds, visible):
-        edges = []
-        for a, b in Plane.wireframe(*bounds):
-            for bound in bounds:
-                if not (bound.allows_point(a) and bound.allows_point(b)):
-                    continue
-            if not self.testing and np.linalg.norm(a - b) > 0.1:
-                continue  # ignore bounds that are really far away
-            edge = [a, b]
-            edges.extend(edge)
-        plot = gl.GLLinePlotItem(pos=np.array(edges), color=(1, 0, 0, 0.2), width=4, mode="lines")
-        plot.setVisible(visible)
-        self.view.addItem(plot)
-        return plot
-
-    def addGeometry(self, geom: Geometry, key=None):
-        if key is None:
-            key = geom.name
-        self._itemsByDevice.setdefault(key, {})
-        self._itemsByDevice[key]["geometry object"] = geom
-        mesh = geom.glMesh()
-        self.view.addItem(mesh)
-        self._itemsByDevice[key]["geometry"] = mesh
-
-    def _removeDevice(self, dev):
-        if dev not in self._itemsByDevice:
-            return
-        items = self._itemsByDevice[dev]
-        items.pop("geometry object", None)
-
-        # Disconnect signals
-        if not self.testing:  # todo properly mock devices for the tests
-            dev.sigGeometryChanged.disconnect(self.handleGeometryChange)
-            dev.sigGlobalTransformChanged.disconnect(self.handleTransformUpdate)
-
-        # Remove tree item
-        tree_item = items.pop("checkbox root")
-        index = self.deviceTree.indexOfTopLevelItem(tree_item)
-        if index != -1:
-            self.deviceTree.takeTopLevelItem(index)
-        items.pop("checkboxes", None)
-
-        if "path" in items:
-            path = items.pop("path")
-            path.safelyDestroy()
-
-        # Remove everything else from view
-        for component in items.values():
-            self.view.removeItem(component)
-
-        for other, o_items in self._itemsByDevice.items():
-            if "path" in o_items:
-                o_items["path"].removeDevice(dev)
-
-        del self._itemsByDevice[dev]
-
-    def handleTransformUpdate(self, moved_device: "OptomechDevice", cause_device: "OptomechDevice"):
-        geom = self._itemsByDevice.get(moved_device, {}).get("geometry object")
-        if geom is None:
-            return
-        xform = moved_device.globalPhysicalTransform() * geom.transform.as_pyqtgraph()
-        self.setMeshTransform(moved_device, xform)
-
-    def setMeshTransform(self, dev, xform):
-        self._itemsByDevice[dev]["geometry"].setTransform(xform)
-
-    def handleGeometryChange(self, dev: "OptomechDevice"):
-        self._removeDevice(dev)
-        self._itemsByDevice[dev] = {}
-        self.addDevice(dev)
-        # TODO reprime caches
+    def findAdapter(self, test: Callable):
+        for adapter in self._adapters:
+            if test(adapter):
+                return adapter
+        return None

--- a/acq4/modules/Visualize3D/module.py
+++ b/acq4/modules/Visualize3D/module.py
@@ -6,8 +6,9 @@ from .gui import VisualizerWindow
 
 
 class Visualize3D(Module):
-    moduleDisplayName = "3D Visualization"
+    moduleDisplayName = "Visualize3D"
     moduleCategory = "Utilities"
+    interfaceName = "3D Visualizable"
 
     win = None
 
@@ -15,13 +16,29 @@ class Visualize3D(Module):
         super().__init__(manager, name, config)
         self.isReady = threading.Event()
         self.openWindow()
-        for dev in manager.listInterfaces("OptomechDevice"):
-            dev = manager.getDevice(dev)
-            self.win.addDevice(dev, self.isReady)
+        self._adapters = {}
+        manager.interfaceDir.sigInterfaceListChanged.connect(self.onInterfaceListChanged)
+        self.onInterfaceListChanged([self.interfaceName])
+
+    @inGuiThread
+    def onInterfaceListChanged(self, types: list):
+        if self.interfaceName in types:
+            seen = set()
+            for name in self.manager.listInterfaces(self.interfaceName):
+                seen.add(name)
+                if name not in self._adapters:
+                    obj = self.manager.getInterface(self.interfaceName, name)
+                    adapter = obj.visualize3DAdapter(self.win)
+                    if adapter is not None:
+                        self.win.addAdapter(adapter, self.isReady)
+                        self._adapters[name] = adapter
+            for name in list(self._adapters.keys()):
+                if name not in seen:
+                    self.win.removeAdapter(self._adapters[name])
+                    del self._adapters[name]
 
     @inGuiThread
     def openWindow(self):
         if self.win is None:
-            self.win = VisualizerWindow(len(self.manager.listInterfaces("OptomechDevice")))
+            self.win = VisualizerWindow(len(self.manager.listInterfaces(self.interfaceName)))
         self.win.show()
-        self.win.clear()

--- a/acq4/modules/Visualize3D/travelers_proxy.py
+++ b/acq4/modules/Visualize3D/travelers_proxy.py
@@ -11,12 +11,27 @@ from coorx import TTransform
 from pyqtgraph import opengl as gl
 
 
-class VisualizePathPlan(Qt.QObject):
-    def __init__(self, window, traveler: "OptomechDevice"):
+class MovePathException(Exception):
+    def __init__(self, message, path, failing_point):
+        super().__init__(message)
+        self.path = path
+        self.failing_point = failing_point
+
+    def offset_points(self, offset):
+        self.path = [tuple(np.asarray(p) + offset) for p in self.path]
+        self.failing_point = tuple(np.asarray(self.failing_point) + offset)
+
+    def visualize(self, adapter):
+        adapter.setPathError(self.path, self.failing_point)
+        adapter.win.focus()
+
+
+class VisualizePathSearch(Qt.QObject):
+    def __init__(self, adapter):
         super().__init__()
         self.moveToThread(Qt.QApplication.instance().thread())
-        self._window = window
-        self._traveler = traveler
+        self._adapter = adapter
+        self._traveler = adapter.device
 
         self._initGui()
 
@@ -31,11 +46,12 @@ class VisualizePathPlan(Qt.QObject):
 
     @inGuiThread
     def _initGui(self):
-        show_path = self._window.ensurePathTogglerExists(self._traveler)
-        self._startTarget = self._window.target(show_path)
-        self._destTarget = self._window.target(show_path, color=(0, 1, 0, 1))
-        self._activePath = self._window.path((0.1, 1, 0.7, 0.5), show_path)
-        self._previousPath = self._window.path((1, 0.7, 0, 0.01), show_path)
+        path_param = self._adapter._param.child('Path plan')
+        show_path = path_param.value() and path_param.opts.get('enabled', True)
+        self._startTarget = self._adapter.win.target(show_path)
+        self._destTarget = self._adapter.win.target(show_path, color=(0, 1, 0, 1))
+        self._activePath = self._adapter.win.path((0.1, 1, 0.7, 0.5), show_path)
+        self._previousPath = self._adapter.win.path((1, 0.7, 0, 0.01), show_path)
 
     @inGuiThread
     def reset(self):
@@ -50,8 +66,9 @@ class VisualizePathPlan(Qt.QObject):
 
     @future_wrap
     def startPath(self, path, bounds, _future):
+        # TODO this is going to break with bitrot
         if self._bounds is None:
-            self._bounds = self._window.createBounds(bounds, False)
+            self._bounds = self._adapter.createBounds(bounds, False)
         self._startPath(path, bounds)
 
     @inGuiThread
@@ -69,7 +86,7 @@ class VisualizePathPlan(Qt.QObject):
         self._appendPath(path)
 
     def focus(self):
-        self._window.focus()
+        self._adapter.win.focus()
 
     def endPath(self, path):
         self.updatePath(path, skip=1)
@@ -81,16 +98,15 @@ class VisualizePathPlan(Qt.QObject):
         self._activePath.setVisible(visible)
         self._previousPath.setVisible(visible)
         self._bounds.setVisible(visible)
+        device_visible = self._adapter._param.value()
         for name, obstacle in self._obstacles.items():
-            obst_toggle = self._window.getDeviceCheckboxes(name)["obstacle"]
-            dev_obst_visible = obst_toggle.checkState(0) == Qt.Qt.Checked
-            dev_visible = obst_toggle.parent().checkState(0) == Qt.Qt.Checked
-            obstacle.setVisible(visible and dev_visible and dev_obst_visible)
+            dev_param = self._adapter._obstacles[name]["device param"]
+            obst_visible = dev_param.child('Obstacle').value()
+            obstacle.setVisible(visible and device_visible and dev_param.value() and obst_visible)
         for name, voxels in self._voxels.items():
-            vox_toggle = self._window.getDeviceCheckboxes(name)["voxels"]
-            dev_vox_visible = vox_toggle.checkState(0) == Qt.Qt.Checked
-            dev_visible = vox_toggle.parent().checkState(0) == Qt.Qt.Checked
-            voxels.setVisible(visible and dev_visible and dev_vox_visible)
+            dev_param = self._adapter._obstacles[name]["device param"]
+            vox_visible = dev_param.child('Raw Obstacle Voxels').value()
+            voxels.setVisible(visible and device_visible and dev_param.value() and vox_visible)
 
     def updatePath(self, path, skip=3):
         self._pathUpdates.put((path, skip))
@@ -100,7 +116,7 @@ class VisualizePathPlan(Qt.QObject):
         while not self._stopThread:
             path, skip = self._pathUpdates.get()
             n_updates += 1
-            if self._window.testing or n_updates % skip == 0:
+            if n_updates % skip == 0:
                 self._appendPath(path)
                 time.sleep(0.05)
 
@@ -143,26 +159,24 @@ class VisualizePathPlan(Qt.QObject):
 
     @property
     def shouldShowPath(self):
-        togglers = self._window.getDeviceCheckboxes(self._traveler.name())
-        generally_visible = togglers["geometry"].parent().checkState(0) == Qt.Qt.Checked
-        return generally_visible and togglers["path"].checkState(0) == Qt.Qt.Checked
+        param = self._adapter._param
+        return param.value() and param.child('Path plan').value()
 
     @inGuiThread
     def _setInitialObstacleVisibility(self, name):
-        togglers = self._window.getDeviceCheckboxes(name)
-        general_checkbox = togglers["geometry"].parent()
-        generally_visible = general_checkbox.checkState(0) == Qt.Qt.Checked
+        generally_visible = self._adapter._param.value()
+        dev_param = self._adapter._obstacles[name]["device param"]
 
-        obst_visible = togglers["obstacle"].checkState(0) == Qt.Qt.Checked
-        self._obstacles[name].setVisible(generally_visible and obst_visible and self.shouldShowPath)
+        obst_visible = dev_param.child('Obstacle').value()
+        self._obstacles[name].setVisible(generally_visible and dev_param.value() and obst_visible and self.shouldShowPath)
 
-        voxels_visible = togglers["voxels"].checkState(0) == Qt.Qt.Checked
-        self._voxels[name].setVisible(generally_visible and voxels_visible and self.shouldShowPath)
+        vox_visible = dev_param.child('Raw Obstacle Voxels').value()
+        self._voxels[name].setVisible(generally_visible and dev_param.value() and vox_visible and self.shouldShowPath)
 
     @inGuiThread
     def _buildVoxelVolume(self, name, vol_data):
         self._voxels[name] = gl.GLVolumeItem(vol_data, sliceDensity=10, smooth=False, glOptions="additive")
-        self._window.view.addItem(self._voxels[name])
+        self._adapter.win.view.addItem(self._voxels[name])
 
     @inGuiThread
     def _buildObstacleMesh(self, name, verts, faces):
@@ -170,19 +184,19 @@ class VisualizePathPlan(Qt.QObject):
         self._obstacles[name] = gl.GLMeshItem(
             meshdata=mesh_data, smooth=True, color=(0.1, 0.1, 0.3, 0.25), shader="balloon", glOptions="additive"
         )
-        self._window.view.addItem(self._obstacles[name])
+        self._adapter.win.view.addItem(self._obstacles[name])
 
     @inGuiThread
     def removeDevice(self, dev):
         for name, obst in self._obstacles.items():
             if dev.name() in name:
-                self._window.view.removeItem(obst)
+                self._adapter.win.view.removeItem(obst)
                 obst.deleteLater()
                 del self._obstacles[name]
                 break
         for name, voxels in self._voxels.items():
             if dev.name() in name:
-                self._window.view.removeItem(voxels)
+                self._adapter.win.view.removeItem(voxels)
                 voxels.deleteLater()
                 del self._voxels[name]
                 break
@@ -197,19 +211,19 @@ class VisualizePathPlan(Qt.QObject):
     @inGuiThread
     def safelyDestroy(self):
         self._stopThread = True
-        self._window.view.removeItem(self._startTarget)
+        self._adapter.win.view.removeItem(self._startTarget)
         self._startTarget.deleteLater()
-        self._window.view.removeItem(self._destTarget)
+        self._adapter.win.view.removeItem(self._destTarget)
         self._destTarget.deleteLater()
-        self._window.view.removeItem(self._activePath)
+        self._adapter.win.view.removeItem(self._activePath)
         self._activePath.deleteLater()
-        self._window.view.removeItem(self._previousPath)
+        self._adapter.win.view.removeItem(self._previousPath)
         self._previousPath.deleteLater()
-        self._window.view.removeItem(self._bounds)
+        self._adapter.win.view.removeItem(self._bounds)
         self._bounds.deleteLater()
         for obst in self._obstacles.values():
-            self._window.view.removeItem(obst)
+            self._adapter.win.view.removeItem(obst)
         self._obstacles = None
         for voxels in self._voxels.values():
-            self._window.view.removeItem(voxels)
+            self._adapter.win.view.removeItem(voxels)
         self._voxels = None


### PR DESCRIPTION
## Summary

- **Transform system migration**: `OptomechDevice` now uses `coorx` transforms (`SRT3DTransform`, `AffineTransform`) throughout, replacing `pg.SRTTransform3D`. Inverse and global transforms are now computed via `.inverse` and chained multiplication rather than manual cache entries. The `_mapTransform` helper is replaced by a module-level `map_through_transform` function. Cached inverse transforms (`__inverseTransform`, `__inverseGlobalTransform`, etc.) are removed; only `__globalTransform` and `__globalPhysicalTransform` are cached.
- **Visualize3D adapter pattern**: Devices no longer register themselves directly with the `Visualize3D` module. Instead, `OptomechDevice` now declares the `"3D Visualizable"` interface and implements `visualize3DAdapter(win)`, which returns an `OptomechDeviceVisualizerAdapter`. `Visualize3D` discovers devices via interface list changes and calls `visualize3DAdapter()` for each.
- **`VisualizerWindow` GUI overhaul**: The right-hand panel is now a `pyqtgraph.ParameterTree` instead of a `QTreeWidget`. Device management methods (`addDevice`, `_removeDevice`, `handleTransformUpdate`, etc.) are replaced by `addAdapter`, `removeAdapter`, and `findAdapter(predicate)`. `OptomechDeviceVisualizerAdapter` manages its own mesh, bounds visualization, and parameter tree entries.
- **`PipetteVisualizerAdapter`** added in new `acq4/devices/Pipette/visualization.py`: extends `OptomechDeviceVisualizerAdapter` with pipette-specific visualization — planned path, actual motion path, target marker, error highlighting, and a history slider for reviewing past path plans.
- **`MovePathException`** introduced in `travelers_proxy.py`: raised by the path executor when a move fails, carries the path and failing point so the pipette can offset the points and hand them to the visualizer for error display. `VisualizePathPlan` is renamed `VisualizePathSearch`.
- **`Manager.py` cleanups**: Logging setup refactored — `setup_logging(TEMP_LOG)` call and temp-log migration logic moved into `set_log_file()`; `--log-level`/`--root-log-level` CLI args removed. `DeviceLocker` moved to `Device.py`. `getOrLoadModule(name)` added for lazy module loading. `reserveDevices()` gains a `reserver` parameter for deadlock diagnostics. Window shortcut now un-minimizes the window before raising it. Shutdown log messages promoted from DEBUG to INFO.
- **Pipette additions and fixes**: `iterativelyFindTip()` method added for convergent tip-finding loops. `resetGlobalPosition()` corrected to compute offset in manipulator coordinates. `_updateTransform()` uses `AffineTransform.set_mapping()`. `focusTip`/`focusTarget` use `imagingDevice()` instead of `scopeDevice()`. `saveManualTipPosition` now saves axis yaw and pitch alongside tip position, and uses a timestamped filename. `getRecordingChambers`/`getCleaningWell` return type updated to `InteractionSite`. `getNucleusDepositionWell()` and `getElectrodeSolutionWell()` added. Motion planners gain `_default_name()` overrides for clearer move names.
- **`planners.py`**: Path validation now raises `ValueError` (instead of asserting) for non-finite positions; `checkGlobalLimits` now receives the `linear` flag. Error paths are visualized via the adapter. `getOrLoadModule("Visualize3D")` replaces `getModule(...)`.

## Test plan

- [ ] Open `Visualize3D` module and confirm that all `OptomechDevice` instances appear in the `ParameterTree` with working visibility toggles
- [ ] Toggle `Geometry`, `Range of Motion`, and per-device visibility on/off for at least two devices
- [ ] Click `Center View` for a device and verify the 3D camera moves to that device's position
- [ ] Run a path plan for a pipette and verify the planned path and actual motion path appear in the 3D view
- [ ] Trigger a path planning failure (e.g., move to an out-of-range position) and verify the error path is highlighted and the window comes to front
- [ ] Use the `History` slider to review previous path plans
- [ ] Confirm `Visualize3D` can be opened after devices are loaded (lazy via `getOrLoadModule`)
- [ ] Confirm no errors when `Visualize3D` is closed and then a pipette move is attempted
- [ ] Verify `iterativelyFindTip` converges and raises `TimeoutError` when it cannot
- [ ] Confirm `saveManualTipPosition` saves yaw/pitch alongside tip position and uses timestamped filename
- [ ] Verify window keyboard shortcut un-minimizes the window before raising it
- [ ] Run existing unit tests for `OptomechDevice` transforms to confirm coorx-backed transforms behave correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

## Dependencies

> **Must be merged before this PR:**
> - #500 (axis-of-diagonevil) — extends `Stage.checkGlobalLimits()` to accept the `linear` argument that `planners.py` now passes
> - #501 (step-into-my-chambers) — renames RecordingChamber to InteractionSite