### PR TITLE
fix: add reserver= args to device.reserve() call sites

### DIFF
--- a/acq4/devices/MultiClamp/multiclamp.py
+++ b/acq4/devices/MultiClamp/multiclamp.py
@@ -304,7 +304,7 @@ class MultiClamp(PatchClamp):
         It is important to have this because the amplifier's holding values cannot be changed
         before switching modes.
         """
-        with self.dm.reserveDevices([self, self.config['commandChannel']['device']]):
+        with self.dm.reserveDevices([self, self.config['commandChannel']['device']], reserver="MultiClamp.setHolding"):
             currentMode = self.mc.getMode()
             if mode is None:  ## If no mode is specified, use the current mode
                 mode = currentMode
@@ -345,15 +345,15 @@ class MultiClamp(PatchClamp):
             daqDev.setChannelValue(chan, holding*scale, block=False)
 
     def autoPipetteOffset(self):
-        with self.dm.reserveDevices([self]):
+        with self.dm.reserveDevices([self], reserver="MultiClamp.autoPipetteOffset"):
             self.mc.autoPipetteOffset()
-        
+
     def autoBridgeBalance(self):
-        with self.dm.reserveDevices([self]):
+        with self.dm.reserveDevices([self], reserver="MultiClamp.autoBridgeBalance"):
             self.mc.autoBridgeBal()
 
     def autoCapComp(self):
-        with self.dm.reserveDevices([self]):
+        with self.dm.reserveDevices([self], reserver="MultiClamp.autoCapComp"):
             self.mc.autoFastComp()
             self.mc.autoSlowComp()
 
@@ -373,7 +373,7 @@ class MultiClamp(PatchClamp):
         for param in self.mode_dependent_params:
             self._paramCache.pop(param, None)
 
-        with self.dm.reserveDevices([self, self.config['commandChannel']['device']]):
+        with self.dm.reserveDevices([self, self.config['commandChannel']['device']], reserver="MultiClamp.setMode"):
             mcMode = self.mc.getMode()
             if mcMode == mode:  ## Mode is already correct
                 return

--- a/acq4/devices/MultiClamp/multiclamp.py
+++ b/acq4/devices/MultiClamp/multiclamp.py
@@ -174,14 +174,14 @@ class MultiClamp(PatchClamp):
             self.mc = mc.getChannel(self.config['channelID'], multiprocess.proxy(self.mcUpdate, callSync='off'))
         else:
             self.mc = mc.getChannel(self.config['channelID'], self.mcUpdate)
-        
+
         ## wait for first update..
         start = time.time()
         while self.mc.getState() is None:
             time.sleep(0.1)
             if time.time() - start > 10:
                 raise Exception("Timed out waiting for first update from multi clamp commander.")
-        
+
         print("Created MultiClamp device", self.config['channelID'])
 
         ## set configured holding values
@@ -200,7 +200,7 @@ class MultiClamp(PatchClamp):
                 self.mc.setParams(defaults[mode])
         self.setMode('I=0')  ## safest mode to leave clamp in
 
-        
+
         dm.declareInterface(name, ['clamp'], self)
 
     def description(self):
@@ -253,7 +253,7 @@ class MultiClamp(PatchClamp):
             return 50
         else:
             return 2.5e9
-        
+
     def getState(self):
         return self.mc.getState()
 
@@ -284,10 +284,10 @@ class MultiClamp(PatchClamp):
 
     def taskInterface(self, taskRunner):
         return MultiClampTaskGui(self, taskRunner)
-    
+
     def createTask(self, cmd, parentTask):
         return MultiClampTask(self, cmd, parentTask)
-    
+
     def getHolding(self, mode=None):
         if mode is None:  ## If no mode is specified, use the current mode
             mode = self.mc.getMode()
@@ -296,15 +296,15 @@ class MultiClamp(PatchClamp):
             return 0.0
         else:
             return self.holding[mode]
-            
+
     def setHolding(self, mode=None, value=None):
-        """Define and/or set the holding values for this device. 
+        """Define and/or set the holding values for this device.
 
         Note--these are ACQ4-controlled holding values, NOT the holding values used by the amplifier.
         It is important to have this because the amplifier's holding values cannot be changed
         before switching modes.
         """
-        with self.dm.reserveDevices([self, self.config['commandChannel']['device']], reserver="MultiClamp.setHolding"):
+        with self.dm.reserveDevices([self, self.config['commandChannel']['device']], reserver=f"{self.name()}.setHolding"):
             currentMode = self.mc.getMode()
             if mode is None:  ## If no mode is specified, use the current mode
                 mode = currentMode
@@ -345,21 +345,21 @@ class MultiClamp(PatchClamp):
             daqDev.setChannelValue(chan, holding*scale, block=False)
 
     def autoPipetteOffset(self):
