### PR TITLE
Add descriptive names to device movements and operations

### DIFF
--- a/acq4/devices/DoverStage/doverstage.py
+++ b/acq4/devices/DoverStage/doverstage.py
@@ -71,9 +71,11 @@ class DoverStage(Stage):
     def positionUpdatesPerSecond(self):
         return 1 / self.dev.control_thread.poll_interval
 
-    def _move(self, pos, speed, linear, **kwds):
+    def _move(self, pos, speed, linear, name=None, **kwds):
         speed = self._interpretSpeed(speed)
-        self._lastMove = DoverMoveFuture(self, pos, speed, kwds.get("name", "unnamed move"))
+        if name is None:
+            name = f"{self.name()} move"
+        self._lastMove = DoverMoveFuture(self, pos, speed, name)
         return self._lastMove
 
     def targetPosition(self):

--- a/acq4/devices/DoverStage/doverstage.py
+++ b/acq4/devices/DoverStage/doverstage.py
@@ -73,9 +73,7 @@ class DoverStage(Stage):
 
     def _move(self, pos, speed, linear, name=None, **kwds):
         speed = self._interpretSpeed(speed)
-        if name is None:
-            name = f"{self.name()} move"
-        self._lastMove = DoverMoveFuture(self, pos, speed, name)
+        self._lastMove = DoverMoveFuture(self, pos, speed, name=name)
         return self._lastMove
 
     def targetPosition(self):
@@ -133,11 +131,11 @@ class DoverStage(Stage):
 class DoverMoveFuture(MoveFuture):
     """Provides access to a move-in-progress on a Dover stage."""
 
-    def __init__(self, dev, pos, speed, name):
-        MoveFuture.__init__(self, dev, pos, speed, name)
+    def __init__(self, dev, pos, speed, name=None):
+        MoveFuture.__init__(self, dev, pos, speed, name=name)
         self.dev = dev
         self.target = np.asarray(pos)
-        self._future = self.dev.dev.move(list(pos), self.speed * 1e3, name=name)
+        self._future = self.dev.dev.move(list(pos), self.speed * 1e3, name=self.name)
         self._future.set_callback(self._future_finished)
 
     def _future_finished(self, req_fut):

--- a/acq4/devices/InteractionSite.py
+++ b/acq4/devices/InteractionSite.py
@@ -187,10 +187,10 @@ class InteractionSite(Device, OptomechDevice):
         approach_pos = pos_config['site global']
         # TODO this will still need a real motion planner
         # TODO we'll maybe also need to make sure the other devices are out of the way...
-        _future.waitFor(self.moveToGlobal(approach_pos, speed=speed), timeout=120)
-        _future.waitFor(other._moveToGlobal(approach_pos, speed=speed), timeout=120)
+        _future.waitFor(self.moveToGlobal(approach_pos, speed=speed, name=f"move {self.name()} to approach {other.name()}"), timeout=120)
+        _future.waitFor(other._moveToGlobal(approach_pos, speed=speed, name=f"move {other.name()} to approach {self.name()}"), timeout=120)
         interact_global = pos_config['interact global']
-        _future.waitFor(other._moveToGlobal(interact_global, speed=speed))
+        _future.waitFor(other._moveToGlobal(interact_global, speed=speed, name=f"move {other.name()} to interact with {self.name()}"))
 
     @future_wrap
     def moveToApproach(self, other, speed='fast', _future=None):
@@ -199,8 +199,8 @@ class InteractionSite(Device, OptomechDevice):
         pos_config = self.positions[other.name()]
         if 'site global' not in pos_config:
             raise RuntimeError(f"No site global position saved for {other.name()} at {self.name()}")
-        _future.waitFor(self.moveToGlobal(pos_config['site global'], speed=speed), timeout=120)
-        _future.waitFor(other._moveToGlobal(pos_config['site global'], speed=speed), timeout=120)
+        _future.waitFor(self.moveToGlobal(pos_config['site global'], speed=speed, name=f"move {self.name()} to approach {other.name()}"), timeout=120)
+        _future.waitFor(other._moveToGlobal(pos_config['site global'], speed=speed, name=f"move {other.name()} to approach {self.name()}"), timeout=120)
 
     # @future_wrap
     # def moveToInteract(self, other, speed='fast', _future=None):