-        with self.dm.reserveDevices([self], reserver="MultiClamp.autoPipetteOffset"):
+        with self.dm.reserveDevices([self], reserver=f"{self.name()}.autoPipetteOffset"):
             self.mc.autoPipetteOffset()
 
     def autoBridgeBalance(self):
-        with self.dm.reserveDevices([self], reserver="MultiClamp.autoBridgeBalance"):
+        with self.dm.reserveDevices([self], reserver=f"{self.name()}.autoBridgeBalance"):
             self.mc.autoBridgeBal()
 
     def autoCapComp(self):
-        with self.dm.reserveDevices([self], reserver="MultiClamp.autoCapComp"):
+        with self.dm.reserveDevices([self], reserver=f"{self.name()}.autoCapComp"):
             self.mc.autoFastComp()
             self.mc.autoSlowComp()
 
     def listSignals(self, mode):
         return self.mc.listSignals(mode)
-        
+
     def getMode(self):
         return self.mc.getMode()
 
@@ -373,7 +373,7 @@ class MultiClamp(PatchClamp):
         for param in self.mode_dependent_params:
             self._paramCache.pop(param, None)
 
-        with self.dm.reserveDevices([self, self.config['commandChannel']['device']], reserver="MultiClamp.setMode"):
+        with self.dm.reserveDevices([self, self.config['commandChannel']['device']], reserver=f"{self.name()}.setMode"):
             mcMode = self.mc.getMode()
             if mcMode == mode:  ## Mode is already correct
                 return

--- a/acq4/devices/NiDAQ/nidaq.py
+++ b/acq4/devices/NiDAQ/nidaq.py
@@ -86,7 +86,7 @@ class NiDAQ(Device):
         if ignoreLock:
             res = True
         else:
-            res = self.reserve(block=block)
+            res = self.reserve(block=block, reserver="NiDAQ.setChannelValue")
 
         self.verifyChannelBelongs(chan)
 
@@ -135,7 +135,7 @@ class NiDAQ(Device):
             mode = self.config.get('defaultAIMode', None)
 
         self.verifyChannelBelongs(chan)
-        res = self.reserve(block=block)
+        res = self.reserve(block=block, reserver="NiDAQ.getChannelValue")
         if not res:  ## False means non-blocking lock attempt failed.
             return False
         try:

--- a/acq4/devices/NiDAQ/nidaq.py
+++ b/acq4/devices/NiDAQ/nidaq.py
@@ -86,7 +86,7 @@ class NiDAQ(Device):
         if ignoreLock:
             res = True
         else:
-            res = self.reserve(block=block, reserver="NiDAQ.setChannelValue")
+            res = self.reserve(block=block, reserver=f"{self.name()}.setChannelValue")
 
         self.verifyChannelBelongs(chan)
 
@@ -135,7 +135,7 @@ class NiDAQ(Device):
             mode = self.config.get('defaultAIMode', None)
 
         self.verifyChannelBelongs(chan)
-        res = self.reserve(block=block, reserver="NiDAQ.getChannelValue")
+        res = self.reserve(block=block, reserver=f"{self.name()}.getChannelValue")
         if not res:  ## False means non-blocking lock attempt failed.
             return False
         try:


### PR DESCRIPTION
## Summary

Fills in the required \`reserver=\` argument for all call sites that call \`Device.reserve()\` or \`Manager.reserveDevices()\` without one, fixing the \`ValueError\` raised by the new \`Device.reserve(reserver=required)\` API introduced in PR #510.

Changes:
- **\`NiDAQ.setChannelValue\`**: adds \`reserver="NiDAQ.setChannelValue"\`
- **\`NiDAQ.getChannelValue\`**: adds \`reserver="NiDAQ.getChannelValue"\`
- **\`MultiClamp.setHolding\`**: adds \`reserver="MultiClamp.setHolding"\`
- **\`MultiClamp.autoPipetteOffset\`**: adds \`reserver="MultiClamp.autoPipetteOffset"\`
- **\`MultiClamp.autoBridgeBalance\`**: adds \`reserver="MultiClamp.autoBridgeBalance"\`
- **\`MultiClamp.autoCapComp\`**: adds \`reserver="MultiClamp.autoCapComp"\`
- **\`MultiClamp.setMode\`**: adds \`reserver="MultiClamp.setMode"\`

> **Note:** \`imaging/sequencer.py\` also has \`reserveDevices\` calls that need updating, but those are intertwined with larger sequencer changes in the mini-rig stack and will be addressed separately.

## Dependencies

> **Must be merged before this PR:**
> - #510 — introduces the \`Device.reserve(reserver=required)\` API that makes these call-site fixes necessary

## Test plan
- [ ] Run a DAQ set/get channel value and confirm no \`ValueError\` about missing \`reserver\`
- [ ] Switch MultiClamp mode and confirm no \`ValueError\`
- [ ] Run autoPipetteOffset, autoBridgeBalance, autoCapComp and confirm they complete without error

🤖 Generated with [Claude Code](https://claude.ai/code)