--- a/acq4/devices/MicroManagerStage/mmstage.py
+++ b/acq4/devices/MicroManagerStage/mmstage.py
@@ -293,8 +293,6 @@ class MicroManagerMoveFuture(MoveFuture):
     """
 
     def __init__(self, dev, pos, speed, userSpeed, moveXY=True, moveZ=True, name=None):
-        if name is None:
-            name = f'{dev.name()} move'
         MoveFuture.__init__(self, dev, pos, speed, name=name)
         self._interrupted = False
         self._errorMSg = None

--- a/acq4/devices/MicroManagerStage/mmstage.py
+++ b/acq4/devices/MicroManagerStage/mmstage.py
@@ -216,7 +216,7 @@ class MicroManagerStage(Stage):
         self.monitor.stop()
         Stage.quit(self)
 
-    def _move(self, pos, speed, linear, **kwds):
+    def _move(self, pos, speed, linear, name=None, **kwds):
         with self.lock:
             if self._lastMove is not None and not self._lastMove.isDone():
                 self.stop()
@@ -227,7 +227,7 @@ class MicroManagerStage(Stage):
 
             speed = self._interpretSpeed(speed)
 
-            self._lastMove = MicroManagerMoveFuture(self, pos, speed, self.userSpeed, moveXY=moveXY, moveZ=moveZ)
+            self._lastMove = MicroManagerMoveFuture(self, pos, speed, self.userSpeed, moveXY=moveXY, moveZ=moveZ, name=name)
             return self._lastMove
 
     def deviceInterface(self, win):
@@ -292,8 +292,10 @@ class MicroManagerMoveFuture(MoveFuture):
     """Provides access to a move-in-progress on a micromanager stage.
     """
 
-    def __init__(self, dev, pos, speed, userSpeed, moveXY=True, moveZ=True):
-        MoveFuture.__init__(self, dev, pos, speed, name=f'{dev.name()}_move')
+    def __init__(self, dev, pos, speed, userSpeed, moveXY=True, moveZ=True, name=None):
+        if name is None:
+            name = f'{dev.name()} move'
+        MoveFuture.__init__(self, dev, pos, speed, name=name)
         self._interrupted = False
         self._errorMSg = None
         self._finished = False

--- a/acq4/devices/Microscope/Microscope.py
+++ b/acq4/devices/Microscope/Microscope.py
@@ -284,7 +284,7 @@ class Microscope(Device, OptomechDevice):
         if (idx := find_surface(z_stack, threshold)) is not None:
             depth = z_stack[idx].mapFromFrameToGlobal([0, 0, 0])[2]
             self.setSurfaceDepth(depth)
-            _future.waitFor(self.setFocusDepth(depth))
+            _future.waitFor(self.setFocusDepth(depth, name=f"{self.name()} focus to detected surface"))
             if returnStack:
                 return depth, z_stack
             return depth
@@ -364,7 +364,7 @@ class Microscope(Device, OptomechDevice):
         z = obj.getDipHeight()
         if z is None:
             raise RuntimeError(f"No dip height set for objective '{obj.name()}'")
-        return self.setFocusDepth(z, speed=speed)
+        return self.setFocusDepth(z, speed=speed, name=f"{self.name()} move to dip height")
 
     def moveLift(self, speed='fast'):
         """Move to the lift height configured for the current objective."""
@@ -374,7 +374,7 @@ class Microscope(Device, OptomechDevice):
         z = obj.getLiftHeight()
         if z is None:
             raise RuntimeError(f"No lift height set for objective '{obj.name()}'")
-        return self.setFocusDepth(z, speed=speed)
+        return self.setFocusDepth(z, speed=speed, name=f"{self.name()} move to lift height")
 
     def positionDevice(self):
         if self._positionDevice is None:
@@ -579,7 +579,7 @@ class ScopeGUI(Qt.QWidget):
         obj = self._currentObjectiveForSlot(slot)
         z = obj.getDipHeight()
         if z is not None:
-            self.dev.setFocusDepth(z)
+            self.dev.setFocusDepth(z, name=f"{self.dev.name()} go to dip height")
 
     def _setLiftHeight(self, slot):
         obj = self._currentObjectiveForSlot(slot)
@@ -590,7 +590,7 @@ class ScopeGUI(Qt.QWidget):
         obj = self._currentObjectiveForSlot(slot)
         z = obj.getLiftHeight()
         if z is not None:
-            self.dev.setFocusDepth(z)
+            self.dev.setFocusDepth(z, name=f"{self.dev.name()} go to lift height")
 
     def _updateDipLiftButtons(self, slot):
         """Enable/disable Go buttons based on whether heights have been set."""
@@ -716,7 +716,7 @@ class FocusSpinBox(Qt.QAbstractSpinBox):
         tpos = fd.globalTargetPosition()
         if tpos is None:
             tpos = fd.globalPosition()
-        self._dev.setFocusDepth(tpos[2] + steps * self._step)
+        self._dev.setFocusDepth(tpos[2] + steps * self._step, name=f"{self._dev.name()} spinbox step")
 
     def stepEnabled(self):
         return self.StepUpEnabled | self.StepDownEnabled
@@ -748,7 +748,7 @@ class FocusSpinBox(Qt.QAbstractSpinBox):
                 text = text[: -len(suffix)].strip()
                 break
         try:
-            self._dev.setFocusDepth(float(text) * 1e-6)
+            self._dev.setFocusDepth(float(text) * 1e-6, name=f"{self._dev.name()} spinbox set")
         except ValueError:
             pass
         self._updateDisplay()
@@ -842,7 +842,7 @@ class ScopeCameraModInterface(CameraModuleInterface):
 
     def focusChangedFromWidget(self, depth):
         """Handle focus changes from the Z-position widget."""
-        mfut = self.getDevice().setFocusDepth(depth)
+        mfut = self.getDevice().setFocusDepth(depth, name=f"{self.getDevice().name()} focus from Z-widget")
         mfut.sigFinished.connect(self._handleRefocusFinished)
 
     def _handleRefocusFinished(self):

--- a/acq4/devices/MockStage.py
+++ b/acq4/devices/MockStage.py
@@ -103,7 +103,7 @@ class MockStage(Stage):
     def axes(self):
         return ['x', 'y', 'z', 'd'][:self.nAxes]
 
-    def _move(self, pos, speed, linear, **kwds):
+    def _move(self, pos, speed, linear, name=None, **kwds):
         """Called by base stage class when the user requests to move to an
         absolute or relative position.
         """
@@ -111,7 +111,7 @@ class MockStage(Stage):
             self._interruptMove()
             pos = self._toAbsolutePosition(pos)
             speed = self._interpretSpeed(speed)
-            self._lastMove = MockMoveFuture(self, pos, speed)
+            self._lastMove = MockMoveFuture(self, pos, speed, name=name)
             return self._lastMove
 
     def _interpretSpeed(self, speed):
@@ -205,8 +205,10 @@ class MockStage(Stage):
 class MockMoveFuture(MoveFuture):
     """Provides access to a move-in-progress on a mock manipulator.
     """
-    def __init__(self, dev, pos, speed):
-        MoveFuture.__init__(self, dev, pos, speed, name=f'{dev.name()}_move')
+    def __init__(self, dev, pos, speed, name=None):
+        if name is None:
+            name = f'{dev.name()} move'
+        MoveFuture.__init__(self, dev, pos, speed, name=name)
         self.targetPos = pos
 
         self.dev.stageThread.setTarget(self, pos, speed)

--- a/acq4/devices/MockStage.py
+++ b/acq4/devices/MockStage.py
@@ -206,8 +206,6 @@ class MockMoveFuture(MoveFuture):
     """Provides access to a move-in-progress on a mock manipulator.
     """
     def __init__(self, dev, pos, speed, name=None):
-        if name is None:
-            name = f'{dev.name()} move'
         MoveFuture.__init__(self, dev, pos, speed, name=name)
         self.targetPos = pos
 

--- a/acq4/devices/NewScaleMPM.py
+++ b/acq4/devices/NewScaleMPM.py
@@ -114,8 +114,6 @@ class NewScaleMPM(Stage):
 
 class NewScaleMoveFuture(MoveFuture):
     def __init__(self, dev, pos, speed, linear, name=None):
-        if name is None:
-            name = f"{dev.name()} move"
         MoveFuture.__init__(self, dev, pos, speed, name=name)
 
         self._linear = linear

--- a/acq4/devices/NewScaleMPM.py
+++ b/acq4/devices/NewScaleMPM.py
@@ -97,10 +97,10 @@ class NewScaleMPM(Stage):
         Stage.quit(self)
         self.dev.close()
 
-    def _move(self, pos, speed, linear, **kwds):
+    def _move(self, pos, speed, linear, name=None, **kwds):
         with self.lock:
             speed = self._interpretSpeed(speed)
-            self._lastMove = NewScaleMoveFuture(self, pos, speed, linear)
+            self._lastMove = NewScaleMoveFuture(self, pos, speed, linear, name=name)
             return self._lastMove
 
     def monitor(self):
@@ -113,8 +113,10 @@ class NewScaleMPM(Stage):
 
 
 class NewScaleMoveFuture(MoveFuture):
-    def __init__(self, dev, pos, speed, linear):
-        MoveFuture.__init__(self, dev, pos, speed, name=f"{dev.name} move")
+    def __init__(self, dev, pos, speed, linear, name=None):
+        if name is None:
+            name = f"{dev.name()} move"
+        MoveFuture.__init__(self, dev, pos, speed, name=name)
 
         self._linear = linear
         self._interrupted = False

--- a/acq4/devices/PatchPipette/states/nucleus_collect.py
+++ b/acq4/devices/PatchPipette/states/nucleus_collect.py
@@ -52,7 +52,7 @@ class NucleusCollectState(PatchPipetteState):
         # self.approachPos = self.collectionPos - pip.globalDirection() * config['approachDistance']
 
         # self.waitFor([pip._moveToGlobal(self.approachPos, speed='fast')])
-        self.waitFor(pip._moveToGlobal(self.collectionPos, speed='fast'), timeout=None)
+        self.waitFor(pip._moveToGlobal(self.collectionPos, speed='fast', name=f"{pip.name()} move to nucleus collection position"), timeout=None)
 
         if dev.sonicatorDevice is not None:
             self.sonication = dev.sonicatorDevice.doProtocol(config['sonicationProtocol'])

--- a/acq4/devices/Pipette/calibration.py
+++ b/acq4/devices/Pipette/calibration.py
@@ -223,7 +223,7 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
         # focus 2mm above surface
         surfaceZ = scopeDevice.getSurfaceDepth()
         startDepth = surfaceZ + 2e-3
-        _future.waitFor(imager.setFocusDepth(startDepth))
+        _future.waitFor(imager.setFocusDepth(startDepth, name=f"{imager.name()} focus above surface for {pipette.name()} auto-calibrate"))
 
         # move pipette to search position
         center = imager.globalCenterPosition(mode='roi')
@@ -233,7 +233,7 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
         searchPos1 = center + pipVector * 1.5e-3 + pipY * 2e-3
         searchPos2 = center + pipVector * 1.5e-3 - pipY * 2e-3
         # using a planner avoids possible collisions with the objective
-        planner = PipetteMotionPlanner(pipette, searchPos1, speed='fast')
+        planner = PipetteMotionPlanner(pipette, searchPos1, speed='fast', name=f"{pipette.name()} auto-calibrate search")
         _future.waitFor(planner.move())
 
         # collect background images, analyze noise
@@ -261,7 +261,7 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
         centerPipPos = getPipettePositionAtTime(posEvents, centerTime)
 
         # move back to center position
-        _future.waitFor(pipette._moveToGlobal(centerPipPos, speed='fast'))
+        _future.waitFor(pipette._moveToGlobal(centerPipPos, speed='fast', name=f"{pipette.name()} auto-calibrate return to center"))
 
         # todo: at this point we could compare the current image to the previously collected video
         # to see whether we made it back to the desired position (and if not, apply
@@ -273,7 +273,7 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
         pipetteCameraDelay = frames[mostSimilarFrame].info()['time'] - frames[centerIndex].info()['time']
         correctedCenterTime = frames[centerIndex].info()['time'] - pipetteCameraDelay
         correctedCenterPipPos = getPipettePositionAtTime(posEvents, correctedCenterTime)
-        _future.waitFor(pipette._moveToGlobal(correctedCenterPipPos, speed='fast'))
+        _future.waitFor(pipette._moveToGlobal(correctedCenterPipPos, speed='fast', name=f"{pipette.name()} auto-calibrate corrected center"))
 
         # record from imager and pipette position while retracting pipette out of frame
         retractPos = centerPipPos - pipVector * 2e-3
@@ -314,7 +314,7 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
         centerPipPos2 = endPipPos + np.array([0, yDist, 0])
 
         # move to new center
-        _future.waitFor(pipette._moveToGlobal(centerPipPos2, speed='fast'))
+        _future.waitFor(pipette._moveToGlobal(centerPipPos2, speed='fast', name=f"{pipette.name()} auto-calibrate move to new center"))
 
         # autofocus
         z_range = (startDepth - 500e-6, startDepth + 500e-6, 20e-6)
@@ -358,7 +358,7 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
 
         # do initial coarse registration: reset offset to detected position, center in frame
         pipette.resetGlobalPosition(globalPos)
-        _future.waitFor(pipette._moveToGlobal(imager.globalCenterPosition(), 'fast'))
+        _future.waitFor(pipette._moveToGlobal(imager.globalCenterPosition(), 'fast', name=f"{pipette.name()} auto-calibrate coarse center"))
 
         # iteratively refine tip position until convergence
         _future.waitFor(pipette.iterativelyFindTip(30), timeout=None)
@@ -418,7 +418,7 @@ def watchMovingPipette(pipette: Pipette, imager: Camera, pos, speed, _future):
         try:
             imgFuture = imager.acquireFrames()
             pipRecorder = pipette.startRecording()
-            pipFuture = pipette._moveToGlobal(pos, speed=speed)
+            pipFuture = pipette._moveToGlobal(pos, speed=speed, name=f"{pipette.name()} watchMovingPipette")
             _future.waitFor(pipFuture, timeout=40)  # for some reason one of these moves takes a long time to finish..
         finally:
             if pipRecorder is not None:
@@ -502,7 +502,7 @@ def calibrate_manipulator_axes(
             # Move along this axis to the next absolute position.
             target_pos = list(axis_start_pos)
             target_pos[axis] = axis_start_pos[axis] + step_idx * (step_size / scale[axis])
-            _future.waitFor(manipulator.move(target_pos, 'slow'))
+            _future.waitFor(manipulator.move(target_pos, 'slow', name=f"{manipulator.name()} calibrate axis {axis} step {step_idx}"))
 
             # Locate the tip via z-stack scan; this handles unknown axis orientation by
             # searching a range of focal depths around the current focus.
@@ -523,7 +523,7 @@ def calibrate_manipulator_axes(
             calibration_points.append((device_pos, parent_pos))
 
         # Return to the starting position before sweeping the next axis.
-        _future.waitFor(manipulator.move(axis_start_pos, 'slow'))
+        _future.waitFor(manipulator.move(axis_start_pos, 'slow', name=f"{manipulator.name()} calibrate axis {axis} return"))
         # Re-locate tip at start before recording the first point of the next axis.
         _future.waitFor(pipette.iterativelyFindTip(10))
 

--- a/acq4/devices/Pipette/pipette.py
+++ b/acq4/devices/Pipette/pipette.py
@@ -456,7 +456,7 @@ class Pipette(Device, OptomechDevice):
                 )
                 _future.waitFor(seq_future)
             finally:
-                _future.waitFor(cam.setFocusDepth(depth))
+                _future.waitFor(cam.setFocusDepth(depth, name=f"{cam.name()} restore focus after {self.name()} manual calibration stack"))
             fh = seq_future.imagesSavedIn
             info = {
                 **fh.info(),

--- a/acq4/devices/Pipette/planners.py
+++ b/acq4/devices/Pipette/planners.py
@@ -450,7 +450,8 @@ class SearchMotionPlanner(PipetteMotionPlanner):
 
     @future_wrap
     def _move(self, _future):
-        _future.name = f"{self.pip.name()} {self.name}"
+        base = f"{self.pip.name()} {self.name}"
+        _future.name = base
         pip = self.pip
         speed = self.speed
         distance = self.kwds.get("distance", 0)
@@ -468,7 +469,7 @@ class SearchMotionPlanner(PipetteMotionPlanner):
         # move scope such that camera will be focused at searchDepth
         if focusDepth < searchDepth:
             scopeFocus = scope.getFocusDepth()
-            fut = scope.setFocusDepth(scopeFocus + searchDepth - focusDepth, name=f"set focus for {self.pip.name()} {self.name}")
+            fut = scope.setFocusDepth(scopeFocus + searchDepth - focusDepth, name=f"{base}: focus above surface")
             # wait for objective to lift before starting pipette motion
             _future.waitFor(fut)
 
@@ -481,7 +482,7 @@ class SearchMotionPlanner(PipetteMotionPlanner):
 
         path = self.safePath(pip.globalPosition(), globalTarget, speed)
 
-        _future.waitFor(pip._movePath(path, name=f"{self.pip.name()} {self.name}"))
+        _future.waitFor(pip._movePath(path, name=f"{base}: pipette path"))
 
 
 class ApproachMotionPlanner(PipetteMotionPlanner):
@@ -518,15 +519,16 @@ class AboveTargetMotionPlanner(PipetteMotionPlanner):
 
     @future_wrap
     def _move(self, _future):
-        _future.name = f"{self.pip.name()} {self.name}"
+        base = f"{self.pip.name()} {self.name}"
+        _future.name = base
         pip = self.pip
         speed = self.speed
         scope = pip.scopeDevice()
         waypoint1, waypoint2 = self.aboveTargetPath()
 
         path = self.safePath(pip.globalPosition(), waypoint1, speed, APPROACH_TO_CORRECT_FOR_HYSTERESIS)
-        _future.waitFor(pip._movePath(path + [(waypoint2, "fast", True, "Above target")], name=f"{pip.name()} {self.name}"))
-        move_scope = scope.setGlobalPosition(waypoint2, name=f"move scope for {self.pip.name()} {self.name}")
+        _future.waitFor(pip._movePath(path + [(waypoint2, "fast", True, "Above target")], name=f"{base}: pipette path"))
+        move_scope = scope.setGlobalPosition(waypoint2, name=f"{base}: scope recenter")
         _future.waitFor(move_scope)  # TODO act simultaneously once we can handle motion planning around moving objects
 
     def aboveTargetPath(self):
@@ -565,7 +567,8 @@ class IdleMotionPlanner(PipetteMotionPlanner):
 
     @future_wrap
     def _move(self, _future):
-        _future.name = f"{self.pip.name()} {self.name}"
+        base = f"{self.pip.name()} {self.name}"
+        _future.name = base
         pip = self.pip
         speed = self.speed
 
@@ -580,14 +583,14 @@ class IdleMotionPlanner(PipetteMotionPlanner):
         # If the tip is below idle depth, bring it up along the axis of the electrode.
         pos = pip.globalPosition()
         if pos[2] < idleDepth:
-            pip.advance(idleDepth, speed, name=f"{pip.name()} {self.name} advance")
+            pip.advance(idleDepth, speed, name=f"{base}: ascend to idle depth")
 
         # From here, move directly to idle position
         angle = pip.yawRadians()
         ds = pip._opts["idleDistance"]  # move to 7 mm from center
         globalIdlePos = -ds * np.cos(angle), -ds * np.sin(angle), idleDepth
 
-        _future.waitFor(pip._moveToGlobal(globalIdlePos, speed, name=f"{pip.name()} {self.name}"))
+        _future.waitFor(pip._moveToGlobal(globalIdlePos, speed, name=f"{base}: move to edge"))
 
 
 def defaultMotionPlanners() -> dict[str, type[PipetteMotionPlanner]]:

--- a/acq4/devices/Pipette/planners.py
+++ b/acq4/devices/Pipette/planners.py
@@ -348,7 +348,7 @@ class PipetteMotionPlanner:
             self.future.stop()
 
     def _move(self):
-        return self.pip._movePath(self.path(), name=f"{self.pip.name()} {self.name} path")
+        return self.pip._movePath(self.path(), name=f"{self.pip.name()} {self.name}")
 
     def path(self):
         startPosGlobal = self.pip.globalPosition()
@@ -446,11 +446,11 @@ class SearchMotionPlanner(PipetteMotionPlanner):
     """
 
     def _default_name(self):
-        return "search"
+        return "move to search"
 
     @future_wrap
     def _move(self, _future):
-        _future.name = f"{self.pip.name()} search"
+        _future.name = f"{self.pip.name()} {self.name}"
         pip = self.pip
         speed = self.speed
         distance = self.kwds.get("distance", 0)
@@ -468,7 +468,7 @@ class SearchMotionPlanner(PipetteMotionPlanner):
         # move scope such that camera will be focused at searchDepth
         if focusDepth < searchDepth:
             scopeFocus = scope.getFocusDepth()
-            fut = scope.setFocusDepth(scopeFocus + searchDepth - focusDepth, name=f"set focus for {self.pip.name()} search")
+            fut = scope.setFocusDepth(scopeFocus + searchDepth - focusDepth, name=f"set focus for {self.pip.name()} {self.name}")
             # wait for objective to lift before starting pipette motion
             _future.waitFor(fut)
 
@@ -481,7 +481,7 @@ class SearchMotionPlanner(PipetteMotionPlanner):
 
         path = self.safePath(pip.globalPosition(), globalTarget, speed)
 
-        _future.waitFor(pip._movePath(path, name=f"{self.pip.name()} search path"))
+        _future.waitFor(pip._movePath(path, name=f"{self.pip.name()} {self.name}"))
 
 
 class ApproachMotionPlanner(PipetteMotionPlanner):
@@ -518,14 +518,15 @@ class AboveTargetMotionPlanner(PipetteMotionPlanner):
 
     @future_wrap
     def _move(self, _future):
+        _future.name = f"{self.pip.name()} {self.name}"
         pip = self.pip
         speed = self.speed
         scope = pip.scopeDevice()
         waypoint1, waypoint2 = self.aboveTargetPath()
 
         path = self.safePath(pip.globalPosition(), waypoint1, speed, APPROACH_TO_CORRECT_FOR_HYSTERESIS)
-        _future.waitFor(pip._movePath(path + [(waypoint2, "fast", True, "Above target")], name=f"{pip.name()} above target path"))
-        move_scope = scope.setGlobalPosition(waypoint2, name=f"move scope for {self.pip.name()} above target")
+        _future.waitFor(pip._movePath(path + [(waypoint2, "fast", True, "Above target")], name=f"{pip.name()} {self.name}"))
+        move_scope = scope.setGlobalPosition(waypoint2, name=f"move scope for {self.pip.name()} {self.name}")
         _future.waitFor(move_scope)  # TODO act simultaneously once we can handle motion planning around moving objects
 
     def aboveTargetPath(self):
@@ -559,8 +560,12 @@ class IdleMotionPlanner(PipetteMotionPlanner):
     chamber.
     """
 
+    def _default_name(self):
+        return "move to idle"
+
     @future_wrap
     def _move(self, _future):
+        _future.name = f"{self.pip.name()} {self.name}"
         pip = self.pip
         speed = self.speed
 
@@ -575,14 +580,14 @@ class IdleMotionPlanner(PipetteMotionPlanner):
         # If the tip is below idle depth, bring it up along the axis of the electrode.
         pos = pip.globalPosition()
         if pos[2] < idleDepth:
-            pip.advance(idleDepth, speed)
+            pip.advance(idleDepth, speed, name=f"{pip.name()} {self.name} advance")
 
         # From here, move directly to idle position
         angle = pip.yawRadians()
         ds = pip._opts["idleDistance"]  # move to 7 mm from center
         globalIdlePos = -ds * np.cos(angle), -ds * np.sin(angle), idleDepth
 
-        _future.waitFor(pip._moveToGlobal(globalIdlePos, speed, name=f"{pip.name()} idle"))
+        _future.waitFor(pip._moveToGlobal(globalIdlePos, speed, name=f"{pip.name()} {self.name}"))
 
 
 def defaultMotionPlanners() -> dict[str, type[PipetteMotionPlanner]]:

--- a/acq4/devices/Pipette/tracker.py
+++ b/acq4/devices/Pipette/tracker.py
@@ -568,7 +568,7 @@ class CorrelationPipetteTracker(PipetteTracker):
                         offsets.append(offset)
 
                         # move manipulator
-                        mfut = self.pipette._moveToGlobal(pos + offset, speed)
+                        mfut = self.pipette._moveToGlobal(pos + offset, speed, name=f"{self.pipette.name()} tracker calibration step {i}")
 
                         # move camera
                         if moveStageXY:
@@ -576,7 +576,7 @@ class CorrelationPipetteTracker(PipetteTracker):
                         else:
                             cpos = imager.globalCenterPosition("roi")
                             cpos[2] = pos[2]
-                        ffut = imager.moveCenterToGlobal(cpos, speed, center="roi")
+                        ffut = imager.moveCenterToGlobal(cpos, speed, center="roi", name=f"{imager.name()} center on {self.pipette.name()} for tracker calibration step {i}")
                     if i > 0:
                         ind = inds[order[i - 1]]
 
@@ -613,7 +613,7 @@ class CorrelationPipetteTracker(PipetteTracker):
 
                     # step back to actual target position
                     try:
-                        self.pipette._moveToGlobal(pos, speed).wait(updates=True)
+                        self.pipette._moveToGlobal(pos, speed, name=f"{self.pipette.name()} tracker calibration return to target").wait(updates=True)
                     except RuntimeError as exc:
                         misses += 1
                         logger.exception("Manipulator missed target:")
@@ -626,8 +626,8 @@ class CorrelationPipetteTracker(PipetteTracker):
                     if dlg.wasCanceled():
                         return None
         finally:
-            self.pipette._moveToGlobal(start, "fast")
-            self.pipette.scopeDevice().setFocusDepth(start[2], "fast")
+            self.pipette._moveToGlobal(start, "fast", name=f"{self.pipette.name()} tracker calibration return to start")
+            self.pipette.scopeDevice().setFocusDepth(start[2], "fast", name=f"{self.pipette.scopeDevice().name()} tracker calibration return focus to start")
 
         self.errorMap = {
             "err": err,

--- a/acq4/devices/Scientifica/scientifica.py
+++ b/acq4/devices/Scientifica/scientifica.py
@@ -250,8 +250,6 @@ class Scientifica(Stage):
             if self._lastMove is not None and not self._lastMove.isDone():
                 self.stop()
             speed = self._interpretSpeed(speed)
-            if name is None:
-                name = f"{self.name()} move"
 
             self._lastMove = ScientificaMoveFuture(self, pos, speed, name=name, **kwds)
             return self._lastMove

--- a/acq4/devices/Scientifica/scientifica.py
+++ b/acq4/devices/Scientifica/scientifica.py
@@ -250,6 +250,8 @@ class Scientifica(Stage):
             if self._lastMove is not None and not self._lastMove.isDone():
                 self.stop()
             speed = self._interpretSpeed(speed)
+            if name is None:
+                name = f"{self.name()} move"
 
             self._lastMove = ScientificaMoveFuture(self, pos, speed, name=name, **kwds)
             return self._lastMove
@@ -300,7 +302,7 @@ class ScientificaMoveFuture(MoveFuture):
             self.doStepwise = True
             currentPos = dev.getPosition()
             targetPos = [currentPos[i] if pos[i] is None else pos[i] for i in range(len(pos))]
-            super().__init__(dev, targetPos, speed)
+            super().__init__(dev, targetPos, speed, name=name)
             self.stepwiseThread.start()
         else:
             self._moveReq = dev.driver.moveTo(np.array(pos), speed / 1e-6, name=name, **kwds)
@@ -340,7 +342,7 @@ class ScientificaMoveFuture(MoveFuture):
                 now = ptime.time()
                 fracComplete = min(1, (now - startTime) / duration)
                 step = start + (stop-start) * fracComplete
-                self.f = self.dev.driver.moveTo(step, speed=minSpeed)
+                self.f = self.dev.driver.moveTo(step, speed=minSpeed, name=f"{self.dev.name()} stepwise substep")
                 self.f.wait()
                 if fracComplete == 1:
                     self._taskDone()
@@ -502,7 +504,7 @@ class ScientificaGUI(StageInterface):
                         diff += self._zeroAxis(axis)
 
             self.dev.logger.info(f"Auto-zeroed {self.dev.name()} by {diff}")
-            move_future = self.dev.moveToGlobal(globalStartPos + diff, "fast")
+            move_future = self.dev.moveToGlobal(globalStartPos + diff, "fast", name=f"{self.dev.name()} return to start after auto-zero")
             slippedAxes = np.abs(diff) > 50e-6
             if np.any(slippedAxes):
                 msg = f"Detected axis slip on {self.dev.name()}:"
@@ -531,7 +533,7 @@ class ScientificaGUI(StageInterface):
         else:
             dest = [None, None, None]
             dest[axis] = pos[axis]
-        f = self.dev._move(dest, "fast", False, attempts_allowed=1)
+        f = self.dev._move(dest, "fast", False, attempts_allowed=1, name=f"{self.dev.name()} auto-zero axis {axis}")
         while not f.isDone():
             _future.sleep(0.1)
 

--- a/acq4/devices/Sensapex.py
+++ b/acq4/devices/Sensapex.py
@@ -233,6 +233,8 @@ class Sensapex(Stage):
         if self._force_nonlinear_movement:
             linear = False
         speed = self._interpretSpeed(speed)
+        if name is None:
+            name = f"{self.name()} move"
         with self.lock:
             self._lastMove = SensapexMoveFuture(self, pos, speed, linear, name=name, **kwds)
             return self._lastMove

--- a/acq4/devices/Sensapex.py
+++ b/acq4/devices/Sensapex.py
@@ -233,8 +233,6 @@ class Sensapex(Stage):
         if self._force_nonlinear_movement:
             linear = False
         speed = self._interpretSpeed(speed)
-        if name is None:
-            name = f"{self.name()} move"
         with self.lock:
             self._lastMove = SensapexMoveFuture(self, pos, speed, linear, name=name, **kwds)
             return self._lastMove

--- a/acq4/devices/Stage/Stage.py
+++ b/acq4/devices/Stage/Stage.py
@@ -707,6 +707,8 @@ class MoveFuture(Future):
     """Used to track the progress of a requested move operation."""
 
     def __init__(self, dev: Stage, pos, speed, name=None):
+        if name is None:
+            name = f"{dev.name()} move"
         Future.__init__(self, name=name)
         self.startTime = ptime.time()
         self.dev = dev

--- a/acq4/devices/Stage/Stage.py
+++ b/acq4/devices/Stage/Stage.py
@@ -844,7 +844,7 @@ class MovePathFuture(MoveFuture):
             step['position'] = fwdPath[i]['position']
             step['explanation'] = f"undo {step.get('explanation')}"
             revPath.append(step)
-        return self.dev.movePath(revPath)
+        return self.dev.movePath(revPath, name=f"undo {self.name}")
 
 
 class StageInterface(Qt.QWidget):

--- a/acq4/devices/SutterMPC200/SutterMPC200.py
+++ b/acq4/devices/SutterMPC200/SutterMPC200.py
@@ -291,8 +291,6 @@ class MPC200MoveFuture(MoveFuture):
     """Provides access to a move-in-progress on an MPC200 drive.
     """
     def __init__(self, dev, pos, speed, name=None):
-        if name is None:
-            name = f'{dev.name()} move'
         MoveFuture.__init__(self, dev, pos, speed, name=name)
         
         # because of MPC200 idiosyncracies, we must coordinate with the monitor

--- a/acq4/devices/SutterMPC200/SutterMPC200.py
+++ b/acq4/devices/SutterMPC200/SutterMPC200.py
@@ -151,7 +151,7 @@ class SutterMPC200(Stage):
     def positionUpdatesPerSecond(self):
         return 1.0 / SutterMPC200._monitor.minInterval
 
-    def _move(self, pos, speed, linear, **kwds):
+    def _move(self, pos, speed, linear, name=None, **kwds):
         # convert speed to values accepted by MPC200
         if speed == 'slow':
             speed = self.slowSpeed
@@ -162,8 +162,8 @@ class SutterMPC200(Stage):
                 speed = 'fast'
         else:
             speed = self._getClosestSpeed(speed)
-        
-        self._lastMove = MPC200MoveFuture(self, pos, speed)
+
+        self._lastMove = MPC200MoveFuture(self, pos, speed, name=name)
         return self._lastMove
 
     def _getClosestSpeed(self, speed):
@@ -290,8 +290,10 @@ class MonitorThread(Thread):
 class MPC200MoveFuture(MoveFuture):
     """Provides access to a move-in-progress on an MPC200 drive.
     """
-    def __init__(self, dev, pos, speed):
-        MoveFuture.__init__(self, dev, pos, speed)
+    def __init__(self, dev, pos, speed, name=None):
+        if name is None:
+            name = f'{dev.name()} move'
+        MoveFuture.__init__(self, dev, pos, speed, name=name)
         
         # because of MPC200 idiosyncracies, we must coordinate with the monitor
         # thread to do a move.

--- a/acq4/devices/ThorlabsMFC1/MFC1.py
+++ b/acq4/devices/ThorlabsMFC1/MFC1.py
@@ -96,14 +96,14 @@ class ThorlabsMFC1(Stage):
             self.posChanged([0, 0, pos])
         return [0, 0, pos]
 
-    def _move(self, pos, speed, linear, **kwds):
+    def _move(self, pos, speed, linear, name=None, **kwds):
         pos = self._toAbsolutePosition(pos)
         limits = self.getLimits()[2]
         if limits[0] is not None:
             pos[2] = max(pos[2], limits[0])
         if limits[1] is not None:
             pos[2] = min(pos[2], limits[1])
-        return MFC1MoveFuture(self, pos, speed)
+        return MFC1MoveFuture(self, pos, speed, name=name)
 
     @property
     def positionUpdatesPerSecond(self):
@@ -216,8 +216,10 @@ class MFC1StageInterface(StageInterface):
 class MFC1MoveFuture(MoveFuture):
     """Provides access to a move-in-progress on an MPC200 drive.
     """
-    def __init__(self, dev, pos, speed):
-        MoveFuture.__init__(self, dev, pos, speed)
+    def __init__(self, dev, pos, speed, name=None):
+        if name is None:
+            name = f'{dev.name()} move'
+        MoveFuture.__init__(self, dev, pos, speed, name=name)
         self.startPos = dev.getPosition()
         self.stopPos = pos
         self._moveStatus = {'status': None}

--- a/acq4/devices/ThorlabsMFC1/MFC1.py
+++ b/acq4/devices/ThorlabsMFC1/MFC1.py
@@ -217,8 +217,6 @@ class MFC1MoveFuture(MoveFuture):
     """Provides access to a move-in-progress on an MPC200 drive.
     """
     def __init__(self, dev, pos, speed, name=None):
-        if name is None:
-            name = f'{dev.name()} move'
         MoveFuture.__init__(self, dev, pos, speed, name=name)
         self.startPos = dev.getPosition()
         self.stopPos = pos

--- a/acq4/devices/zeiss/ZeissMicroscope.py
+++ b/acq4/devices/zeiss/ZeissMicroscope.py
@@ -71,7 +71,7 @@ class ZeissMicroscope(Microscope):
 
         # should return to same focal plane, correcting for new objective
         if self._startDepth is not None:
-            self.setFocusDepth(self._startDepth).wait()
+            self.setFocusDepth(self._startDepth, name=f"{self.name()} restore focus after objective change").wait()
             self._startDepth = None
 
     def quit(self):
@@ -95,4 +95,4 @@ class ZeissMicroscope(Microscope):
         """Move focus to a safe position for switching objectives.
         """
         safeDepth = self.safeFocusDepth
-        return self.setFocusDepth(safeDepth, speed=speed)
+        return self.setFocusDepth(safeDepth, speed=speed, name=f"{self.name()} move to safe focus depth")

--- a/acq4/modules/AutomationDebug/AutomationDebug.py
+++ b/acq4/modules/AutomationDebug/AutomationDebug.py
@@ -275,7 +275,7 @@ class AutomationDebugWindow(Qt.QWidget):
             )
             depth = depth_fut.getResult() - 50 * µm  # Target below surface
             _future.checkStop()
-            self.cameraDevice.setFocusDepth(depth)  # Set focus depth
+            self.cameraDevice.setFocusDepth(depth, name=f"{self.cameraDevice.name()} focus below surface for autoTarget")  # Set focus depth
 
             _future.waitFor(
                 self._detector._detectNeuronsZStack(), timeout=600

--- a/acq4/modules/AutomationDebug/detection.py
+++ b/acq4/modules/AutomationDebug/detection.py
@@ -145,7 +145,7 @@ class CellDetector:
             working_stack = detection_stack
             multichannel = False
 
-        win.cameraDevice.setFocusDepth(depth)  # Restore focus
+        win.cameraDevice.setFocusDepth(depth, name=f"{win.cameraDevice.name()} restore focus after detection z-stack")  # Restore focus
 
         global_pos = _future.waitFor(
             detect_neurons(

--- a/acq4/modules/Imager/Imager.py
+++ b/acq4/modules/Imager/Imager.py
@@ -847,8 +847,8 @@ class Imager(Module):
     def getFocusDepth(self):
         return self.scannerDev.getFocusDepth()
 
-    def setFocusDepth(self, depth):
-        return self.scannerDev.setFocusDepth(depth)
+    def setFocusDepth(self, depth, **kwds):
+        return self.scannerDev.setFocusDepth(depth, **kwds)
 
     def getFocusDevice(self):
         return self.scannerDev.getFocusDevice()


### PR DESCRIPTION
## Summary
This PR adds descriptive `name` parameters to device movement operations throughout the codebase to improve logging, debugging, and user-facing operation tracking. These names provide context about what operation is being performed and which devices are involved.

## Key Changes

- **Pipette motion planners**: Updated `SearchMotionPlanner`, `ApproachMotionPlanner`, and `IdleMotionPlanner` to use descriptive names like "move to search", "move to idle" instead of generic names, and propagate `self.name` through operation names for consistency
- **Calibration operations**: Added descriptive names to all device movements during pipette auto-calibration, including focus adjustments, search movements, and position corrections
- **Microscope focus operations**: Added names to `setFocusDepth` calls in dip/lift height movements and focus widget interactions
- **Stage implementations**: Updated `_move` method signatures across multiple stage drivers (`SutterMPC200`, `MicroManagerStage`, `MockStage`, `NewScaleMPM`, `ThorlabsMFC1`, `DoverStage`, `Scientifica`, `Sensapex`) to accept and propagate `name` parameter
- **Tracker calibration**: Added descriptive names to pipette and camera movements during tracker calibration steps
- **Interaction sites**: Added names to approach and interaction movements between devices
- **Microscope objective changes**: Added name to focus restoration after objective switching
- **Automation and detection**: Added names to focus depth changes in automation debug and neuron detection workflows

## Implementation Details

- The `name` parameter is now consistently passed through the `_move` method signature in all stage/manipulator implementations
- When `name` is not provided, a sensible default is generated using the device name (e.g., `f"{dev.name()} move"`)
- Motion planner names now use `self.name` property to generate consistent operation descriptions
- All `MoveFuture` subclasses properly handle the `name` parameter in their constructors

https://claude.ai/code/session_012XKEtLYV3b5XTjB23NhkAF