### PR TITLE
feat: context-aware logging and blocking-by-default future execution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,44 @@ ACQ4 is a platform for neurophysiology acquisition and analysis, focusing on pat
 * Favor small, maintainable changes; avoid redesigning large surfaces.
 * Preserve existing comments unless demonstrably incorrect.
 
+## Concurrency — Future and threading primitives
+
+acq4 uses a thread-backed `Future` class (`acq4.util.future`) for async tasks.
+
+**Starting async work:**
+```python
+from acq4.util.future import Future
+fut = Future(fn, (arg1, arg2), name="task name")  # starts thread immediately
+result = fut.wait()                                # block and return result
+```
+
+**Inside functions that run in a Future:**
+```python
+from acq4.util.future import sleep, check_stop, Queue, Event, Stopped
+
+sleep(0.5)      # interruptible; raises Stopped if the future is stopped
+check_stop()    # raises Stopped immediately if stopped; use in tight loops
+q = Queue()     # queue.Queue replacement; q.get() raises Stopped if stopped
+ev = Event()    # threading.Event replacement; ev.wait() raises Stopped
+```
+
+Do NOT use `time.sleep`, `queue.Queue`, or `threading.Event` inside functions
+that run inside a Future — they ignore stop requests and block cancellation.
+Use the drop-in replacements above instead.
+
+**Cooperative cancellation:**
+- `future.stop()` requests cancellation; it cascades to child futures automatically.
+- `sleep()`, `check_stop()`, `Queue.get()`, and `Event.wait()` raise `Stopped` when
+  the current future is stopped.
+- `Stopped` is caught in `_executeAndSetReturn_v2` and marks the future as stopped.
+
+**Worker threads (queue-based, long-lived):**
+Capture `task_stack.get()` at job submission time and restore with
+`task_stack.push_full(caller_stack)` in the worker. See `SmartStageControlThread`
+and `ScientificaControlThread` for examples.
+
+**Do not use `@future_wrap`** — it has been removed. Use `Future(fn)` directly.
+
 ## Shared Guidance
 
 - Workflow, testing, technology, and architecture expectations are detailed in `CONTRIBUTING.md`; follow them unless explicitly directed otherwise.

--- a/acq4/devices/Camera/Camera.py
+++ b/acq4/devices/Camera/Camera.py
@@ -715,7 +715,7 @@ class CameraTask(DAQGenericTask):
 
     def isDone(self):
         # If camera stopped, then probably there was a problem and we are finished.
-        return self._future.isDone() or self._stopTime is not None or not self.dev.isRunning()
+        return self._future.is_done or self._stopTime is not None or not self.dev.isRunning()
 
     def stop(self, abort=False):
         """Warning: this won't stop everything and you'll also need to call *getResult* within the
@@ -742,13 +742,13 @@ class CameraTask(DAQGenericTask):
     def getResult(self):
         if self.resultObj is None:
             daqResult = DAQGenericTask.getResult(self)
-            while time.time() - self._stopTime < 1 and not self._future.isDone():
+            while time.time() - self._stopTime < 1 and not self._future.is_done:
                 # Wait up to 1 second for all frames to arrive from camera thread before returning results.
                 # In some cases, acquisition thread can get bogged down and we may need to wait for it
                 # to catch up.
                 time.sleep(0.05)
             self._future.stop()  # TODO this could error for fixedFrameCount!=None
-            self.resultObj = CameraTaskResult(self, self._future.getResult(timeout=1), daqResult)
+            self.resultObj = CameraTaskResult(self, self._future.get_result(timeout=1), daqResult)
             if self._dev_needs_restart or not self._dev_was_running:
                 self.dev.stop(block=True)
                 if self._dev_was_running:
@@ -1121,7 +1121,7 @@ class FrameAcquisitionFuture(Future):
                 stack.enter_context(self._camera.ensureRunning(ensureFreshFrames=True))
             lastFrameTime = ptime.time()
             while True:
-                if self.isDone():
+                if self.is_done:
                     break
                 try:
                     frame = self._queue.get_nowait()
@@ -1158,7 +1158,7 @@ class FrameAcquisitionFuture(Future):
         if (
             timeout is None
             and self._frame_count is None
-            and not self.isDone()
+            and not self.is_done
             and not self._stopRequested
         ):
             raise ValueError(

--- a/acq4/devices/Camera/Camera.py
+++ b/acq4/devices/Camera/Camera.py
@@ -20,7 +20,7 @@ from acq4.util import Qt
 from acq4.util.Mutex import Mutex
 from acq4.util.Mutex import RecursiveMutex
 from acq4.util.Thread import Thread
-from acq4.util.future import Future, future_wrap
+from acq4.util.future import Future, check_stop
 from acq4.util.imaging.frame import Frame
 from coorx import TTransform, SRT3DTransform
 from pyqtgraph import Vector
@@ -250,7 +250,7 @@ class Camera(DAQGeneric, OptomechDevice):
         return Future.immediate()
 
     def presetHotkeyPressed(self, dev, changes, presetName):
-        self.loadPreset(presetName, _sync="async")
+        Future(self.loadPreset, (presetName,))
 
     def newFrames(self):
         """Returns a list of all new frames that have arrived since the last call. The list looks like:
@@ -364,9 +364,8 @@ class Camera(DAQGeneric, OptomechDevice):
             raise ValueError("ensureFreshFrames=True is not compatible with n=None")
         return FrameAcquisitionFuture(self, n, ensureFreshFrames=ensureFreshFrames)
 
-    @future_wrap
     def driverSupportedFixedFrameAcquisition(
-        self, n: int = 1, name=None, _future: Future = None
+        self, n: int = 1
     ) -> list[Frame]:
         """Ask the camera driver to acquire a specific number of frames and return a Future.
 
@@ -404,8 +403,7 @@ class Camera(DAQGeneric, OptomechDevice):
                 raise TimeoutError("Timed out waiting for frame processing thread to stop")
         DAQGeneric.quit(self)
 
-    @future_wrap
-    def getEstimatedFrameRate(self, name=None, _future: Future = None):
+    def getEstimatedFrameRate(self):
         """Return the estimated frame rate of the camera."""
         with self.ensureRunning():
             return self.acqThread.getEstimatedFrameRate()
@@ -708,7 +706,7 @@ class CameraTask(DAQGenericTask):
         # arm recording
         self.stopRecording = False
         if self.fixedFrameCount is not None:
-            self._future = self.dev.driverSupportedFixedFrameAcquisition(n=self.fixedFrameCount, _sync="async")
+            self._future = Future(self.dev.driverSupportedFixedFrameAcquisition, (self.fixedFrameCount,))
         elif not self.dev.isRunning():
             self.dev.start(block=True)
 
@@ -1066,14 +1064,13 @@ class AcquireThread(Thread):
                 pass
             self.sigShowMessage.emit("ERROR starting acquisition (see console output)")
 
-    @future_wrap
-    def getEstimatedFrameRate(self, name=None, _future: Future = None):
+    def getEstimatedFrameRate(self):
         """Return the estimated frame rate of the camera."""
         if not self.isRunning():
             raise RuntimeError("Cannot get frame rate while camera is not running.")
         while len(self._recentFPS) < self._recentFPS.maxlen:
             time.sleep(0.01)
-            _future.checkStop()
+            check_stop()
         return np.mean(self._recentFPS)
 
     def stop(self, block=False):

--- a/acq4/devices/Camera/Camera.py
+++ b/acq4/devices/Camera/Camera.py
@@ -250,7 +250,7 @@ class Camera(DAQGeneric, OptomechDevice):
         return Future.immediate()
 
     def presetHotkeyPressed(self, dev, changes, presetName):
-        self.loadPreset(presetName)
+        self.loadPreset(presetName, _sync="async")
 
     def newFrames(self):
         """Returns a list of all new frames that have arrived since the last call. The list looks like:
@@ -366,7 +366,7 @@ class Camera(DAQGeneric, OptomechDevice):
 
     @future_wrap
     def driverSupportedFixedFrameAcquisition(
-        self, n: int = 1, _future: Future = None
+        self, n: int = 1, name=None, _future: Future = None
     ) -> list[Frame]:
         """Ask the camera driver to acquire a specific number of frames and return a Future.
 
@@ -405,10 +405,10 @@ class Camera(DAQGeneric, OptomechDevice):
         DAQGeneric.quit(self)
 
     @future_wrap
-    def getEstimatedFrameRate(self, _future: Future):
+    def getEstimatedFrameRate(self, name=None, _future: Future = None):
         """Return the estimated frame rate of the camera."""
         with self.ensureRunning():
-            return _future.waitFor(self.acqThread.getEstimatedFrameRate()).getResult()
+            return self.acqThread.getEstimatedFrameRate()
 
     # @ftrace
     def createTask(self, cmd, parentTask):
@@ -708,7 +708,7 @@ class CameraTask(DAQGenericTask):
         # arm recording
         self.stopRecording = False
         if self.fixedFrameCount is not None:
-            self._future = self.dev.driverSupportedFixedFrameAcquisition(n=self.fixedFrameCount)
+            self._future = self.dev.driverSupportedFixedFrameAcquisition(n=self.fixedFrameCount, _sync="async")
         elif not self.dev.isRunning():
             self.dev.start(block=True)
 
@@ -1067,7 +1067,7 @@ class AcquireThread(Thread):
             self.sigShowMessage.emit("ERROR starting acquisition (see console output)")
 
     @future_wrap
-    def getEstimatedFrameRate(self, _future: Future = None):
+    def getEstimatedFrameRate(self, name=None, _future: Future = None):
         """Return the estimated frame rate of the camera."""
         if not self.isRunning():
             raise RuntimeError("Cannot get frame rate while camera is not running.")

--- a/acq4/devices/Camera/Camera.py
+++ b/acq4/devices/Camera/Camera.py
@@ -330,7 +330,7 @@ class Camera(DAQGeneric, OptomechDevice):
 
         Usage::
             with camera.ensureRunning():
-                frames = camera.acquireFrames(10).getResult()
+                frames = camera.acquireFrames(10).get_result()
         """
         running = self.isRunning()
         if ensureFreshFrames and running:

--- a/acq4/devices/DAQSonicator.py
+++ b/acq4/devices/DAQSonicator.py
@@ -142,7 +142,7 @@ class DAQSonicator(Sonicator):
         )
 
     @future_wrap
-    def _doProtocol(self, protocol: str | dict, _future):
+    def _doProtocol(self, protocol: str | dict, name=None, _future=None):
         if isinstance(protocol, str):
             protocol = load_stimulus(json.loads(protocol))
         else:

--- a/acq4/devices/DAQSonicator.py
+++ b/acq4/devices/DAQSonicator.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from acq4.devices.DAQGeneric import DAQGeneric
 from acq4.devices.Sonicator import Sonicator
-from acq4.util.future import future_wrap
+from acq4.util.future import sleep
 from neuroanalysis.stimuli import load_stimulus
 from pyqtgraph.units import nF, A
 
@@ -141,8 +141,7 @@ class DAQSonicator(Sonicator):
             name=f"__sonicator{self.name()}DAQ",
         )
 
-    @future_wrap
-    def _doProtocol(self, protocol: str | dict, name=None, _future=None):
+    def _doProtocol(self, protocol: str | dict):
         if isinstance(protocol, str):
             protocol = load_stimulus(json.loads(protocol))
         else:
@@ -176,7 +175,7 @@ class DAQSonicator(Sonicator):
                 raise RuntimeError("Overload detected. Please check the sonicator device.")
             task.execute(block=False, processEvents=False)
             while not task.isDone():
-                _future.sleep(0.1)
+                sleep(0.1)
             if "overload" in self.config and self._daq.getChannelValue("overload"):
                 raise RuntimeError("Overload detected. Command likely required too much power.")
         except Exception:

--- a/acq4/devices/FalconTurret/falconturret.py
+++ b/acq4/devices/FalconTurret/falconturret.py
@@ -1,5 +1,6 @@
-import logging, threading, time
+import logging, threading
 from acq4.util import Qt
+from acq4.util.future import sleep
 import falconoptics
 from ..FilterWheel.filterwheel import FilterWheel, FilterWheelFuture, FilterWheelDevGui
 
@@ -65,8 +66,8 @@ class FalconTurret(FilterWheel):
 
     def _setInitialPos(self):
         # used to wait on the initial home move and then switch to initial slot
-        while not self._initialFuture.isDone():
-            time.sleep(0.1)
+        while not self._initialFuture.is_done:
+            sleep(0.1)
         self.setPosition(self._initialSlot)
 
     def getPositionCount(self):

--- a/acq4/devices/InteractionSite.py
+++ b/acq4/devices/InteractionSite.py
@@ -176,7 +176,7 @@ class InteractionSite(Device, OptomechDevice):
         self.setDeviceTransform(tr)
 
     @future_wrap
-    def moveToInteract(self, other, speed='fast', _future=None):
+    def moveToInteract(self, other, speed='fast', name=None, _future=None):
         if other.name() not in self.positions:
             raise RuntimeError(f"No positions saved for {other.name()} at {self.name()}")
         pos_config = self.positions[other.name()]
@@ -193,7 +193,7 @@ class InteractionSite(Device, OptomechDevice):
         _future.waitFor(other._moveToGlobal(interact_global, speed=speed, name=f"move {other.name()} to interact with {self.name()}"))
 
     @future_wrap
-    def moveToApproach(self, other, speed='fast', _future=None):
+    def moveToApproach(self, other, speed='fast', name=None, _future=None):
         if other.name() not in self.positions:
             raise RuntimeError(f"No positions saved for {other.name()} at {self.name()}")
         pos_config = self.positions[other.name()]

--- a/acq4/devices/InteractionSite.py
+++ b/acq4/devices/InteractionSite.py
@@ -7,7 +7,7 @@ from acq4.util import Qt
 from .Device import Device
 from .OptomechDevice import OptomechDevice
 from .Stage import Stage
-from ..util.future import future_wrap, Future
+from ..util.future import Future
 from ..util.target import color_for_diff
 
 
@@ -175,8 +175,7 @@ class InteractionSite(Device, OptomechDevice):
         tr.rotation = (np.degrees(angle), axis)
         self.setDeviceTransform(tr)
 
-    @future_wrap
-    def moveToInteract(self, other, speed='fast', name=None, _future=None):
+    def moveToInteract(self, other, speed='fast'):
         if other.name() not in self.positions:
             raise RuntimeError(f"No positions saved for {other.name()} at {self.name()}")
         pos_config = self.positions[other.name()]
@@ -187,20 +186,19 @@ class InteractionSite(Device, OptomechDevice):
         approach_pos = pos_config['site global']
         # TODO this will still need a real motion planner
         # TODO we'll maybe also need to make sure the other devices are out of the way...
-        _future.waitFor(self.moveToGlobal(approach_pos, speed=speed, name=f"move {self.name()} to approach {other.name()}"), timeout=120)
-        _future.waitFor(other._moveToGlobal(approach_pos, speed=speed, name=f"move {other.name()} to approach {self.name()}"), timeout=120)
+        self.moveToGlobal(approach_pos, speed=speed, name=f"move {self.name()} to approach {other.name()}").wait(timeout=120)
+        other._moveToGlobal(approach_pos, speed=speed, name=f"move {other.name()} to approach {self.name()}").wait(timeout=120)
         interact_global = pos_config['interact global']
-        _future.waitFor(other._moveToGlobal(interact_global, speed=speed, name=f"move {other.name()} to interact with {self.name()}"))
+        other._moveToGlobal(interact_global, speed=speed, name=f"move {other.name()} to interact with {self.name()}").wait()
 
-    @future_wrap
-    def moveToApproach(self, other, speed='fast', name=None, _future=None):
+    def moveToApproach(self, other, speed='fast'):
         if other.name() not in self.positions:
             raise RuntimeError(f"No positions saved for {other.name()} at {self.name()}")
         pos_config = self.positions[other.name()]
         if 'site global' not in pos_config:
             raise RuntimeError(f"No site global position saved for {other.name()} at {self.name()}")
-        _future.waitFor(self.moveToGlobal(pos_config['site global'], speed=speed, name=f"move {self.name()} to approach {other.name()}"), timeout=120)
-        _future.waitFor(other._moveToGlobal(pos_config['site global'], speed=speed, name=f"move {other.name()} to approach {self.name()}"), timeout=120)
+        self.moveToGlobal(pos_config['site global'], speed=speed, name=f"move {self.name()} to approach {other.name()}").wait(timeout=120)
+        other._moveToGlobal(pos_config['site global'], speed=speed, name=f"move {other.name()} to approach {self.name()}").wait(timeout=120)
 
     # @future_wrap
     # def moveToInteract(self, other, speed='fast', _future=None):

--- a/acq4/devices/MicroManagerStage/mmstage.py
+++ b/acq4/devices/MicroManagerStage/mmstage.py
@@ -5,6 +5,7 @@ from pyqtgraph import debug
 
 from acq4.util.Mutex import Mutex
 from acq4.util.Thread import Thread
+from acq4.util.future import sleep
 from acq4.util.micromanager import getMMCorePy
 from ..Stage import Stage, MoveFuture, StageInterface
 
@@ -211,7 +212,7 @@ class MicroManagerStage(Stage):
 
     def _move(self, pos, speed, linear, name=None, **kwds):
         with self.lock:
-            if self._lastMove is not None and not self._lastMove.isDone():
+            if self._lastMove is not None and not self._lastMove.is_done:
                 self.stop()
 
             # Decide which axes to move
@@ -275,10 +276,10 @@ class MonitorThread(Thread):
                 else:
                     interval = min(maxInterval, interval * 2)
 
-                time.sleep(interval)
+                sleep(interval)
             except Exception:
                 self.dev.logger.exception('Error in MicromanagerStage monitor thread:')
-                time.sleep(maxInterval)
+                sleep(maxInterval)
 
 
 class MicroManagerMoveFuture(MoveFuture):

--- a/acq4/devices/Microscope/Microscope.py
+++ b/acq4/devices/Microscope/Microscope.py
@@ -171,24 +171,20 @@ class Microscope(Device, OptomechDevice):
             return list(self.selectedObjectives.values())
 
     @future_wrap
-    def loadPreset(self, name, _future):
+    def loadPreset(self, name, _future=None):
         conf = self.presets[name]
-        futures: list[Future] = []
         for dev_name, state in conf.items():
             if dev_name == "objective":
                 self.setObjectiveIndex(state)
             elif dev_name != "hotkey":
                 dev = self.dm.getDevice(dev_name)
                 if hasattr(dev, "loadPreset"):
-                    futures.append(dev.loadPreset(state))
-        for fut in futures:
-            if fut is not None:
-                _future.waitFor(fut)
+                    dev.loadPreset(state)
 
     def handlePresetHotkey(self, kb_dev, changes, name):
         key, pressed = changes.get('keys', [])[0]
         if pressed:
-            self.loadPreset(name)
+            self.loadPreset(name, _sync="async")
 
     def deviceInterface(self, win):
         iface = ScopeGUI(self, win)
@@ -258,18 +254,18 @@ class Microscope(Device, OptomechDevice):
             name = cameras[0]
         return self.dm.getDevice(name)
 
-    def getZStack(self, imager: "Device", z_range, block=False, name="z stack") -> Future[list[Frame]]:
+    def getZStack(self, imager: "Device", z_range, name="z stack") -> list:
         """Acquire a z-stack of images using the given imager.
 
         The z-stack is returned as frames.
         """
         from acq4.util.imaging.sequencer import acquire_z_stack
 
-        return acquire_z_stack(imager, *z_range, block=block, name=name)
+        return acquire_z_stack(imager, *z_range, name=name)
 
     @future_wrap
     def findSurfaceDepth(
-        self, imager: "Device", searchDistance=200 * µm, searchStep=5 * µm, returnStack=False, _future: Future = None
+        self, imager: "Device", searchDistance=200 * µm, searchStep=5 * µm, returnStack=False, name=None, _future: Future = None
     ) -> float | tuple[float, list[Frame]]:
         """Set the surface of the sample based on how focused the images are."""
         z_range = (
@@ -277,9 +273,7 @@ class Microscope(Device, OptomechDevice):
             self.getSurfaceDepth() - searchDistance,
             searchStep,
         )
-        z_stack: list[Frame] = _future.waitFor(
-            self.getZStack(imager, z_range, name="finding surface")
-        ).getResult()
+        z_stack: list[Frame] = self.getZStack(imager, z_range, name="finding surface")
         threshold = self.config.get('surfaceDetectionPercentileThreshold', 96)
         if (idx := find_surface(z_stack, threshold)) is not None:
             depth = z_stack[idx].mapFromFrameToGlobal([0, 0, 0])[2]
@@ -602,7 +596,7 @@ class ScopeGUI(Qt.QWidget):
     def loadPreset(self):
         btn = self.sender()
         name = btn.objectName()
-        self.dev.loadPreset(name)
+        self.dev.loadPreset(name, _sync="async")
 
     def objectiveChanged(self, obj):
         ## Microscope says new objective has been selected; update selection radio
@@ -814,7 +808,7 @@ class ScopeCameraModInterface(CameraModuleInterface):
         self.transformChanged()
 
     def findSurface(self):
-        return self.getDevice().findSurfaceDepth(self.getDevice().getDefaultImager())
+        return self.getDevice().findSurfaceDepth(self.getDevice().getDefaultImager(), _sync="async")
 
     def surfaceDepthChanged(self, depth):
         self.zPositionWidget.setSurfaceDepth(depth)

--- a/acq4/devices/Microscope/Microscope.py
+++ b/acq4/devices/Microscope/Microscope.py
@@ -11,7 +11,7 @@ from acq4.modules.Camera import CameraModuleInterface
 from acq4.util import Qt
 from acq4.util.Mutex import Mutex
 from acq4.util.acq4_typing import Number
-from acq4.util.future import Future, MultiFuture, future_wrap, FutureButton
+from acq4.util.future import Future, MultiFuture, FutureButton
 from acq4.util.imaging import Frame
 from acq4.util.surface import find_surface
 from acq4.util.ui.ZPositionWidget import ZPositionWidget
@@ -170,8 +170,7 @@ class Microscope(Device, OptomechDevice):
         with self.lock:
             return list(self.selectedObjectives.values())
 
-    @future_wrap
-    def loadPreset(self, name, _future=None):
+    def loadPreset(self, name):
         conf = self.presets[name]
         for dev_name, state in conf.items():
             if dev_name == "objective":
@@ -184,7 +183,7 @@ class Microscope(Device, OptomechDevice):
     def handlePresetHotkey(self, kb_dev, changes, name):
         key, pressed = changes.get('keys', [])[0]
         if pressed:
-            self.loadPreset(name, _sync="async")
+            Future(self.loadPreset, (name,))
 
     def deviceInterface(self, win):
         iface = ScopeGUI(self, win)
@@ -263,9 +262,8 @@ class Microscope(Device, OptomechDevice):
 
         return acquire_z_stack(imager, *z_range, name=name)
 
-    @future_wrap
     def findSurfaceDepth(
-        self, imager: "Device", searchDistance=200 * µm, searchStep=5 * µm, returnStack=False, name=None, _future: Future = None
+        self, imager: "Device", searchDistance=200 * µm, searchStep=5 * µm, returnStack=False
     ) -> float | tuple[float, list[Frame]]:
         """Set the surface of the sample based on how focused the images are."""
         z_range = (
@@ -278,7 +276,7 @@ class Microscope(Device, OptomechDevice):
         if (idx := find_surface(z_stack, threshold)) is not None:
             depth = z_stack[idx].mapFromFrameToGlobal([0, 0, 0])[2]
             self.setSurfaceDepth(depth)
-            _future.waitFor(self.setFocusDepth(depth, name=f"{self.name()} focus to detected surface"))
+            self.setFocusDepth(depth, name=f"{self.name()} focus to detected surface").wait()
             if returnStack:
                 return depth, z_stack
             return depth
@@ -596,7 +594,7 @@ class ScopeGUI(Qt.QWidget):
     def loadPreset(self):
         btn = self.sender()
         name = btn.objectName()
-        self.dev.loadPreset(name, _sync="async")
+        Future(self.dev.loadPreset, (name,))
 
     def objectiveChanged(self, obj):
         ## Microscope says new objective has been selected; update selection radio
@@ -808,7 +806,7 @@ class ScopeCameraModInterface(CameraModuleInterface):
         self.transformChanged()
 
     def findSurface(self):
-        return self.getDevice().findSurfaceDepth(self.getDevice().getDefaultImager(), _sync="async")
+        return Future(self.getDevice().findSurfaceDepth, (self.getDevice().getDefaultImager(),))
 
     def surfaceDepthChanged(self, depth):
         self.zPositionWidget.setSurfaceDepth(depth)

--- a/acq4/devices/MockSonicator.py
+++ b/acq4/devices/MockSonicator.py
@@ -94,7 +94,7 @@ class MockSonicator(Sonicator):
         self.audio_thread.start()
 
     @future_wrap
-    def sonicate(self, frequency, duration, lock=True, _future=None):
+    def sonicate(self, frequency, duration, lock=True, name=None, _future=None):
         if lock:
             self.actionLock.acquire()
         try:

--- a/acq4/devices/MockSonicator.py
+++ b/acq4/devices/MockSonicator.py
@@ -5,7 +5,7 @@ import pyaudio
 
 import pyqtgraph as pg
 from acq4.devices.Sonicator import Sonicator
-from acq4.util.future import future_wrap
+from acq4.util.future import sleep
 from pyqtgraph import siFormat
 
 
@@ -93,8 +93,7 @@ class MockSonicator(Sonicator):
         self.audio_thread = threading.Thread(target=stop_sound, name="MockSonicatorAudioStopThread")
         self.audio_thread.start()
 
-    @future_wrap
-    def sonicate(self, frequency, duration, lock=True, name=None, _future=None):
+    def sonicate(self, frequency, duration, lock=True):
         if lock:
             self.actionLock.acquire()
         try:
@@ -108,7 +107,7 @@ class MockSonicator(Sonicator):
             self.play_sound(frequency, duration)
 
             # Wait for duration
-            _future.sleep(duration)
+            sleep(duration)
 
             self.sigSonicationChanged.emit(0.0)
         finally:

--- a/acq4/devices/MockStage.py
+++ b/acq4/devices/MockStage.py
@@ -167,7 +167,7 @@ class MockStage(Stage):
         self.stageThread.stop()
         
     def _interruptMove(self):
-        if self._lastMove is not None and not self._lastMove.isDone():
+        if self._lastMove is not None and not self._lastMove.is_done:
             self._lastMove.mockInterrupt()
 
     def setUserSpeed(self, v):
@@ -205,7 +205,7 @@ class MockMoveFuture(MoveFuture):
         self.dev.stageThread.setTarget(self, pos, speed)
 
     def mockFinish(self):
-        if not self.isDone():
+        if not self.is_done:
             self._taskDone()
 
     def mockInterrupt(self):

--- a/acq4/devices/OdorDelivery.py
+++ b/acq4/devices/OdorDelivery.py
@@ -425,7 +425,7 @@ class OdorTask(DeviceTask):
             self.dev.setChannelValue(chan, 1 if chan == first_chan else 0)
 
     def isDone(self):
-        return self._future is not None and self._future.isDone()
+        return self._future is not None and self._future.is_done
 
     def getResult(self):
         cmd = self._cmd.copy()
@@ -454,7 +454,7 @@ class OdorFuture(Future):
         self._thread.start()
 
     def percentDone(self):
-        if self.isDone():
+        if self.is_done:
             return 100
         return 100 * self._time_elapsed / self._duration
 

--- a/acq4/devices/PatchClamp/testpulse.py
+++ b/acq4/devices/PatchClamp/testpulse.py
@@ -3,6 +3,8 @@ import time
 from threading import Thread
 from typing import Literal
 
+from acq4.util.future import sleep
+
 import numpy as np
 from MetaArray import MetaArray
 from acq4.analysis.dataModels.PatchEPhys import getBridgeBalanceCompensation
@@ -126,7 +128,7 @@ class TestPulseThread(QtThread):
                     now = ptime.time()
                     if now >= nextRun:
                         break
-                    time.sleep(min(0.03, nextRun-now))
+                    sleep(min(0.03, nextRun-now))
                     self.checkStop()
             except self.StopRequested:
                 break

--- a/acq4/devices/PatchPipette/devgui.py
+++ b/acq4/devices/PatchPipette/devgui.py
@@ -35,7 +35,12 @@ class PatchPipetteDeviceGui(Qt.QWidget):
         self.layout.addLayout(self.positionBtnLayout, row, 0)
 
     def doClean(self):
-        return self.dev.setState("clean")
+        from acq4.util.future import current_future
+        state = self.dev.setState("clean")
+        fut = current_future()
+        if fut is not None:
+            fut._stopsToPropagate.append(state)
+        state.wait()
 
     def setPositionClicked(self):
         btn = self.sender()

--- a/acq4/devices/PatchPipette/patchpipette.py
+++ b/acq4/devices/PatchPipette/patchpipette.py
@@ -170,7 +170,7 @@ class PatchPipette(Device):
             self.pipetteDevice.globalPosition(), speed=speed, name=f"Focus on {self.name()} tip"
         )
         if raiseErrors:
-            fut.raiseErrors("Error while focusing on pipette tip: {error}")
+            fut.raise_errors("Error while focusing on pipette tip: {error}")
         return fut
 
     def focusOnTarget(self, speed, raiseErrors=False):
@@ -179,7 +179,7 @@ class PatchPipette(Device):
             self.pipetteDevice.targetPosition(), speed=speed, name=f"Focus on {self.name()} target"
         )
         if raiseErrors:
-            fut.raiseErrors("Error while focusing on pipette target: {error}")
+            fut.raise_errors("Error while focusing on pipette target: {error}")
         return fut
 
     def newPipette(self):

--- a/acq4/devices/PatchPipette/states/_base.py
+++ b/acq4/devices/PatchPipette/states/_base.py
@@ -12,7 +12,7 @@ import numpy as np
 from acq4 import getManager
 from acq4.util import Qt
 from acq4.util.debug import log_and_ignore_exception
-from acq4.util.future import Future, future_wrap
+from acq4.util.future import Future, sleep
 from neuroanalysis.test_pulse import PatchClampTestPulse
 from pyqtgraph import disconnect
 from pyqtgraph.units import µm
@@ -290,11 +290,10 @@ class PatchPipetteState(Future):
     def adjustPressureForDepth(self):
         """While not that slow, we still want to keep the innermost loop as fast as we can."""
         if self._pressureAdjustment is None:
-            self._pressureAdjustment = self._adjustPressureForDepth(_sync="async")
+            self._pressureAdjustment = Future(self._adjustPressureForDepth)
             self._pressureAdjustment.onFinish(self._finishPressureAdjustment)
 
-    @future_wrap(logLevel='debug')
-    def _adjustPressureForDepth(self, name=None, _future=None):
+    def _adjustPressureForDepth(self):
         depth = self.depthBelowSurface()
         if depth < 0:  # above surface
             pressure = self.config["aboveSurfacePressure"]
@@ -309,15 +308,12 @@ class PatchPipetteState(Future):
     def cleanup(self) -> Future:
         with self._cleanupMutex:
             if self._cleanupFuture is None:
-                if hasattr(self._cleanup, '__wrapped__'):
-                    self._cleanupFuture = self._cleanup(_sync="async")
-                else:
-                    self._cleanupFuture = self._cleanup()
+                self._cleanupFuture = Future(self._cleanup)
             return self._cleanupFuture
 
-    def _cleanup(self) -> Future:
+    def _cleanup(self):
         """Called after job completes, whether it failed or succeeded. Ask `self.wasInterrupted()` to see if the
-        state was stopped early. Return a Future that completes when cleanup is done.
+        state was stopped early.
         """
         disconnect(self.dev.sigTargetChanged, self._onTargetChanged)
         with log_and_ignore_exception(Exception, "Error disabling visual target tracking"):
@@ -329,7 +325,6 @@ class PatchPipetteState(Future):
                 self._cell.enableTracking(False)
                 self._visualTargetTrackingFuture.stop("State cleanup")
             self._visualTargetTrackingFuture = None
-        return Future.immediate()
 
     def checkStop(self):
         # extend checkStop to also see if the pipette was deactivated.
@@ -405,7 +400,7 @@ class PatchPipetteState(Future):
         cell.sigTrackingMultipleFramesFinish.disconnect(self._resumePipetteAfterExtendedTracking)
         cell.sigTrackingMultipleFramesStart.connect(self._pausePipetteForExtendedTracking)
 
-    def _waitForMoveWhileTargetChanges(self, position_fn, speed, continuous, future, interval=None, step=None, move_restart_threshold=3.0):
+    def _waitForMoveWhileTargetChanges(self, position_fn, speed, continuous, interval=None, step=None, move_restart_threshold=3.0):
         """Wait for a move to complete while also monitoring for changes in the target position.
 
         When the target position updates, the move will be updated as well to track the new target.
@@ -421,7 +416,7 @@ class PatchPipetteState(Future):
                     if move_fut is not None:
                         move_fut.stop("Paused", wait=True)
                         move_fut = None
-                    future.sleep(0.1)
+                    sleep(0.1)
                     continue
                 current_target_pos = position_fn()
                 if move_fut is None or restart_move or last_destination is None:
@@ -429,13 +424,11 @@ class PatchPipetteState(Future):
                     if continuous:
                         move_fut = self.dev.pipetteDevice._moveToGlobal(current_target_pos, speed=speed, name="Update move towards target")
                     else:
-                        move_fut = self.dev.pipetteDevice.stepwiseAdvance(
-                            target=current_target_pos,
-                            speed=speed,
-                            interval=interval,
-                            step=step,
+                        move_fut = Future(
+                            self.dev.pipetteDevice.stepwiseAdvance,
+                            (),
+                            {"target": current_target_pos, "speed": speed, "interval": interval, "step": step},
                             name="Update stepwise move towards target",
-                            _sync="async",
                         )
                     self.setState(f"Moving towards target at {current_target_pos}")
                     last_destination = current_target_pos
@@ -459,7 +452,7 @@ class PatchPipetteState(Future):
                             f"{'>' if restart_move else '<'} {move_restart_threshold}°; "
                             f"{'update path' if restart_move else 'keep current path'}")
                 if not restart_move:
-                    future.sleep(0.1)
+                    sleep(0.1)
         except Exception:
             if move_fut is not None and not move_fut.isDone():
                 move_fut.stop("Error while moving", wait=True)

--- a/acq4/devices/PatchPipette/states/_base.py
+++ b/acq4/devices/PatchPipette/states/_base.py
@@ -161,7 +161,7 @@ class PatchPipetteState(Future):
 
     def setResult(self, *args, **kwargs):
         if 'error' in kwargs:
-            self.setState(f"{self.stateName} failed: {kwargs['error']}")
+            self.set_state(f"{self.stateName} failed: {kwargs['error']}")
         super().setResult(*args, **kwargs)
 
     def initialize(self):
@@ -192,14 +192,14 @@ class PatchPipetteState(Future):
             with contextlib.ExitStack() as stack:
                 if self.config["reserveDAQ"]:
                     daq_name = self.dev.clampDevice.getDAQName("primary")
-                    self.setState(f"{self.stateName}: waiting for {daq_name} lock")
+                    self.set_state(f"{self.stateName}: waiting for {daq_name} lock")
                     stack.enter_context(
                         getManager().reserveDevices(
                             [daq_name],
                             timeout=self.config["DAQReservationTimeout"],
                             reserver=f"PatchPipette.{self.stateName}",
                         ))
-                    self.setState(f"{self.stateName}: {daq_name} lock acquired")
+                    self.set_state(f"{self.stateName}: {daq_name} lock acquired")
 
                 # TODO: can we use the rval of the Future for this?
                 self.nextState = self.run()
@@ -269,7 +269,7 @@ class PatchPipetteState(Future):
     def processAtLeastOneTestPulse(self) -> list[PatchClampTestPulse]:
         """Wait for at least one test pulse to be processed."""
         while not (tps := self.getTestPulses(timeout=0.2)):
-            self.checkStop()
+            self.check_stop()
         return tps
 
     def testPulseFinished(self, clamp, result):
@@ -291,7 +291,7 @@ class PatchPipetteState(Future):
         """While not that slow, we still want to keep the innermost loop as fast as we can."""
         if self._pressureAdjustment is None:
             self._pressureAdjustment = Future(self._adjustPressureForDepth)
-            self._pressureAdjustment.onFinish(self._finishPressureAdjustment)
+            self._pressureAdjustment.on_finish(self._finishPressureAdjustment)
 
     def _adjustPressureForDepth(self):
         depth = self.depthBelowSurface()
@@ -326,11 +326,11 @@ class PatchPipetteState(Future):
                 self._visualTargetTrackingFuture.stop("State cleanup")
             self._visualTargetTrackingFuture = None
 
-    def checkStop(self):
-        # extend checkStop to also see if the pipette was deactivated.
+    def check_stop(self):
+        # extend check_stop to also see if the pipette was deactivated.
         if self.dev.active is False:
             raise self.StopRequested("Stop state because device is not 'active'")
-        Future.checkStop(self)
+        Future.check_stop(self)
 
     def __repr__(self):
         return f'<{type(self).__name__} "{self.stateName}">'
@@ -411,7 +411,7 @@ class PatchPipetteState(Future):
         restart_move = False
         last_destination = None
         try:
-            while move_fut is None or not move_fut.isDone():
+            while move_fut is None or not move_fut.is_done:
                 if self._pauseMovement:
                     if move_fut is not None:
                         move_fut.stop("Paused", wait=True)
@@ -430,7 +430,7 @@ class PatchPipetteState(Future):
                             {"target": current_target_pos, "speed": speed, "interval": interval, "step": step},
                             name="Update stepwise move towards target",
                         )
-                    self.setState(f"Moving towards target at {current_target_pos}")
+                    self.set_state(f"Moving towards target at {current_target_pos}")
                     last_destination = current_target_pos
                 else:
                     restart_move = False
@@ -454,7 +454,7 @@ class PatchPipetteState(Future):
                 if not restart_move:
                     sleep(0.1)
         except Exception:
-            if move_fut is not None and not move_fut.isDone():
+            if move_fut is not None and not move_fut.is_done:
                 move_fut.stop("Error while moving", wait=True)
             raise
 

--- a/acq4/devices/PatchPipette/states/_base.py
+++ b/acq4/devices/PatchPipette/states/_base.py
@@ -157,7 +157,7 @@ class PatchPipetteState(Future):
         """Start a background thread that executes this state. This should only be called by the state manager.
 
         When runJob completes, self.sigFinished will be emitted."""
-        self._executeInThread_v2(self.runJob, (), {})
+        self._executeInThread(self.runJob, (), {})
 
     def setResult(self, *args, **kwargs):
         if 'error' in kwargs:

--- a/acq4/devices/PatchPipette/states/_base.py
+++ b/acq4/devices/PatchPipette/states/_base.py
@@ -157,7 +157,7 @@ class PatchPipetteState(Future):
         """Start a background thread that executes this state. This should only be called by the state manager.
 
         When runJob completes, self.sigFinished will be emitted."""
-        self.executeInThread(self.runJob, args=(), kwds={})
+        self._executeInThread_v2(self.runJob, (), {})
 
     def setResult(self, *args, **kwargs):
         if 'error' in kwargs:
@@ -173,7 +173,7 @@ class PatchPipetteState(Future):
         self.initializePressure()
         self.initializeClamp()
 
-    def runJob(self, _future):  # _future is self
+    def runJob(self):
         """Called in background thread to start the state.
 
         Initialize pressure, clamp, etc. and run the subclass-defined run() method if it exists.

--- a/acq4/devices/PatchPipette/states/_base.py
+++ b/acq4/devices/PatchPipette/states/_base.py
@@ -290,11 +290,11 @@ class PatchPipetteState(Future):
     def adjustPressureForDepth(self):
         """While not that slow, we still want to keep the innermost loop as fast as we can."""
         if self._pressureAdjustment is None:
-            self._pressureAdjustment = self._adjustPressureForDepth()
+            self._pressureAdjustment = self._adjustPressureForDepth(_sync="async")
             self._pressureAdjustment.onFinish(self._finishPressureAdjustment)
 
     @future_wrap(logLevel='debug')
-    def _adjustPressureForDepth(self, _future):
+    def _adjustPressureForDepth(self, name=None, _future=None):
         depth = self.depthBelowSurface()
         if depth < 0:  # above surface
             pressure = self.config["aboveSurfacePressure"]
@@ -309,7 +309,10 @@ class PatchPipetteState(Future):
     def cleanup(self) -> Future:
         with self._cleanupMutex:
             if self._cleanupFuture is None:
-                self._cleanupFuture = self._cleanup()
+                if hasattr(self._cleanup, '__wrapped__'):
+                    self._cleanupFuture = self._cleanup(_sync="async")
+                else:
+                    self._cleanupFuture = self._cleanup()
             return self._cleanupFuture
 
     def _cleanup(self) -> Future:
@@ -432,6 +435,7 @@ class PatchPipetteState(Future):
                             interval=interval,
                             step=step,
                             name="Update stepwise move towards target",
+                            _sync="async",
                         )
                     self.setState(f"Moving towards target at {current_target_pos}")
                     last_destination = current_target_pos

--- a/acq4/devices/PatchPipette/states/approach.py
+++ b/acq4/devices/PatchPipette/states/approach.py
@@ -9,7 +9,7 @@ import pyqtgraph as pg
 from acq4 import getManager
 from acq4.util import ptime
 from acq4.util.functions import plottable_booleans
-from acq4.util.future import future_wrap
+from acq4.util.future import Future
 from acq4.util.imaging.sequencer import run_image_sequence
 from ._base import PatchPipetteState, SteadyStateAnalysisBase, exponential_decay_avg
 
@@ -286,13 +286,11 @@ class ApproachState(PatchPipetteState):
         end = start + config["cellfieHeight"]
         save_in = self.dev.dm.getCurrentDir().getDir("cell detect initial z stack", create=True)
         self.waitFor(
-            run_image_sequence(
-                self.dev.imagingDevice(),
-                z_stack=(start, end, config["cellfieStep"]),
-                storage_dir=save_in,
-                name="cellfie",
-                _sync="async",
-            )
+            Future(run_image_sequence, (self.dev.imagingDevice(),), {
+                'z_stack': (start, end, config["cellfieStep"]),
+                'storage_dir': save_in,
+                'name': "cellfie",
+            })
         )
 
     def maybeRecalibratePipette(self):
@@ -313,29 +311,26 @@ class ApproachState(PatchPipetteState):
         pip = self.dev.pipetteDevice
         try:
             tip_fut = self.waitFor(
-                pip.iterativelyFindTip(
-                    max_allowed_offset=self.config["pipetteRecalibrationMaxChange"],
-                    go_to_tip_first=True,
-                    _sync="async",
-                )
+                Future(pip.iterativelyFindTip, (), {
+                    'max_allowed_offset': self.config["pipetteRecalibrationMaxChange"],
+                    'go_to_tip_first': True,
+                })
             )
         except Exception as e:
             self.setState(f"failed pipette position update: {e}")
 
-    @future_wrap
-    def _move(self, name=None, _future=None):
+    def _move(self):
         config = self.config
         if self.aboveSurface():
             self.setState("move to surface")
             self._waitForMoveWhileTargetChanges(
-                self.surfaceIntersectionPosition, config['aboveSurfaceSpeed'], True, _future
+                self.surfaceIntersectionPosition, config['aboveSurfaceSpeed'], True
             )
         self.setState(f'move to endpoint: {self.endpoint()}')
         self._waitForMoveWhileTargetChanges(
             position_fn=self.endpoint,
             speed=config['belowSurfaceSpeed'],
             continuous=config["advanceContinuous"],
-            future=_future,
             interval=config['advanceStepInterval'],
             step=config['advanceStepDistance'],
         )

--- a/acq4/devices/PatchPipette/states/approach.py
+++ b/acq4/devices/PatchPipette/states/approach.py
@@ -234,14 +234,14 @@ class ApproachState(PatchPipetteState):
                 f"Cannot approach a target depth {target[2] * 1e6:0.2f}µm that is above the surface {surface * 1e6:0.2f}µm."
             )
         # move to approach position + auto pipette offset
-        self.waitFor(pip.goApproach("fast"))
+        self.wait_for(pip.goApproach("fast"))
         self.dev.clampDevice.autoPipetteOffset()
         self.dev.clampDevice.resetTestPulseHistory()
         self._maybeTakeACellfie()
         if self.config["autoAdvance"]:
             self.monitorTestPulse()
             while True:
-                self.checkStop()
+                self.check_stop()
                 self.processAtLeastOneTestPulse()
                 self.adjustPressureForDepth()
                 self.maybeRecalibratePipette()
@@ -258,9 +258,9 @@ class ApproachState(PatchPipetteState):
                         return {"state": "fouled"}
                 if self._moveFuture is None:
                     self._moveFuture = self._move()
-                if self._moveFuture.isDone():
+                if self._moveFuture.is_done:
                     self._moveFuture.wait()  # check for errors
-                    self.setState('Move finished; next state')
+                    self.set_state('Move finished; next state')
                     break
 
         # if self.config['recalibratePipette']:
@@ -280,12 +280,12 @@ class ApproachState(PatchPipetteState):
             or self._distanceToTarget() <= config["cellfiePipetteClearance"]
         ):
             return
-        self.setState("approach: taking initial z-stack")
-        self.waitFor(self.dev.focusOnTarget("fast"))
+        self.set_state("approach: taking initial z-stack")
+        self.wait_for(self.dev.focusOnTarget("fast"))
         start = self.dev.pipetteDevice.targetPosition()[2] - (config["cellfieHeight"] / 2)
         end = start + config["cellfieHeight"]
         save_in = self.dev.dm.getCurrentDir().getDir("cell detect initial z stack", create=True)
-        self.waitFor(
+        self.wait_for(
             Future(run_image_sequence, (self.dev.imagingDevice(),), {
                 'z_stack': (start, end, config["cellfieStep"]),
                 'storage_dir': save_in,
@@ -310,23 +310,23 @@ class ApproachState(PatchPipetteState):
 
         pip = self.dev.pipetteDevice
         try:
-            tip_fut = self.waitFor(
+            tip_fut = self.wait_for(
                 Future(pip.iterativelyFindTip, (), {
                     'max_allowed_offset': self.config["pipetteRecalibrationMaxChange"],
                     'go_to_tip_first': True,
                 })
             )
         except Exception as e:
-            self.setState(f"failed pipette position update: {e}")
+            self.set_state(f"failed pipette position update: {e}")
 
     def _move(self):
         config = self.config
         if self.aboveSurface():
-            self.setState("move to surface")
+            self.set_state("move to surface")
             self._waitForMoveWhileTargetChanges(
                 self.surfaceIntersectionPosition, config['aboveSurfaceSpeed'], True
             )
-        self.setState(f'move to endpoint: {self.endpoint()}')
+        self.set_state(f'move to endpoint: {self.endpoint()}')
         self._waitForMoveWhileTargetChanges(
             position_fn=self.endpoint,
             speed=config['belowSurfaceSpeed'],
@@ -378,7 +378,7 @@ class ApproachState(PatchPipetteState):
         )
 
     def avoidObstacle(self, already_retracted=False):
-        self.setState("avoiding obstacle" + (" (recursively)" if already_retracted else ""))
+        self.set_state("avoiding obstacle" + (" (recursively)" if already_retracted else ""))
         if self._moveFuture is not None:
             self._moveFuture.stop("Obstacle detected", wait=True)
             self._moveFuture = None
@@ -392,7 +392,7 @@ class ApproachState(PatchPipetteState):
             retract_pos = init_pos
         else:
             retract_pos = init_pos - self.config["sidestepBackupDistance"] * direction
-            self.waitFor(pip._moveToGlobal(retract_pos, speed=speed, name='obstacle avoidance retract'))
+            self.wait_for(pip._moveToGlobal(retract_pos, speed=speed, name='obstacle avoidance retract'))
 
         start_time = ptime.time()
         while self._analysis.obstacle_detected():
@@ -403,24 +403,24 @@ class ApproachState(PatchPipetteState):
         # pick a sidestep point orthogonal to the pipette direction on the xy plane
         sidestep = self.config["sidestepLateralDistance"] * self.sidestepDirection(direction)
         sidestep_pos = retract_pos + sidestep
-        self.waitFor(pip._moveToGlobal(sidestep_pos, speed=speed, name='obstacle avoidance sidestep'))
+        self.wait_for(pip._moveToGlobal(sidestep_pos, speed=speed, name='obstacle avoidance sidestep'))
 
         go_past_pos = sidestep_pos + self.config["sidestepPassDistance"] * direction
         move = pip._moveToGlobal(go_past_pos, speed=speed, name='obstacle avoidance pass')
-        while not move.isDone():
+        while not move.is_done:
             self.processAtLeastOneTestPulse()
             if self._analysis.obstacle_detected():
                 move.stop("Obstacle detected while sidestepping")
-                self.waitFor(pip._moveToGlobal(retract_pos, speed=speed, name='obstacle avoidance retract after detection'))
+                self.wait_for(pip._moveToGlobal(retract_pos, speed=speed, name='obstacle avoidance retract after detection'))
                 return self.avoidObstacle(already_retracted=True)
-            self.checkStop()
-        self.waitFor(move)
+            self.check_stop()
+        self.wait_for(move)
         pos = np.array(pip.globalPosition())
-        self.waitFor(pip._moveToGlobal(pos - sidestep, speed=speed, name='obstacle avoidance return to path'))
+        self.wait_for(pip._moveToGlobal(pos - sidestep, speed=speed, name='obstacle avoidance return to path'))
 
     def _cleanup(self):
         try:
-            if self._moveFuture is not None and not self._moveFuture.isDone():
+            if self._moveFuture is not None and not self._moveFuture.is_done:
                 self._moveFuture.stop("State finished", wait=True)
         except Exception:
             self.dev.logger.exception("Error stopping pipette advance during cleanup")

--- a/acq4/devices/PatchPipette/states/approach.py
+++ b/acq4/devices/PatchPipette/states/approach.py
@@ -291,6 +291,7 @@ class ApproachState(PatchPipetteState):
                 z_stack=(start, end, config["cellfieStep"]),
                 storage_dir=save_in,
                 name="cellfie",
+                _sync="async",
             )
         )
 
@@ -315,13 +316,14 @@ class ApproachState(PatchPipetteState):
                 pip.iterativelyFindTip(
                     max_allowed_offset=self.config["pipetteRecalibrationMaxChange"],
                     go_to_tip_first=True,
+                    _sync="async",
                 )
             )
         except Exception as e:
             self.setState(f"failed pipette position update: {e}")
 
     @future_wrap
-    def _move(self, _future):
+    def _move(self, name=None, _future=None):
         config = self.config
         if self.aboveSurface():
             self.setState("move to surface")

--- a/acq4/devices/PatchPipette/states/bath.py
+++ b/acq4/devices/PatchPipette/states/bath.py
@@ -50,7 +50,7 @@ class BathState(PatchPipetteState):
         bathResistances = []
 
         while True:
-            self.checkStop()
+            self.check_stop()
 
             # pull in all new test pulses (hopefully only one since the last time we checked)
             tps = self.getTestPulses(timeout=0.2)
@@ -74,7 +74,7 @@ class BathState(PatchPipetteState):
             if initialResistance is None:
                 if len(bathResistances) > 8:
                     initialResistance = np.median(bathResistances)
-                    self.setState(f"initial resistance measured: {initialResistance * 1e-6:0.2f} MOhm")
+                    self.set_state(f"initial resistance measured: {initialResistance * 1e-6:0.2f} MOhm")
 
                     # record initial resistance
                     patchrec = dev.patchRecord()
@@ -88,14 +88,14 @@ class BathState(PatchPipetteState):
                     continue
 
             if config['breakThreshold'] is not None and (ssr < initialResistance + config['breakThreshold']):
-                self.setState(f"Pipette break detected using `breakThreshold`; {ssr * 1e-6:0.2f}MOhm < {(initialResistance + config['breakThreshold']) * 1e-6:0.2f}MOhm")
+                self.set_state(f"Pipette break detected using `breakThreshold`; {ssr * 1e-6:0.2f}MOhm < {(initialResistance + config['breakThreshold']) * 1e-6:0.2f}MOhm")
                 self.setResult(
                     error=f"Pipette break detected using `breakThreshold`; {ssr * 1e-6:0.2f}MOhm < {(initialResistance + config['breakThreshold']) * 1e-6:0.2f}MOhm",
                 )
                 return {"state": 'broken'}
 
             if config['clogThreshold'] is not None and (ssr > initialResistance + config['clogThreshold']):
-                self.setState('clogged pipette detected')
+                self.set_state('clogged pipette detected')
                 self.setResult(
                     error=f"Pipette clog detected using `clogThreshold`; {ssr * 1e-6:0.2f}MOhm > {(initialResistance + config['clogThreshold']) * 1e-6:0.2f}MOhm",
                 )

--- a/acq4/devices/PatchPipette/states/blowout.py
+++ b/acq4/devices/PatchPipette/states/blowout.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from acq4.util import ptime
+from acq4.util.future import sleep
 from ._base import PatchPipetteState
 
 
@@ -25,16 +26,16 @@ class BlowoutState(PatchPipetteState):
 
         fut = self.dev.pipetteDevice.retractFromSurface()
         if fut is not None:
-            self.waitFor(fut, timeout=None)
+            self.wait_for(fut, timeout=None)
 
         self.dev.pressureDevice.setPressure(source='regulator', pressure=config['blowoutPressure'])
-        self.sleep(config['blowoutDuration'])
+        sleep(config['blowoutDuration'])
         self.dev.pressureDevice.setPressure(source='atmosphere', pressure=0)
 
         # wait until we have a test pulse that ran after blowout was finished.
         start = ptime.time()
         while True:
-            self.checkStop()
+            self.check_stop()
             tps = self.getTestPulses(timeout=0.2)
             if len(tps) == 0 or tps[-1].start_time < start:
                 continue

--- a/acq4/devices/PatchPipette/states/break_in.py
+++ b/acq4/devices/PatchPipette/states/break_in.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import time
-
 from acq4.util import ptime
 from acq4.util.future import sleep
 from pyqtgraph import units
@@ -86,12 +84,12 @@ class BreakInState(PatchPipetteState):
             while True:
                 time_until_next = (lastPulse + config['pulseInterval']) - ptime.time()
                 if time_until_next > 0:
-                    self.sleep(time_until_next)
+                    sleep(time_until_next)
                 self.checkBreakIn()
                 nPulses = config['nPulses'][attempt]
                 pdur = config['pulseDurations'][attempt]
                 press = config['pulsePressures'][attempt]
-                self.setState('Break in attempt %d' % attempt)
+                self.set_state('Break in attempt %d' % attempt)
                 self.attemptBreakIn(nPulses, pdur, press)
                 attempt += 1
                 lastPulse = ptime.time()
@@ -104,7 +102,7 @@ class BreakInState(PatchPipetteState):
             return {"state": 'whole cell'}
         except BreakInFailed as exc:
             patchrec['breakinSuccessful'] = False
-            self.setState(str(exc))
+            self.set_state(str(exc))
             return {"state": self.config['fallbackState']}
 
     def attemptBreakIn(self, nPulses, duration, pressure):
@@ -138,7 +136,7 @@ class BreakInState(PatchPipetteState):
         """
         start = ptime.time()
         while True:
-            self.checkStop()
+            self.check_stop()
             tps = self.getTestPulses(timeout=0.2)
             if len(tps) > 0:
                 break

--- a/acq4/devices/PatchPipette/states/break_in.py
+++ b/acq4/devices/PatchPipette/states/break_in.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import time
 
 from acq4.util import ptime
+from acq4.util.future import sleep
 from pyqtgraph import units
 from ._base import PatchPipetteState
 
@@ -119,13 +120,13 @@ class BreakInState(PatchPipetteState):
                     if remaining > 0.2:
                         self.checkBreakIn()
                     elif remaining > 0:
-                        time.sleep(remaining)
+                        sleep(remaining)
                     else:
                         break
             finally:
                 self.dev.pressureDevice.setPressure(source='atmosphere')
             if i < nPulses - 1:
-                time.sleep(0.1)  # short delay between pulses
+                sleep(0.1)  # short delay between pulses
             self.checkBreakIn()
 
     def checkBreakIn(self):

--- a/acq4/devices/PatchPipette/states/cell_attached.py
+++ b/acq4/devices/PatchPipette/states/cell_attached.py
@@ -68,7 +68,7 @@ class CellAttachedState(PatchPipetteState):
             if delay is not None and ptime.time() - startTime > delay:
                 return {"state": 'break in'}
 
-            self.checkStop()
+            self.check_stop()
 
             tps = self.getTestPulses(timeout=0.2)
             if len(tps) == 0:

--- a/acq4/devices/PatchPipette/states/cell_detect.py
+++ b/acq4/devices/PatchPipette/states/cell_detect.py
@@ -10,7 +10,7 @@ import pyqtgraph as pg
 from acq4.util import ptime
 from acq4.util.debug import log_and_ignore_exception
 from acq4.util.functions import plottable_booleans
-from acq4.util.future import future_wrap
+from acq4.util.future import Future, sleep
 from pyqtgraph.units import µm
 from ._base import PatchPipetteState, SteadyStateAnalysisBase, exponential_decay_avg
 
@@ -297,7 +297,7 @@ class CellDetectState(PatchPipetteState):
 
         return self._transition_to_fallback("Timed out waiting for cell detect.")
 
-    def pokeCell(self, _future):
+    def pokeCell(self):
         """Move pipette slightly deeper towards center of cell"""
         poke = self.config['pokeDistance']
         if poke == 0:
@@ -309,7 +309,7 @@ class CellDetectState(PatchPipetteState):
         dist = np.linalg.norm(dif)
         if dist > poke:
             goto = pos + dif * (poke / dist)
-            _future.waitFor(pip._moveToGlobal(goto, self.config['detectionSpeed'], name='poke cell'))
+            pip._moveToGlobal(goto, self.config['detectionSpeed'], name='poke cell')
 
     def processAtLeastOneTestPulse(self):
         tps = super().processAtLeastOneTestPulse()
@@ -404,8 +404,7 @@ class CellDetectState(PatchPipetteState):
 
         return endpoint
 
-    @future_wrap
-    def _move(self, name=None, _future=None):
+    def _move(self):
         """Move pipette along search path."""
         self.setState("pipette advance")
         config = self.config
@@ -414,38 +413,34 @@ class CellDetectState(PatchPipetteState):
                 self.surfaceIntersectionPosition,
                 config['aboveSurfaceSpeed'],
                 True,
-                _future,
             )
             self.setState("moved to surface")
         if not self.closeEnoughToTargetToDetectCell():
             self._waitForMoveWhileTargetChanges(
-                self.fastTravelEndpoint, config['belowSurfaceSpeed'], True, _future
+                self.fastTravelEndpoint, config['belowSurfaceSpeed'], True
             )
             self.setState("moved to detection area")
         if config['preTargetWiggle']:
-            self._wiggle(_future, self.finalSearchEndpoint())
+            self._wiggle(self.finalSearchEndpoint())
         if config['preTargetReposition']:
-            _future.waitFor(
-                self.dev.pipetteDevice._moveToGlobal(
-                    self.preTargetPosition(), speed=config['detectionSpeed'], name='pre-target reposition'
-                )
+            self.dev.pipetteDevice._moveToGlobal(
+                self.preTargetPosition(), speed=config['detectionSpeed'], name='pre-target reposition'
             )
         self.setState("moving to final search endpoint")
         self._waitForMoveWhileTargetChanges(
             position_fn=self.finalSearchEndpoint,
             speed=config['detectionSpeed'],
             continuous=True,
-            future=_future,
             interval=config['advanceStepInterval'],
             step=config['advanceStepDistance'],
         )
         if config['searchAroundAtTarget']:
-            self._searchAround(_future)
+            self._searchAround()
 
-        self.pokeCell(_future)
+        self.pokeCell()
         self._reachedEndpoint = True
 
-    def _wiggle(self, future, endpoint):
+    def _wiggle(self, endpoint):
         if self._hasWiggled:
             return
         config = self.config
@@ -457,24 +452,23 @@ class CellDetectState(PatchPipetteState):
         for _ in range(count):
             self.setState("pre-target wiggle")
             retract_pos = dev.pipetteDevice.globalPosition() - wiggle_step
-            future.waitFor(dev.pipetteDevice._moveToGlobal(retract_pos, speed=speed, name='pre-target wiggle retract'), timeout=None)
+            dev.pipetteDevice._moveToGlobal(retract_pos, speed=speed, name='pre-target wiggle retract')
             with self._wiggleLock:  # used to prevent cell detect
                 self.waitFor(
-                    dev.pipetteDevice.wiggle(
-                        speed=config['preTargetWiggleSpeed'],
-                        radius=config['preTargetWiggleRadius'],
-                        repetitions=1,
-                        duration=config['preTargetWiggleDuration'],
-                        pipette_direction=self.direction_unit,
-                        _sync="async",
-                    ),
+                    Future(dev.pipetteDevice.wiggle, (), {
+                        'speed': config['preTargetWiggleSpeed'],
+                        'radius': config['preTargetWiggleRadius'],
+                        'repetitions': 1,
+                        'duration': config['preTargetWiggleDuration'],
+                        'pipette_direction': self.direction_unit,
+                    }),
                     timeout=None,
                 )
             step_pos = dev.pipetteDevice.globalPosition() + wiggle_step
-            future.waitFor(dev.pipetteDevice._moveToGlobal(step_pos, speed=speed, name='pre-target wiggle advance'), timeout=None)
+            dev.pipetteDevice._moveToGlobal(step_pos, speed=speed, name='pre-target wiggle advance')
         self._hasWiggled = True
 
-    def _searchAround(self, future):
+    def _searchAround(self):
         """Slowly describe a circle on a vertical plane perpendicular to the yaw of the pipette."""
         self.setState("searching around target")
         radius = self.config['searchAroundAtTargetRadius']
@@ -491,8 +485,8 @@ class CellDetectState(PatchPipetteState):
         ) * radius
         for rel_pos in steps:
             pos = rel_pos + self.dev.pipetteDevice.targetPosition()
-            future.waitFor(self.dev.pipetteDevice._moveToGlobal(pos, speed, name='search around target'))
-            future.sleep(1)
+            self.dev.pipetteDevice._moveToGlobal(pos, speed, name='search around target')
+            sleep(1)
 
     def _cleanup(self):
         if self._moveFuture is not None and not self._moveFuture.isDone():

--- a/acq4/devices/PatchPipette/states/cell_detect.py
+++ b/acq4/devices/PatchPipette/states/cell_detect.py
@@ -405,7 +405,7 @@ class CellDetectState(PatchPipetteState):
         return endpoint
 
     @future_wrap
-    def _move(self, _future):
+    def _move(self, name=None, _future=None):
         """Move pipette along search path."""
         self.setState("pipette advance")
         config = self.config
@@ -466,6 +466,7 @@ class CellDetectState(PatchPipetteState):
                         repetitions=1,
                         duration=config['preTargetWiggleDuration'],
                         pipette_direction=self.direction_unit,
+                        _sync="async",
                     ),
                     timeout=None,
                 )

--- a/acq4/devices/PatchPipette/states/cell_detect.py
+++ b/acq4/devices/PatchPipette/states/cell_detect.py
@@ -276,7 +276,7 @@ class CellDetectState(PatchPipetteState):
                     self._moveFuture.stop("cell detected", wait=True)
                     self._moveFuture = None
                 return self._transition_to_seal(detectedThresholdSpeed)
-            self.checkStop()
+            self.check_stop()
             self.processAtLeastOneTestPulse()
             self.adjustPressureForDepth()
             self.maybeVisuallyTrackTarget()
@@ -287,8 +287,8 @@ class CellDetectState(PatchPipetteState):
             if config['autoAdvance']:
                 if self._moveFuture is None:
                     self._moveFuture = self._move()
-                if self._moveFuture.isDone():
-                    self._moveFuture.logErrors("Error during move")
+                if self._moveFuture.is_done:
+                    self._moveFuture.log_errors("Error during move")
                     self._moveFuture = None
                     if self._reachedEndpoint:
                         return self._transition_to_fallback(
@@ -338,7 +338,7 @@ class CellDetectState(PatchPipetteState):
         return {"state": self.config['fallbackState']}
 
     def _transition_to_seal(self, speed):
-        self.setState(f"cell detected ({speed} criteria)")
+        self.set_state(f"cell detected ({speed} criteria)")
         self.dev.patchRecord()['detectedCell'] = True
         return {"state": self.config['reachedEndpointState']}
 
@@ -406,7 +406,7 @@ class CellDetectState(PatchPipetteState):
 
     def _move(self):
         """Move pipette along search path."""
-        self.setState("pipette advance")
+        self.set_state("pipette advance")
         config = self.config
         if self.aboveSurface():
             self._waitForMoveWhileTargetChanges(
@@ -414,19 +414,19 @@ class CellDetectState(PatchPipetteState):
                 config['aboveSurfaceSpeed'],
                 True,
             )
-            self.setState("moved to surface")
+            self.set_state("moved to surface")
         if not self.closeEnoughToTargetToDetectCell():
             self._waitForMoveWhileTargetChanges(
                 self.fastTravelEndpoint, config['belowSurfaceSpeed'], True
             )
-            self.setState("moved to detection area")
+            self.set_state("moved to detection area")
         if config['preTargetWiggle']:
             self._wiggle(self.finalSearchEndpoint())
         if config['preTargetReposition']:
             self.dev.pipetteDevice._moveToGlobal(
                 self.preTargetPosition(), speed=config['detectionSpeed'], name='pre-target reposition'
             )
-        self.setState("moving to final search endpoint")
+        self.set_state("moving to final search endpoint")
         self._waitForMoveWhileTargetChanges(
             position_fn=self.finalSearchEndpoint,
             speed=config['detectionSpeed'],
@@ -450,11 +450,11 @@ class CellDetectState(PatchPipetteState):
         count = int(distance / config['preTargetWiggleStep'])
         wiggle_step = self.direction_unit * config['preTargetWiggleStep']
         for _ in range(count):
-            self.setState("pre-target wiggle")
+            self.set_state("pre-target wiggle")
             retract_pos = dev.pipetteDevice.globalPosition() - wiggle_step
             dev.pipetteDevice._moveToGlobal(retract_pos, speed=speed, name='pre-target wiggle retract')
             with self._wiggleLock:  # used to prevent cell detect
-                self.waitFor(
+                self.wait_for(
                     Future(dev.pipetteDevice.wiggle, (), {
                         'speed': config['preTargetWiggleSpeed'],
                         'radius': config['preTargetWiggleRadius'],
@@ -470,7 +470,7 @@ class CellDetectState(PatchPipetteState):
 
     def _searchAround(self):
         """Slowly describe a circle on a vertical plane perpendicular to the yaw of the pipette."""
-        self.setState("searching around target")
+        self.set_state("searching around target")
         radius = self.config['searchAroundAtTargetRadius']
         speed = self.config['detectionSpeed']
         vertical = np.array((0, 0, 1))
@@ -489,7 +489,7 @@ class CellDetectState(PatchPipetteState):
             sleep(1)
 
     def _cleanup(self):
-        if self._moveFuture is not None and not self._moveFuture.isDone():
+        if self._moveFuture is not None and not self._moveFuture.is_done:
             with log_and_ignore_exception(Exception, "Error stopping move during cleanup"):
                 self._moveFuture.stop()
         with log_and_ignore_exception(Exception, "Error storing target position"):

--- a/acq4/devices/PatchPipette/states/clean.py
+++ b/acq4/devices/PatchPipette/states/clean.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from acq4.util.future import Future
+from acq4.util.future import Future, sleep
 from pyqtgraph import units
 from ._base import PatchPipetteState
 
@@ -55,7 +55,7 @@ class CleanState(PatchPipetteState):
         dev = self.dev
         pip = dev.pipetteDevice
 
-        self.setState('cleaning')
+        self.set_state('cleaning')
 
         # for stage in ('clean', 'rinse'):
         #     self.checkStop()
@@ -68,7 +68,7 @@ class CleanState(PatchPipetteState):
         #
         #
         #
-        #     self.waitFor(pip.moveTo(stage, "fast"), timeout=30)
+        #     self.wait_for(pip.moveTo(stage, "fast"), timeout=30)
         #
         #     if dev.sonicatorDevice is not None:
         #         self.sonication = dev.sonicatorDevice.doProtocol(config['sonicationProtocol'])
@@ -78,7 +78,7 @@ class CleanState(PatchPipetteState):
         #         self.sleep(delay)
         #
         #     if self.sonication is not None and not self.sonication.isDone():
-        #         self.waitFor(self.sonication)
+        #         self.wait_for(self.sonication)
 
         sequence = config['cleanSequence']
         if isinstance(sequence, str):
@@ -92,36 +92,36 @@ class CleanState(PatchPipetteState):
             (np.array([-90e-3, 20e-3, 30e-3]), "waaay out of the way"),
         ]
         for wp, name in waypoints:
-            self.waitFor(scope.setGlobalPosition(wp, 20e-3, name=name))
+            self.wait_for(scope.setGlobalPosition(wp, 20e-3, name=name))
 
         cw = pip.getCleaningWell()
         pip.retractFromSurface('fast')
         pip._moveToGlobal([0, 0, 10e-3], 'fast', name='safe position before cleaning well')
-        self.waitFor(Future(cw.moveToInteract, (pip,)), timeout=60)
+        self.wait_for(Future(cw.moveToInteract, (pip,)), timeout=60)
 
         if dev.sonicatorDevice is not None:
             self.sonication = Future(dev.sonicatorDevice.doProtocol, (config['sonicationProtocol'],))
 
         for pressure, delay in sequence:
             dev.pressureDevice.setPressure(source='regulator', pressure=pressure)
-            self.sleep(delay)
+            sleep(delay)
 
-        if self.sonication is not None and not self.sonication.isDone():
-            self.waitFor(self.sonication)
+        if self.sonication is not None and not self.sonication.is_done:
+            self.wait_for(self.sonication)
 
-        self.waitFor(Future(cw.moveToApproach, (pip,)))
+        self.wait_for(Future(cw.moveToApproach, (pip,)))
 
         dev.pressureDevice.setPressure(source='atmosphere', pressure=0)
 
-        # self.waitFor(pip.moveTo('home', 'fast'))  # motion planning doesn't work so well from here
-        self.waitFor(pip.parentStage.goHome('fast'))
+        # self.wait_for(pip.moveTo('home', 'fast'))  # motion planning doesn't work so well from here
+        self.wait_for(pip.parentStage.goHome('fast'))
         waypoints = waypoints[::-1] + [(start_pos, "initial pos")]
         for wp, name in waypoints:
-            self.waitFor(scope.setGlobalPosition(wp, 20e-3, name=name))
+            self.wait_for(scope.setGlobalPosition(wp, 20e-3, name=name))
 
         # TODO this could have worked...
         # cw = pip.getCleaningWell()
-        # self.waitFor(cw.moveToInteract(pip), timeout=60)
+        # self.wait_for(cw.moveToInteract(pip), timeout=60)
         #
         # if dev.sonicatorDevice is not None:
         #     self.sonication = dev.sonicatorDevice.doProtocol(config['sonicationProtocol'])
@@ -131,14 +131,14 @@ class CleanState(PatchPipetteState):
         #     self.sleep(delay)
         #
         # if self.sonication is not None and not self.sonication.isDone():
-        #     self.waitFor(self.sonication)
+        #     self.wait_for(self.sonication)
         #
-        # self.waitFor(cw.moveToApproach(pip))
+        # self.wait_for(cw.moveToApproach(pip))
         #
         # dev.pressureDevice.setPressure(source='atmosphere', pressure=0)
         #
-        # self.waitFor(pip.parentStage.goHome('fast'))
-        # self.waitFor(cw._unwindKludgePath(pip))
+        # self.wait_for(pip.parentStage.goHome('fast'))
+        # self.wait_for(cw._unwindKludgePath(pip))
 
         dev.pipetteRecord()['cleanCount'] += 1
         dev.setTipClean(True)
@@ -151,12 +151,12 @@ class CleanState(PatchPipetteState):
         if self.moveFuture is not None:
             fut = self.moveFuture.undo()
             self.moveFuture = None
-            parent_future.waitFor(fut, timeout=None)
+            parent_future.wait_for(fut, timeout=None)
 
     def _cleanup(self):
         dev = self.dev
         try:
-            if self.sonication is not None and not self.sonication.isDone():
+            if self.sonication is not None and not self.sonication.is_done:
                 self.sonication.stop("parent task is cleaning up before sonication finished")
         except Exception:
             dev.logger.exception("Error stopping sonication")

--- a/acq4/devices/PatchPipette/states/clean.py
+++ b/acq4/devices/PatchPipette/states/clean.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from acq4.util.future import future_wrap
+from acq4.util.future import Future
 from pyqtgraph import units
 from ._base import PatchPipetteState
 
@@ -95,12 +95,12 @@ class CleanState(PatchPipetteState):
             self.waitFor(scope.setGlobalPosition(wp, 20e-3, name=name))
 
         cw = pip.getCleaningWell()
-        self.waitFor(pip.retractFromSurface('fast'))
-        self.waitFor(pip._moveToGlobal([0, 0, 10e-3], 'fast', name='safe position before cleaning well'))
-        self.waitFor(cw.moveToInteract(pip, _sync="async"), timeout=60)
+        pip.retractFromSurface('fast')
+        pip._moveToGlobal([0, 0, 10e-3], 'fast', name='safe position before cleaning well')
+        self.waitFor(Future(cw.moveToInteract, (pip,)), timeout=60)
 
         if dev.sonicatorDevice is not None:
-            self.sonication = dev.sonicatorDevice.doProtocol(config['sonicationProtocol'], _sync="async")
+            self.sonication = Future(dev.sonicatorDevice.doProtocol, (config['sonicationProtocol'],))
 
         for pressure, delay in sequence:
             dev.pressureDevice.setPressure(source='regulator', pressure=pressure)
@@ -109,7 +109,7 @@ class CleanState(PatchPipetteState):
         if self.sonication is not None and not self.sonication.isDone():
             self.waitFor(self.sonication)
 
-        self.waitFor(cw.moveToApproach(pip, _sync="async"))
+        self.waitFor(Future(cw.moveToApproach, (pip,)))
 
         dev.pressureDevice.setPressure(source='atmosphere', pressure=0)
 
@@ -153,8 +153,7 @@ class CleanState(PatchPipetteState):
             self.moveFuture = None
             parent_future.waitFor(fut, timeout=None)
 
-    @future_wrap
-    def _cleanup(self, name=None, _future=None):
+    def _cleanup(self):
         dev = self.dev
         try:
             if self.sonication is not None and not self.sonication.isDone():
@@ -166,10 +165,5 @@ class CleanState(PatchPipetteState):
             dev.pressureDevice.setPressure(source='atmosphere', pressure=0)
         except Exception:
             dev.logger.exception("Error resetting pressure after clean")
-
-        # try:
-        #     _future.waitFor(dev.pipetteDevice.moveTo('home', 'fast'))
-        # except Exception:
-        #     dev.logger.exception("Error resetting pipette position after clean")
 
         super()._cleanup()

--- a/acq4/devices/PatchPipette/states/clean.py
+++ b/acq4/devices/PatchPipette/states/clean.py
@@ -97,10 +97,10 @@ class CleanState(PatchPipetteState):
         cw = pip.getCleaningWell()
         self.waitFor(pip.retractFromSurface('fast'))
         self.waitFor(pip._moveToGlobal([0, 0, 10e-3], 'fast', name='safe position before cleaning well'))
-        self.waitFor(cw.moveToInteract(pip), timeout=60)
+        self.waitFor(cw.moveToInteract(pip, _sync="async"), timeout=60)
 
         if dev.sonicatorDevice is not None:
-            self.sonication = dev.sonicatorDevice.doProtocol(config['sonicationProtocol'])
+            self.sonication = dev.sonicatorDevice.doProtocol(config['sonicationProtocol'], _sync="async")
 
         for pressure, delay in sequence:
             dev.pressureDevice.setPressure(source='regulator', pressure=pressure)
@@ -109,7 +109,7 @@ class CleanState(PatchPipetteState):
         if self.sonication is not None and not self.sonication.isDone():
             self.waitFor(self.sonication)
 
-        self.waitFor(cw.moveToApproach(pip))
+        self.waitFor(cw.moveToApproach(pip, _sync="async"))
 
         dev.pressureDevice.setPressure(source='atmosphere', pressure=0)
 
@@ -154,7 +154,7 @@ class CleanState(PatchPipetteState):
             parent_future.waitFor(fut, timeout=None)
 
     @future_wrap
-    def _cleanup(self, _future):
+    def _cleanup(self, name=None, _future=None):
         dev = self.dev
         try:
             if self.sonication is not None and not self.sonication.isDone():
@@ -172,4 +172,4 @@ class CleanState(PatchPipetteState):
         # except Exception:
         #     dev.logger.exception("Error resetting pipette position after clean")
 
-        _future.waitFor(super()._cleanup(), timeout=None)
+        super()._cleanup()

--- a/acq4/devices/PatchPipette/states/contact_cell.py
+++ b/acq4/devices/PatchPipette/states/contact_cell.py
@@ -208,6 +208,7 @@ class ContactCellState(PatchPipetteState):
                 pip.iterativelyFindTip(
                     max_allowed_offset=self.config["pipetteRecalibrationMaxChange"],
                     go_to_tip_first=True,
+                    _sync="async",
                 )
             )
         except Exception as e:

--- a/acq4/devices/PatchPipette/states/contact_cell.py
+++ b/acq4/devices/PatchPipette/states/contact_cell.py
@@ -4,6 +4,7 @@ import numpy as np
 from pyqtgraph.units import µm, MΩ
 
 from acq4.util.debug import log_and_ignore_exception
+from acq4.util.future import Future
 from ._base import PatchPipetteState
 from .cell_detect import CellDetectAnalysis
 from acq4 import getManager
@@ -205,11 +206,10 @@ class ContactCellState(PatchPipetteState):
         self.setState(f"Check pipette tip..")
         try:
             tip_fut = self.waitFor(
-                pip.iterativelyFindTip(
-                    max_allowed_offset=self.config["pipetteRecalibrationMaxChange"],
-                    go_to_tip_first=True,
-                    _sync="async",
-                )
+                Future(pip.iterativelyFindTip, (), {
+                    'max_allowed_offset': self.config["pipetteRecalibrationMaxChange"],
+                    'go_to_tip_first': True,
+                })
             )
         except Exception as e:
             self.setState(f"failed pipette position update: {e}")

--- a/acq4/devices/PatchPipette/states/contact_cell.py
+++ b/acq4/devices/PatchPipette/states/contact_cell.py
@@ -4,7 +4,7 @@ import numpy as np
 from pyqtgraph.units import µm, MΩ
 
 from acq4.util.debug import log_and_ignore_exception
-from acq4.util.future import Future
+from acq4.util.future import Future, sleep
 from ._base import PatchPipetteState
 from .cell_detect import CellDetectAnalysis
 from acq4 import getManager
@@ -108,18 +108,18 @@ class ContactCellState(PatchPipetteState):
         target = np.array(pip.targetPosition())
         initial_pos = target.copy()
         initial_pos[2] += config['initialApproachHeight']
-        self.setState("moving to initial approach position")
+        self.set_state("moving to initial approach position")
         self._moveFuture = pip._moveToGlobal(initial_pos, speed=config['moveSpeed'], name='move to initial approach position')
-        self.waitFor(self._moveFuture)
+        self.wait_for(self._moveFuture)
         self._moveFuture = None
 
         self._startZ = pip.globalPosition()[2]
         iterations = 0
 
         # 5. Main descent loop
-        self.setState("descending toward cell")
+        self.set_state("descending toward cell")
         while True:
-            self.checkStop()
+            self.check_stop()
 
             # Process test pulses and check for broken tip
             self.processAtLeastOneTestPulse()
@@ -132,7 +132,7 @@ class ContactCellState(PatchPipetteState):
                 if self._contactDepth is None:
                     current_z = pip.globalPosition()[2]
                     self._contactDepth = current_z
-                    self.setState("cell contact detected, continuing descent")
+                    self.set_state("cell contact detected, continuing descent")
                     self.dev.patchRecord()['detectedCell'] = True
                     self.dev.patchRecord()['contactDepth'] = current_z
 
@@ -141,14 +141,14 @@ class ContactCellState(PatchPipetteState):
                 current_z = pip.globalPosition()[2]
                 depth_past_contact = self._contactDepth - current_z
                 if depth_past_contact >= config['depthPastContact']:
-                    self.setState("reached target depth past contact")
+                    self.set_state("reached target depth past contact")
                     return {"state": config['nextState']}
 
             # Check if we've traveled too far without contact
             current_z = pip.globalPosition()[2]
             total_descent = self._startZ - current_z
             if total_descent >= config['maxTravelWithoutContact']:
-                self.setState("max travel reached without contact, giving up")
+                self.set_state("max travel reached without contact, giving up")
                 self.dev.patchRecord()['detectedCell'] = False
                 return {"state": config['fallbackState']}
 
@@ -162,11 +162,11 @@ class ContactCellState(PatchPipetteState):
             ])
 
             self._moveFuture = pip._moveToGlobal(next_pos, speed=config['moveSpeed'], name='contact cell descent step')
-            self.waitFor(self._moveFuture)
+            self.wait_for(self._moveFuture)
             self._moveFuture = None
 
             # Wait between iterations
-            self.sleep(config['stepInterval'])
+            sleep(config['stepInterval'])
 
     def processAtLeastOneTestPulse(self):
         tps = super().processAtLeastOneTestPulse()
@@ -194,7 +194,7 @@ class ContactCellState(PatchPipetteState):
     #         self._cell = None
 
     def _cleanup(self):
-        if self._moveFuture is not None and not self._moveFuture.isDone():
+        if self._moveFuture is not None and not self._moveFuture.is_done:
             with log_and_ignore_exception(Exception, "Error stopping move during cleanup"):
                 self._moveFuture.stop()
         # with log_and_ignore_exception(Exception, "Error disabling visual tracking"):
@@ -203,13 +203,13 @@ class ContactCellState(PatchPipetteState):
 
     def recalibratePipette(self):
         pip = self.dev.pipetteDevice
-        self.setState(f"Check pipette tip..")
+        self.set_state(f"Check pipette tip..")
         try:
-            tip_fut = self.waitFor(
+            tip_fut = self.wait_for(
                 Future(pip.iterativelyFindTip, (), {
                     'max_allowed_offset': self.config["pipetteRecalibrationMaxChange"],
                     'go_to_tip_first': True,
                 })
             )
         except Exception as e:
-            self.setState(f"failed pipette position update: {e}")
+            self.set_state(f"failed pipette position update: {e}")

--- a/acq4/devices/PatchPipette/states/move_nucleus_to_home.py
+++ b/acq4/devices/PatchPipette/states/move_nucleus_to_home.py
@@ -25,7 +25,7 @@ class MoveNucleusToHomeState(PatchPipetteState):
     }
 
     def run(self):
-        self.waitFor(self.dev.pressureDevice.rampPressure(maximum=self.config['pressureLimit']), timeout=None)
+        self.waitFor(self.dev.pressureDevice.rampPressure(maximum=self.config['pressureLimit'], _sync="async"), timeout=None)
         self.waitFor(self.dev.pipetteDevice.moveTo(self.config['positionName'], 'fast'), timeout=None)
         return {
             "state": "out",

--- a/acq4/devices/PatchPipette/states/move_nucleus_to_home.py
+++ b/acq4/devices/PatchPipette/states/move_nucleus_to_home.py
@@ -26,8 +26,8 @@ class MoveNucleusToHomeState(PatchPipetteState):
     }
 
     def run(self):
-        self.waitFor(Future(self.dev.pressureDevice.rampPressure, (), {'maximum': self.config['pressureLimit']}), timeout=None)
-        self.waitFor(self.dev.pipetteDevice.moveTo(self.config['positionName'], 'fast'), timeout=None)
+        self.wait_for(Future(self.dev.pressureDevice.rampPressure, (), {'maximum': self.config['pressureLimit']}), timeout=None)
+        self.wait_for(self.dev.pipetteDevice.moveTo(self.config['positionName'], 'fast'), timeout=None)
         return {
             "state": "out",
             "initialPressure": self.config['pressureLimit'],

--- a/acq4/devices/PatchPipette/states/move_nucleus_to_home.py
+++ b/acq4/devices/PatchPipette/states/move_nucleus_to_home.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from acq4.util.future import Future
 from ._base import PatchPipetteState
 
 
@@ -25,7 +26,7 @@ class MoveNucleusToHomeState(PatchPipetteState):
     }
 
     def run(self):
-        self.waitFor(self.dev.pressureDevice.rampPressure(maximum=self.config['pressureLimit'], _sync="async"), timeout=None)
+        self.waitFor(Future(self.dev.pressureDevice.rampPressure, (), {'maximum': self.config['pressureLimit']}), timeout=None)
         self.waitFor(self.dev.pipetteDevice.moveTo(self.config['positionName'], 'fast'), timeout=None)
         return {
             "state": "out",

--- a/acq4/devices/PatchPipette/states/nucleus_collect.py
+++ b/acq4/devices/PatchPipette/states/nucleus_collect.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from acq4.util.future import Future
+from acq4.util.future import Future, sleep
 from pyqtgraph import units
 from ._base import PatchPipetteState
 
@@ -44,14 +44,14 @@ class NucleusCollectState(PatchPipetteState):
         dev = self.dev
         pip = dev.pipetteDevice
 
-        self.setState('nucleus collection')
+        self.set_state('nucleus collection')
 
         # move to top of collection tube
         self.startPos = pip.globalPosition()
         self.collectionPos = pip.loadPosition('collect')
         # self.approachPos = self.collectionPos - pip.globalDirection() * config['approachDistance']
 
-        # self.waitFor([pip._moveToGlobal(self.approachPos, speed='fast')])
+        # self.wait_for([pip._moveToGlobal(self.approachPos, speed='fast')])
         pip._moveToGlobal(self.collectionPos, speed='fast', name=f"{pip.name()} move to nucleus collection position")
 
         if dev.sonicatorDevice is not None:
@@ -63,17 +63,17 @@ class NucleusCollectState(PatchPipetteState):
 
         for pressure, delay in sequence:
             dev.pressureDevice.setPressure(source='regulator', pressure=pressure)
-            self.sleep(delay)
+            sleep(delay)
 
-        if self.sonication is not None and not self.sonication.isDone():
-            self.waitFor(self.sonication)
+        if self.sonication is not None and not self.sonication.is_done:
+            self.wait_for(self.sonication)
 
         dev.pipetteRecord()['expelled_nucleus'] = True
         return {"state": 'out'}
 
         # # current version using InteractionSite moveToInteract/unwindKludgePath:
         # well = pip.getNucleusDepositionWell()
-        # self.waitFor(well.moveToInteract(pip))
+        # self.wait_for(well.moveToInteract(pip))
         #
         # if dev.sonicatorDevice is not None:
         #     self.sonication = dev.sonicatorDevice.doProtocol(config['sonicationProtocol'])
@@ -87,20 +87,20 @@ class NucleusCollectState(PatchPipetteState):
         #     self.sleep(delay)
         #
         # if self.sonication is not None and not self.sonication.isDone():
-        #     self.waitFor(self.sonication)
+        #     self.wait_for(self.sonication)
         #
         # dev.pipetteRecord()['expelled_nucleus'] = True
-        # self.waitFor(well._unwindKludgePath(pip))
+        # self.wait_for(well._unwindKludgePath(pip))
         # return {"state": 'out'}
 
     def resetPosition(self):
         pip = self.dev.pipetteDevice
-        if self.isDone():
+        if self.is_done:
             pip._moveToGlobal(self.startPos, speed='fast', name='return to start position')
 
     def _cleanup(self):
         try:
-            if self.sonication is not None and not self.sonication.isDone():
+            if self.sonication is not None and not self.sonication.is_done:
                 self.sonication.stop("parent task is cleaning up before sonication finished")
         except Exception:
             self.dev.logger.exception("Error stopping sonication")

--- a/acq4/devices/PatchPipette/states/nucleus_collect.py
+++ b/acq4/devices/PatchPipette/states/nucleus_collect.py
@@ -55,7 +55,7 @@ class NucleusCollectState(PatchPipetteState):
         self.waitFor(pip._moveToGlobal(self.collectionPos, speed='fast', name=f"{pip.name()} move to nucleus collection position"), timeout=None)
 
         if dev.sonicatorDevice is not None:
-            self.sonication = dev.sonicatorDevice.doProtocol(config['sonicationProtocol'])
+            self.sonication = dev.sonicatorDevice.doProtocol(config['sonicationProtocol'], _sync="async")
 
         sequence = config['pressureSequence']
         if isinstance(sequence, str):
@@ -100,7 +100,7 @@ class NucleusCollectState(PatchPipetteState):
             _future.waitFor(pip._moveToGlobal(self.startPos, speed='fast', name='return to start position'), timeout=None)
 
     @future_wrap
-    def _cleanup(self, _future):
+    def _cleanup(self, name=None, _future=None):
         try:
             if self.sonication is not None and not self.sonication.isDone():
                 self.sonication.stop("parent task is cleaning up before sonication finished")
@@ -117,4 +117,4 @@ class NucleusCollectState(PatchPipetteState):
         except Exception:
             self.dev.logger.exception("Error resetting pipette position after collection")
 
-        _future.waitFor(super()._cleanup(), timeout=None)
+        super()._cleanup()

--- a/acq4/devices/PatchPipette/states/nucleus_collect.py
+++ b/acq4/devices/PatchPipette/states/nucleus_collect.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from acq4.util.future import future_wrap
+from acq4.util.future import Future
 from pyqtgraph import units
 from ._base import PatchPipetteState
 
@@ -52,10 +52,10 @@ class NucleusCollectState(PatchPipetteState):
         # self.approachPos = self.collectionPos - pip.globalDirection() * config['approachDistance']
 
         # self.waitFor([pip._moveToGlobal(self.approachPos, speed='fast')])
-        self.waitFor(pip._moveToGlobal(self.collectionPos, speed='fast', name=f"{pip.name()} move to nucleus collection position"), timeout=None)
+        pip._moveToGlobal(self.collectionPos, speed='fast', name=f"{pip.name()} move to nucleus collection position")
 
         if dev.sonicatorDevice is not None:
-            self.sonication = dev.sonicatorDevice.doProtocol(config['sonicationProtocol'], _sync="async")
+            self.sonication = Future(dev.sonicatorDevice.doProtocol, (config['sonicationProtocol'],))
 
         sequence = config['pressureSequence']
         if isinstance(sequence, str):
@@ -93,14 +93,12 @@ class NucleusCollectState(PatchPipetteState):
         # self.waitFor(well._unwindKludgePath(pip))
         # return {"state": 'out'}
 
-    def resetPosition(self, _future=None):
+    def resetPosition(self):
         pip = self.dev.pipetteDevice
         if self.isDone():
-            # self.waitFor([pip._moveToGlobal(self.approachPos, speed='fast')])
-            _future.waitFor(pip._moveToGlobal(self.startPos, speed='fast', name='return to start position'), timeout=None)
+            pip._moveToGlobal(self.startPos, speed='fast', name='return to start position')
 
-    @future_wrap
-    def _cleanup(self, name=None, _future=None):
+    def _cleanup(self):
         try:
             if self.sonication is not None and not self.sonication.isDone():
                 self.sonication.stop("parent task is cleaning up before sonication finished")
@@ -113,7 +111,7 @@ class NucleusCollectState(PatchPipetteState):
             self.dev.logger.exception("Error resetting pressure after collection")
 
         try:
-            self.resetPosition(_future)
+            self.resetPosition()
         except Exception:
             self.dev.logger.exception("Error resetting pipette position after collection")
 

--- a/acq4/devices/PatchPipette/states/reseal.py
+++ b/acq4/devices/PatchPipette/states/reseal.py
@@ -8,7 +8,7 @@ import pyqtgraph as pg
 from acq4.util import ptime
 from acq4.util.debug import log_and_ignore_exception
 from acq4.util.functions import plottable_booleans
-from acq4.util.future import Future, check_stop
+from acq4.util.future import Future, check_stop, sleep
 from ._base import PatchPipetteState, SteadyStateAnalysisBase, exponential_decay_avg
 
 
@@ -321,7 +321,7 @@ class ResealState(PatchPipetteState):
 
     def nuzzle(self):
         """Wiggle the pipette around inside the cell to clear space for a nucleus to be extracted."""
-        self.setState("nuzzling")
+        self.set_state("nuzzling")
 
         @contextlib.contextmanager
         def pressure_ramp():
@@ -332,9 +332,9 @@ class ResealState(PatchPipetteState):
                 'target': self.config['nuzzlePressureLimit'], 'duration': self.config['nuzzleDuration']
             })
             yield
-            self.waitFor(self._pressureFuture)
+            self.wait_for(self._pressureFuture)
 
-        self.waitFor(
+        self.wait_for(
             Future(self.dev.pipetteDevice.wiggle, (), {
                 'speed': self.config['nuzzleSpeed'],
                 'radius': self.config['nuzzleLateralWiggleRadius'],
@@ -385,7 +385,7 @@ class ResealState(PatchPipetteState):
     def isRetractionSuccessful(self):
         distance = self.retractionDistance()
         if distance > self.config['retractionSuccessDistance']:
-            self.setState("retraction distance sufficient for success")
+            self.set_state("retraction distance sufficient for success")
             return True
 
         success = (
@@ -402,7 +402,7 @@ class ResealState(PatchPipetteState):
         elif ptime.time() - (self._firstSuccessTime or 0) < self.config['resealSuccessDuration']:
             success = False
         else:  # sustained success!
-            self.setState("resistance sufficient for success")
+            self.set_state("resistance sufficient for success")
         return success
 
     def processAtLeastOneTestPulse(self):
@@ -430,9 +430,9 @@ class ResealState(PatchPipetteState):
         baseline_future = Future(self.startRollingResistanceThresholds)
         if config['extractNucleus'] is True:
             self.nuzzle()
-        self.checkStop()
-        self.setState("measuring baseline resistance")
-        self.waitFor(baseline_future, timeout=2 * self.config['repairTau'])
+        self.check_stop()
+        self.set_state("measuring baseline resistance")
+        self.wait_for(baseline_future, timeout=2 * self.config['repairTau'])
         dev.pressureDevice.setPressure(source='regulator', pressure=config['retractionPressure'])
 
         start_time = ptime.time()  # getting the nucleus and baseline measurements doesn't count
@@ -453,12 +453,12 @@ class ResealState(PatchPipetteState):
             self.processAtLeastOneTestPulse()
 
             if self.isStretching():
-                if retraction_future and not retraction_future.isDone():
-                    self.setState("handling stretch")
+                if retraction_future and not retraction_future.is_done:
+                    self.set_state("handling stretch")
                     retraction_future.stop()
             elif self.isTearing():
-                if retraction_future and not retraction_future.isDone():
-                    self.setState("handling tear")
+                if retraction_future and not retraction_future.is_done:
+                    self.set_state("handling tear")
                     retraction_future.stop()
                     self._moveFuture = recovery_future = Future(dev.pipetteDevice.stepwiseAdvance, (), {
                         'depth': self._targetPosition[2],
@@ -468,9 +468,9 @@ class ResealState(PatchPipetteState):
                         'name': 'reseal tear recovery',
                     })
             elif self.isTorn():
-                if retraction_future and not retraction_future.isDone():
+                if retraction_future and not retraction_future.is_done:
                     retraction_future.stop()
-                self.setState("tissue is torn beyond repair")
+                self.set_state("tissue is torn beyond repair")
                 self.setResult(error="Tissue is torn beyond repair (via `tornDetectionThreshold`).")
                 return {
                     "state": config['fallbackState'],
@@ -478,13 +478,13 @@ class ResealState(PatchPipetteState):
                     "initialPressureSource": config['initialPressureSource'],
                 }
 
-            elif retraction_future is None or retraction_future.wasInterrupted():
+            elif retraction_future is None or retraction_future.was_interrupted:
                 if retraction_future is not None:
-                    retraction_future.logErrors("Reseal retraction error")
+                    retraction_future.log_errors("Reseal retraction error")
                 if recovery_future is not None:
                     recovery_future.stop(wait=True)
-                    recovery_future.logErrors("Reseal recovery error")
-                self.setState("retracting")
+                    recovery_future.log_errors("Reseal recovery error")
+                self.set_state("retracting")
                 self._moveFuture = retraction_future = Future(dev.pipetteDevice.stepwiseAdvance, (), {
                     'depth': dev.pipetteDevice.approachDepth(),
                     'speed': config['maxRetractionSpeed'],
@@ -499,21 +499,21 @@ class ResealState(PatchPipetteState):
                     dev.imagingDevice().globalCenterPosition() - dev.pipetteDevice.globalPosition()
                 )
             ):
-                self.waitFor(dev.focusOnTip('slow'))
-            self.sleep(0.2)
+                self.wait_for(dev.focusOnTip('slow'))
+            sleep(0.2)
 
         if self._moveFuture is not None:
             self._moveFuture.stop(wait=True)
-        self.setState("retracting pipette from surface")
+        self.set_state("retracting pipette from surface")
         self._moveFuture = self._retractFromTissue()
-        self.waitFor(self._moveFuture)
+        self.wait_for(self._moveFuture)
 
-        self.setState("go above target before slurp")
+        self.set_state("go above target before slurp")
         self._moveFuture = dev.pipetteDevice.goAboveTarget(speed=100e-6)
-        self.waitFor(self._moveFuture, timeout=120)
-        self.waitFor(dev.pipetteDevice.focusTip())
+        self.wait_for(self._moveFuture, timeout=120)
+        self.wait_for(dev.pipetteDevice.focusTip())
 
-        self.setState("slurping in nucleus")
+        self.set_state("slurping in nucleus")
         dev.pressureDevice.setPressure(source='regulator', pressure=config['slurpPressure'])
         slurp_start = ptime.time()
         final_pressure = config['initialPressure']
@@ -521,14 +521,14 @@ class ResealState(PatchPipetteState):
             tps = self.processAtLeastOneTestPulse()
             resistance = tps[-1].analysis['steady_state_resistance']
             if resistance < config['slurpStopThreshold']:
-                self.setState(
+                self.set_state(
                     f"Slurp complete; resistance {resistance} dropped below threshold {config['slurpStopThreshold']}"
                 )
                 final_pressure = 0
                 break
             now = ptime.time()
             if now > slurp_start + config['slurpDuration']:
-                self.setState(f"Slurp complete; max duration {config['slurpDuration']} elapsed.")
+                self.set_state(f"Slurp complete; max duration {config['slurpDuration']} elapsed.")
                 break
 
         dev.pressureDevice.setPressure(source='regulator', pressure=final_pressure)

--- a/acq4/devices/PatchPipette/states/reseal.py
+++ b/acq4/devices/PatchPipette/states/reseal.py
@@ -8,7 +8,7 @@ import pyqtgraph as pg
 from acq4.util import ptime
 from acq4.util.debug import log_and_ignore_exception
 from acq4.util.functions import plottable_booleans
-from acq4.util.future import Future, future_wrap
+from acq4.util.future import Future, check_stop
 from ._base import PatchPipetteState, SteadyStateAnalysisBase, exponential_decay_avg
 
 
@@ -328,31 +328,29 @@ class ResealState(PatchPipetteState):
             self.dev.pressureDevice.setPressure(
                 source='regulator', pressure=self.config['nuzzleInitialPressure']
             )
-            self._pressureFuture = self.dev.pressureDevice.rampPressure(
-                target=self.config['nuzzlePressureLimit'], duration=self.config['nuzzleDuration'], _sync="async"
-            )
+            self._pressureFuture = Future(self.dev.pressureDevice.rampPressure, (), {
+                'target': self.config['nuzzlePressureLimit'], 'duration': self.config['nuzzleDuration']
+            })
             yield
             self.waitFor(self._pressureFuture)
 
         self.waitFor(
-            self.dev.pipetteDevice.wiggle(
-                speed=self.config['nuzzleSpeed'],
-                radius=self.config['nuzzleLateralWiggleRadius'],
-                duration=self.config['nuzzleDuration'],
-                repetitions=self.config['nuzzleRepetitions'],
-                extra=pressure_ramp,
-                _sync="async",
-            ),
+            Future(self.dev.pipetteDevice.wiggle, (), {
+                'speed': self.config['nuzzleSpeed'],
+                'radius': self.config['nuzzleLateralWiggleRadius'],
+                'duration': self.config['nuzzleDuration'],
+                'repetitions': self.config['nuzzleRepetitions'],
+                'extra': pressure_ramp,
+            }),
             timeout=None,
         )
 
-    @future_wrap
-    def startRollingResistanceThresholds(self, name=None, _future: Future = None):
+    def startRollingResistanceThresholds(self):
         """Start a rolling average of the resistance to detect stretching and tearing. Load the first 20s of data."""
         self.monitorTestPulse()
         start = ptime.time()
         while ptime.time() - start < self.config['repairTau']:
-            _future.checkStop()
+            check_stop()
             self.processAtLeastOneTestPulse()
 
     def isStretching(self) -> bool:
@@ -429,7 +427,7 @@ class ResealState(PatchPipetteState):
         self._sanityChecks()
         config = self.config
         dev = self.dev
-        baseline_future = self.startRollingResistanceThresholds(_sync="async")
+        baseline_future = Future(self.startRollingResistanceThresholds)
         if config['extractNucleus'] is True:
             self.nuzzle()
         self.checkStop()
@@ -462,14 +460,13 @@ class ResealState(PatchPipetteState):
                 if retraction_future and not retraction_future.isDone():
                     self.setState("handling tear")
                     retraction_future.stop()
-                    self._moveFuture = recovery_future = dev.pipetteDevice.stepwiseAdvance(
-                        depth=self._targetPosition[2],
-                        speed=self.config['maxRetractionSpeed'],
-                        interval=config['retractionStepInterval'],
-                        step=1e-6,
-                        name='reseal tear recovery',
-                        _sync="async",
-                    )
+                    self._moveFuture = recovery_future = Future(dev.pipetteDevice.stepwiseAdvance, (), {
+                        'depth': self._targetPosition[2],
+                        'speed': self.config['maxRetractionSpeed'],
+                        'interval': config['retractionStepInterval'],
+                        'step': 1e-6,
+                        'name': 'reseal tear recovery',
+                    })
             elif self.isTorn():
                 if retraction_future and not retraction_future.isDone():
                     retraction_future.stop()
@@ -488,14 +485,13 @@ class ResealState(PatchPipetteState):
                     recovery_future.stop(wait=True)
                     recovery_future.logErrors("Reseal recovery error")
                 self.setState("retracting")
-                self._moveFuture = retraction_future = dev.pipetteDevice.stepwiseAdvance(
-                    depth=dev.pipetteDevice.approachDepth(),
-                    speed=config['maxRetractionSpeed'],
-                    interval=config['retractionStepInterval'],
-                    step=1e-6,
-                    name='reseal retraction',
-                    _sync="async",
-                )
+                self._moveFuture = retraction_future = Future(dev.pipetteDevice.stepwiseAdvance, (), {
+                    'depth': dev.pipetteDevice.approachDepth(),
+                    'speed': config['maxRetractionSpeed'],
+                    'interval': config['retractionStepInterval'],
+                    'step': 1e-6,
+                    'name': 'reseal retraction',
+                })
 
             if (
                 config['focusFollowsTip']

--- a/acq4/devices/PatchPipette/states/reseal.py
+++ b/acq4/devices/PatchPipette/states/reseal.py
@@ -329,7 +329,7 @@ class ResealState(PatchPipetteState):
                 source='regulator', pressure=self.config['nuzzleInitialPressure']
             )
             self._pressureFuture = self.dev.pressureDevice.rampPressure(
-                target=self.config['nuzzlePressureLimit'], duration=self.config['nuzzleDuration']
+                target=self.config['nuzzlePressureLimit'], duration=self.config['nuzzleDuration'], _sync="async"
             )
             yield
             self.waitFor(self._pressureFuture)
@@ -341,12 +341,13 @@ class ResealState(PatchPipetteState):
                 duration=self.config['nuzzleDuration'],
                 repetitions=self.config['nuzzleRepetitions'],
                 extra=pressure_ramp,
+                _sync="async",
             ),
             timeout=None,
         )
 
     @future_wrap
-    def startRollingResistanceThresholds(self, _future: Future):
+    def startRollingResistanceThresholds(self, name=None, _future: Future = None):
         """Start a rolling average of the resistance to detect stretching and tearing. Load the first 20s of data."""
         self.monitorTestPulse()
         start = ptime.time()
@@ -428,7 +429,7 @@ class ResealState(PatchPipetteState):
         self._sanityChecks()
         config = self.config
         dev = self.dev
-        baseline_future = self.startRollingResistanceThresholds()
+        baseline_future = self.startRollingResistanceThresholds(_sync="async")
         if config['extractNucleus'] is True:
             self.nuzzle()
         self.checkStop()
@@ -467,6 +468,7 @@ class ResealState(PatchPipetteState):
                         interval=config['retractionStepInterval'],
                         step=1e-6,
                         name='reseal tear recovery',
+                        _sync="async",
                     )
             elif self.isTorn():
                 if retraction_future and not retraction_future.isDone():
@@ -492,6 +494,7 @@ class ResealState(PatchPipetteState):
                     interval=config['retractionStepInterval'],
                     step=1e-6,
                     name='reseal retraction',
+                    _sync="async",
                 )
 
             if (

--- a/acq4/devices/PatchPipette/states/seal.py
+++ b/acq4/devices/PatchPipette/states/seal.py
@@ -410,7 +410,7 @@ class SealState(PatchPipetteState):
             start = ptime.time()
             self.waitForFutureOrSuccess(
                 self.dev.pressureDevice.rampPressure(
-                    target=high, duration=self.config['pressureScanDuration']
+                    target=high, duration=self.config['pressureScanDuration'], _sync="async"
                 )
             )
             if self._analysis.success():
@@ -418,7 +418,7 @@ class SealState(PatchPipetteState):
             turnaround = ptime.time()
             self.waitForFutureOrSuccess(
                 self.dev.pressureDevice.rampPressure(
-                    target=low, duration=self.config['pressureScanDuration']
+                    target=low, duration=self.config['pressureScanDuration'], _sync="async"
                 )
             )
             end = ptime.time()

--- a/acq4/devices/PatchPipette/states/seal.py
+++ b/acq4/devices/PatchPipette/states/seal.py
@@ -7,7 +7,7 @@ from typing import Any
 import numpy as np
 
 from acq4.util import ptime, Qt
-from acq4.util.future import Future
+from acq4.util.future import Future, sleep
 import pyqtgraph as pg
 from acq4.util.debug import log_and_ignore_exception
 from acq4.util.functions import plottable_booleans
@@ -321,19 +321,19 @@ class SealState(PatchPipetteState):
         self.processAtLeastOneTestPulse()
 
         startTime = ptime.time()
-        self.setState(f'beginning seal (mode: {config["pressureMode"] !r})')
+        self.set_state(f'beginning seal (mode: {config["pressureMode"] !r})')
         self.setInitialPressure()
         if config['focusOnCell']:
-            self.waitFor(dev.focusOnTarget('slow'))
+            self.wait_for(dev.focusOnTarget('slow'))
 
         self._patchrec['attemptedSeal'] = True
 
         while True:
-            self.checkStop()
+            self.check_stop()
             self.processAtLeastOneTestPulse()
 
             if not holdingSet and self._analysis.hold():
-                self.setState(f'enable holding potential {config["holdingPotential"] * 1000:0.1f} mV')
+                self.set_state(f'enable holding potential {config["holdingPotential"] * 1000:0.1f} mV')
                 dev.clampDevice.setHolding(mode="VC", value=config['holdingPotential'])
                 holdingSet = True
 
@@ -366,7 +366,7 @@ class SealState(PatchPipetteState):
                 self.updatePressure()
 
         # Success!
-        self.setState('gigaohm seal detected')
+        self.set_state('gigaohm seal detected')
 
         # delay for a short period, possibly applying pressure to allow seal to stabilize
         if config['delayAfterSeal'] > 0:
@@ -374,7 +374,7 @@ class SealState(PatchPipetteState):
                 dev.pressureDevice.setPressure(source='atmosphere', pressure=0)
             else:
                 dev.pressureDevice.setPressure(source='regulator', pressure=config['afterSealPressure'])
-            self.sleep(config['delayAfterSeal'])
+            sleep(config['delayAfterSeal'])
 
         dev.pressureDevice.setPressure(source='atmosphere', pressure=0)
 
@@ -427,7 +427,7 @@ class SealState(PatchPipetteState):
             if self._analysis.success():
                 return  # already sealed during pressure scan
             self.pressure = self.best_pressure(start, turnaround, end)
-            self.setState(f'scanned for pressure: {self.pressure / kPa:0.1f} kPa')
+            self.set_state(f'scanned for pressure: {self.pressure / kPa:0.1f} kPa')
             self._lastPressureScan = end
 
         self.pressure = np.clip(self.pressure, config['pressureLimit'], 0)
@@ -438,7 +438,7 @@ class SealState(PatchPipetteState):
         start = time.time()
         while True:
             try:
-                self.checkStop()
+                self.check_stop()
             except self.StopRequested:
                 future.stop(reason="parent task stop requested")
                 raise
@@ -450,7 +450,7 @@ class SealState(PatchPipetteState):
                 future.wait(0.1)
                 break
             except self.Timeout as e:
-                if future.wasInterrupted():  # a _real_ timeout, as opposed to our 0.1s loopbeat
+                if future.was_interrupted:  # a _real_ timeout, as opposed to our 0.1s loopbeat
                     future.wait()  # let it sing
                 if timeout is not None and time.time() - start > timeout:
                     raise self.Timeout(f"Timed out waiting {timeout}s for {future!r}") from e
@@ -461,7 +461,7 @@ class SealState(PatchPipetteState):
         resist_forward = resistances.time_slice(start, turnaround)
         resist_backward = resistances.time_slice(turnaround, end)
         if len(resist_forward) < 2 or len(resist_backward) < 2:
-            self.setState('insufficient resistance data for pressure scan')
+            self.set_state('insufficient resistance data for pressure scan')
             return self.pressure
         best_forwards = find_optimal_pressure(
             pressures.time_slice(start, turnaround),

--- a/acq4/devices/PatchPipette/states/seal.py
+++ b/acq4/devices/PatchPipette/states/seal.py
@@ -7,6 +7,7 @@ from typing import Any
 import numpy as np
 
 from acq4.util import ptime, Qt
+from acq4.util.future import Future
 import pyqtgraph as pg
 from acq4.util.debug import log_and_ignore_exception
 from acq4.util.functions import plottable_booleans
@@ -409,17 +410,17 @@ class SealState(PatchPipetteState):
             self.processAtLeastOneTestPulse()
             start = ptime.time()
             self.waitForFutureOrSuccess(
-                self.dev.pressureDevice.rampPressure(
-                    target=high, duration=self.config['pressureScanDuration'], _sync="async"
-                )
+                Future(self.dev.pressureDevice.rampPressure, (), {
+                    'target': high, 'duration': self.config['pressureScanDuration']
+                })
             )
             if self._analysis.success():
                 return  # already sealed during pressure scan
             turnaround = ptime.time()
             self.waitForFutureOrSuccess(
-                self.dev.pressureDevice.rampPressure(
-                    target=low, duration=self.config['pressureScanDuration'], _sync="async"
-                )
+                Future(self.dev.pressureDevice.rampPressure, (), {
+                    'target': low, 'duration': self.config['pressureScanDuration']
+                })
             )
             end = ptime.time()
             self.processAtLeastOneTestPulse()

--- a/acq4/devices/PatchPipette/states/whole_cell.py
+++ b/acq4/devices/PatchPipette/states/whole_cell.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from acq4.util import ptime
+from acq4.util.future import sleep
 from ._base import PatchPipetteState
 
 
@@ -24,7 +25,7 @@ class WholeCellState(PatchPipetteState):
 
         while True:
             # TODO: monitor for cell loss
-            self.sleep(0.1)
+            sleep(0.1)
 
     def _cleanup(self):
         patchrec = self.dev.patchRecord()

--- a/acq4/devices/Pipette/calibration.py
+++ b/acq4/devices/Pipette/calibration.py
@@ -165,8 +165,8 @@ def scan_pipette_z_stack(pipette, imager=None, z_range=50e-6, z_step=5e-6, show=
     z_end = current_z + z_range
 
     frames = acquire_z_stack(
-        imager, z_start, z_end, z_step, block=True, name="ML pipette detection stack"
-    ).getResult()
+        imager, z_start, z_end, z_step, name="ML pipette detection stack"
+    )
 
     pipette_dir = pipette.globalDirection()
     global_positions = []
@@ -214,7 +214,7 @@ def _show_z_stack_detection_widget(frames, image_positions, z_um, confidences, h
 
 
 @future_wrap
-def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.4e-3, _future=None):
+def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.4e-3, name=None, _future=None):
     """
     Find the tip of a new pipette by moving it across the objective while recording from the imager.
     """
@@ -318,7 +318,7 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
 
         # autofocus
         z_range = (startDepth - 500e-6, startDepth + 500e-6, 20e-6)
-        zStack = _future.waitFor(acquire_z_stack(imager, *z_range, block=True, max_dz_per_frame=np.inf, name="finding pipette depth")).getResult()
+        zStack = acquire_z_stack(imager, *z_range, max_dz_per_frame=np.inf, name="finding pipette depth")
         zStackArray = np.stack([frame.data() for frame in zStack])
         zDiff = np.abs(np.diff(zStackArray.astype(float), axis=0))
         zProfile = zDiff.max(axis=2).max(axis=1)  # most-changed pixel in each frame
@@ -361,7 +361,7 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
         _future.waitFor(pipette._moveToGlobal(imager.globalCenterPosition(), 'fast', name=f"{pipette.name()} auto-calibrate coarse center"))
 
         # iteratively refine tip position until convergence
-        _future.waitFor(pipette.iterativelyFindTip(30), timeout=None)
+        pipette.iterativelyFindTip(30)
     finally:
         _future.l = locals().copy()
 
@@ -444,6 +444,7 @@ def calibrate_manipulator_axes(
     n_steps: int = 10,
     step_size: float = 50e-6,
     z_search_range: float = 100e-6,
+    name=None,
     _future=None,
 ):
     """Automatically collect axis calibration data for a manipulator using the pipette tip finder.
@@ -487,7 +488,7 @@ def calibrate_manipulator_axes(
     calibration_points = []
 
     # Accurately locate the tip before starting the sweep.
-    _future.waitFor(pipette.iterativelyFindTip(10))
+    pipette.iterativelyFindTip(10)
 
     for axis in range(manipulator.nAxes):
         axis_start_pos = list(manipulator.getPosition())
@@ -525,6 +526,6 @@ def calibrate_manipulator_axes(
         # Return to the starting position before sweeping the next axis.
         _future.waitFor(manipulator.move(axis_start_pos, 'slow', name=f"{manipulator.name()} calibrate axis {axis} return"))
         # Re-locate tip at start before recording the first point of the next axis.
-        _future.waitFor(pipette.iterativelyFindTip(10))
+        pipette.iterativelyFindTip(10)
 
     return calibration_points

--- a/acq4/devices/Pipette/calibration.py
+++ b/acq4/devices/Pipette/calibration.py
@@ -4,7 +4,6 @@ import scipy.interpolate
 import pyqtgraph as pg
 from acq4.devices.Camera import Camera
 from acq4.util import Qt
-from acq4.util.future import future_wrap
 from acq4.util.imaging.sequencer import acquire_z_stack
 from .pipette import Pipette
 from .planners import PipetteMotionPlanner
@@ -213,8 +212,7 @@ def _show_z_stack_detection_widget(frames, image_positions, z_um, confidences, h
     _z_stack_detection_window.setData(frames, image_positions, z_um, confidences, heatmaps)
 
 
-@future_wrap
-def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.4e-3, name=None, _future=None):
+def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.4e-3):
     """
     Find the tip of a new pipette by moving it across the objective while recording from the imager.
     """
@@ -223,7 +221,7 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
         # focus 2mm above surface
         surfaceZ = scopeDevice.getSurfaceDepth()
         startDepth = surfaceZ + 2e-3
-        _future.waitFor(imager.setFocusDepth(startDepth, name=f"{imager.name()} focus above surface for {pipette.name()} auto-calibrate"))
+        imager.setFocusDepth(startDepth, name=f"{imager.name()} focus above surface for {pipette.name()} auto-calibrate").wait()
 
         # move pipette to search position
         center = imager.globalCenterPosition(mode='roi')
@@ -234,16 +232,16 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
         searchPos2 = center + pipVector * 1.5e-3 - pipY * 2e-3
         # using a planner avoids possible collisions with the objective
         planner = PipetteMotionPlanner(pipette, searchPos1, speed='fast', name=f"{pipette.name()} auto-calibrate search")
-        _future.waitFor(planner.move())
+        planner.move().wait()
 
         # collect background images, analyze noise
         with imager.ensureRunning():
-            bgFrames = _future.waitFor(imager.acquireFrames(10)).getResult()
+            bgFrames = imager.acquireFrames(10).getResult()
             bgFrameArray = np.stack([f.data() for f in bgFrames], axis=0)
             bgFrame = bgFrameArray.mean(axis=0)
 
         # record from imager and pipette position while moving pipette across the objecive
-        frames, posEvents = watchMovingPipette(pipette, imager, searchPos2, speed=searchSpeed, _future=_future)
+        frames, posEvents = watchMovingPipette(pipette, imager, searchPos2, speed=searchSpeed)
         framesArray = np.stack([f.data() for f in frames])
 
         # analyze frames for center point
@@ -261,26 +259,26 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
         centerPipPos = getPipettePositionAtTime(posEvents, centerTime)
 
         # move back to center position
-        _future.waitFor(pipette._moveToGlobal(centerPipPos, speed='fast', name=f"{pipette.name()} auto-calibrate return to center"))
+        pipette._moveToGlobal(centerPipPos, speed='fast', name=f"{pipette.name()} auto-calibrate return to center").wait()
 
         # todo: at this point we could compare the current image to the previously collected video
         # to see whether we made it back to the desired position (and if not, apply
         # a correction as well as remember the apparent time delay between camera images and
         # position updates)
-        compareFrame = _future.waitFor(imager.acquireFrames(1)).getResult()[0].data().astype(float)
+        compareFrame = imager.acquireFrames(1).getResult()[0].data().astype(float)
         comparisonError = ((framesArray.astype(float) - compareFrame[None, ...])**2).sum(axis=1).sum(axis=1)
         mostSimilarFrame = np.argmin(comparisonError)
         pipetteCameraDelay = frames[mostSimilarFrame].info()['time'] - frames[centerIndex].info()['time']
         correctedCenterTime = frames[centerIndex].info()['time'] - pipetteCameraDelay
         correctedCenterPipPos = getPipettePositionAtTime(posEvents, correctedCenterTime)
-        _future.waitFor(pipette._moveToGlobal(correctedCenterPipPos, speed='fast', name=f"{pipette.name()} auto-calibrate corrected center"))
+        pipette._moveToGlobal(correctedCenterPipPos, speed='fast', name=f"{pipette.name()} auto-calibrate corrected center").wait()
 
         # record from imager and pipette position while retracting pipette out of frame
         retractPos = centerPipPos - pipVector * 2e-3
-        frames2, posEvents2 = watchMovingPipette(pipette, imager, retractPos, speed=searchSpeed, _future=_future)
+        frames2, posEvents2 = watchMovingPipette(pipette, imager, retractPos, speed=searchSpeed)
         frames2Array = np.stack([f.data() for f in frames2])
 
-        # measure image intensity at a line perpendicular to the pipette that crosses the center of the frame        
+        # measure image intensity at a line perpendicular to the pipette that crosses the center of the frame
         profile, interpCoords = interpolate_orthogonal_line(frames2, bgFrame, pipVector)
         # avg should be drifting at the beginning and flat at the end
         # the point where we transition from drifting to flat should be where the pipette tip crosses
@@ -314,7 +312,7 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
         centerPipPos2 = endPipPos + np.array([0, yDist, 0])
 
         # move to new center
-        _future.waitFor(pipette._moveToGlobal(centerPipPos2, speed='fast', name=f"{pipette.name()} auto-calibrate move to new center"))
+        pipette._moveToGlobal(centerPipPos2, speed='fast', name=f"{pipette.name()} auto-calibrate move to new center").wait()
 
         # autofocus
         z_range = (startDepth - 500e-6, startDepth + 500e-6, 20e-6)
@@ -358,12 +356,12 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
 
         # do initial coarse registration: reset offset to detected position, center in frame
         pipette.resetGlobalPosition(globalPos)
-        _future.waitFor(pipette._moveToGlobal(imager.globalCenterPosition(), 'fast', name=f"{pipette.name()} auto-calibrate coarse center"))
+        pipette._moveToGlobal(imager.globalCenterPosition(), 'fast', name=f"{pipette.name()} auto-calibrate coarse center").wait()
 
         # iteratively refine tip position until convergence
         pipette.iterativelyFindTip(30)
     finally:
-        _future.l = locals().copy()
+        pass
 
 
 def frame_pipette_direction(frame, pipVector):
@@ -411,7 +409,7 @@ def interpolate_orthogonal_line(frames, bgFrame, pipVector):
     return profile, interpCoords
 
 
-def watchMovingPipette(pipette: Pipette, imager: Camera, pos, speed, _future):
+def watchMovingPipette(pipette: Pipette, imager: Camera, pos, speed):
     with imager.ensureRunning():
         pipRecorder = None
         imgFuture = None
@@ -419,12 +417,12 @@ def watchMovingPipette(pipette: Pipette, imager: Camera, pos, speed, _future):
             imgFuture = imager.acquireFrames()
             pipRecorder = pipette.startRecording()
             pipFuture = pipette._moveToGlobal(pos, speed=speed, name=f"{pipette.name()} watchMovingPipette")
-            _future.waitFor(pipFuture, timeout=40)  # for some reason one of these moves takes a long time to finish..
+            pipFuture.wait(timeout=40)  # for some reason one of these moves takes a long time to finish..
         finally:
             if pipRecorder is not None:
                 pipRecorder.stop()
             if imgFuture is not None:
-                imgFuture.stop()    
+                imgFuture.stop()
 
     # return only position change events
     events = [ev for ev in pipRecorder.events if ev['event'] == 'position_change']
@@ -438,14 +436,11 @@ def getPipettePositionAtTime(events, time):
     return events[pipIndex]['position']
 
 
-@future_wrap
 def calibrate_manipulator_axes(
     pipette: Pipette,
     n_steps: int = 10,
     step_size: float = 50e-6,
     z_search_range: float = 100e-6,
-    name=None,
-    _future=None,
 ):
     """Automatically collect axis calibration data for a manipulator using the pipette tip finder.
 
@@ -503,7 +498,7 @@ def calibrate_manipulator_axes(
             # Move along this axis to the next absolute position.
             target_pos = list(axis_start_pos)
             target_pos[axis] = axis_start_pos[axis] + step_idx * (step_size / scale[axis])
-            _future.waitFor(manipulator.move(target_pos, 'slow', name=f"{manipulator.name()} calibrate axis {axis} step {step_idx}"))
+            manipulator.move(target_pos, 'slow', name=f"{manipulator.name()} calibrate axis {axis} step {step_idx}").wait()
 
             # Locate the tip via z-stack scan; this handles unknown axis orientation by
             # searching a range of focal depths around the current focus.
@@ -516,7 +511,7 @@ def calibrate_manipulator_axes(
             # Update the tip position without the normal validation prompt, since
             # we expect the tip to have moved during calibration.
             pipette.resetGlobalPosition(detected_pos)
-            _future.waitFor(pipette.focusTip())
+            pipette.focusTip().wait()
 
             device_pos = list(manipulator.getPosition())
             global_pos = list(pipette.globalPosition())
@@ -524,7 +519,7 @@ def calibrate_manipulator_axes(
             calibration_points.append((device_pos, parent_pos))
 
         # Return to the starting position before sweeping the next axis.
-        _future.waitFor(manipulator.move(axis_start_pos, 'slow', name=f"{manipulator.name()} calibrate axis {axis} return"))
+        manipulator.move(axis_start_pos, 'slow', name=f"{manipulator.name()} calibrate axis {axis} return").wait()
         # Re-locate tip at start before recording the first point of the next axis.
         pipette.iterativelyFindTip(10)
 

--- a/acq4/devices/Pipette/calibration.py
+++ b/acq4/devices/Pipette/calibration.py
@@ -236,7 +236,7 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
 
         # collect background images, analyze noise
         with imager.ensureRunning():
-            bgFrames = imager.acquireFrames(10).getResult()
+            bgFrames = imager.acquireFrames(10).get_result()
             bgFrameArray = np.stack([f.data() for f in bgFrames], axis=0)
             bgFrame = bgFrameArray.mean(axis=0)
 
@@ -265,7 +265,7 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
         # to see whether we made it back to the desired position (and if not, apply
         # a correction as well as remember the apparent time delay between camera images and
         # position updates)
-        compareFrame = imager.acquireFrames(1).getResult()[0].data().astype(float)
+        compareFrame = imager.acquireFrames(1).get_result()[0].data().astype(float)
         comparisonError = ((framesArray.astype(float) - compareFrame[None, ...])**2).sum(axis=1).sum(axis=1)
         mostSimilarFrame = np.argmin(comparisonError)
         pipetteCameraDelay = frames[mostSimilarFrame].info()['time'] - frames[centerIndex].info()['time']
@@ -427,7 +427,7 @@ def watchMovingPipette(pipette: Pipette, imager: Camera, pos, speed):
     # return only position change events
     events = [ev for ev in pipRecorder.events if ev['event'] == 'position_change']
 
-    return imgFuture.getResult(), events
+    return imgFuture.get_result(), events
 
 
 def getPipettePositionAtTime(events, time):

--- a/acq4/devices/Pipette/pipette.py
+++ b/acq4/devices/Pipette/pipette.py
@@ -330,21 +330,18 @@ class Pipette(Device, OptomechDevice):
         return True
 
     @future_wrap
-    def setTipOffsetIfAcceptable(self, pos, _future=None):
+    def setTipOffsetIfAcceptable(self, pos, name=None, _future=None):
         if self.tipOffsetIsReasonable(pos):
             self.resetGlobalPosition(pos)
         else:
             dist = np.linalg.norm(np.array(self.mapToGlobal((0, 0, 0))) - pos)
             dist = siFormat(dist, suffix='m', precision=3)
-            button_text = _future.waitFor(
-                prompt(
-                    title="Pipette displacement detected",
-                    text=f"The tip offset for {self.name()} is {dist} off from its initial value.",
-                    extra_text="Do you want to use it, discard it or override all historic offsets?",
-                    choices=["Use", "Discard", "Override"],
-                ),
-                timeout=None,
-            ).getResult()
+            button_text = prompt(
+                title="Pipette displacement detected",
+                text=f"The tip offset for {self.name()} is {dist} off from its initial value.",
+                extra_text="Do you want to use it, discard it or override all historic offsets?",
+                choices=["Use", "Discard", "Override"],
+            )
             if button_text == "Use":
                 self.recordTipOffsetInHistory(pos)
             elif button_text == "Discard":
@@ -356,21 +353,18 @@ class Pipette(Device, OptomechDevice):
         return True
 
     @future_wrap
-    def setNewPipetteTipOffsetIfAcceptable(self, pos, _future=None):
+    def setNewPipetteTipOffsetIfAcceptable(self, pos, name=None, _future=None):
         """Returns whether the tip position was saved. Otherwise, the user requested a re-do."""
         if self.newPipetteTipOffsetIsReasonable(pos):
             self.recordTipOffsetInHistory(pos)
         else:
-            button_text = _future.waitFor(
-                prompt(
-                    title="Initial tip offset outlier",
-                    text=f"The tip offset for {self.name()} is outside of its normal range.",
-                    extra_text="Do you want to include this outlier, discard the value, override all historic "
-                    "offsets, or only use this as a temporary offset?",
-                    choices=["Include", "Discard", "Override", "Temporary"],
-                ),
-                timeout=None,
-            ).getResult()
+            button_text = prompt(
+                title="Initial tip offset outlier",
+                text=f"The tip offset for {self.name()} is outside of its normal range.",
+                extra_text="Do you want to include this outlier, discard the value, override all historic "
+                "offsets, or only use this as a temporary offset?",
+                choices=["Include", "Discard", "Override", "Temporary"],
+            )
             if button_text == "Include":
                 self.recordTipOffsetInHistory(pos)
             elif button_text == "Discard":
@@ -420,7 +414,7 @@ class Pipette(Device, OptomechDevice):
             return self.offset
 
     @future_wrap
-    def saveManualTipPosition(self, stack=True, _future=None):
+    def saveManualTipPosition(self, stack=True, name=None, _future=None):
         path = os.path.join(self.configPath(), "manual-calibrations")
         path = self.dm.configFileName(path)
         path = self.dm.dirHandle(path, create=True)
@@ -453,6 +447,7 @@ class Pipette(Device, OptomechDevice):
                     z_stack=(depth - scan_dist, depth + scan_dist, step),
                     storage_dir=path,
                     name="manual calibration stack",
+                    _sync="async",
                 )
                 _future.waitFor(seq_future)
             finally:
@@ -720,7 +715,7 @@ class Pipette(Device, OptomechDevice):
 
     @future_wrap
     def wiggle(
-        self, speed, radius, repetitions, duration, pipette_direction=None, extra=None, _future=None
+        self, speed, radius, repetitions, duration, pipette_direction=None, extra=None, name=None, _future=None
     ):
         if pipette_direction is None:
             pipette_direction = self.globalDirection()
@@ -880,9 +875,9 @@ class Pipette(Device, OptomechDevice):
         return PipetteRecorder(self)
 
     @future_wrap
-    def iterativelyFindTip(self, max_reps=10, found_threshold=3e-6, delay_after_move=0.4, 
+    def iterativelyFindTip(self, max_reps=10, found_threshold=3e-6, delay_after_move=0.4,
                            max_allowed_offset=None, delay_after_update=0, reserve_devices=True,
-                           go_to_tip_first=False, _future=None):
+                           go_to_tip_first=False, name=None, _future=None):
         """Iteratively refine the tip position by finding the tip in frame and focusing, until convergence.
         
         Returns if convergence is reached (tip position changes less than *found_threshold* between iterations) or after *max_reps* iterations.
@@ -923,7 +918,7 @@ class Pipette(Device, OptomechDevice):
                     _future.sleep(delay_after_move)
                 for _ in range(max_reps):
                     pos = self.tracker.findTipInFrame()
-                    _future.waitFor(self.setTipOffsetIfAcceptable(pos), timeout=None)
+                    self.setTipOffsetIfAcceptable(pos)
                     converged = last_pos is not None and np.linalg.norm(np.array(pos) - np.array(last_pos)) < found_threshold
                     _future.sleep(delay_after_update)
                     if converged:
@@ -945,7 +940,7 @@ class Pipette(Device, OptomechDevice):
     def findNewPipette(self):
         from acq4.devices.Pipette.calibration import findNewPipette
 
-        future = findNewPipette(self, self.imagingDevice(), self.scopeDevice())
+        future = findNewPipette(self, self.imagingDevice(), self.scopeDevice(), _sync="async")
         self._last_calibration_future = future  # keep for easy debugging of calibration algorithm
         return future
 
@@ -1238,7 +1233,7 @@ class PipetteCamModInterface(CameraModuleInterface):
     def autoCalibrateClicked(self):
         pip = self.getDevice()
         pos = pip.tracker.findTipInFrame()
-        tip_future = pip.setTipOffsetIfAcceptable(pos)
+        tip_future = pip.setTipOffsetIfAcceptable(pos, _sync="async")
         tip_future.onFinish(self._handleTipPositionSet)
 
     def _handleTipPositionSet(self, future):
@@ -1250,7 +1245,7 @@ class PipetteCamModInterface(CameraModuleInterface):
         dev = self.getDevice()
         zrange = dev.config.get('referenceZRange', None)
         zstep = dev.config.get('referenceZStep', None)
-        dev.tracker.takeReferenceFrames(zRange=zrange, zStep=zstep)
+        dev.tracker.takeReferenceFrames(zRange=zrange, zStep=zstep, _sync="async")
 
     def aboveTargetClicked(self):
         self.getDevice().goAboveTarget(self.selectedSpeed())

--- a/acq4/devices/Pipette/pipette.py
+++ b/acq4/devices/Pipette/pipette.py
@@ -657,13 +657,12 @@ class Pipette(Device, OptomechDevice):
         pos = self.positionAtDepth(depth)
         return self._moveToGlobal(pos, speed, name=name)
 
-    def retractFromSurface(self, speed='slow') -> Future:
+    def retractFromSurface(self, speed='slow'):
         """Retract the pipette along its axis until it is above the slice surface."""
         depth = self.globalPosition()[2]
         appDepth = self.approachDepth()
         if depth < appDepth:
-            return self.advance(appDepth, speed=speed, name='retract from surface')
-        return Future.immediate()
+            self.advance(appDepth, speed=speed, name='retract from surface')
 
     def stepwiseAdvance(
         self,

--- a/acq4/devices/Pipette/pipette.py
+++ b/acq4/devices/Pipette/pipette.py
@@ -16,7 +16,7 @@ from acq4.devices.OptomechDevice import OptomechDevice
 from acq4.devices.Stage import Stage, MovePathFuture
 from acq4.modules.Camera import CameraModuleInterface
 from acq4.util import Qt, ptime
-from acq4.util.future import future_wrap, Future
+from acq4.util.future import Future, sleep, check_stop
 from acq4.util.target import Target
 from coorx import AffineTransform
 from pyqtgraph import Point, siFormat
@@ -329,8 +329,7 @@ class Pipette(Device, OptomechDevice):
                 return False
         return True
 
-    @future_wrap
-    def setTipOffsetIfAcceptable(self, pos, name=None, _future=None):
+    def setTipOffsetIfAcceptable(self, pos):
         if self.tipOffsetIsReasonable(pos):
             self.resetGlobalPosition(pos)
         else:
@@ -352,8 +351,7 @@ class Pipette(Device, OptomechDevice):
                 raise AssertionError("Unknown button clicked")
         return True
 
-    @future_wrap
-    def setNewPipetteTipOffsetIfAcceptable(self, pos, name=None, _future=None):
+    def setNewPipetteTipOffsetIfAcceptable(self, pos):
         """Returns whether the tip position was saved. Otherwise, the user requested a re-do."""
         if self.newPipetteTipOffsetIsReasonable(pos):
             self.recordTipOffsetInHistory(pos)
@@ -413,8 +411,7 @@ class Pipette(Device, OptomechDevice):
         else:
             return self.offset
 
-    @future_wrap
-    def saveManualTipPosition(self, stack=True, name=None, _future=None):
+    def saveManualTipPosition(self, stack=True):
         path = os.path.join(self.configPath(), "manual-calibrations")
         path = self.dm.configFileName(path)
         path = self.dm.dirHandle(path, create=True)
@@ -427,7 +424,7 @@ class Pipette(Device, OptomechDevice):
 
         cam: Camera = self.imagingDevice()
         with cam.ensureRunning():
-            img = _future.waitFor(cam.acquireFrames(n=1, ensureFreshFrames=True)).getResult()[0]
+            img = cam.acquireFrames(n=1, ensureFreshFrames=True).getResult()[0]
         img.addInfo(pip_info)
         timestamp = time.strftime("%Y%m%d-%H%M%S")
         path.writeFile(
@@ -441,17 +438,19 @@ class Pipette(Device, OptomechDevice):
             is_below_surface = depth <= self.scopeDevice().getSurfaceDepth()
             scan_dist = (2 + (np.random.random()**2) * (100 if is_below_surface else 100)) * 1e-6
             step = max(1e-6, scan_dist / 4)
-            try:
-                seq_future = run_image_sequence(
-                    cam,
+            seq_future = Future(
+                run_image_sequence,
+                (cam,),
+                dict(
                     z_stack=(depth - scan_dist, depth + scan_dist, step),
                     storage_dir=path,
                     name="manual calibration stack",
-                    _sync="async",
-                )
-                _future.waitFor(seq_future)
+                ),
+            )
+            try:
+                seq_future.wait()
             finally:
-                _future.waitFor(cam.setFocusDepth(depth, name=f"{cam.name()} restore focus after {self.name()} manual calibration stack"))
+                cam.setFocusDepth(depth, name=f"{cam.name()} restore focus after {self.name()} manual calibration stack").wait()
             fh = seq_future.imagesSavedIn
             info = {
                 **fh.info(),
@@ -666,7 +665,6 @@ class Pipette(Device, OptomechDevice):
             return self.advance(appDepth, speed=speed, name='retract from surface')
         return Future.immediate()
 
-    @future_wrap
     def stepwiseAdvance(
         self,
         depth: float | None = None,
@@ -674,8 +672,6 @@ class Pipette(Device, OptomechDevice):
         speed: float = 10e-6,
         interval: float = 5,
         step: float = 1e-6,
-        name: str | None = None,
-        _future=None,
     ):
         """Retract/advance in small steps, allowing for manual user movements.
 
@@ -708,14 +704,13 @@ class Pipette(Device, OptomechDevice):
                 break  # overshot
             distance = np.linalg.norm(direction)
             next_pos = pos + step * direction / distance
-            _future.waitFor(self._moveToGlobal(next_pos, speed=speed, linear=True, name=name))
+            self._moveToGlobal(next_pos, speed=speed, linear=True, name=None).wait()
             if distance <= step:
                 break
-            _future.sleep(interval)
+            sleep(interval)
 
-    @future_wrap
     def wiggle(
-        self, speed, radius, repetitions, duration, pipette_direction=None, extra=None, name=None, _future=None
+        self, speed, radius, repetitions, duration, pipette_direction=None, extra=None
     ):
         if pipette_direction is None:
             pipette_direction = self.globalDirection()
@@ -739,9 +734,9 @@ class Pipette(Device, OptomechDevice):
                 while ptime.time() - start < duration:
                     while np.dot(direction := random_wiggle_direction(), prev_dir) > 0:
                         pass  # ensure different direction from previous
-                    _future.waitFor(self._moveToGlobal(pos=pos + radius * direction, speed=speed, name=f"wiggle step {step_i}"))
+                    self._moveToGlobal(pos=pos + radius * direction, speed=speed, name=f"wiggle step {step_i}").wait()
                     prev_dir = direction
-                _future.waitFor(self._moveToGlobal(pos=pos, speed=speed, name=f"wiggle return {step_i}"))
+                self._moveToGlobal(pos=pos, speed=speed, name=f"wiggle return {step_i}").wait()
 
     def globalPosition(self):
         """Return the position of the electrode tip in global coordinates.
@@ -874,10 +869,9 @@ class Pipette(Device, OptomechDevice):
         """Return an object that records all motion updates from this pipette"""
         return PipetteRecorder(self)
 
-    @future_wrap
     def iterativelyFindTip(self, max_reps=10, found_threshold=3e-6, delay_after_move=0.4,
                            max_allowed_offset=None, delay_after_update=0, reserve_devices=True,
-                           go_to_tip_first=False, name=None, _future=None):
+                           go_to_tip_first=False):
         """Iteratively refine the tip position by finding the tip in frame and focusing, until convergence.
         
         Returns if convergence is reached (tip position changes less than *found_threshold* between iterations) or after *max_reps* iterations.
@@ -914,13 +908,13 @@ class Pipette(Device, OptomechDevice):
                 last_pos = None
                 start_pos = self.globalPosition()
                 if go_to_tip_first:
-                    _future.waitFor(self.focusTip())
-                    _future.sleep(delay_after_move)
+                    self.focusTip().wait()
+                    sleep(delay_after_move)
                 for _ in range(max_reps):
                     pos = self.tracker.findTipInFrame()
                     self.setTipOffsetIfAcceptable(pos)
                     converged = last_pos is not None and np.linalg.norm(np.array(pos) - np.array(last_pos)) < found_threshold
-                    _future.sleep(delay_after_update)
+                    sleep(delay_after_update)
                     if converged:
                         diff = np.linalg.norm(np.array(pos) - np.array(start_pos))
                         if max_allowed_offset is not None and diff > max_allowed_offset:
@@ -928,8 +922,8 @@ class Pipette(Device, OptomechDevice):
                         return
 
                     last_pos = pos
-                    _future.waitFor(self.focusTip())
-                    _future.sleep(delay_after_move)
+                    self.focusTip().wait()
+                    sleep(delay_after_move)
                 raise TimeoutError(f"Iterative tip finding did not converge after {max_reps} iterations.")
             except Exception as exc:
                 # reset position to start if we fail, to avoid leaving the pipette in a bad position
@@ -940,7 +934,7 @@ class Pipette(Device, OptomechDevice):
     def findNewPipette(self):
         from acq4.devices.Pipette.calibration import findNewPipette
 
-        future = findNewPipette(self, self.imagingDevice(), self.scopeDevice(), _sync="async")
+        future = Future(findNewPipette, (self, self.imagingDevice(), self.scopeDevice()))
         self._last_calibration_future = future  # keep for easy debugging of calibration algorithm
         return future
 
@@ -1233,7 +1227,7 @@ class PipetteCamModInterface(CameraModuleInterface):
     def autoCalibrateClicked(self):
         pip = self.getDevice()
         pos = pip.tracker.findTipInFrame()
-        tip_future = pip.setTipOffsetIfAcceptable(pos, _sync="async")
+        tip_future = Future(pip.setTipOffsetIfAcceptable, (pos,))
         tip_future.onFinish(self._handleTipPositionSet)
 
     def _handleTipPositionSet(self, future):
@@ -1245,7 +1239,7 @@ class PipetteCamModInterface(CameraModuleInterface):
         dev = self.getDevice()
         zrange = dev.config.get('referenceZRange', None)
         zstep = dev.config.get('referenceZStep', None)
-        dev.tracker.takeReferenceFrames(zRange=zrange, zStep=zstep, _sync="async")
+        Future(dev.tracker.takeReferenceFrames, (), dict(zRange=zrange, zStep=zstep))
 
     def aboveTargetClicked(self):
         self.getDevice().goAboveTarget(self.selectedSpeed())

--- a/acq4/devices/Pipette/pipette.py
+++ b/acq4/devices/Pipette/pipette.py
@@ -238,7 +238,7 @@ class Pipette(Device, OptomechDevice):
         self.currentMotionPlanner = plannerClass(self, position, speed, **kwds)
         future = self.currentMotionPlanner.move()
         if raiseErrors is not False:
-            future.raiseErrors(
+            future.raise_errors(
                 message=f"Move to {position} position failed ({{error}}); requested from:\n{{stack}}"
             )
 
@@ -424,7 +424,7 @@ class Pipette(Device, OptomechDevice):
 
         cam: Camera = self.imagingDevice()
         with cam.ensureRunning():
-            img = cam.acquireFrames(n=1, ensureFreshFrames=True).getResult()[0]
+            img = cam.acquireFrames(n=1, ensureFreshFrames=True).get_result()[0]
         img.addInfo(pip_info)
         timestamp = time.strftime("%Y%m%d-%H%M%S")
         path.writeFile(
@@ -805,7 +805,7 @@ class Pipette(Device, OptomechDevice):
             pos, speed=speed, name=f"focus on {self.name()}"
         )
         if raiseErrors:
-            future.raiseErrors("Focus on pipette tip failed ({error}); requested from:\n{stack})")
+            future.raise_errors("Focus on pipette tip failed ({error}); requested from:\n{stack})")
         return future
 
     def focusTarget(self, speed='fast', raiseErrors=False):
@@ -814,7 +814,7 @@ class Pipette(Device, OptomechDevice):
             pos, speed=speed, name=f"focus on target for {self.name()}"
         )
         if raiseErrors:
-            future.raiseErrors(
+            future.raise_errors(
                 "Focus on pipette target failed ({error}); requested from:\n{stack})"
             )
         return future
@@ -1227,10 +1227,10 @@ class PipetteCamModInterface(CameraModuleInterface):
         pip = self.getDevice()
         pos = pip.tracker.findTipInFrame()
         tip_future = Future(pip.setTipOffsetIfAcceptable, (pos,))
-        tip_future.onFinish(self._handleTipPositionSet)
+        tip_future.on_finish(self._handleTipPositionSet)
 
     def _handleTipPositionSet(self, future):
-        success = future.getResult()
+        success = future.get_result()
         if not success:
             return self.autoCalibrateClicked()
 

--- a/acq4/devices/Pipette/planners.py
+++ b/acq4/devices/Pipette/planners.py
@@ -216,7 +216,7 @@ class GeometryAwarePathGenerator(PipettePathGenerator):
     def __init__(self, pip: Pipette):
         super().__init__(pip)
         self._cachePrimer = Future(self._primeCaches)
-        self._cachePrimer.raiseErrors("error priming path planning caches")
+        self._cachePrimer.raise_errors("error priming path planning caches")
 
     def _getPlanningContext(self):
         man = getManager()

--- a/acq4/devices/Pipette/planners.py
+++ b/acq4/devices/Pipette/planners.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Union
 
 import pyqtgraph as pg
-from acq4.util.future import future_wrap
+from acq4.util.future import Future, check_stop, sleep
 from coorx import SRT3DTransform
 from ... import getManager
 from ...util.geometry import GeometryMotionPlanner, Plane
@@ -215,7 +215,7 @@ class PipettePathGenerator:
 class GeometryAwarePathGenerator(PipettePathGenerator):
     def __init__(self, pip: Pipette):
         super().__init__(pip)
-        self._cachePrimer = self._primeCaches(_sync="async")
+        self._cachePrimer = Future(self._primeCaches)
         self._cachePrimer.raiseErrors("error priming path planning caches")
 
     def _getPlanningContext(self):
@@ -244,15 +244,14 @@ class GeometryAwarePathGenerator(PipettePathGenerator):
         )
         return planner, from_pip_to_global
 
-    @future_wrap
-    def _primeCaches(self, name=None, _future=None):
+    def _primeCaches(self):
         try:
             man = getManager()
             while not man.isReady.wait(0.05):
-                _future.checkStop()
+                check_stop()
             mod = man.getOrLoadModule("Visualize3D")
             while not mod.isReady.wait(0.05):
-                _future.checkStop()
+                check_stop()
             viz = mod.window().findAdapter(lambda a: a.device == self.pip).pathSearchVisualizer()
             planner, from_pip_to_global = self._getPlanningContext()
             planner.make_convolved_obstacles(self.pip.getGeometry(), from_pip_to_global, viz)
@@ -340,10 +339,7 @@ class PipetteMotionPlanner:
         if self.future is not None:
             self.stop()
 
-        if hasattr(self._move, '__wrapped__'):
-            self.future = self._move(_sync="async")
-        else:
-            self.future = self._move()
+        self.future = self._move()
         return self.future
 
     def stop(self):
@@ -451,10 +447,11 @@ class SearchMotionPlanner(PipetteMotionPlanner):
     def _default_name(self):
         return "move to search"
 
-    @future_wrap
-    def _move(self, name=None, _future=None):
+    def _move(self):
+        return Future(self._doMove)
+
+    def _doMove(self):
         base = f"{self.pip.name()} {self.name}"
-        _future.name = base
         pip = self.pip
         speed = self.speed
         distance = self.kwds.get("distance", 0)
@@ -474,7 +471,7 @@ class SearchMotionPlanner(PipetteMotionPlanner):
             scopeFocus = scope.getFocusDepth()
             fut = scope.setFocusDepth(scopeFocus + searchDepth - focusDepth, name=f"{base}: focus above surface")
             # wait for objective to lift before starting pipette motion
-            _future.waitFor(fut)
+            fut.wait()
 
         # Here's where we want the pipette tip in global coordinates:
         globalCenter = cam.globalCenterPosition("roi")
@@ -485,7 +482,7 @@ class SearchMotionPlanner(PipetteMotionPlanner):
 
         path = self.safePath(pip.globalPosition(), globalTarget, speed)
 
-        _future.waitFor(pip._movePath(path, name=f"{base}: pipette path"))
+        pip._movePath(path, name=f"{base}: pipette path").wait()
 
 
 class ApproachMotionPlanner(PipetteMotionPlanner):
@@ -520,19 +517,20 @@ class AboveTargetMotionPlanner(PipetteMotionPlanner):
     def _default_name(self):
         return "move above target"
 
-    @future_wrap
-    def _move(self, name=None, _future=None):
+    def _move(self):
+        return Future(self._doMove)
+
+    def _doMove(self):
         base = f"{self.pip.name()} {self.name}"
-        _future.name = base
         pip = self.pip
         speed = self.speed
         scope = pip.scopeDevice()
         waypoint1, waypoint2 = self.aboveTargetPath()
 
         path = self.safePath(pip.globalPosition(), waypoint1, speed, APPROACH_TO_CORRECT_FOR_HYSTERESIS)
-        _future.waitFor(pip._movePath(path + [(waypoint2, "fast", True, "Above target")], name=f"{base}: pipette path"))
+        pip._movePath(path + [(waypoint2, "fast", True, "Above target")], name=f"{base}: pipette path").wait()
         move_scope = scope.setGlobalPosition(waypoint2, name=f"{base}: scope recenter")
-        _future.waitFor(move_scope)  # TODO act simultaneously once we can handle motion planning around moving objects
+        move_scope.wait()  # TODO act simultaneously once we can handle motion planning around moving objects
 
     def aboveTargetPath(self):
         """Return the path to the "above target" recalibration position.
@@ -568,10 +566,11 @@ class IdleMotionPlanner(PipetteMotionPlanner):
     def _default_name(self):
         return "move to idle"
 
-    @future_wrap
-    def _move(self, name=None, _future=None):
+    def _move(self):
+        return Future(self._doMove)
+
+    def _doMove(self):
         base = f"{self.pip.name()} {self.name}"
-        _future.name = base
         pip = self.pip
         speed = self.speed
 
@@ -593,7 +592,7 @@ class IdleMotionPlanner(PipetteMotionPlanner):
         ds = pip._opts["idleDistance"]  # move to 7 mm from center
         globalIdlePos = -ds * np.cos(angle), -ds * np.sin(angle), idleDepth
 
-        _future.waitFor(pip._moveToGlobal(globalIdlePos, speed, name=f"{base}: move to edge"))
+        pip._moveToGlobal(globalIdlePos, speed, name=f"{base}: move to edge").wait()
 
 
 def defaultMotionPlanners() -> dict[str, type[PipetteMotionPlanner]]:

--- a/acq4/devices/Pipette/planners.py
+++ b/acq4/devices/Pipette/planners.py
@@ -215,7 +215,7 @@ class PipettePathGenerator:
 class GeometryAwarePathGenerator(PipettePathGenerator):
     def __init__(self, pip: Pipette):
         super().__init__(pip)
-        self._cachePrimer = self._primeCaches()
+        self._cachePrimer = self._primeCaches(_sync="async")
         self._cachePrimer.raiseErrors("error priming path planning caches")
 
     def _getPlanningContext(self):
@@ -245,7 +245,7 @@ class GeometryAwarePathGenerator(PipettePathGenerator):
         return planner, from_pip_to_global
 
     @future_wrap
-    def _primeCaches(self, _future):
+    def _primeCaches(self, name=None, _future=None):
         try:
             man = getManager()
             while not man.isReady.wait(0.05):
@@ -340,7 +340,10 @@ class PipetteMotionPlanner:
         if self.future is not None:
             self.stop()
 
-        self.future = self._move()
+        if hasattr(self._move, '__wrapped__'):
+            self.future = self._move(_sync="async")
+        else:
+            self.future = self._move()
         return self.future
 
     def stop(self):
@@ -449,7 +452,7 @@ class SearchMotionPlanner(PipetteMotionPlanner):
         return "move to search"
 
     @future_wrap
-    def _move(self, _future):
+    def _move(self, name=None, _future=None):
         base = f"{self.pip.name()} {self.name}"
         _future.name = base
         pip = self.pip
@@ -518,7 +521,7 @@ class AboveTargetMotionPlanner(PipetteMotionPlanner):
         return "move above target"
 
     @future_wrap
-    def _move(self, _future):
+    def _move(self, name=None, _future=None):
         base = f"{self.pip.name()} {self.name}"
         _future.name = base
         pip = self.pip
@@ -566,7 +569,7 @@ class IdleMotionPlanner(PipetteMotionPlanner):
         return "move to idle"
 
     @future_wrap
-    def _move(self, _future):
+    def _move(self, name=None, _future=None):
         base = f"{self.pip.name()} {self.name}"
         _future.name = base
         pip = self.pip

--- a/acq4/devices/Pipette/tracker.py
+++ b/acq4/devices/Pipette/tracker.py
@@ -8,7 +8,7 @@ import scipy.ndimage as ndi
 import pyqtgraph as pg
 from acq4.Manager import getManager
 from acq4.util import Qt
-from acq4.util.future import Future, future_wrap
+from acq4.util.future import Future
 from acq4.util.image_registration import imageTemplateMatch
 from acq4.util.imaging.sequencer import acquire_z_stack
 from .pipette_detection import TemplateMatchPipetteDetector
@@ -354,9 +354,8 @@ class CorrelationPipetteTracker(PipetteTracker):
         # currently just returns the length of 100 pixels in the frame
         return frame.info()["pixelSize"][0] * 100
 
-    @future_wrap
     def takeReferenceFrames(
-        self, zRange=None, zStep=None, imager=None, tipLength=None, name=None, _future: Future = None
+        self, zRange=None, zStep=None, imager=None, tipLength=None
     ):
         """Collect a series of images of the pipette tip at various focal depths.
 
@@ -390,7 +389,7 @@ class CorrelationPipetteTracker(PipetteTracker):
         frames = np.stack([f.data()[minImgPos[0]:maxImgPos[0], minImgPos[1]:maxImgPos[1]] for f in frames], axis=0).astype(float)
 
         # collect background stack
-        _future.waitFor(self.pipette._moveToLocal([-tipLength * 3, 0, 0], "slow"))
+        self.pipette._moveToLocal([-tipLength * 3, 0, 0], "slow").wait()
         bg_frames = acquire_z_stack(
             imager, zStart, zEnd, zStep, name="background for subtracting"
         )

--- a/acq4/devices/Pipette/tracker.py
+++ b/acq4/devices/Pipette/tracker.py
@@ -171,7 +171,7 @@ class ResnetPipetteTracker(PipetteTracker):
             start=z_center + z_range,
             stop=z_center - z_range,
             step=z_step,
-        ).getResult()
+        )
 
         px_size = frames[0].info()['pixelSize'][0]
 
@@ -356,7 +356,7 @@ class CorrelationPipetteTracker(PipetteTracker):
 
     @future_wrap
     def takeReferenceFrames(
-        self, zRange=None, zStep=None, imager=None, tipLength=None, _future: Future = None
+        self, zRange=None, zStep=None, imager=None, tipLength=None, name=None, _future: Future = None
     ):
         """Collect a series of images of the pipette tip at various focal depths.
 
@@ -384,16 +384,16 @@ class CorrelationPipetteTracker(PipetteTracker):
 
         # collect pipette stack
         frames = acquire_z_stack(
-            imager, zStart, zEnd, zStep, block=True, name="pipette reference stack"
-        ).getResult()
+            imager, zStart, zEnd, zStep, name="pipette reference stack"
+        )
         pxSize = frames[0].info()["pixelSize"]
         frames = np.stack([f.data()[minImgPos[0]:maxImgPos[0], minImgPos[1]:maxImgPos[1]] for f in frames], axis=0).astype(float)
 
         # collect background stack
         _future.waitFor(self.pipette._moveToLocal([-tipLength * 3, 0, 0], "slow"))
         bg_frames = acquire_z_stack(
-            imager, zStart, zEnd, zStep, block=True, name="background for subtracting"
-        ).getResult()
+            imager, zStart, zEnd, zStep, name="background for subtracting"
+        )
         bg_frames = np.stack([f.data()[minImgPos[0]:maxImgPos[0], minImgPos[1]:maxImgPos[1]] for f in bg_frames], axis=0).astype(float)
 
         # return pipette to original position

--- a/acq4/devices/Pipette/tracker.py
+++ b/acq4/devices/Pipette/tracker.py
@@ -28,7 +28,7 @@ class PipetteTracker:
         """
         imager = self._getImager(imager)
         with imager.ensureRunning(ensureFreshFrames=True):
-            return imager.acquireFrames(1).getResult()[0]
+            return imager.acquireFrames(1).get_result()[0]
 
     def _getImager(self, imager=None):
         if imager is None:

--- a/acq4/devices/Pipette/tracker.py
+++ b/acq4/devices/Pipette/tracker.py
@@ -8,7 +8,7 @@ import scipy.ndimage as ndi
 import pyqtgraph as pg
 from acq4.Manager import getManager
 from acq4.util import Qt
-from acq4.util.future import Future
+from acq4.util.future import Future, sleep
 from acq4.util.image_registration import imageTemplateMatch
 from acq4.util.imaging.sequencer import acquire_z_stack
 from .pipette_detection import TemplateMatchPipetteDetector
@@ -617,7 +617,7 @@ class CorrelationPipetteTracker(PipetteTracker):
                         misses += 1
                         logger.exception("Manipulator missed target:")
 
-                    time.sleep(0.2)
+                    sleep(0.2)
 
                     frame = self.takeFrame()
                     reportedPos = self.pipette.globalPosition()

--- a/acq4/devices/PressureControl/device.py
+++ b/acq4/devices/PressureControl/device.py
@@ -88,7 +88,7 @@ class PressureControl(Device):
             self.pressure = pressure
         if source == 'regulator':
             if pressure is not None:
-                time.sleep(self.regulatorSettlingTime)  # let pressure settle before switching valves
+                sleep(self.regulatorSettlingTime)  # let pressure settle before switching valves
             self._setSource(source)
             self.source = source
 

--- a/acq4/devices/PressureControl/device.py
+++ b/acq4/devices/PressureControl/device.py
@@ -40,6 +40,7 @@ class PressureControl(Device):
         minimum: Optional[float] = None,
         rate: Optional[float] = None,
         duration: Optional[float] = None,
+        name=None,
         _future: Optional[Future] = None,
     ) -> None:
         if target is None and maximum is None and minimum is None:

--- a/acq4/devices/PressureControl/device.py
+++ b/acq4/devices/PressureControl/device.py
@@ -4,7 +4,7 @@ from typing import Optional
 from acq4.util import Qt, ptime
 from .widgets import PressureControlWidget
 from ..Device import Device
-from ...util.future import Future, future_wrap
+from ...util.future import sleep
 
 
 class PressureControl(Device):
@@ -31,7 +31,6 @@ class PressureControl(Device):
         self.source = None
         self.sources = ("regulator", "user", "atmosphere")
 
-    @future_wrap
     def rampPressure(
         self,
         target: Optional[float] = None,
@@ -40,8 +39,6 @@ class PressureControl(Device):
         minimum: Optional[float] = None,
         rate: Optional[float] = None,
         duration: Optional[float] = None,
-        name=None,
-        _future: Optional[Future] = None,
     ) -> None:
         if target is None and maximum is None and minimum is None:
             raise ValueError("Must specify at least one of target, maximum, or minimum")
@@ -70,7 +67,7 @@ class PressureControl(Device):
         while frac_done < 1:
             frac_done = min((ptime.time() - start_time) / duration, 1)
             self.setPressure("regulator", start_pressure + frac_done * (end_pressure - start_pressure))
-            _future.sleep(self.regulatorSettlingTime)
+            sleep(self.regulatorSettlingTime)
 
     def isValidForPatchPipettes(self):
         # only allow use with patch pipettes if regulator control is available (for fine pressure control)

--- a/acq4/devices/Scanner/DeviceGui.py
+++ b/acq4/devices/Scanner/DeviceGui.py
@@ -365,7 +365,7 @@ class ScannerDeviceGui(Qt.QWidget):
         xRange = (self.ui.xMinSpin.value(), self.ui.xMaxSpin.value())
         yRange = (self.ui.yMinSpin.value(), self.ui.yMaxSpin.value())
 
-        background = camera.acquireFrames(1, ensureFreshFrames=True).getResult()[0]
+        background = camera.acquireFrames(1, ensureFreshFrames=True).get_result()[0]
 
         laser.setAlignmentMode()
         try:
@@ -381,7 +381,7 @@ class ScannerDeviceGui(Qt.QWidget):
                     y = yRange[0] + dy * j
                     positions.append([x, y])
                     self.dev.setCommand([x, y])
-                    images.append(camera.acquireFrames(1, ensureFreshFrames=True).getResult()[0])
+                    images.append(camera.acquireFrames(1, ensureFreshFrames=True).get_result()[0])
         finally:
             laser.closeShutter()
         return background.data(), images, positions

--- a/acq4/devices/Scientifica/scientifica.py
+++ b/acq4/devices/Scientifica/scientifica.py
@@ -11,7 +11,7 @@ from acq4.util import ptime
 from acq4.devices.Stage import Stage, MoveFuture, StageInterface
 from acq4.drivers.Scientifica import Scientifica as ScientificaDriver
 from acq4.util import Qt
-from acq4.util.future import future_wrap, Future, FutureButton
+from acq4.util.future import Future, FutureButton, sleep
 from acq4.util.threadrun import runInGuiThread
 from pyqtgraph import SpinBox, siFormat
 
@@ -457,10 +457,9 @@ class ScientificaGUI(StageInterface):
             self.sigBusyMoving.emit(False)
             return Future.immediate(error="User requested stop", stopped=True)
 
-        return self._doAutoZero(axis, _sync="async")
+        return Future(self._doAutoZero, (axis,))
 
-    @future_wrap
-    def _doAutoZero(self, axis: int = None, name=None, _future: Future = None) -> None:
+    def _doAutoZero(self, axis: int = None) -> None:
         self._savedLimits = self.dev.getLimits()
         try:
             diff = np.zeros(3)  # keep track of offset changes
@@ -472,7 +471,7 @@ class ScientificaGUI(StageInterface):
             if axis is not None and far_away[axis] is None:
                 raise Exception(f"Requested auto zero for axis {'XYZ'[axis]}, but autoZeroDirection is disabled for this axis in the configuration.")
 
-            self._moveAndWait(far_away, axis, _future)
+            self._moveAndWait(far_away, axis)
             diff += self._zeroAxis(axis)
 
             # This part is a pain: if the approach switch is enabled on the control cube, then it's possible for the
@@ -489,9 +488,9 @@ class ScientificaGUI(StageInterface):
                         currentPos = self.dev.getPosition()
                         currentPos[otherAxis] += 300 * dir
                         # small step to move z (x) away from its limit switch
-                        self._moveAndWait(currentPos, otherAxis, _future)
+                        self._moveAndWait(currentPos, otherAxis)
                         # far step to get x (z) to its limit switch
-                        self._moveAndWait(far_away, axis, _future)
+                        self._moveAndWait(far_away, axis)
                         diff += self._zeroAxis(axis)
 
             self.dev.logger.info(f"Auto-zeroed {self.dev.name()} by {diff}")
@@ -504,14 +503,14 @@ class ScientificaGUI(StageInterface):
                         axis = 'XYZ'[ax]
                         msg = f"{msg} {axis}={siFormat(diff[ax], suffix='m')}"
                 runInGuiThread(Qt.QMessageBox.warning, self, "Large slippage detected", msg, Qt.QMessageBox.Ok)
-            _future.waitFor(move_future)
+            move_future.wait()
         finally:
             self.sigBusyMoving.emit(False)
             self.dev.stop()
             self.dev.setLimits(*self._savedLimits)
 
-    def _moveAndWait(self, pos, axis, _future):
-        """Move to pos and wait for the move to complete. 
+    def _moveAndWait(self, pos, axis):
+        """Move to pos and wait for the move to complete.
         If axis is None, move all three axes to the specified position.
         If axis is 0,1,2, move only the specified axis to pos[axis].
 
@@ -526,7 +525,7 @@ class ScientificaGUI(StageInterface):
             dest[axis] = pos[axis]
         f = self.dev._move(dest, "fast", False, attempts_allowed=1, name=f"{self.dev.name()} auto-zero axis {axis}")
         while not f.isDone():
-            _future.sleep(0.1)
+            sleep(0.1)
 
         # raise errors not related to missing the target
         missed = f.wasInterrupted() and 'Stopped moving before reaching target' in f.errorMessage()

--- a/acq4/devices/Scientifica/scientifica.py
+++ b/acq4/devices/Scientifica/scientifica.py
@@ -240,7 +240,7 @@ class Scientifica(Stage):
 
     def _move(self, pos, speed, linear, name=None, **kwds):
         with self.lock:
-            if self._lastMove is not None and not self._lastMove.isDone():
+            if self._lastMove is not None and not self._lastMove.is_done:
                 self.stop()
             speed = self._interpretSpeed(speed)
 
@@ -524,12 +524,12 @@ class ScientificaGUI(StageInterface):
             dest = [None, None, None]
             dest[axis] = pos[axis]
         f = self.dev._move(dest, "fast", False, attempts_allowed=1, name=f"{self.dev.name()} auto-zero axis {axis}")
-        while not f.isDone():
+        while not f.is_done:
             sleep(0.1)
 
         # raise errors not related to missing the target
-        missed = f.wasInterrupted() and 'Stopped moving before reaching target' in f.errorMessage()
-        if f.wasInterrupted() and not missed:
+        missed = f.was_interrupted and 'Stopped moving before reaching target' in f.error_message
+        if f.was_interrupted and not missed:
             f.wait()
 
         return not missed

--- a/acq4/devices/Scientifica/scientifica.py
+++ b/acq4/devices/Scientifica/scientifica.py
@@ -457,10 +457,10 @@ class ScientificaGUI(StageInterface):
             self.sigBusyMoving.emit(False)
             return Future.immediate(error="User requested stop", stopped=True)
 
-        return self._doAutoZero(axis)
+        return self._doAutoZero(axis, _sync="async")
 
     @future_wrap
-    def _doAutoZero(self, axis: int = None, _future: Future = None) -> None:
+    def _doAutoZero(self, axis: int = None, name=None, _future: Future = None) -> None:
         self._savedLimits = self.dev.getLimits()
         try:
             diff = np.zeros(3)  # keep track of offset changes

--- a/acq4/devices/Sensapex.py
+++ b/acq4/devices/Sensapex.py
@@ -3,6 +3,8 @@ import threading
 import time
 from typing import Optional
 
+from acq4.util.future import sleep
+
 import numpy as np
 
 import pyqtgraph as pg
@@ -210,7 +212,7 @@ class Sensapex(Stage):
             # do not report changes < 100 nm
             if self._lastPos is None or dif > 0.1:
                 self.posChanged(pos)
-                time.sleep(updateInterval)
+                sleep(updateInterval)
 
     def quit(self):
         self._quitRequested = True

--- a/acq4/devices/SensapexObjectiveChanger.py
+++ b/acq4/devices/SensapexObjectiveChanger.py
@@ -59,7 +59,7 @@ class SensapexObjectiveChanger(Device):
         self._pos_poller.start()
 
     def setLensPosition(self, pos):
-        if self._lensChangeFuture is None or self._lensChangeFuture.isDone():
+        if self._lensChangeFuture is None or self._lensChangeFuture.is_done:
             self._lensChangeFuture = ObjectiveChangeFuture(self, pos)
         return self._lensChangeFuture
 
@@ -136,4 +136,4 @@ class ObjectiveChangeFuture(Future):
         Future.stop(self)
 
     def percentDone(self):
-        return 100 if self.isDone() else 0
+        return 100 if self.is_done else 0

--- a/acq4/devices/Sonicator.py
+++ b/acq4/devices/Sonicator.py
@@ -6,7 +6,7 @@ from functools import cached_property
 from acq4.devices.Device import Device
 from acq4.util import Qt
 from acq4.util.PromptUser import prompt
-from acq4.util.future import Future, FutureButton, future_wrap
+from acq4.util.future import Future, FutureButton
 
 
 class Sonicator(Device):
@@ -36,7 +36,7 @@ class Sonicator(Device):
         super().__init__(deviceManager, config, name)
         self.protocols = config.get("protocols", {})
 
-    def safeToSonicate(self, _future: Future = None, askUser=True) -> bool:
+    def safeToSonicate(self, askUser=True) -> bool:
         return True  # TODO unbroke this
         pos = self.patchPipetteDevice.pipetteDevice.globalPosition()
         well = self.patchPipetteDevice.pipetteDevice.getCleaningWell()
@@ -57,9 +57,8 @@ class Sonicator(Device):
         )
         return response == "Yes"
 
-    @future_wrap
-    def doProtocol(self, protocol: str | object, name=None, _future=None):
-        if not self.safeToSonicate(_future):
+    def doProtocol(self, protocol: str | object):
+        if not self.safeToSonicate():
             self.logger.info("Sonication deemed unsafe. Aborting.")
             return
         status = "Running"
@@ -67,7 +66,7 @@ class Sonicator(Device):
             status = protocol
             protocol = self.protocols[protocol]
         self.sigSonicationChanged.emit(status)
-        _future.waitFor(self._doProtocol(protocol), timeout=self._protocolDuration(protocol)*1.3)
+        Future(self._doProtocol, (protocol,)).wait(timeout=self._protocolDuration(protocol)*1.3)
         self._onProtocolFinished()
 
     def _doProtocol(self, protocol: object) -> Future:
@@ -142,7 +141,7 @@ class SonicatorGUI(Qt.QWidget):
         """Run the specified protocol and update UI accordingly"""
         protocol = self.sender().objectName()
         self.updateButtonStates(True, protocol)
-        return self.dev.doProtocol(protocol, _sync="async")
+        return Future(self.dev.doProtocol, (protocol,))
 
     def onProtocolFinished(self):
         """Called when a protocol completes"""

--- a/acq4/devices/Sonicator.py
+++ b/acq4/devices/Sonicator.py
@@ -50,17 +50,15 @@ class Sonicator(Device):
         if not askUser:
             return False
         print(f"{well} {well.containsPoint(pos, tolerance=5e-6)} {pos} {lower_bound}")
-        response = _future.waitFor(
-            prompt(
-                "Sonication Safety Warning",
-                "Sonication may be unsafe at the current pipette position. Proceed?",
-                ["Yes", "No"],
-            )
-        ).getResult()
+        response = prompt(
+            "Sonication Safety Warning",
+            "Sonication may be unsafe at the current pipette position. Proceed?",
+            ["Yes", "No"],
+        )
         return response == "Yes"
 
     @future_wrap
-    def doProtocol(self, protocol: str | object, _future):
+    def doProtocol(self, protocol: str | object, name=None, _future=None):
         if not self.safeToSonicate(_future):
             self.logger.info("Sonication deemed unsafe. Aborting.")
             return
@@ -144,7 +142,7 @@ class SonicatorGUI(Qt.QWidget):
         """Run the specified protocol and update UI accordingly"""
         protocol = self.sender().objectName()
         self.updateButtonStates(True, protocol)
-        return self.dev.doProtocol(protocol)
+        return self.dev.doProtocol(protocol, _sync="async")
 
     def onProtocolFinished(self):
         """Called when a protocol completes"""

--- a/acq4/devices/Stage/Stage.py
+++ b/acq4/devices/Stage/Stage.py
@@ -370,7 +370,7 @@ class Stage(Device, OptomechDevice):
         self._defaultSpeed = speed
 
     def isMoving(self):
-        return self._lastMove is not None and not self._lastMove.isDone()
+        return self._lastMove is not None and not self._lastMove.is_done
 
     def move(self, position, speed=None, progress=False, linear=False, **kwds) -> MoveFuture:
         """Move the device to a new position.
@@ -724,7 +724,7 @@ class MoveFuture(Future):
         the percent complete. Devices that do not provide position updates while
         moving should reimplement this method.
         """
-        if self.isDone():
+        if self.is_done:
             return 100
         s = np.array(self.startPos)
         t = np.array(self.targetPos)
@@ -738,7 +738,7 @@ class MoveFuture(Future):
     def stop(self, reason="stop requested", wait=False):
         """Stop the move in progress."""
         with self._isStopCallable as can_call_stop:
-            if can_call_stop and not self.isDone():
+            if can_call_stop and not self.is_done:
                 self.dev.stop()
                 super().stop(reason=reason, wait=wait)
 
@@ -800,7 +800,7 @@ class MovePathFuture(MoveFuture):
                     )
                     fut._pathStep = i
                     self._currentFuture = fut
-                    while not fut.isDone():
+                    while not fut.is_done:
                         with contextlib.suppress(fut.Timeout):
                             fut.wait(timeout=0.1)  # raises Timeout
                             self.currentStep = i + 1
@@ -816,10 +816,10 @@ class MovePathFuture(MoveFuture):
                         )
                         return
 
-                    if fut.wasInterrupted():
+                    if fut.was_interrupted:
                         self._taskDone(
                             interrupted=True,
-                            error=f"Path step {i + 1:d}/{len(self.path):d}: {fut.errorMessage()}",
+                            error=f"Path step {i + 1:d}/{len(self.path):d}: {fut.error_message}",
                             excInfo=fut._excInfo,
                         )
                         return
@@ -834,7 +834,7 @@ class MovePathFuture(MoveFuture):
                     )
                     return
         finally:
-            if not self.isDone():
+            if not self.is_done:
                 self._taskDone()  # success!
 
     def undo(self):

--- a/acq4/devices/Stage/Stage.py
+++ b/acq4/devices/Stage/Stage.py
@@ -961,7 +961,7 @@ class StageInterface(Qt.QWidget):
         self.dev.setLimits(**{self.dev.axes()[axis]: tuple(limit)})
 
     def goHomeClicked(self):
-        return self.dev.goHome()
+        self.dev.goHome().wait()
 
     def setHomeClicked(self):
         self.dev.setHomePosition()

--- a/acq4/devices/Stage/calibration.py
+++ b/acq4/devices/Stage/calibration.py
@@ -226,7 +226,7 @@ class ManipulatorAxesCalibrationWindow(Qt.QWidget):
             return
         self.autoCollectBtn.setEnabled(False)
         self.autoCollectBtn.setText("collecting...")
-        future = calibrate_manipulator_axes(pipette)
+        future = calibrate_manipulator_axes(pipette, _sync="async")
         future.onFinish(self._autoCollectFinished)
 
     def _autoCollectFinished(self, future):

--- a/acq4/devices/Stage/calibration.py
+++ b/acq4/devices/Stage/calibration.py
@@ -228,7 +228,7 @@ class ManipulatorAxesCalibrationWindow(Qt.QWidget):
         self.autoCollectBtn.setText("collecting...")
         from acq4.util.future import Future
         future = Future(calibrate_manipulator_axes, (pipette,))
-        future.onFinish(self._autoCollectFinished)
+        future.on_finish(self._autoCollectFinished)
 
     def _autoCollectFinished(self, future):
         from acq4.util.threadrun import runInGuiThread
@@ -238,7 +238,7 @@ class ManipulatorAxesCalibrationWindow(Qt.QWidget):
         self.autoCollectBtn.setEnabled(True)
         self.autoCollectBtn.setText("auto collect")
         try:
-            points = future.getResult()
+            points = future.get_result()
         except Exception:
             self.dev.logger.exception("Auto collect calibration failed")
             return
@@ -514,7 +514,7 @@ class AutomatedStageCalibration(object):
 
     def handleNewFrame(self, frame):
         try:
-            if self._move is not None and not self._move.isDone():
+            if self._move is not None and not self._move.is_done:
                 # stage is still moving; ignore frame
                 return
 

--- a/acq4/devices/Stage/calibration.py
+++ b/acq4/devices/Stage/calibration.py
@@ -226,7 +226,8 @@ class ManipulatorAxesCalibrationWindow(Qt.QWidget):
             return
         self.autoCollectBtn.setEnabled(False)
         self.autoCollectBtn.setText("collecting...")
-        future = calibrate_manipulator_axes(pipette, _sync="async")
+        from acq4.util.future import Future
+        future = Future(calibrate_manipulator_axes, (pipette,))
         future.onFinish(self._autoCollectFinished)
 
     def _autoCollectFinished(self, future):

--- a/acq4/devices/SutterMPC200/SutterMPC200.py
+++ b/acq4/devices/SutterMPC200/SutterMPC200.py
@@ -4,6 +4,7 @@ from acq4.drivers.SutterMPC200 import SutterMPC200 as MPC200_Driver
 from acq4.util import Qt, ptime
 from acq4.util.Mutex import Mutex
 from acq4.util.Thread import Thread
+from acq4.util.future import sleep
 from pyqtgraph import debug
 
 from ..Stage import Stage, MoveFuture
@@ -275,10 +276,10 @@ class MonitorThread(Thread):
                         with self.lock:
                             self._moveStatus[mid] = (start, True)
 
-                time.sleep(interval)
+                sleep(interval)
             except:
                 self.dev.logger.exception('Error in MPC200 monitor thread:')
-                time.sleep(maxInterval)
+                sleep(maxInterval)
                 
 
 class MPC200MoveFuture(MoveFuture):

--- a/acq4/devices/ThorlabsMFC1/MFC1.py
+++ b/acq4/devices/ThorlabsMFC1/MFC1.py
@@ -1,9 +1,8 @@
-import time
-
 from acq4.drivers.ThorlabsMFC1 import MFC1 as MFC1_Driver
 from acq4.util import Qt
 from acq4.util.Mutex import Mutex
 from acq4.util.Thread import Thread
+from acq4.util.future import sleep
 from pyqtgraph import debug
 from ..Stage import Stage, StageInterface, MoveFuture
 
@@ -187,10 +186,10 @@ class MonitorThread(Thread):
                     interval = min(maxInterval, interval*2)
                 lastPos = pos
 
-                time.sleep(interval)
+                sleep(interval)
             except:
                 self.dev.logger.exception('Error in MFC1 monitor thread:')
-                time.sleep(maxInterval)
+                sleep(maxInterval)
 
 
 class MFC1StageInterface(StageInterface):

--- a/acq4/devices/VimbaXCamera.py
+++ b/acq4/devices/VimbaXCamera.py
@@ -406,8 +406,7 @@ def main():
 
         cam.setParam('exposure', 0.01)
         cam.setParam('triggerMode', 'Normal')
-        fut = cam.driverSupportedFixedFrameAcquisition(5)
-        res = fut.getResult()
+        res = cam.driverSupportedFixedFrameAcquisition(5)
         print(len(res), res[0].data().shape)
         # with cam.ensureRunning():
         #     fut = cam.acquireFrames(5)

--- a/acq4/drivers/Scientifica/control_thread.py
+++ b/acq4/drivers/Scientifica/control_thread.py
@@ -8,6 +8,8 @@ import time
 
 import numpy as np
 
+from acq4.util.future import task_stack
+
 logger = logging.getLogger(__name__)
 
 
@@ -94,22 +96,23 @@ class ScientificaControlThread:
         return fut
 
     def _handle_request(self, fut: ScientificaRequestFuture):
-        cmd = fut.request
-        try:
-            if cmd == 'stop':
-                self._handle_stop(fut)
-                fut.set_result(None)
-            elif cmd == 'move':
-                self._handle_move(fut)
-            elif cmd == 'quit':
-                self.quit_request = fut
-            elif cmd == 'cancel':
-                self._handle_cancel(fut)
-            else:
-                raise ValueError(f'unrecognized request {cmd}')
+        with task_stack.push_full(fut.caller_stack):
+            cmd = fut.request
+            try:
+                if cmd == 'stop':
+                    self._handle_stop(fut)
+                    fut.set_result(None)
+                elif cmd == 'move':
+                    self._handle_move(fut)
+                elif cmd == 'quit':
+                    self.quit_request = fut
+                elif cmd == 'cancel':
+                    self._handle_cancel(fut)
+                else:
+                    raise ValueError(f'unrecognized request {cmd}')
 
-        except Exception:
-            fut.set_exc_info(sys.exc_info())
+            except Exception:
+                fut.set_exc_info(sys.exc_info())
 
     def _handle_move(self, fut):
         if self.current_move is not None and fut is not self.current_move:
@@ -257,6 +260,7 @@ class ScientificaRequestFuture:
         self.exc_info = None
         self.error = None
         self.n_attempts = 0
+        self.caller_stack = task_stack.get()  # snapshot of caller's task chain at submission time
 
     def done(self):
         """Return True if the request has finished."""

--- a/acq4/drivers/dovermotion/control_thread.py
+++ b/acq4/drivers/dovermotion/control_thread.py
@@ -8,6 +8,7 @@ import threading
 import numpy as np
 
 from .motionsynergy_api import get_motionsynergyapi, initialize, check, MotionSynergyException
+from acq4.util.future import task_stack
 
 logger = logging.getLogger(__name__)
 
@@ -145,34 +146,35 @@ class SmartStageControlThread:
                 logger.exception("Error in enabled state callback")
 
     def _handle_request(self, fut: SmartStageRequestFuture):
-        cmd = fut.request
-        try:
-            if cmd == 'stop':
-                self._handle_stop()
-                fut.set_result(None)
-            elif cmd == 'position':
-                fut.set_result(self._get_pos())
-            elif cmd == 'move':
-                self._handle_move(fut)
-            elif cmd == 'quit':
-                self.quit_request = fut
-            elif cmd == 'cancel':
-                self._handle_cancel(fut)
-            elif cmd == 'disable':
-                self._handle_disable(fut)
-            elif cmd == 'enable':
-                self._handle_enable(fut)
-            elif cmd == 'disable_axis':
-                self._handle_disable_axis(fut)
-            elif cmd == 'enable_axis':
-                self._handle_enable_axis(fut)
-            elif cmd == 'enabled_state':
-                fut.set_result(self._get_enabled_state())
-            else:
-                raise ValueError(f'unrecognized request {cmd}')
+        with task_stack.push_full(fut.caller_stack):
+            cmd = fut.request
+            try:
+                if cmd == 'stop':
+                    self._handle_stop()
+                    fut.set_result(None)
+                elif cmd == 'position':
+                    fut.set_result(self._get_pos())
+                elif cmd == 'move':
+                    self._handle_move(fut)
+                elif cmd == 'quit':
+                    self.quit_request = fut
+                elif cmd == 'cancel':
+                    self._handle_cancel(fut)
+                elif cmd == 'disable':
+                    self._handle_disable(fut)
+                elif cmd == 'enable':
+                    self._handle_enable(fut)
+                elif cmd == 'disable_axis':
+                    self._handle_disable_axis(fut)
+                elif cmd == 'enable_axis':
+                    self._handle_enable_axis(fut)
+                elif cmd == 'enabled_state':
+                    fut.set_result(self._get_enabled_state())
+                else:
+                    raise ValueError(f'unrecognized request {cmd}')
 
-        except Exception:
-            fut.set_exc_info(sys.exc_info())
+            except Exception:
+                fut.set_exc_info(sys.exc_info())
 
     def _handle_move(self, fut):
         if self.current_move is not None:
@@ -294,6 +296,7 @@ class SmartStageRequestFuture:
         self.exc_info = None
         self.error = None
         self.tasks = []
+        self.caller_stack = task_stack.get()  # snapshot of caller's task chain at submission time
 
     @property
     def label(self):

--- a/acq4/drivers/dovermotion/motionsynergy_client.py
+++ b/acq4/drivers/dovermotion/motionsynergy_client.py
@@ -30,6 +30,7 @@ def get_client(dll_path):
                 dll_path=dll_path,
                 log_addr=log_server.address,
             )
+        ms_client._import('acq4.util.future').setup_teleprox_context_propagation()
     if not ms_client["smartstage"].control_thread.is_running():
         ms_client["smartstage"].control_thread.start_thread()
     return ms_client

--- a/acq4/logging_config.py
+++ b/acq4/logging_config.py
@@ -130,6 +130,10 @@ def setup_logging(
     if log_server is None:
         log_server = LogServer(acq4_logger)
 
+    # Register task_stack propagation hooks with teleprox.
+    from acq4.util.future import setup_teleprox_context_propagation
+    setup_teleprox_context_propagation()
+
     # GUI Log Window handler (all messages)
     if gui:
         log_window = get_log_window()
@@ -181,6 +185,9 @@ def set_log_file(log_file: str | None, is_temp_file: bool = False) -> None:
         exc_info_as_array=True,
     )
     log_file_handler.setFormatter(json_formatter)
+    # Inject task_stack into every record written to the log file.
+    from acq4.util.future import _TaskStackFilter
+    log_file_handler.addFilter(_TaskStackFilter())
     root_logger.addHandler(log_file_handler)
 
     # replaced by the copy operation above

--- a/acq4/modules/AutomationDebug/AutomationDebug.py
+++ b/acq4/modules/AutomationDebug/AutomationDebug.py
@@ -77,13 +77,13 @@ class AutomationDebugWindow(Qt.QWidget):
         self.ui.clearBtn.clicked.connect(self._detector.clearCells)
         self.ui.showRoisBtn.toggled.connect(self._toggleCellRois)
         self.ui.zStackDetectBtn.setOpts(
-            future_producer=self._detector._detectNeuronsZStack, stoppable=True
+            future_producer=lambda: self._detector._detectNeuronsZStack(_sync="async"), stoppable=True
         )
         self.ui.zStackDetectBtn.sigFinished.connect(self._detector._handleDetectResults)
-        self.ui.testUIBtn.setOpts(future_producer=self._detector._testUI, stoppable=True)
+        self.ui.testUIBtn.setOpts(future_producer=lambda: self._detector._testUI(_sync="async"), stoppable=True)
         self.ui.testUIBtn.sigFinished.connect(self._detector._handleDetectResults)
         self.ui.addCellFromTargetBtn.setOpts(
-            future_producer=self._detector._addCellFromTarget, stoppable=True
+            future_producer=lambda: self._detector._addCellFromTarget(_sync="async"), stoppable=True
         )
 
         self.ui.motionPlannerSelector.currentIndexChanged.connect(
@@ -103,7 +103,7 @@ class AutomationDebugWindow(Qt.QWidget):
             self._mock_handler._selectMockClassificationFile
         )
 
-        self.ui.autoTargetBtn.setOpts(future_producer=self._autoTarget, stoppable=True)
+        self.ui.autoTargetBtn.setOpts(future_producer=lambda: self._autoTarget(_sync="async"), stoppable=True)
         self.ui.autoTargetBtn.sigFinished.connect(self._handleAutoFinish)
 
         self._motionPlanners = {}
@@ -115,7 +115,7 @@ class AutomationDebugWindow(Qt.QWidget):
                 self.ui.cameraSelector.addItem(name)
 
         self.ui.trackFeaturesBtn.setOpts(
-            future_producer=self._feature_tracker.doFeatureTracking,
+            future_producer=lambda: self._feature_tracker.doFeatureTracking(_sync="async"),
             processing="Stop tracking",
             stoppable=True,
         )
@@ -128,7 +128,7 @@ class AutomationDebugWindow(Qt.QWidget):
         self.ui.visualizeTrackingBtn.setEnabled(True)
 
         self.ui.testPipetteBtn.setOpts(
-            future_producer=self._feature_tracker.doPipetteCalibrationTest,
+            future_producer=lambda: self._feature_tracker.doPipetteCalibrationTest(_sync="async"),
             stoppable=True,
             processing="Interrupt pipette\ncalibration test",
         )
@@ -145,7 +145,7 @@ class AutomationDebugWindow(Qt.QWidget):
 
         self.ui.autopatchDemoBtn.setToolTip("Patch a cell! Repeat! REPEAT!")
         self.ui.autopatchDemoBtn.setOpts(
-            future_producer=self._autopatcher._autopatchDemo, stoppable=True
+            future_producer=lambda: self._autopatcher._autopatchDemo(_sync="async"), stoppable=True
         )
         self.ui.autopatchDemoBtn.sigFinished.connect(
             self._autopatcher._handleAutopatchDemoFinish
@@ -257,7 +257,7 @@ class AutomationDebugWindow(Qt.QWidget):
         self._yBottomSpin.setValue(bound[1])
 
     @future_wrap
-    def _autoTarget(self, _future):
+    def _autoTarget(self, name=None, _future=None):
         self.sigWorking.emit(self.ui.autoTargetBtn)
         # If _unranked_cells is populated, use it. Otherwise, run detection.
         if not self._unranked_cells:
@@ -269,18 +269,15 @@ class AutomationDebugWindow(Qt.QWidget):
                 )
             )
             # TODO don't know why this hangs when using waitFor, but it does
-            depth_fut = self.scopeDevice.findSurfaceDepth(
+            depth = self.scopeDevice.findSurfaceDepth(
                 self.cameraDevice,
                 searchDistance=50 * µm,
-                searchStep=15 * µm,  # , block=True, checkStopThrough=_future
-            )
-            depth = depth_fut.getResult() - 50 * µm  # Target below surface
+                searchStep=15 * µm,
+            ) - 50 * µm  # Target below surface
             _future.checkStop()
             self.cameraDevice.setFocusDepth(depth, name=f"{self.cameraDevice.name()} focus below surface for autoTarget")  # Set focus depth
 
-            _future.waitFor(
-                self._detector._detectNeuronsZStack(), timeout=600
-            )  # Side-effect: populates _unranked_cells
+            self._detector._detectNeuronsZStack()  # Side-effect: populates _unranked_cells
         if not self._unranked_cells:
             raise RuntimeError(
                 "Neuron detection ran, but no cells found for autoTarget."

--- a/acq4/modules/AutomationDebug/AutomationDebug.py
+++ b/acq4/modules/AutomationDebug/AutomationDebug.py
@@ -17,7 +17,7 @@ from acq4.logging_config import get_logger
 from acq4.modules.Module import Module
 from acq4.util import Qt
 import pyqtgraph as pg
-from acq4.util.future import Future, future_wrap
+from acq4.util.future import Future, check_stop
 from pyqtgraph.units import µm
 from .autopatch import Autopatcher
 from .detection import CellDetector
@@ -77,13 +77,13 @@ class AutomationDebugWindow(Qt.QWidget):
         self.ui.clearBtn.clicked.connect(self._detector.clearCells)
         self.ui.showRoisBtn.toggled.connect(self._toggleCellRois)
         self.ui.zStackDetectBtn.setOpts(
-            future_producer=lambda: self._detector._detectNeuronsZStack(_sync="async"), stoppable=True
+            future_producer=lambda: Future(self._detector._detectNeuronsZStack), stoppable=True
         )
         self.ui.zStackDetectBtn.sigFinished.connect(self._detector._handleDetectResults)
-        self.ui.testUIBtn.setOpts(future_producer=lambda: self._detector._testUI(_sync="async"), stoppable=True)
+        self.ui.testUIBtn.setOpts(future_producer=lambda: Future(self._detector._testUI), stoppable=True)
         self.ui.testUIBtn.sigFinished.connect(self._detector._handleDetectResults)
         self.ui.addCellFromTargetBtn.setOpts(
-            future_producer=lambda: self._detector._addCellFromTarget(_sync="async"), stoppable=True
+            future_producer=lambda: Future(self._detector._addCellFromTarget), stoppable=True
         )
 
         self.ui.motionPlannerSelector.currentIndexChanged.connect(
@@ -103,7 +103,7 @@ class AutomationDebugWindow(Qt.QWidget):
             self._mock_handler._selectMockClassificationFile
         )
 
-        self.ui.autoTargetBtn.setOpts(future_producer=lambda: self._autoTarget(_sync="async"), stoppable=True)
+        self.ui.autoTargetBtn.setOpts(future_producer=lambda: Future(self._autoTarget), stoppable=True)
         self.ui.autoTargetBtn.sigFinished.connect(self._handleAutoFinish)
 
         self._motionPlanners = {}
@@ -115,7 +115,7 @@ class AutomationDebugWindow(Qt.QWidget):
                 self.ui.cameraSelector.addItem(name)
 
         self.ui.trackFeaturesBtn.setOpts(
-            future_producer=lambda: self._feature_tracker.doFeatureTracking(_sync="async"),
+            future_producer=lambda: Future(self._feature_tracker.doFeatureTracking),
             processing="Stop tracking",
             stoppable=True,
         )
@@ -128,7 +128,7 @@ class AutomationDebugWindow(Qt.QWidget):
         self.ui.visualizeTrackingBtn.setEnabled(True)
 
         self.ui.testPipetteBtn.setOpts(
-            future_producer=lambda: self._feature_tracker.doPipetteCalibrationTest(_sync="async"),
+            future_producer=lambda: Future(self._feature_tracker.doPipetteCalibrationTest),
             stoppable=True,
             processing="Interrupt pipette\ncalibration test",
         )
@@ -145,7 +145,7 @@ class AutomationDebugWindow(Qt.QWidget):
 
         self.ui.autopatchDemoBtn.setToolTip("Patch a cell! Repeat! REPEAT!")
         self.ui.autopatchDemoBtn.setOpts(
-            future_producer=lambda: self._autopatcher._autopatchDemo(_sync="async"), stoppable=True
+            future_producer=lambda: Future(self._autopatcher._autopatchDemo), stoppable=True
         )
         self.ui.autopatchDemoBtn.sigFinished.connect(
             self._autopatcher._handleAutopatchDemoFinish
@@ -256,25 +256,22 @@ class AutomationDebugWindow(Qt.QWidget):
         self._xRightSpin.setValue(bound[0])
         self._yBottomSpin.setValue(bound[1])
 
-    @future_wrap
-    def _autoTarget(self, name=None, _future=None):
+    def _autoTarget(self):
         self.sigWorking.emit(self.ui.autoTargetBtn)
         # If _unranked_cells is populated, use it. Otherwise, run detection.
         if not self._unranked_cells:
             logger.info("Need new potential cells; running detection")
             x, y = self._randomLocation()
-            _future.waitFor(
-                self.scopeDevice.setGlobalPosition(
-                    (x, y), name="random move to find cells"
-                )
-            )
+            self.scopeDevice.setGlobalPosition(
+                (x, y), name="random move to find cells"
+            ).wait()
             # TODO don't know why this hangs when using waitFor, but it does
             depth = self.scopeDevice.findSurfaceDepth(
                 self.cameraDevice,
                 searchDistance=50 * µm,
                 searchStep=15 * µm,
             ) - 50 * µm  # Target below surface
-            _future.checkStop()
+            check_stop()
             self.cameraDevice.setFocusDepth(depth, name=f"{self.cameraDevice.name()} focus below surface for autoTarget")  # Set focus depth
 
             self._detector._detectNeuronsZStack()  # Side-effect: populates _unranked_cells

--- a/acq4/modules/AutomationDebug/AutomationDebug.py
+++ b/acq4/modules/AutomationDebug/AutomationDebug.py
@@ -77,13 +77,13 @@ class AutomationDebugWindow(Qt.QWidget):
         self.ui.clearBtn.clicked.connect(self._detector.clearCells)
         self.ui.showRoisBtn.toggled.connect(self._toggleCellRois)
         self.ui.zStackDetectBtn.setOpts(
-            future_producer=lambda: Future(self._detector._detectNeuronsZStack), stoppable=True
+            fn=self._detector._detectNeuronsZStack, stoppable=True
         )
         self.ui.zStackDetectBtn.sigFinished.connect(self._detector._handleDetectResults)
-        self.ui.testUIBtn.setOpts(future_producer=lambda: Future(self._detector._testUI), stoppable=True)
+        self.ui.testUIBtn.setOpts(fn=self._detector._testUI, stoppable=True)
         self.ui.testUIBtn.sigFinished.connect(self._detector._handleDetectResults)
         self.ui.addCellFromTargetBtn.setOpts(
-            future_producer=lambda: Future(self._detector._addCellFromTarget), stoppable=True
+            fn=self._detector._addCellFromTarget, stoppable=True
         )
 
         self.ui.motionPlannerSelector.currentIndexChanged.connect(
@@ -103,7 +103,7 @@ class AutomationDebugWindow(Qt.QWidget):
             self._mock_handler._selectMockClassificationFile
         )
 
-        self.ui.autoTargetBtn.setOpts(future_producer=lambda: Future(self._autoTarget), stoppable=True)
+        self.ui.autoTargetBtn.setOpts(fn=self._autoTarget, stoppable=True)
         self.ui.autoTargetBtn.sigFinished.connect(self._handleAutoFinish)
 
         self._motionPlanners = {}
@@ -115,7 +115,7 @@ class AutomationDebugWindow(Qt.QWidget):
                 self.ui.cameraSelector.addItem(name)
 
         self.ui.trackFeaturesBtn.setOpts(
-            future_producer=lambda: Future(self._feature_tracker.doFeatureTracking),
+            fn=self._feature_tracker.doFeatureTracking,
             processing="Stop tracking",
             stoppable=True,
         )
@@ -128,7 +128,7 @@ class AutomationDebugWindow(Qt.QWidget):
         self.ui.visualizeTrackingBtn.setEnabled(True)
 
         self.ui.testPipetteBtn.setOpts(
-            future_producer=lambda: Future(self._feature_tracker.doPipetteCalibrationTest),
+            fn=self._feature_tracker.doPipetteCalibrationTest,
             stoppable=True,
             processing="Interrupt pipette\ncalibration test",
         )
@@ -145,7 +145,7 @@ class AutomationDebugWindow(Qt.QWidget):
 
         self.ui.autopatchDemoBtn.setToolTip("Patch a cell! Repeat! REPEAT!")
         self.ui.autopatchDemoBtn.setOpts(
-            future_producer=lambda: Future(self._autopatcher._autopatchDemo), stoppable=True
+            fn=self._autopatcher._autopatchDemo, stoppable=True
         )
         self.ui.autopatchDemoBtn.sigFinished.connect(
             self._autopatcher._handleAutopatchDemoFinish

--- a/acq4/modules/AutomationDebug/autopatch.py
+++ b/acq4/modules/AutomationDebug/autopatch.py
@@ -27,7 +27,7 @@ class Autopatcher:
         win.ui.reuseLastCellBtn.setEnabled(win._cell is not None)
 
     @future_wrap
-    def _autopatchDemo(self, _future):
+    def _autopatchDemo(self, name=None, _future=None):
         win = self._window
         win.sigWorking.emit(win.ui.autopatchDemoBtn)
         ppip: PatchPipette = win.patchPipetteDevice
@@ -36,7 +36,7 @@ class Autopatcher:
         multipatch_win = runInGuiThread(man.getModule, 'MultiPatch').win
         demo_dir = self._makeValidDemoDir()
         man.setCurrentDir(demo_dir)
-        _future.waitFor(win.cameraDevice.scopeDev.findSurfaceDepth(win.cameraDevice)).getResult()
+        win.cameraDevice.scopeDev.findSurfaceDepth(win.cameraDevice)
         try:
             while True:
                 cell_dir = runInGuiThread(data_manager.createNewFolder, "Cell")
@@ -66,10 +66,10 @@ class Autopatcher:
                     _future.waitFor(ppip.pipetteDevice.goAboveTarget("fast"))
                     _future.setState("Autopatch: finding pipette tip")
                     ppip.clampDevice.autoPipetteOffset()
-                    _future.waitFor(win.pipetteDevice.iterativelyFindTip())
+                    win.pipetteDevice.iterativelyFindTip()
                     if started_clean:
                         _future.setState("Quick clean")
-                        _future.waitFor(ppip.sonicatorDevice.doProtocol("quick clean"))
+                        ppip.sonicatorDevice.doProtocol("quick clean")
 
                     _future.setState("Autopatch: go approach")
                     _future.waitFor(ppip.pipetteDevice.goApproach("fast"))
@@ -90,11 +90,11 @@ class Autopatcher:
                     self._autopatchRunTaskRunner(_future)
 
                     _future.setState("Autopatch: Taking cell images")
-                    _future.waitFor(win.scopeDevice.loadPreset('GFP'))
+                    win.scopeDevice.loadPreset('GFP')
                     self._saveStack("patched GFP cellfie", _future)
                     # win.scopeDevice.loadPreset('tdTomato')
                     # self._saveStack("patched tdTomato cellfie", _future)
-                    _future.waitFor(win.scopeDevice.loadPreset('brightfield'))
+                    win.scopeDevice.loadPreset('brightfield')
 
                     # TODO too slow for today's demo
                     # _future.setState("Autopatch: resealing")
@@ -169,7 +169,7 @@ class Autopatcher:
             #     win.cameraDevice.scopeDev.findSurfaceDepth(win.cameraDevice)
             # ).getResult()
             # _future.waitFor(win.cameraDevice.setFocusDepth(surf - 60e-6, "fast"))
-            z_stack = win._detector._detectNeuronsZStack()
+            z_stack = win._detector._detectNeuronsZStack(_sync="async")
             z_stack.sigFinished.connect(win._detector._handleDetectResults)
             _future.waitFor(z_stack, timeout=600)
 

--- a/acq4/modules/AutomationDebug/autopatch.py
+++ b/acq4/modules/AutomationDebug/autopatch.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from acq4.devices.PatchPipette import PatchPipette
 from acq4.logging_config import get_logger
-from acq4.util.future import future_wrap
+from acq4.util.future import Future, Stopped, sleep
 from acq4.util.threadrun import runInGuiThread
 from acq4.util.imaging.sequencer import run_image_sequence
 from ..TaskRunner import TaskRunner
@@ -26,8 +26,7 @@ class Autopatcher:
         win.sigWorking.emit(False)
         win.ui.reuseLastCellBtn.setEnabled(win._cell is not None)
 
-    @future_wrap
-    def _autopatchDemo(self, name=None, _future=None):
+    def _autopatchDemo(self):
         win = self._window
         win.sigWorking.emit(win.ui.autopatchDemoBtn)
         ppip: PatchPipette = win.patchPipetteDevice
@@ -43,40 +42,39 @@ class Autopatcher:
                 try:
                     started_clean = ppip.isTipClean()
                     if not started_clean:
-                        _future.setState("Autopatch: cleaning pipette")
+                        logger.debug("Autopatch: cleaning pipette")
                         try:
-                            _future.waitFor(ppip.setState("clean", nextState="bath"), timeout=600)
+                            ppip.setState("clean", nextState="bath").wait(timeout=600)
                         except Exception:
-                            _future.setState("Clean is unsafe to undo; quitting demo")
                             logger.exception("Error during pipette clean - quitting autopatch demo")
                             return
                         if not ppip.isTipClean():
-                            _future.setState("Pipette still not clean after clean state; quitting demo")
+                            logger.debug("Pipette still not clean after clean state; quitting demo")
                             return
-                        _future.waitFor(win.scopeDevice.moveDip())
+                        win.scopeDevice.moveDip().wait()
 
-                    cell = self._autopatchFindCell(_future)
+                    cell = self._autopatchFindCell()
                     if cell is None:
-                        _future.setState("No cells found; quitting demo")
+                        logger.debug("No cells found; quitting demo")
                         return
-                    _future.setState("Autopatch: cell found")
+                    logger.debug("Autopatch: cell found")
                     ppip.newPatchAttempt()
                     runInGuiThread(multipatch_win.ui.recordBtn.setChecked, True)
-                    _future.setState("Autopatch: go above target")
-                    _future.waitFor(ppip.pipetteDevice.goAboveTarget("fast"))
-                    _future.setState("Autopatch: finding pipette tip")
+                    logger.debug("Autopatch: go above target")
+                    ppip.pipetteDevice.goAboveTarget("fast").wait()
+                    logger.debug("Autopatch: finding pipette tip")
                     ppip.clampDevice.autoPipetteOffset()
                     win.pipetteDevice.iterativelyFindTip()
                     if started_clean:
-                        _future.setState("Quick clean")
+                        logger.debug("Quick clean")
                         ppip.sonicatorDevice.doProtocol("quick clean")
 
-                    _future.setState("Autopatch: go approach")
-                    _future.waitFor(ppip.pipetteDevice.goApproach("fast"))
+                    logger.debug("Autopatch: go approach")
+                    ppip.pipetteDevice.goApproach("fast").wait()
                     try:
-                        _future.setState("Autopatch: patch cell")
+                        logger.debug("Autopatch: patch cell")
                         logger.warning("Autopatch: Start cell patching")
-                        state = self._autopatchCellPatch(cell, _future)
+                        state = self._autopatchCellPatch(cell)
                     except Exception:
                         logger.exception("Autopatch: Exception during cell patching")
                         raise
@@ -86,42 +84,40 @@ class Autopatcher:
                         logger.warning("Autopatch: Next cell!")
                         continue
                     cell_dir.setInfo({'important': True})
-                    _future.setState("Autopatch: Whole cell; running task")
-                    self._autopatchRunTaskRunner(_future)
+                    logger.debug("Autopatch: Whole cell; running task")
+                    self._autopatchRunTaskRunner()
 
-                    _future.setState("Autopatch: Taking cell images")
+                    logger.debug("Autopatch: Taking cell images")
                     win.scopeDevice.loadPreset('GFP')
-                    self._saveStack("patched GFP cellfie", _future)
+                    self._saveStack("patched GFP cellfie")
                     # win.scopeDevice.loadPreset('tdTomato')
-                    # self._saveStack("patched tdTomato cellfie", _future)
+                    # self._saveStack("patched tdTomato cellfie")
                     win.scopeDevice.loadPreset('brightfield')
 
                     # TODO too slow for today's demo
-                    # _future.setState("Autopatch: resealing")
-                    # _future.waitFor(ppip.setState("reseal"), timeout=None)
-                    # self._saveStack("resealed nucleus", _future)
+                    # logger.debug("Autopatch: resealing")
+                    # ppip.setState("reseal").wait(timeout=None)
+                    # self._saveStack("resealed nucleus")
                     #
                     # # start nucleus collection
                     # homeFut = ppip.setState("home with nucleus")
                     #
                     # # check on the resealed cell
                     # win.scopeDevice.loadPreset('GFP')
-                    # _future.waitFor(
-                    #     win.cameraDevice.moveCenterToGlobal(cell.position, "fast", name="center on resealed cell")
-                    # )
-                    # self._saveStack("GFP cell without nucleus", _future)
-                    # _future.waitFor(homeFut)
+                    # win.cameraDevice.moveCenterToGlobal(cell.position, "fast", name="center on resealed cell").wait()
+                    # self._saveStack("GFP cell without nucleus")
+                    # homeFut.wait()
 
                     # collect the nucleus
                     # TODO once we have motion planning
-                    # _future.waitFor(ppip.setState("collect"))
-                    # _future.waitFor(ppip.pipetteDevice.goAboveTarget("fast"))
-                    # self._saveStack("post-collection", _future)
+                    # ppip.setState("collect").wait()
+                    # ppip.pipetteDevice.goAboveTarget("fast").wait()
+                    # self._saveStack("post-collection")
 
-                    _future.waitFor(ppip.pipetteDevice.goHome())
+                    ppip.pipetteDevice.goHome().wait()
                     ppip.setState("bath")
 
-                except (_future.StopRequested, _future.Stopped):
+                except Stopped:
                     raise
                 except Exception:
                     logger.exception("Error during protocol:")
@@ -140,7 +136,7 @@ class Autopatcher:
             parent = parent.parent()
         return parent.mkdir('AutopatchDemo', autoIncrement=True)
 
-    def _autopatchCellPatch(self, cell, _future):
+    def _autopatchCellPatch(self, cell):
         win = self._window
         ppip = win.patchPipetteDevice
         ppip.setState("approach", startANewCell=False)
@@ -148,32 +144,28 @@ class Autopatcher:
         while True:
             if (state := ppip.getState().stateName) not in ("approach", "cell detect", "contact cell"):
                 if not detect_finished:
-                    _future.waitFor(
-                        win.cameraDevice.moveCenterToGlobal(
-                            cell.position, "fast", name="center on cell during patching"
-                        )
-                    )
+                    win.cameraDevice.moveCenterToGlobal(
+                        cell.position, "fast", name="center on cell during patching"
+                    ).wait()
                     detect_finished = True
             if state in ("whole cell", "bath", "broken", "fouled"):
-                _future.setState(f"Exiting patch loop - ended in state {state}")
+                logger.debug(f"Exiting patch loop - ended in state {state}")
                 break
-            _future.sleep(0.1)
+            sleep(0.1)
         return state
 
-    def _autopatchFindCell(self, _future):
+    def _autopatchFindCell(self):
         win = self._window
         if not win._unranked_cells:
-            _future.setState("Autopatch: searching for cells")
+            logger.debug("Autopatch: searching for cells")
             return None
-            # surf = _future.waitFor(
-            #     win.cameraDevice.scopeDev.findSurfaceDepth(win.cameraDevice)
-            # ).getResult()
-            # _future.waitFor(win.cameraDevice.setFocusDepth(surf - 60e-6, "fast"))
-            z_stack = win._detector._detectNeuronsZStack(_sync="async")
+            # surf = win.cameraDevice.scopeDev.findSurfaceDepth(win.cameraDevice)
+            # win.cameraDevice.setFocusDepth(surf - 60e-6, "fast").wait()
+            z_stack = Future(win._detector._detectNeuronsZStack)
             z_stack.sigFinished.connect(win._detector._handleDetectResults)
-            _future.waitFor(z_stack, timeout=600)
+            z_stack.wait(timeout=600)
 
-        _future.setState("Autopatch: checking selected cell")
+        logger.debug("Autopatch: checking selected cell")
         cell = win._unranked_cells.pop(0)
         win._ranked_cells.append(cell)
         win.patchPipetteDevice.setCell(cell)
@@ -184,19 +176,19 @@ class Autopatcher:
         # if (pos - margin) not in stack or (pos + margin) not in stack:
         # stack = None
         try:
-            _future.waitFor(cell.initializeTracker(win.cameraDevice))
-        except _future.StopRequested:
+            cell.initializeTracker(win.cameraDevice).wait()
+        except Stopped:
             raise
         except ValueError as e:
             if win._mockDemo:
                 logger.info(f"Autopatch: Mocking cell despite {e}")
                 return cell
             logger.info(f"Cell moved too much? {e}\nRetrying")
-            return self._autopatchFindCell(_future)
+            return self._autopatchFindCell()
         logger.info(f"Autopatch: Cell found at {cell.position}")
         return cell
 
-    def _autopatchRunTaskRunner(self, _future):
+    def _autopatchRunTaskRunner(self):
         win = self._window
         man = win.module.manager
         ppip = win.patchPipetteDevice
@@ -214,24 +206,19 @@ class Autopatcher:
         expected_duration = (
             taskrunner.sequenceInfo["period"] * taskrunner.sequenceInfo["totalParams"]
         )
-        _future.waitFor(
-            # runInGuiThread(taskrunner.runSequence, store=True, storeDirHandle=self.dh), timeout=expected_duration
-            runInGuiThread(taskrunner.runSequence, store=False),
+        runInGuiThread(taskrunner.runSequence, store=False).wait(
             timeout=max(30, expected_duration * 20),
         )
         logger.warning("Autopatch: Task runner sequence completed.")
 
-    def _saveStack(self, name, future):
+    def _saveStack(self, name):
         ppip = self._window.patchPipetteDevice
         start = ppip.pipetteDevice.targetPosition()[2] - (20e-6 / 2)
         end = start + 20e-6
         save_in = ppip.dm.getCurrentDir().getDir(f"{name} stack", create=True)
-        future.waitFor(
-            run_image_sequence(
-                ppip.imagingDevice(),
-                z_stack=(start, end, 1e-6),
-                storage_dir=save_in,
-                name="cellfie",
-            )
-        )
-        future.sleep(5)  # pose for the user
+        Future(
+            run_image_sequence,
+            (ppip.imagingDevice(),),
+            dict(z_stack=(start, end, 1e-6), storage_dir=save_in, name="cellfie"),
+        ).wait()
+        sleep(5)  # pose for the user

--- a/acq4/modules/AutomationDebug/detection.py
+++ b/acq4/modules/AutomationDebug/detection.py
@@ -41,7 +41,7 @@ class CellDetector:
             self._window.ui.rankingSaveDirEdit.setText(path)
 
     @future_wrap
-    def _addCellFromTarget(self, _future):
+    def _addCellFromTarget(self, name=None, _future=None):
         target = Point(self._window.pipetteDevice.targetPosition(), "global")
         cell = self._window.patchPipetteDevice.cell
         if cell is None or cell.position != target:
@@ -52,7 +52,7 @@ class CellDetector:
         _future.waitFor(futureInGuiThread(self._displayBoundingBoxes, boxPositions))
 
     @future_wrap
-    def _testUI(self, _future):
+    def _testUI(self, name=None, _future=None):
         with self._window.cameraDevice.ensureRunning():
             frame = _future.waitFor(self._window.cameraDevice.acquireFrames(1)).getResult()[0]
         points = np.random.random((20, 3))
@@ -63,7 +63,7 @@ class CellDetector:
 
     @future_wrap
     def _detectNeuronsZStack(
-        self, _future: Future
+        self, name=None, _future: Future = None
     ) -> tuple[list, list[Frame] | None, list[Frame] | None] | list:
         """Acquires Z-stack(s) and runs neuron detection. Returns (bboxes, detection_stack, classification_stack)."""
         from acq4_automation.object_detection import detect_neurons
@@ -102,7 +102,7 @@ class CellDetector:
                 raise RuntimeError("Failed to load mock detection stack.")
 
         else:  # --- Real Acquisition ---
-            surface = _future.waitFor(win.scopeDevice.findSurfaceDepth(win.cameraDevice)).getResult()
+            surface = win.scopeDevice.findSurfaceDepth(win.cameraDevice)
 
             start_z = surface - win.ui.zStackStartDepthSpin.value()
             stop_z = surface - win.ui.zStackStopDepthSpin.value()
@@ -112,22 +112,16 @@ class CellDetector:
                     f"Starting multichannel Z-stack acquisition: Detection='{detection_preset}', "
                     f"Classification='{classification_preset}'"
                 )
-                _future.waitFor(win.scopeDevice.loadPreset(detection_preset))
-            detection_stack = _future.waitFor(
-                acquire_z_stack(
-                    win.cameraDevice, start_z, stop_z, step_z, slow_fallback=False, name="neuron detection stack"
-                ),
-                timeout=100,
-            ).getResult()
+                win.scopeDevice.loadPreset(detection_preset)
+            detection_stack = acquire_z_stack(
+                win.cameraDevice, start_z, stop_z, step_z, slow_fallback=False, name="neuron detection stack"
+            )
 
             if multichannel_processing_intended:
-                _future.waitFor(win.scopeDevice.loadPreset(classification_preset))
-                classification_stack = _future.waitFor(
-                    acquire_z_stack(
-                        win.cameraDevice, start_z, stop_z, step_z, slow_fallback=False, name="neuron classification stack"
-                    ),
-                    timeout=100,
-                ).getResult()
+                win.scopeDevice.loadPreset(classification_preset)
+                classification_stack = acquire_z_stack(
+                    win.cameraDevice, start_z, stop_z, step_z, slow_fallback=False, name="neuron classification stack"
+                )
 
                 if len(detection_stack) != len(classification_stack):
                     logger.warning(

--- a/acq4/modules/AutomationDebug/detection.py
+++ b/acq4/modules/AutomationDebug/detection.py
@@ -8,7 +8,7 @@ import numpy as np
 from acq4.logging_config import get_logger
 from acq4.modules.Camera import CameraWindow
 from acq4.util import Qt
-from acq4.util.future import Future, future_wrap
+from acq4.util.future import Future
 from acq4.util.imaging.sequencer import acquire_z_stack
 from acq4.util.target import TargetBox
 from acq4.util.threadrun import futureInGuiThread, runInGuiThread
@@ -40,30 +40,27 @@ class CellDetector:
         if path:
             self._window.ui.rankingSaveDirEdit.setText(path)
 
-    @future_wrap
-    def _addCellFromTarget(self, name=None, _future=None):
+    def _addCellFromTarget(self):
         target = Point(self._window.pipetteDevice.targetPosition(), "global")
         cell = self._window.patchPipetteDevice.cell
         if cell is None or cell.position != target:
             cell = Cell(target)
-            _future.waitFor(cell.initializeTracker(self._window.cameraDevice))
+            cell.initializeTracker(self._window.cameraDevice).wait()
         self._window._unranked_cells.append(cell)
         boxPositions = [c.position for c in self._window._unranked_cells]
-        _future.waitFor(futureInGuiThread(self._displayBoundingBoxes, boxPositions))
+        futureInGuiThread(self._displayBoundingBoxes, boxPositions).wait()
 
-    @future_wrap
-    def _testUI(self, name=None, _future=None):
+    def _testUI(self):
         with self._window.cameraDevice.ensureRunning():
-            frame = _future.waitFor(self._window.cameraDevice.acquireFrames(1)).getResult()[0]
+            frame = self._window.cameraDevice.acquireFrames(1).getResult()[0]
         points = np.random.random((20, 3))
         points[:, 2] *= 20e-6
         points[:, 1] *= frame.shape[0]
         points[:, 0] *= frame.shape[1]
         return [frame.mapFromFrameToGlobal(pt) for pt in points]
 
-    @future_wrap
     def _detectNeuronsZStack(
-        self, name=None, _future: Future = None
+        self,
     ) -> tuple[list, list[Frame] | None, list[Frame] | None] | list:
         """Acquires Z-stack(s) and runs neuron detection. Returns (bboxes, detection_stack, classification_stack)."""
         from acq4_automation.object_detection import detect_neurons
@@ -95,9 +92,7 @@ class CellDetector:
         )
 
         if win.ui.mockCheckBox.isChecked():
-            detection_stack, classification_stack, step_z = win._mock_handler._mockNeuronStacks(
-                _future
-            )
+            detection_stack, classification_stack, step_z = win._mock_handler._mockNeuronStacks()
             if detection_stack is None:
                 raise RuntimeError("Failed to load mock detection stack.")
 
@@ -141,20 +136,17 @@ class CellDetector:
 
         win.cameraDevice.setFocusDepth(depth, name=f"{win.cameraDevice.name()} restore focus after detection z-stack")  # Restore focus
 
-        global_pos = _future.waitFor(
-            detect_neurons(
-                working_stack,  # Prepared based on mock/real and single/multi
-                segmenter=segmenter,
-                autoencoder=autoencoder,
-                classifier=classifier,
-                resnet_classifier=resnet_classifier,
-                xy_scale=pixel_size,  # Global pixel_size
-                z_scale=step_z,  # Actual step_z from mock or real (1um for real)
-                multichannel=multichannel,  # Actual flag for detect_neurons
-                trim_edges=True,
-            ),
-            timeout=600,
-        ).getResult()
+        global_pos = detect_neurons(
+            working_stack,  # Prepared based on mock/real and single/multi
+            segmenter=segmenter,
+            autoencoder=autoencoder,
+            classifier=classifier,
+            resnet_classifier=resnet_classifier,
+            xy_scale=pixel_size,  # Global pixel_size
+            z_scale=step_z,  # Actual step_z from mock or real (1um for real)
+            multichannel=multichannel,  # Actual flag for detect_neurons
+            trim_edges=True,
+        ).wait(timeout=600).getResult()
         logger.info(f"Neuron detection finished. Found {len(global_pos)} potential neurons.")
 
         win._current_detection_stack = detection_stack

--- a/acq4/modules/AutomationDebug/detection.py
+++ b/acq4/modules/AutomationDebug/detection.py
@@ -142,11 +142,11 @@ class CellDetector:
             autoencoder=autoencoder,
             classifier=classifier,
             resnet_classifier=resnet_classifier,
-            xy_scale=pixel_size,  # Global pixel_size
+            xy_scale=pixel_size,  # Global pixel_scale
             z_scale=step_z,  # Actual step_z from mock or real (1um for real)
             multichannel=multichannel,  # Actual flag for detect_neurons
             trim_edges=True,
-        ).wait(timeout=600).getResult()
+        )
         logger.info(f"Neuron detection finished. Found {len(global_pos)} potential neurons.")
 
         win._current_detection_stack = detection_stack

--- a/acq4/modules/AutomationDebug/detection.py
+++ b/acq4/modules/AutomationDebug/detection.py
@@ -52,7 +52,7 @@ class CellDetector:
 
     def _testUI(self):
         with self._window.cameraDevice.ensureRunning():
-            frame = self._window.cameraDevice.acquireFrames(1).getResult()[0]
+            frame = self._window.cameraDevice.acquireFrames(1).get_result()[0]
         points = np.random.random((20, 3))
         points[:, 2] *= 20e-6
         points[:, 1] *= frame.shape[0]
@@ -158,10 +158,10 @@ class CellDetector:
         """Handles results from _detectNeuronsZStack or _testUI."""
         win = self._window
         try:
-            if future.wasInterrupted():
+            if future.was_interrupted:
                 logger.info("Cell detection failed.")
                 return
-            neurons = future.getResult()
+            neurons = future.get_result()
 
             logger.info(f"Cell detection complete. Found {len(neurons)} potential cells")
             self._displayBoundingBoxes(neurons)

--- a/acq4/modules/AutomationDebug/feature_tracking.py
+++ b/acq4/modules/AutomationDebug/feature_tracking.py
@@ -21,7 +21,7 @@ class FeatureTracker:
         self._window = window
 
     @future_wrap
-    def doPipetteCalibrationTest(self, _future):
+    def doPipetteCalibrationTest(self, name=None, _future=None):
         win = self._window
         win.sigWorking.emit(win.ui.testPipetteBtn)
         camera = win.cameraDevice
@@ -32,7 +32,7 @@ class FeatureTracker:
         pipette.moveTo("home", "fast")
         while True:
             try:
-                _future.waitFor(findNewPipette(pipette, camera, camera.scopeDev))
+                findNewPipette(pipette, camera, camera.scopeDev)
                 error = np.linalg.norm(pipette.globalPosition() - true_tip_position)
                 win.sigLogMessage.emit(
                     f"Calibration complete: {error * 1e6:.2g}µm error"
@@ -48,7 +48,7 @@ class FeatureTracker:
                 break
 
     @future_wrap
-    def doFeatureTracking(self, _future: Future):
+    def doFeatureTracking(self, name=None, _future: Future = None):
         win = self._window
         win.sigWorking.emit(win.ui.trackFeaturesBtn)
         pipette = win.pipetteDevice

--- a/acq4/modules/AutomationDebug/feature_tracking.py
+++ b/acq4/modules/AutomationDebug/feature_tracking.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from acq4.devices.Pipette.calibration import findNewPipette
 from acq4.logging_config import get_logger
-from acq4.util.future import Future, future_wrap
+from acq4.util.future import Future, Stopped, sleep
 from acq4_automation.feature_tracking.cell import Cell
 from coorx import Point
 
@@ -20,8 +20,7 @@ class FeatureTracker:
     def __init__(self, window: AutomationDebugWindow):
         self._window = window
 
-    @future_wrap
-    def doPipetteCalibrationTest(self, name=None, _future=None):
+    def doPipetteCalibrationTest(self):
         win = self._window
         win.sigWorking.emit(win.ui.testPipetteBtn)
         camera = win.cameraDevice
@@ -43,24 +42,23 @@ class FeatureTracker:
                     win.sigLogMessage.emit(
                         f'....so bad. Why? Check man.getModule("AutomationDebug").failedCalibrations[{i}]'
                     )
-            except Future.Stopped:
+            except Stopped:
                 win.sigLogMessage.emit("Calibration interrupted by user request")
                 break
 
-    @future_wrap
-    def doFeatureTracking(self, name=None, _future: Future = None):
+    def doFeatureTracking(self):
         win = self._window
         win.sigWorking.emit(win.ui.trackFeaturesBtn)
         pipette = win.pipetteDevice
         target = Point(pipette.targetPosition(), "global")
         cell = win._cell = Cell(target)
-        _future.waitFor(cell.initializeTracker(win.cameraDevice))
+        cell.initializeTracker(win.cameraDevice).wait()
         cell.enableTracking()
         cell.sigPositionChanged.connect(self._updatePipetteTarget)
         win.sigWorking.emit(win.ui.trackFeaturesBtn)
         try:
             while cell.isTracking():
-                _future.sleep(1)
+                sleep(1)
         except Exception:
             cell.enableTracking(False)
             cell.sigPositionChanged.disconnect(self._updatePipetteTarget)

--- a/acq4/modules/AutomationDebug/mock_data.py
+++ b/acq4/modules/AutomationDebug/mock_data.py
@@ -128,7 +128,7 @@ class MockDataHandler:
         step_z = 1 * µm
 
         with win.cameraDevice.ensureRunning():
-            base_frame = win.cameraDevice.acquireFrames(1).wait().getResult()[0]
+            base_frame = win.cameraDevice.acquireFrames(1).getResult()[0]
 
         # Load detection stack
         detection_mock_path = win.ui.mockFilePath.text()

--- a/acq4/modules/AutomationDebug/mock_data.py
+++ b/acq4/modules/AutomationDebug/mock_data.py
@@ -8,7 +8,6 @@ from MetaArray import MetaArray
 
 from acq4.logging_config import get_logger
 from acq4.util import Qt
-from acq4.util.future import Future
 from acq4.util.imaging import Frame
 from coorx import AffineTransform, SRT3DTransform
 from pyqtgraph.units import µm, m
@@ -42,7 +41,7 @@ class MockDataHandler:
             self._window.ui.mockClassificationFilePath.setText(filePath)
 
     def _create_mock_stack_from_file(
-        self, mock_file_path: str, base_frame: Frame, _future: Future
+        self, mock_file_path: str, base_frame: Frame
     ) -> tuple[list[Frame] | None, float | None]:
         """
         Loads a MetaArray file and converts it into a list of Frame objects.
@@ -118,7 +117,7 @@ class MockDataHandler:
             return None, None
 
     def _mockNeuronStacks(
-        self, _future: Future
+        self,
     ) -> tuple[list[Frame] | None, list[Frame] | None, float]:
         win = self._window
         logger.info("Using mock Z-stack file(s) for detection.")
@@ -129,15 +128,13 @@ class MockDataHandler:
         step_z = 1 * µm
 
         with win.cameraDevice.ensureRunning():
-            base_frame = _future.waitFor(
-                win.cameraDevice.acquireFrames(1)
-            ).getResult()[0]
+            base_frame = win.cameraDevice.acquireFrames(1).wait().getResult()[0]
 
         # Load detection stack
         detection_mock_path = win.ui.mockFilePath.text()
         if detection_mock_path:
             detection_stack, det_step_z = self._create_mock_stack_from_file(
-                detection_mock_path, base_frame, _future
+                detection_mock_path, base_frame
             )
             if det_step_z is not None:
                 step_z = det_step_z
@@ -150,12 +147,11 @@ class MockDataHandler:
         if win.ui.multiChannelEnableCheck.isChecked() and win.ui.mockCheckBox.isChecked():
             classification_mock_path = win.ui.mockClassificationFilePath.text()
             if classification_mock_path:
-                # The base_frame and _future are passed again.
                 # The step_z from the classification mock file will be returned by _create_mock_stack_from_file.
                 # We prioritize step_z from the detection stack if both are loaded.
                 # Or, one could enforce consistency or average, but for now, just log if different.
                 classification_stack, class_step_z = self._create_mock_stack_from_file(
-                    classification_mock_path, base_frame, _future
+                    classification_mock_path, base_frame
                 )
                 if (
                     class_step_z is not None

--- a/acq4/modules/AutomationDebug/mock_data.py
+++ b/acq4/modules/AutomationDebug/mock_data.py
@@ -128,7 +128,7 @@ class MockDataHandler:
         step_z = 1 * µm
 
         with win.cameraDevice.ensureRunning():
-            base_frame = win.cameraDevice.acquireFrames(1).getResult()[0]
+            base_frame = win.cameraDevice.acquireFrames(1).get_result()[0]
 
         # Load detection stack
         detection_mock_path = win.ui.mockFilePath.text()

--- a/acq4/modules/CameraCalibrator.py
+++ b/acq4/modules/CameraCalibrator.py
@@ -123,7 +123,7 @@ class CameraCalibrator(Module):
                 frameAcquisition.stop()
                 
                 # Get the acquired frames
-                frames = frameAcquisition.getResult()
+                frames = frameAcquisition.get_result()
             
             return {'frames': frames, 'activationTime': activationTime}
             
@@ -143,7 +143,7 @@ class CameraCalibrator(Module):
         self.calibrateBtn.setText("Calibrate Latency")
         
         try:
-            result = future.getResult()
+            result = future.get_result()
             self._displayFrames(result['frames'], result['activationTime'])
             
         except Exception as e:

--- a/acq4/modules/CameraCalibrator.py
+++ b/acq4/modules/CameraCalibrator.py
@@ -9,7 +9,7 @@ import pyqtgraph as pg
 from acq4.modules.Module import Module
 from acq4.util import Qt
 from acq4.util.InterfaceCombo import InterfaceCombo
-from acq4.util.future import future_wrap
+from acq4.util.future import Future
 
 
 class CameraCalibrator(Module):
@@ -99,11 +99,10 @@ class CameraCalibrator(Module):
         self.calibrateBtn.setText("Calibrating...")
         
         # Start the threaded calibration
-        future = self._runCalibration(camera, lightSource, sourceName, _sync="async")
+        future = Future(self._runCalibration, (camera, lightSource, sourceName))
         future.sigFinished.connect(self._calibrationFinished)
         
-    @future_wrap
-    def _runCalibration(self, camera, lightSource, sourceName, name=None, _future=None):
+    def _runCalibration(self, camera, lightSource, sourceName):
         """Run the calibration sequence in a thread."""
         
         try:

--- a/acq4/modules/CameraCalibrator.py
+++ b/acq4/modules/CameraCalibrator.py
@@ -99,11 +99,11 @@ class CameraCalibrator(Module):
         self.calibrateBtn.setText("Calibrating...")
         
         # Start the threaded calibration
-        future = self._runCalibration(camera, lightSource, sourceName)
+        future = self._runCalibration(camera, lightSource, sourceName, _sync="async")
         future.sigFinished.connect(self._calibrationFinished)
         
     @future_wrap
-    def _runCalibration(self, camera, lightSource, sourceName, _future=None):
+    def _runCalibration(self, camera, lightSource, sourceName, name=None, _future=None):
         """Run the calibration sequence in a thread."""
         
         try:

--- a/acq4/modules/MultiPatch/multipatch.py
+++ b/acq4/modules/MultiPatch/multipatch.py
@@ -397,10 +397,10 @@ class MultiPatchWindow(Qt.QWidget):
         spos = pip.scopeDevice().globalPosition()
         pos = [pos.x(), pos.y(), spos[2]]
         tip_future = Future(pip.setTipOffsetIfAcceptable, (pos,))
-        tip_future.onFinish(self._handleManualSetTip, pip, inGui=True)
+        tip_future.on_finish(self._handleManualSetTip, pip, inGui=True)
 
     def _handleManualSetTip(self, future, pip):
-        success = future.getResult()
+        success = future.get_result()
         if not success:
             self._pipsToSetTips.insert(0, pip)
             return
@@ -410,7 +410,7 @@ class MultiPatchWindow(Qt.QWidget):
                 pip.saveManualTipPosition,
                 (),
                 dict(stack=self.module.config.get("useStacksForSavedTipImages", True)),
-            ).raiseErrors("Failed to save tip images")
+            ).raise_errors("Failed to save tip images")
 
         if len(self._pipsToSetTips) == 0:
             self.ui.setTipBtn.setChecked(False)

--- a/acq4/modules/MultiPatch/multipatch.py
+++ b/acq4/modules/MultiPatch/multipatch.py
@@ -16,7 +16,7 @@ from neuroanalysis.test_pulse_stack import H5BackedTestPulseStack
 from .mockPatch import MockPatch
 from .pipetteControl import PipetteControl
 from ...devices.PatchPipette.statemanager import PatchPipetteStateManager
-from ...util.future import MultiFuture, future_wrap
+from ...util.future import MultiFuture, Future
 from ...util.json_encoder import ACQ4JSONEncoder
 
 Ui_MultiPatch = Qt.importTemplate('.multipatchTemplate')
@@ -130,7 +130,7 @@ class MultiPatchWindow(Qt.QWidget):
         self.ui.coarseSearchBtn.setOpts(future_producer=self._coarseSearch, **common_opts)
         self.ui.fineSearchBtn.setOpts(future_producer=self._fineSearch, **common_opts)
         self.ui.aboveTargetBtn.setOpts(future_producer=self._aboveTarget, **common_opts)
-        self.ui.autoFindTipBtn.setOpts(future_producer=lambda: self._autoFindTip(_sync="async"), **common_opts)
+        self.ui.autoFindTipBtn.setOpts(future_producer=lambda: Future(self._autoFindTip), **common_opts)
         self.ui.cellDetectBtn.setOpts(future_producer=self._cellDetect, raiseOnError=False, **common_opts)
         self.ui.breakInBtn.setOpts(future_producer=self._breakIn, raiseOnError=False, **common_opts)
         self.ui.toTargetBtn.setOpts(future_producer=self._toTarget, **common_opts)
@@ -286,8 +286,7 @@ class MultiPatchWindow(Qt.QWidget):
             futures.append(pip.pipetteDevice.goAboveTarget(speed))
         return MultiFuture(futures, name="Move pipettes above target")
 
-    @future_wrap
-    def _autoFindTip(self, max_reps=10, name=None, _future=None):
+    def _autoFindTip(self, max_reps=10):
         work_to_do = self.selectedPipettes()
         while work_to_do:
             patchpip = work_to_do.pop(0)
@@ -397,7 +396,7 @@ class MultiPatchWindow(Qt.QWidget):
         pos = self._cammod.window().getView().mapSceneToView(ev.scenePos())
         spos = pip.scopeDevice().globalPosition()
         pos = [pos.x(), pos.y(), spos[2]]
-        tip_future = pip.setTipOffsetIfAcceptable(pos, _sync="async")
+        tip_future = Future(pip.setTipOffsetIfAcceptable, (pos,))
         tip_future.onFinish(self._handleManualSetTip, pip, inGui=True)
 
     def _handleManualSetTip(self, future, pip):
@@ -407,9 +406,10 @@ class MultiPatchWindow(Qt.QWidget):
             return
 
         if self._shouldSaveTipImages:
-            pip.saveManualTipPosition(
-                stack=self.module.config.get("useStacksForSavedTipImages", True),
-                _sync="async",
+            Future(
+                pip.saveManualTipPosition,
+                (),
+                dict(stack=self.module.config.get("useStacksForSavedTipImages", True)),
             ).raiseErrors("Failed to save tip images")
 
         if len(self._pipsToSetTips) == 0:

--- a/acq4/modules/MultiPatch/multipatch.py
+++ b/acq4/modules/MultiPatch/multipatch.py
@@ -125,21 +125,21 @@ class MultiPatchWindow(Qt.QWidget):
 
         common_opts = dict(stoppable=True, failure="FAILED!", showStatus=False)
 
-        self.ui.homeBtn.setOpts(future_producer=self._moveHome, **common_opts)
-        self.ui.nucleusHomeBtn.setOpts(future_producer=self._nucleusHome, raiseOnError=False, **common_opts)
-        self.ui.coarseSearchBtn.setOpts(future_producer=self._coarseSearch, **common_opts)
-        self.ui.fineSearchBtn.setOpts(future_producer=self._fineSearch, **common_opts)
-        self.ui.aboveTargetBtn.setOpts(future_producer=self._aboveTarget, **common_opts)
-        self.ui.autoFindTipBtn.setOpts(future_producer=lambda: Future(self._autoFindTip), **common_opts)
-        self.ui.cellDetectBtn.setOpts(future_producer=self._cellDetect, raiseOnError=False, **common_opts)
-        self.ui.breakInBtn.setOpts(future_producer=self._breakIn, raiseOnError=False, **common_opts)
-        self.ui.toTargetBtn.setOpts(future_producer=self._toTarget, **common_opts)
-        self.ui.sealBtn.setOpts(future_producer=self._seal, raiseOnError=False, **common_opts)
-        self.ui.reSealBtn.setOpts(future_producer=self._reSeal, raiseOnError=False, **common_opts)
-        self.ui.reSealNoNuzzleBtn.setOpts(future_producer=self._reSealNoNuzzle, raiseOnError=False, **common_opts)
-        self.ui.approachBtn.setOpts(future_producer=self._approach, raiseOnError=False, **common_opts)
-        self.ui.cleanBtn.setOpts(future_producer=self._clean, raiseOnError=False, **common_opts)
-        self.ui.collectBtn.setOpts(future_producer=self._collect, raiseOnError=False, **common_opts)
+        self.ui.homeBtn.setOpts(fn=self._moveHome, **common_opts)
+        self.ui.nucleusHomeBtn.setOpts(fn=self._nucleusHome, raiseOnError=False, **common_opts)
+        self.ui.coarseSearchBtn.setOpts(fn=self._coarseSearch, **common_opts)
+        self.ui.fineSearchBtn.setOpts(fn=self._fineSearch, **common_opts)
+        self.ui.aboveTargetBtn.setOpts(fn=self._aboveTarget, **common_opts)
+        self.ui.autoFindTipBtn.setOpts(fn=self._autoFindTip, **common_opts)
+        self.ui.cellDetectBtn.setOpts(fn=self._cellDetect, raiseOnError=False, **common_opts)
+        self.ui.breakInBtn.setOpts(fn=self._breakIn, raiseOnError=False, **common_opts)
+        self.ui.toTargetBtn.setOpts(fn=self._toTarget, **common_opts)
+        self.ui.sealBtn.setOpts(fn=self._seal, raiseOnError=False, **common_opts)
+        self.ui.reSealBtn.setOpts(fn=self._reSeal, raiseOnError=False, **common_opts)
+        self.ui.reSealNoNuzzleBtn.setOpts(fn=self._reSealNoNuzzle, raiseOnError=False, **common_opts)
+        self.ui.approachBtn.setOpts(fn=self._approach, raiseOnError=False, **common_opts)
+        self.ui.cleanBtn.setOpts(fn=self._clean, raiseOnError=False, **common_opts)
+        self.ui.collectBtn.setOpts(fn=self._collect, raiseOnError=False, **common_opts)
 
         self.ui.profileCombo.currentIndexChanged.connect(self.profileComboChanged)
         self.ui.editProfileBtn.clicked.connect(self.openProfileEditor)
@@ -249,11 +249,11 @@ class MultiPatchWindow(Qt.QWidget):
         self.saveConfig()
 
     def _setAllSelectedPipettesToState(self, state, **config):
-        return MultiFuture([
+        MultiFuture([
             pip.setState(state, **config)
             for pip in self.selectedPipettes()
             if isinstance(pip, PatchPipette)
-        ], name=f"Set pipettes state to {state}")
+        ], name=f"Set pipettes state to {state}").wait()
 
     def _moveHome(self):
         futures = []
@@ -263,20 +263,20 @@ class MultiPatchWindow(Qt.QWidget):
                 pip.setState('out')
                 pip = pip.pipetteDevice
             futures.append(pip.goHome(speed))
-        return MultiFuture(futures, name="Move pipettes home")
+        MultiFuture(futures, name="Move pipettes home").wait()
 
     def _nucleusHome(self):
-        return self._setAllSelectedPipettesToState('home with nucleus')
+        self._setAllSelectedPipettesToState('home with nucleus')
 
     def _coarseSearch(self):
-        return self.moveSearch(self.module.config.get('coarseSearchDistance', 400e-6))
+        self.moveSearch(self.module.config.get('coarseSearchDistance', 400e-6))
 
     def _fineSearch(self):
         if len(self.selectedPipettes()) == 1:
             distance = 0
         else:
             distance = self.module.config.get('fineSearchDistance', 50e-6)
-        return self.moveSearch(distance)
+        self.moveSearch(distance)
 
     def _aboveTarget(self):
         futures = []
@@ -284,7 +284,7 @@ class MultiPatchWindow(Qt.QWidget):
         for pip in self.selectedPipettes():
             pip.setState('bath')
             futures.append(pip.pipetteDevice.goAboveTarget(speed))
-        return MultiFuture(futures, name="Move pipettes above target")
+        MultiFuture(futures, name="Move pipettes above target").wait()
 
     def _autoFindTip(self, max_reps=10):
         work_to_do = self.selectedPipettes()
@@ -294,28 +294,28 @@ class MultiPatchWindow(Qt.QWidget):
             pip.iterativelyFindTip(max_reps=max_reps)
 
     def _cellDetect(self):
-        return self._setAllSelectedPipettesToState('cell detect')
+        self._setAllSelectedPipettesToState('cell detect')
 
     def _breakIn(self):
-        return self._setAllSelectedPipettesToState('break in')
+        self._setAllSelectedPipettesToState('break in')
 
     def _toTarget(self):
         speed = self.selectedSpeed(default='fast')
-        return MultiFuture([
+        MultiFuture([
             (
                 pip.pipetteDevice if isinstance(pip, PatchPipette) else pip
             ).goTarget(speed)
             for pip in self.selectedPipettes()
-        ], name="Move pipettes to target")
+        ], name="Move pipettes to target").wait()
 
     def _seal(self):
-        return self._setAllSelectedPipettesToState('seal')
+        self._setAllSelectedPipettesToState('seal')
 
     def _reSeal(self):
-        return self._setAllSelectedPipettesToState('reseal')
+        self._setAllSelectedPipettesToState('reseal')
 
     def _reSealNoNuzzle(self):
-        return self._setAllSelectedPipettesToState('reseal', extractNucleus=False)
+        self._setAllSelectedPipettesToState('reseal', extractNucleus=False)
 
     def _approach(self):
         futures = []
@@ -324,13 +324,13 @@ class MultiPatchWindow(Qt.QWidget):
                 futures.append(pip.setState('approach'))
             else:
                 futures.append(pip.goApproach(self.selectedSpeed(default='fast')))
-        return MultiFuture(futures, name="Move pipettes to approach")
+        MultiFuture(futures, name="Move pipettes to approach").wait()
 
     def _clean(self):
-        return self._setAllSelectedPipettesToState('clean')
+        self._setAllSelectedPipettesToState('clean')
 
     def _collect(self):
-        return self._setAllSelectedPipettesToState('collect')
+        self._setAllSelectedPipettesToState('collect')
 
     def selectedSpeed(self, default):
         if self.ui.fastBtn.isChecked():
@@ -351,7 +351,7 @@ class MultiPatchWindow(Qt.QWidget):
                 pip.setState('bath')
                 pip = pip.pipetteDevice
             futures.append(pip.goSearch(speed, distance=distance))
-        return MultiFuture(futures, name="Move pipettes to search")
+        MultiFuture(futures, name="Move pipettes to search").wait()
 
     def setTipToggled(self, b):
         cammod = getManager().getModule('Camera')

--- a/acq4/modules/MultiPatch/multipatch.py
+++ b/acq4/modules/MultiPatch/multipatch.py
@@ -130,7 +130,7 @@ class MultiPatchWindow(Qt.QWidget):
         self.ui.coarseSearchBtn.setOpts(future_producer=self._coarseSearch, **common_opts)
         self.ui.fineSearchBtn.setOpts(future_producer=self._fineSearch, **common_opts)
         self.ui.aboveTargetBtn.setOpts(future_producer=self._aboveTarget, **common_opts)
-        self.ui.autoFindTipBtn.setOpts(future_producer=self._autoFindTip, **common_opts)
+        self.ui.autoFindTipBtn.setOpts(future_producer=lambda: self._autoFindTip(_sync="async"), **common_opts)
         self.ui.cellDetectBtn.setOpts(future_producer=self._cellDetect, raiseOnError=False, **common_opts)
         self.ui.breakInBtn.setOpts(future_producer=self._breakIn, raiseOnError=False, **common_opts)
         self.ui.toTargetBtn.setOpts(future_producer=self._toTarget, **common_opts)
@@ -287,12 +287,12 @@ class MultiPatchWindow(Qt.QWidget):
         return MultiFuture(futures, name="Move pipettes above target")
 
     @future_wrap
-    def _autoFindTip(self, max_reps=10, _future=None):
+    def _autoFindTip(self, max_reps=10, name=None, _future=None):
         work_to_do = self.selectedPipettes()
         while work_to_do:
             patchpip = work_to_do.pop(0)
             pip = patchpip.pipetteDevice if isinstance(patchpip, PatchPipette) else patchpip
-            _future.waitFor(pip.iterativelyFindTip(max_reps=max_reps), timeout=None)
+            pip.iterativelyFindTip(max_reps=max_reps)
 
     def _cellDetect(self):
         return self._setAllSelectedPipettesToState('cell detect')
@@ -397,7 +397,7 @@ class MultiPatchWindow(Qt.QWidget):
         pos = self._cammod.window().getView().mapSceneToView(ev.scenePos())
         spos = pip.scopeDevice().globalPosition()
         pos = [pos.x(), pos.y(), spos[2]]
-        tip_future = pip.setTipOffsetIfAcceptable(pos)
+        tip_future = pip.setTipOffsetIfAcceptable(pos, _sync="async")
         tip_future.onFinish(self._handleManualSetTip, pip, inGui=True)
 
     def _handleManualSetTip(self, future, pip):
@@ -408,7 +408,8 @@ class MultiPatchWindow(Qt.QWidget):
 
         if self._shouldSaveTipImages:
             pip.saveManualTipPosition(
-                stack=self.module.config.get("useStacksForSavedTipImages", True)
+                stack=self.module.config.get("useStacksForSavedTipImages", True),
+                _sync="async",
             ).raiseErrors("Failed to save tip images")
 
         if len(self._pipsToSetTips) == 0:

--- a/acq4/modules/MultiPatch/pipetteControl.py
+++ b/acq4/modules/MultiPatch/pipetteControl.py
@@ -107,8 +107,8 @@ class PipetteControl(Qt.QWidget):
         self.ui.icHoldingSpin.valueChanged.connect(self.icHoldingSpinChanged)
         self.ui.autoBiasTargetSpin.valueChanged.connect(self.autoBiasSpinChanged)
 
-        self.ui.newPipetteBtn.setOpts(future_producer=self.newPipetteClicked, stoppable=True)
-        self.ui.cancelBtn.setOpts(future_producer=lambda: Future(self._cancelClicked))
+        self.ui.newPipetteBtn.setOpts(fn=self.newPipetteClicked, stoppable=True)
+        self.ui.cancelBtn.setOpts(fn=self._cancelClicked)
         self.ui.fouledCheck.stateChanged.connect(self.fouledCheckChanged)
         self.ui.brokenCheck.stateChanged.connect(self.brokenCheckChanged)
 
@@ -353,7 +353,7 @@ class PipetteControl(Qt.QWidget):
 
     def newPipetteClicked(self):
         self.ui.newPipetteBtn.setStyleSheet("")
-        return self.pip.newPipette()
+        self.pip.newPipette().wait()
 
     def _cancelClicked(self):
         self.pip.getState().stop("user requested cancel", wait=True)

--- a/acq4/modules/MultiPatch/pipetteControl.py
+++ b/acq4/modules/MultiPatch/pipetteControl.py
@@ -9,7 +9,7 @@ from acq4.util.ui.pipetteEventLog import PipetteEventLog
 from neuroanalysis.data import TSeries
 from neuroanalysis.test_pulse import PatchClampTestPulse
 
-from acq4.util.future import future_wrap
+from acq4.util.future import Future
 
 Ui_PipetteControl = Qt.importTemplate('.pipetteTemplate')
 
@@ -108,7 +108,7 @@ class PipetteControl(Qt.QWidget):
         self.ui.autoBiasTargetSpin.valueChanged.connect(self.autoBiasSpinChanged)
 
         self.ui.newPipetteBtn.setOpts(future_producer=self.newPipetteClicked, stoppable=True)
-        self.ui.cancelBtn.setOpts(future_producer=lambda: self._cancelClicked(_sync="async"))
+        self.ui.cancelBtn.setOpts(future_producer=lambda: Future(self._cancelClicked))
         self.ui.fouledCheck.stateChanged.connect(self.fouledCheckChanged)
         self.ui.brokenCheck.stateChanged.connect(self.brokenCheckChanged)
 
@@ -355,8 +355,7 @@ class PipetteControl(Qt.QWidget):
         self.ui.newPipetteBtn.setStyleSheet("")
         return self.pip.newPipette()
 
-    @future_wrap
-    def _cancelClicked(self, name=None, _future=None):
+    def _cancelClicked(self):
         self.pip.getState().stop("user requested cancel", wait=True)
 
     def tipCleanChanged(self, pip, clean):

--- a/acq4/modules/MultiPatch/pipetteControl.py
+++ b/acq4/modules/MultiPatch/pipetteControl.py
@@ -108,7 +108,7 @@ class PipetteControl(Qt.QWidget):
         self.ui.autoBiasTargetSpin.valueChanged.connect(self.autoBiasSpinChanged)
 
         self.ui.newPipetteBtn.setOpts(future_producer=self.newPipetteClicked, stoppable=True)
-        self.ui.cancelBtn.setOpts(future_producer=self._cancelClicked)
+        self.ui.cancelBtn.setOpts(future_producer=lambda: self._cancelClicked(_sync="async"))
         self.ui.fouledCheck.stateChanged.connect(self.fouledCheckChanged)
         self.ui.brokenCheck.stateChanged.connect(self.brokenCheckChanged)
 
@@ -356,7 +356,7 @@ class PipetteControl(Qt.QWidget):
         return self.pip.newPipette()
 
     @future_wrap
-    def _cancelClicked(self, _future):
+    def _cancelClicked(self, name=None, _future=None):
         self.pip.getState().stop("user requested cancel", wait=True)
 
     def tipCleanChanged(self, pip, clean):

--- a/acq4/modules/Visualize3D/travelers_proxy.py
+++ b/acq4/modules/Visualize3D/travelers_proxy.py
@@ -65,7 +65,7 @@ class VisualizePathSearch(Qt.QObject):
         self._previousPath.setData(pos=[])
 
     @future_wrap
-    def startPath(self, path, bounds, _future):
+    def startPath(self, path, bounds, name=None, _future=None):
         # TODO this is going to break with bitrot
         if self._bounds is None:
             self._bounds = self._adapter.createBounds(bounds, False)
@@ -133,7 +133,7 @@ class VisualizePathSearch(Qt.QObject):
         self._activePath.setData(pos=np.array(path + path[:-1][::-1]))  # it needs to walk back to the origin
 
     @future_wrap
-    def addObstacle(self, name, obstacle, to_global, _future):
+    def addObstacle(self, name, obstacle, to_global, _future=None):
         if name not in self._obstacles:
             self._buildObstacleMesh(name, *obstacle.surface_mesh)
         cs_name = obstacle.transform.systems[0].name

--- a/acq4/modules/Visualize3D/travelers_proxy.py
+++ b/acq4/modules/Visualize3D/travelers_proxy.py
@@ -5,7 +5,6 @@ from threading import Thread
 import numpy as np
 
 from acq4.util import Qt
-from acq4.util.future import future_wrap
 from acq4.util.threadrun import inGuiThread, runInGuiThread
 from coorx import TTransform
 from pyqtgraph import opengl as gl
@@ -64,8 +63,7 @@ class VisualizePathSearch(Qt.QObject):
         self._previousPath.setVisible(False)
         self._previousPath.setData(pos=[])
 
-    @future_wrap
-    def startPath(self, path, bounds, name=None, _future=None):
+    def startPath(self, path, bounds):
         # TODO this is going to break with bitrot
         if self._bounds is None:
             self._bounds = self._adapter.createBounds(bounds, False)
@@ -132,8 +130,7 @@ class VisualizePathSearch(Qt.QObject):
         self._previousPath.setData(pos=prev)
         self._activePath.setData(pos=np.array(path + path[:-1][::-1]))  # it needs to walk back to the origin
 
-    @future_wrap
-    def addObstacle(self, name, obstacle, to_global, _future=None):
+    def addObstacle(self, name, obstacle, to_global):
         if name not in self._obstacles:
             self._buildObstacleMesh(name, *obstacle.surface_mesh)
         cs_name = obstacle.transform.systems[0].name

--- a/acq4/util/PromptUser.py
+++ b/acq4/util/PromptUser.py
@@ -6,7 +6,7 @@ from acq4.util.threadrun import runInGuiThread
 
 
 @future_wrap
-def prompt(title, text, choices, extra_text=None, parent=None, _future=None):
+def prompt(title, text, choices, extra_text=None, parent=None, name=None, _future=None):
     """
     Prompt the user with a choice.
 

--- a/acq4/util/PromptUser.py
+++ b/acq4/util/PromptUser.py
@@ -1,12 +1,11 @@
 from threading import Event
 
 from acq4.util import Qt
-from acq4.util.future import future_wrap
+from acq4.util.future import sleep
 from acq4.util.threadrun import runInGuiThread
 
 
-@future_wrap
-def prompt(title, text, choices, extra_text=None, parent=None, name=None, _future=None):
+def prompt(title, text, choices, extra_text=None, parent=None):
     """
     Prompt the user with a choice.
 
@@ -24,7 +23,7 @@ def prompt(title, text, choices, extra_text=None, parent=None, name=None, _futur
     msg_box = runInGuiThread(_make_message_box, title, text, choices, extra_text, parent, is_done)
 
     while not is_done.is_set():
-        _future.sleep(0.1)
+        sleep(0.1)
     return msg_box.clickedButton().text()
 
 

--- a/acq4/util/future.py
+++ b/acq4/util/future.py
@@ -17,9 +17,14 @@ from acq4.util import Qt, ptime
 from pyqtgraph import FeedbackButton
 
 # ContextVar tracking the innermost running Future on the current thread.
-current_future: contextvars.ContextVar["Future | None"] = contextvars.ContextVar(
+_current_future_var: contextvars.ContextVar["Future | None"] = contextvars.ContextVar(
     "current_future", default=None
 )
+
+
+def current_future() -> "Future | None":
+    """Return the Future currently executing on this thread, or None."""
+    return _current_future_var.get()
 
 
 class TaskStack:
@@ -81,7 +86,7 @@ class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
     class Stopped(Exception):
         """Raised by futures that were politely stopped."""
 
-    class Timeout(Exception):
+    class Timeout(TimeoutError):
         """Raised by wait() if the timeout period elapses."""
 
     @classmethod
@@ -103,7 +108,8 @@ class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
             frame = frame.f_back  # walk up the stack
         return f"(unnamed from {frame.f_code.co_filename}:{frame.f_lineno})"
 
-    def __init__(self, onError=None, name=None, logLevel='debug'):
+    def __init__(self, fn=None, args=(), kwargs=None, *, onError=None, name=None, logLevel='debug',
+                 detach=False, on_finish=None):
         Qt.QObject.__init__(self)
 
         self.startTime = ptime.time()
@@ -130,6 +136,73 @@ class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
         self._creationThread = threading.current_thread()
 
         self.log(f"Future [{self._name}] created")
+
+        # v2-style: fn provided → auto-start, register with parent, wire finish callback
+        if fn is not None:
+            if name is None:
+                self._name = getattr(fn, '__qualname__', repr(fn))
+            if on_finish is not None:
+                self.add_finish_callback(on_finish)
+            parent = current_future()
+            if parent is not None and not detach:
+                parent._stopsToPropagate.append(self)
+            self._executeInThread_v2(fn, tuple(args), dict(kwargs or {}))
+
+    # -- v2 API surface -------------------------------------------------------
+
+    @property
+    def is_done(self) -> bool:
+        return self._isDone
+
+    @property
+    def is_stopped(self) -> bool:
+        return self._stopRequested
+
+    @property
+    def _done(self) -> threading.Event:
+        """v2 compat: threading.Event that is set when the future finishes."""
+        return self.finishedEvent
+
+    def add_finish_callback(self, fn) -> None:
+        """Call fn(result, exception) when done. Calls immediately if already done."""
+        def _wrap(future):
+            exc = future.exceptionRaised()
+            result = future._returnVal
+            fn(result, exc)
+        self.onFinish(_wrap)
+
+    def detach(self) -> None:
+        """Detach from the parent future — parent stop will no longer cascade here."""
+        parent = current_future()
+        if parent is not None and self in parent._stopsToPropagate:
+            parent._stopsToPropagate.remove(self)
+
+    def _executeInThread_v2(self, func, args, kwargs):
+        """Start func in a thread without injecting _future into kwargs."""
+        ctx = contextvars.copy_context()
+        self._executingThread = threading.Thread(
+            target=ctx.run,
+            args=(self._executeAndSetReturn_v2, func, args, kwargs),
+            daemon=True,
+            name=f"execute thread for {repr(self)}",
+        )
+        self._executingThread.start()
+
+    def _executeAndSetReturn_v2(self, func, args, kwargs):
+        cf_token = _current_future_var.set(self)
+        with task_stack.push(self._name):
+            try:
+                self.setResult(rval=func(*args, **kwargs))
+            except Stopped:
+                self._stopRequested = True
+                self.setResult(error="stopped", interrupted=True)
+            except Exception:
+                self.setResult(excInfo=sys.exc_info())
+            finally:
+                _current_future_var.reset(cf_token)
+                self._do_task_completion_jobs()
+
+    # -------------------------------------------------------------------------
 
     def log(self, message):
         if self.logLevel is not None:
@@ -164,7 +237,7 @@ class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
         self._executingThread.start()
 
     def executeAndSetReturn(self, func, args, kwds):
-        cf_token = current_future.set(self)
+        cf_token = _current_future_var.set(self)
         with task_stack.push(self._name):
             try:
                 kwds["_future"] = self
@@ -172,7 +245,7 @@ class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
             except Exception:
                 self.setResult(excInfo=sys.exc_info())
             finally:
-                current_future.reset(cf_token)
+                _current_future_var.reset(cf_token)
                 self._do_task_completion_jobs()
 
     def propagateStopsInto(self, future: Future):
@@ -388,6 +461,8 @@ class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
                 raise RuntimeError(msg) from self.enhanceException(original_exc)
             raise RuntimeError(msg)
 
+        return self._returnVal
+
     def enhanceException(self, exc):
         """Wrap an exception with Future creation stack and execution context in its str()."""
         creation_frames = "".join(traceback.format_list(self._creationStack))
@@ -496,6 +571,133 @@ class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
                 formattedMsg = f"{message} [additional error formatting error message: {exc2}]"
             raise RuntimeError(formattedMsg) from exc
 
+
+# ---------------------------------------------------------------------------
+# v2 module-level primitives
+# ---------------------------------------------------------------------------
+
+# Module-level Stopped alias — matches Future.Stopped for catch-compatibility.
+Stopped = Future.Stopped
+
+
+def sleep(seconds: float, *, interval: float = 0.05) -> None:
+    """Drop-in replacement for time.sleep. Raises Stopped if the current future is stopped.
+
+    Safe to call outside any future — behaves like time.sleep.
+    """
+    fut = current_future()
+    if fut is None:
+        time.sleep(seconds)
+        return
+    deadline = time.monotonic() + seconds
+    while True:
+        if fut._stopRequested:
+            raise Stopped()
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return
+        time.sleep(min(interval, remaining))
+
+
+def check_stop() -> None:
+    """Raise Stopped if the current future has been stopped. Equivalent to sleep(0).
+
+    Use in tight polling loops where a sleep would be inappropriate.
+    """
+    fut = current_future()
+    if fut is not None and fut._stopRequested:
+        raise Stopped()
+
+
+import queue as _queue
+
+
+class Queue:
+    """Drop-in replacement for queue.Queue with stop-aware get().
+
+    get() raises Stopped if the current future is stopped while waiting.
+    """
+
+    def __init__(self, maxsize: int = 0) -> None:
+        self._q = _queue.Queue(maxsize)
+
+    def put(self, item, block=True, timeout=None):
+        self._q.put(item, block=block, timeout=timeout)
+
+    def put_nowait(self, item):
+        self._q.put_nowait(item)
+
+    def get(self, block=True, timeout=None):
+        fut = current_future()
+        if fut is None or not block:
+            return self._q.get(block=block, timeout=timeout)
+        deadline = None if timeout is None else time.monotonic() + timeout
+        poll = 0.05
+        while True:
+            if fut._stopRequested:
+                raise Stopped()
+            remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+            if remaining == 0.0:
+                raise _queue.Empty()
+            wait_for = poll if remaining is None else min(poll, remaining)
+            try:
+                return self._q.get(timeout=wait_for)
+            except _queue.Empty:
+                if remaining is not None and time.monotonic() >= deadline:
+                    raise
+
+    def get_nowait(self):
+        return self._q.get_nowait()
+
+    def empty(self):
+        return self._q.empty()
+
+    def qsize(self):
+        return self._q.qsize()
+
+    def task_done(self):
+        self._q.task_done()
+
+    def join(self):
+        self._q.join()
+
+
+class Event:
+    """Drop-in replacement for threading.Event with stop-aware wait().
+
+    wait() raises Stopped if the current future is stopped while waiting.
+    """
+
+    def __init__(self) -> None:
+        self._event = threading.Event()
+
+    def set(self):
+        self._event.set()
+
+    def clear(self):
+        self._event.clear()
+
+    def is_set(self):
+        return self._event.is_set()
+
+    def wait(self, timeout=None):
+        fut = current_future()
+        if fut is None:
+            return self._event.wait(timeout=timeout)
+        deadline = None if timeout is None else time.monotonic() + timeout
+        poll = 0.05
+        while True:
+            if fut._stopRequested:
+                raise Stopped()
+            remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+            if remaining == 0.0:
+                return self._event.is_set()
+            wait_for = poll if remaining is None else min(poll, remaining)
+            if self._event.wait(wait_for):
+                return True
+
+
+# ---------------------------------------------------------------------------
 
 WRAPPED_FN_PARAMS = ParamSpec("WRAPPED_FN_PARAMS")
 WRAPPED_FN_RETVAL_TYPE = TypeVar("WRAPPED_FN_RETVAL_TYPE")

--- a/acq4/util/future.py
+++ b/acq4/util/future.py
@@ -4,6 +4,7 @@ import contextlib
 import contextvars
 import functools
 import inspect
+import logging
 import sys
 import threading
 import time
@@ -747,3 +748,68 @@ class FutureButton(FeedbackButton):
         if self._showStatus:
             self.setText(state, temporary=True)
         self.sigStateChanged.emit(future, state)
+
+
+class _TaskStackFilter(logging.Filter):
+    """Injects the current task_stack as a string attribute on each log record."""
+
+    def filter(self, record):
+        record.task_stack = task_stack.full_stack()
+        return True
+
+
+def setup_teleprox_context_propagation():
+    """Wire acq4's task_stack into teleprox RPC calls and log records.
+
+    Registers a call-opts provider so every outgoing call_obj includes the
+    current task_stack, and a call-context hook so every incoming call_obj
+    restores task_stack for the duration of that call.  Also adds a log
+    filter to the process-global LogSender (if one exists) so that log
+    records forwarded to the main process carry the task_stack string.
+
+    Safe to call multiple times; provider/hook registration is idempotent
+    and the filter is only added once.
+    """
+    try:
+        import teleprox.client as tc
+        import teleprox.server as ts
+    except ImportError:
+        return
+
+    def _provide_call_opts():
+        stack = task_stack.get()
+        return {'_acq4_task_stack': stack} if stack else None
+
+    tc.set_call_opts_provider(_provide_call_opts)
+
+    @contextlib.contextmanager
+    def _call_context_hook(opts):
+        stack = opts.get('_acq4_task_stack')
+        if stack:
+            with task_stack.push_full(tuple(stack)):
+                yield
+        else:
+            yield
+
+    ts.set_call_context_hook(_call_context_hook)
+
+    _maybe_add_logsender_filter()
+
+
+def _maybe_add_logsender_filter():
+    """Add _TaskStackFilter to the process LogSender if present and not already added."""
+    try:
+        from teleprox.log.remote import sender
+    except ImportError:
+        return
+    if sender is not None and not any(isinstance(f, _TaskStackFilter) for f in sender.filters):
+        sender.addFilter(_TaskStackFilter())
+
+
+# Auto-setup when this module is imported in any process that has teleprox.
+# Remote processes call this path; the main process also calls setup_teleprox_context_propagation()
+# explicitly from setup_logging() after the log file handler exists.
+try:
+    setup_teleprox_context_propagation()
+except Exception:
+    pass

--- a/acq4/util/future.py
+++ b/acq4/util/future.py
@@ -448,17 +448,14 @@ class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
             err = self.errorMessage()
             original_exc = self.exceptionRaised()
 
-            if err is None:
-                if not self._stopRequested and original_exc is not None:
-                    raise self.enhanceException(original_exc)
-                msg = f"Task {self} did not complete (no extra message)."
-            else:
-                msg = f"Task {self} did not complete: {err}"
-
             if self._stopRequested:
+                msg = f"Task {self} did not complete: {err}" if err else f"Task {self} stopped."
                 raise self.Stopped(msg)
             elif original_exc is not None:
-                raise RuntimeError(msg) from self.enhanceException(original_exc)
+                if self._excInfo is not None:
+                    raise original_exc.with_traceback(self._excInfo[2])
+                raise original_exc
+            msg = f"Task {self} did not complete: {err}" if err else f"Task {self} did not complete."
             raise RuntimeError(msg)
 
         return self._returnVal

--- a/acq4/util/future.py
+++ b/acq4/util/future.py
@@ -9,7 +9,7 @@ import sys
 import threading
 import time
 import traceback
-from typing import Any, Callable, ParamSpec, Optional, overload
+from typing import Any, Callable, Optional
 from typing import Generic, TypeVar
 
 from acq4.logging_config import get_logger
@@ -255,34 +255,6 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
 
     def __repr__(self):
         return f"<{self.__class__.__name__} {self._name}>"
-
-    def executeInThread(self, func, args, kwds):
-        """Execute the specified function in a separate thread.
-
-        The function should call _taskDone() when finished (or raise an exception).
-        """
-        # Capture the caller's full context so the thread inherits task_stack and other
-        # ContextVars. Python's threading.Thread does not copy ContextVars automatically.
-        ctx = contextvars.copy_context()
-        self._executingThread = threading.Thread(
-            target=ctx.run,
-            args=(self.executeAndSetReturn, func, args, kwds),
-            daemon=True,
-            name=f"execute thread for {repr(self)}",
-        )
-        self._executingThread.start()
-
-    def executeAndSetReturn(self, func, args, kwds):
-        cf_token = _current_future_var.set(self)
-        with task_stack.push(self._name):
-            try:
-                kwds["_future"] = self
-                self.setResult(rval=func(*args, **kwds))
-            except Exception:
-                self.setResult(excInfo=sys.exc_info())
-            finally:
-                _current_future_var.reset(cf_token)
-                self._do_task_completion_jobs()
 
     def propagateStopsInto(self, future: Future):
         """Add a future to the list of futures that will be stopped if this future is stopped."""
@@ -727,72 +699,6 @@ class Event:
             wait_for = poll if remaining is None else min(poll, remaining)
             if self._event.wait(wait_for):
                 return True
-
-
-# ---------------------------------------------------------------------------
-
-WRAPPED_FN_PARAMS = ParamSpec("WRAPPED_FN_PARAMS")
-WRAPPED_FN_RETVAL_TYPE = TypeVar("WRAPPED_FN_RETVAL_TYPE")
-
-
-class FutureWrapper:
-    def __init__(self, logLevel='debug'):
-        self.logLevel = logLevel
-
-    @overload
-    def __call__(
-        self,
-        func: Callable[WRAPPED_FN_PARAMS, WRAPPED_FN_RETVAL_TYPE],
-    ) -> Callable[WRAPPED_FN_PARAMS, Future[WRAPPED_FN_RETVAL_TYPE]]:
-        ...
-
-    @overload
-    def __call__(
-        self,
-        func: None = None,
-        *,
-        logLevel: str,
-    ) -> "FutureWrapper":
-        ...
-
-    def __call__(self, func=None, *, logLevel=None):
-        """Decorator to wrap a function so it runs inside a Future with context tracking.
-
-        The function must accept a `_future` keyword argument and may accept a `name` argument.
-        Usage:
-            @future_wrap
-            def myFunc(arg1, arg2, name=None, _future=None):
-                _future.checkStop()
-                ...
-
-            result = myFunc(arg1, arg2)                  # blocks, returns result value
-            fut = myFunc(arg1, arg2, _sync="async")      # returns Future immediately
-            result = fut.getResult()
-        """
-        if logLevel is not None:
-            if func is not None:
-                raise ValueError(f"Cannot have func {func} and logLevel {logLevel}")
-            return FutureWrapper(logLevel)
-
-        @functools.wraps(func)
-        def wrapper(*args: WRAPPED_FN_PARAMS.args, **kwds: WRAPPED_FN_PARAMS.kwargs):
-            name = kwds.get("name") or func.__qualname__
-            future = Future(onError=kwds.pop("onFutureError", None), name=name, logLevel=self.logLevel)
-            _sync = kwds.pop("_sync", None)
-            if _sync == "async":
-                future.executeInThread(func, args, kwds)
-                return future
-            else:
-                # Default: run inline (blocking), return the result value directly.
-                if parent := kwds.pop("checkStopThrough", None):
-                    parent.propagateStopsInto(future)
-                future.executeAndSetReturn(func, args, kwds)
-                return future.getResult()
-
-        return wrapper
-
-
-future_wrap = FutureWrapper()
 
 
 class MultiException(Exception):

--- a/acq4/util/future.py
+++ b/acq4/util/future.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import contextlib
+import contextvars
 import functools
 import inspect
 import sys
@@ -13,6 +14,49 @@ from typing import Generic, TypeVar
 from acq4.logging_config import get_logger
 from acq4.util import Qt, ptime
 from pyqtgraph import FeedbackButton
+
+# ContextVar tracking the innermost running Future on the current thread.
+current_future: contextvars.ContextVar["Future | None"] = contextvars.ContextVar(
+    "current_future", default=None
+)
+
+
+class TaskStack:
+    """Wraps a ContextVar[tuple[str, ...]] to track a chain of named task scopes."""
+
+    def __init__(self):
+        self._var: contextvars.ContextVar[tuple[str, ...]] = contextvars.ContextVar(
+            "task_stack", default=()
+        )
+
+    @contextlib.contextmanager
+    def push(self, name: str):
+        """Context manager that appends *name* to the current chain and restores on exit."""
+        token = self._var.set(self._var.get() + (name,))
+        try:
+            yield
+        finally:
+            self._var.reset(token)
+
+    @contextlib.contextmanager
+    def push_full(self, chain: tuple[str, ...]):
+        """Context manager that replaces the entire stack with *chain* and restores on exit."""
+        token = self._var.set(chain)
+        try:
+            yield
+        finally:
+            self._var.reset(token)
+
+    def get(self) -> tuple[str, ...]:
+        """Return the current task chain."""
+        return self._var.get()
+
+    def full_stack(self) -> str:
+        """Return the current chain joined by ' > ', or '' if empty."""
+        return " > ".join(self._var.get())
+
+
+task_stack = TaskStack()
 
 FUTURE_RETVAL_TYPE = TypeVar("FUTURE_RETVAL_TYPE")
 WAITING_RETVAL_TYPE = TypeVar("WAITING_RETVAL_TYPE")
@@ -107,18 +151,28 @@ class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
 
         The function should call _taskDone() when finished (or raise an exception).
         """
-        self._executingThread = threading.Thread(target=self.executeAndSetReturn, args=(func, args, kwds), daemon=True,
-                                                 name=f"execute thread for {repr(self)}")
+        # Capture the caller's full context so the thread inherits task_stack and other
+        # ContextVars. Python's threading.Thread does not copy ContextVars automatically.
+        ctx = contextvars.copy_context()
+        self._executingThread = threading.Thread(
+            target=ctx.run,
+            args=(self.executeAndSetReturn, func, args, kwds),
+            daemon=True,
+            name=f"execute thread for {repr(self)}",
+        )
         self._executingThread.start()
 
     def executeAndSetReturn(self, func, args, kwds):
-        try:
-            kwds["_future"] = self
-            self.setResult(rval=func(*args, **kwds))
-        except Exception:
-            self.setResult(excInfo=sys.exc_info())
-        finally:
-            self._do_task_completion_jobs()
+        cf_token = current_future.set(self)
+        with task_stack.push(self._name):
+            try:
+                kwds["_future"] = self
+                self.setResult(rval=func(*args, **kwds))
+            except Exception:
+                self.setResult(excInfo=sys.exc_info())
+            finally:
+                current_future.reset(cf_token)
+                self._do_task_completion_jobs()
 
     def propagateStopsInto(self, future: Future):
         """Add a future to the list of futures that will be stopped if this future is stopped."""
@@ -334,9 +388,27 @@ class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
             raise RuntimeError(msg)
 
     def enhanceException(self, exc):
-        exc.future_creation_stack = self._creationStack
-        exc.future_creation_thread = self._creationThread
-        return exc
+        """Wrap an exception with Future creation stack and execution context in its str()."""
+        creation_frames = "".join(traceback.format_list(self._creationStack))
+        parts = [f"{type(exc).__name__}: {exc}"]
+        parts.append(f"\n--- Future creation context ---\n{creation_frames}")
+
+        if self._excInfo is not None and self._excInfo[2] is not None:
+            exec_tb = "".join(traceback.format_tb(self._excInfo[2]))
+            exec_thread = self._executingThread
+            if exec_thread is not None and exec_thread != self._creationThread:
+                thread_name = exec_thread.name
+                parts.append(f"\n--- Thread boundary: {thread_name} ---\n{exec_tb}")
+            else:
+                parts.append(f"\n--- Execution context ---\n{exec_tb}")
+
+        enhanced_msg = "".join(parts)
+        try:
+            enhanced = type(exc)(enhanced_msg)
+        except Exception:
+            enhanced = RuntimeError(enhanced_msg)
+        enhanced.__cause__ = exc
+        return enhanced
 
     def _wait(self, duration):
         """Default sleep implementation used by wait(); may be overridden to return early."""
@@ -449,19 +521,18 @@ class FutureWrapper:
         ...
 
     def __call__(self, func=None, *, logLevel=None):
-        """Decorator to execute a function in a Thread wrapped in a future. The function must take a Future
-        named "_future" as a keyword argument. This Future can be variously used to checkStop() the
-        function, wait for other futures, and will be returned by the decorated function call. The function
-        can still be called with `block=True` to prevent threaded execution, if device locking is a concern.
+        """Decorator to wrap a function so it runs inside a Future with context tracking.
+
+        The function must accept a `_future` keyword argument and may accept a `name` argument.
         Usage:
             @future_wrap
-            def myFunc(arg1, arg2, _future=None):
-                ...
+            def myFunc(arg1, arg2, name=None, _future=None):
                 _future.checkStop()
-                _future.waitFor(someOtherFuture)
                 ...
-            result = myFunc(arg1, arg2).getResult()
-            threadless_result = myFunc(arg1, arg2, block=True).getResult()
+
+            result = myFunc(arg1, arg2)                  # blocks, returns result value
+            fut = myFunc(arg1, arg2, _sync="async")      # returns Future immediately
+            result = fut.getResult()
         """
         if logLevel is not None:
             if func is not None:
@@ -469,19 +540,19 @@ class FutureWrapper:
             return FutureWrapper(logLevel)
 
         @functools.wraps(func)
-        def wrapper(*args: WRAPPED_FN_PARAMS.args, **kwds: WRAPPED_FN_PARAMS.kwargs) -> Future[WRAPPED_FN_RETVAL_TYPE]:
-            frame = inspect.currentframe().f_back
-            name = f"(wrapped {func.__qualname__} from {frame.f_code.co_filename}:{frame.f_lineno})"
+        def wrapper(*args: WRAPPED_FN_PARAMS.args, **kwds: WRAPPED_FN_PARAMS.kwargs):
+            name = kwds.get("name") or func.__qualname__
             future = Future(onError=kwds.pop("onFutureError", None), name=name, logLevel=self.logLevel)
-            if kwds.pop("block", False):
-                kwds["_future"] = future
+            _sync = kwds.pop("_sync", None)
+            if _sync == "async":
+                future.executeInThread(func, args, kwds)
+                return future
+            else:
+                # Default: run inline (blocking), return the result value directly.
                 if parent := kwds.pop("checkStopThrough", None):
                     parent.propagateStopsInto(future)
                 future.executeAndSetReturn(func, args, kwds)
-                future.wait()
-            else:
-                future.executeInThread(func, args, kwds)
-            return future
+                return future.getResult()
 
         return wrapper
 
@@ -490,11 +561,13 @@ future_wrap = FutureWrapper()
 
 
 class MultiException(Exception):
-    def __init__(self, message, exceptions):
+    def __init__(self, message, exceptions=None):
         super().__init__(message)
-        self._exceptions = exceptions
+        self._exceptions = exceptions or []
 
     def __str__(self):
+        if not self._exceptions:
+            return super().__str__()
         return f"Oh no! A wild herd ({len(self._exceptions)}) of exceptions appeared!\n" + "\n".join(
             f"Exception #{i}: {e}" for i, e in enumerate(self._exceptions, 1)
         )

--- a/acq4/util/future.py
+++ b/acq4/util/future.py
@@ -891,15 +891,9 @@ class FutureButton(FeedbackButton):
         self.clicked.connect(self._controlTheFuture)
 
     def setOpts(self, **kwds):
-        allowed_args = [
-            "fn",
-            "stoppable",
-            "success",
-            "failure",
-            "processing",
-            "showStatus",
-            "raiseOnError",
-        ]
+        allowed_args = {
+            "fn", "stoppable", "success", "failure", "processing", "showStatus", "raiseOnError",
+        }
         for k, v in kwds.items():
             if k not in allowed_args:
                 raise NameError(f"Unknown option {k}")

--- a/acq4/util/future.py
+++ b/acq4/util/future.py
@@ -71,14 +71,21 @@ class Unset:
     pass
 UNSET = Unset()  # unique sentinel value for "not set"
 
-class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
+class FutureSignals(Qt.QObject):
+    """Companion QObject that holds Qt signals for a Future.
+
+    Created lazily the first time signals are accessed on a Future instance.
+    """
+
+    sigFinished = Qt.Signal(object)
+    sigStateChanged = Qt.Signal(object, object)
+
+
+class Future(Generic[FUTURE_RETVAL_TYPE]):
     """Used to track the progress of an asynchronous task.
 
     The simplest subclasses reimplement percentDone() and call _taskDone() when finished.
     """
-
-    sigFinished = Qt.Signal(object)  # self
-    sigStateChanged = Qt.Signal(object, object)  # self, state
 
     class StopRequested(Exception):
         """Raised by checkStop if stop() has been invoked."""
@@ -110,8 +117,6 @@ class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
 
     def __init__(self, fn=None, args=(), kwargs=None, *, onError=None, name=None, logLevel='debug',
                  detach=False, on_finish=None):
-        Qt.QObject.__init__(self)
-
         self.startTime = ptime.time()
         self._name = self.nameFromStack() if name is None else name
         self.logger = get_logger(f"{__name__}.{self._name}")
@@ -123,7 +128,8 @@ class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
         self._wasInterrupted = False
         self._errorMessage = None
         self._excInfo = None
-        self._stopRequested = False
+        self._stop_requested = threading.Event()
+        self._signals: Optional["FutureSignals"] = None
         self._state = "starting"
         self._errorMonitorThread = None
         self._executingThread = None
@@ -147,6 +153,36 @@ class Future(Qt.QObject, Generic[FUTURE_RETVAL_TYPE]):
             if parent is not None and not detach:
                 parent._stopsToPropagate.append(self)
             self._executeInThread_v2(fn, tuple(args), dict(kwargs or {}))
+
+    # -- Qt signal proxy -------------------------------------------------------
+
+    @property
+    def signals(self) -> "FutureSignals":
+        """Lazily-created QObject companion providing sigFinished and sigStateChanged."""
+        if self._signals is None:
+            with self._completionLock:
+                if self._signals is None:
+                    self._signals = FutureSignals()
+        return self._signals
+
+    @property
+    def sigFinished(self):
+        return self.signals.sigFinished
+
+    @property
+    def sigStateChanged(self):
+        return self.signals.sigStateChanged
+
+    @property
+    def _stopRequested(self) -> bool:
+        return self._stop_requested.is_set()
+
+    @_stopRequested.setter
+    def _stopRequested(self, value: bool):
+        if value:
+            self._stop_requested.set()
+        else:
+            self._stop_requested.clear()
 
     # -- v2 API surface -------------------------------------------------------
 
@@ -588,12 +624,11 @@ def sleep(seconds: float, *, interval: float = 0.05) -> None:
         return
     deadline = time.monotonic() + seconds
     while True:
-        if fut._stopRequested:
-            raise Stopped()
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             return
-        time.sleep(min(interval, remaining))
+        if fut._stop_requested.wait(timeout=min(interval, remaining)):
+            raise Stopped()
 
 
 def check_stop() -> None:
@@ -602,7 +637,7 @@ def check_stop() -> None:
     Use in tight polling loops where a sleep would be inappropriate.
     """
     fut = current_future()
-    if fut is not None and fut._stopRequested:
+    if fut is not None and fut._stop_requested.is_set():
         raise Stopped()
 
 

--- a/acq4/util/future.py
+++ b/acq4/util/future.py
@@ -67,9 +67,13 @@ task_stack = TaskStack()
 FUTURE_RETVAL_TYPE = TypeVar("FUTURE_RETVAL_TYPE")
 WAITING_RETVAL_TYPE = TypeVar("WAITING_RETVAL_TYPE")
 
+
 class Unset:
     pass
+
+
 UNSET = Unset()  # unique sentinel value for "not set"
+
 
 class FutureSignals(Qt.QObject):
     """Companion QObject that holds Qt signals for a Future.
@@ -104,7 +108,12 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
         fut = cls(name=name, logLevel=None)
         if stopped:
             fut.stop(reason=error)
-        fut._taskDone(returnValue=result, error=error, interrupted=(error or excInfo) is not None, excInfo=excInfo)
+        fut._taskDone(
+            returnValue=result,
+            error=error,
+            interrupted=(error or excInfo) is not None,
+            excInfo=excInfo,
+        )
         return fut
 
     @staticmethod
@@ -115,8 +124,18 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
             frame = frame.f_back  # walk up the stack
         return f"(unnamed from {frame.f_code.co_filename}:{frame.f_lineno})"
 
-    def __init__(self, fn=None, args=(), kwargs=None, *, onError=None, name=None, logLevel='debug',
-                 detach=False, on_finish=None):
+    def __init__(
+        self,
+        fn=None,
+        args=(),
+        kwargs=None,
+        *,
+        onError=None,
+        name=None,
+        logLevel='debug',
+        detach=False,
+        on_finish=None,
+    ):
         self.startTime = ptime.time()
         self._name = self.nameFromStack() if name is None else name
         self.logger = get_logger(f"{__name__}.{self._name}")
@@ -143,7 +162,6 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
 
         self.log(f"Future [{self._name}] created")
 
-        # v2-style: fn provided → auto-start, register with parent, wire finish callback
         if fn is not None:
             if name is None:
                 self._name = getattr(fn, '__qualname__', repr(fn))
@@ -152,7 +170,7 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
             parent = current_future()
             if parent is not None and not detach:
                 parent._stopsToPropagate.append(self)
-            self._executeInThread_v2(fn, tuple(args), dict(kwargs or {}))
+            self._executeInThread(fn, tuple(args), dict(kwargs or {}))
 
     # -- Qt signal proxy -------------------------------------------------------
 
@@ -184,8 +202,6 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
         else:
             self._stop_requested.clear()
 
-    # -- v2 API surface -------------------------------------------------------
-
     @property
     def is_done(self) -> bool:
         return self._isDone
@@ -196,15 +212,17 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
 
     @property
     def _done(self) -> threading.Event:
-        """v2 compat: threading.Event that is set when the future finishes."""
+        """Alias for finishedEvent; set when the future finishes."""
         return self.finishedEvent
 
     def add_finish_callback(self, fn) -> None:
         """Call fn(result, exception) when done. Calls immediately if already done."""
+
         def _wrap(future):
             exc = future.exceptionRaised()
             result = future._returnVal
             fn(result, exc)
+
         self.onFinish(_wrap)
 
     def detach(self) -> None:
@@ -213,18 +231,18 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
         if parent is not None and self in parent._stopsToPropagate:
             parent._stopsToPropagate.remove(self)
 
-    def _executeInThread_v2(self, func, args, kwargs):
-        """Start func in a thread without injecting _future into kwargs."""
+    def _executeInThread(self, func, args, kwargs):
+        """Start func in a background thread, propagating the current context."""
         ctx = contextvars.copy_context()
         self._executingThread = threading.Thread(
             target=ctx.run,
-            args=(self._executeAndSetReturn_v2, func, args, kwargs),
+            args=(self._executeAndSetReturn, func, args, kwargs),
             daemon=True,
             name=f"execute thread for {repr(self)}",
         )
         self._executingThread.start()
 
-    def _executeAndSetReturn_v2(self, func, args, kwargs):
+    def _executeAndSetReturn(self, func, args, kwargs):
         cf_token = _current_future_var.set(self)
         with task_stack.push(self._name):
             try:
@@ -287,7 +305,7 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
 
         Must be reimplemented in subclasses.
         """
-        raise NotImplementedError("method must be reimplmented in subclass")
+        raise NotImplementedError("method must be reimplemented in subclass")
 
     def stop(self, reason: str | None = "task stop requested", wait=False):
         """Stop the task (nicely).
@@ -314,10 +332,16 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
         self.setResult(rval=returnValue, error=error, excInfo=excInfo, interrupted=interrupted)
         self._do_task_completion_jobs()
 
-    def setResult(self, rval:Any=UNSET, error:str|None|Unset=UNSET, excInfo:str|None|Unset=UNSET, interrupted:bool|None|Unset=UNSET):
-        """Set result attributes on this future. 
+    def setResult(
+        self,
+        rval: Any = UNSET,
+        error: str | None | Unset = UNSET,
+        excInfo: str | None | Unset = UNSET,
+        interrupted: bool | None | Unset = UNSET,
+    ):
+        """Set result attributes on this future.
         This should only be called internally by the future or subclasses, or when the state of the future is handled externally.
-        
+
         Parameters
         ----------
         rval : Any
@@ -327,13 +351,13 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
         excInfo : str | None | Unset
             The exception information if the future encountered an error.
         interrupted : bool | None | Unset
-            Indicates whether the future was interrupted. 
+            Indicates whether the future was interrupted.
             If unspecified, it will be set to True if there was an error or exception.
         """
         with self._completionLock:
             if self._isDone:
                 raise ValueError("Cannot alter future after future is done.")
-        
+
             if rval is not UNSET:
                 self._returnVal = rval
             if error is not UNSET:
@@ -366,7 +390,9 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
             try:
                 self._onError(self)
             except Exception as e:
-                self.logger.exception(f"{type(e).__name__}: {e} in Future.onError callback: {self._onError}")
+                self.logger.exception(
+                    f"{type(e).__name__}: {e} in Future.onError callback: {self._onError}"
+                )
         self.finishedEvent.set()  # tell wait() that we're done
         self.sigFinished.emit(self)  # tell everyone else that we're done
         self._callCallbacks()
@@ -463,7 +489,9 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
                 if self._excInfo is not None:
                     raise original_exc.with_traceback(self._excInfo[2])
                 raise original_exc
-            msg = f"Task {self} did not complete: {err}" if err else f"Task {self} did not complete."
+            msg = (
+                f"Task {self} did not complete: {err}" if err else f"Task {self} did not complete."
+            )
             raise RuntimeError(msg)
 
         return self._returnVal
@@ -518,7 +546,9 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
             time.sleep(max(0.0, min(interval, stop - now)))
             self.checkStop()
 
-    def waitFor(self, future: Future[WAITING_RETVAL_TYPE], timeout=20.0) -> Future[WAITING_RETVAL_TYPE]:
+    def waitFor(
+        self, future: Future[WAITING_RETVAL_TYPE], timeout=20.0
+    ) -> Future[WAITING_RETVAL_TYPE]:
         """Wait for another future to complete while also checking for stop requests on self."""
         start = time.time()
         while True:
@@ -556,9 +586,14 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
             return
         originalFrame = sys._getframe().f_back
         monitorFn = functools.partial(
-            self._monitorErrors, message=message, pollInterval=pollInterval, originalFrame=originalFrame
+            self._monitorErrors,
+            message=message,
+            pollInterval=pollInterval,
+            originalFrame=originalFrame,
         )
-        self._errorMonitorThread = threading.Thread(target=monitorFn, daemon=True, name=f"error monitor for {self}")
+        self._errorMonitorThread = threading.Thread(
+            target=monitorFn, daemon=True, name=f"error monitor for {self}"
+        )
         self._errorMonitorThread.start()
 
     def _monitorErrors(self, message, pollInterval, originalFrame):
@@ -571,14 +606,14 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
                 stack = None
 
             try:
-                formattedMsg = message.format(stack=stack, error=traceback.format_exception_only(type(exc), exc))
+                formattedMsg = message.format(
+                    stack=stack, error=traceback.format_exception_only(type(exc), exc)
+                )
             except Exception as exc2:
                 formattedMsg = f"{message} [additional error formatting error message: {exc2}]"
             raise RuntimeError(formattedMsg) from exc
 
 
-# ---------------------------------------------------------------------------
-# v2 module-level primitives
 # ---------------------------------------------------------------------------
 
 # Module-level Stopped alias — matches Future.Stopped for catch-compatibility.
@@ -709,8 +744,9 @@ class MultiException(Exception):
     def __str__(self):
         if not self._exceptions:
             return super().__str__()
-        return f"Oh no! A wild herd ({len(self._exceptions)}) of exceptions appeared!\n" + "\n".join(
-            f"Exception #{i}: {e}" for i, e in enumerate(self._exceptions, 1)
+        return (
+            f"Oh no! A wild herd ({len(self._exceptions)}) of exceptions appeared!\n"
+            + "\n".join(f"Exception #{i}: {e}" for i, e in enumerate(self._exceptions, 1))
         )
 
 
@@ -787,15 +823,15 @@ class FutureButton(FeedbackButton):
     sigStateChanged = Qt.Signal(object, object)  # future, state
 
     def __init__(
-            self,
-            fn: Optional[Callable] = None,
-            *args,
-            stoppable: bool = False,
-            success=None,
-            failure=None,
-            raiseOnError: bool = True,
-            processing=None,
-            showStatus: bool = True,
+        self,
+        fn: Optional[Callable] = None,
+        *args,
+        stoppable: bool = False,
+        success=None,
+        failure=None,
+        raiseOnError: bool = True,
+        processing=None,
+        showStatus: bool = True,
     ):
         """Create a new FutureButton.
 
@@ -830,7 +866,13 @@ class FutureButton(FeedbackButton):
 
     def setOpts(self, **kwds):
         allowed_args = {
-            "fn", "stoppable", "success", "failure", "processing", "showStatus", "raiseOnError",
+            "fn",
+            "stoppable",
+            "success",
+            "failure",
+            "processing",
+            "showStatus",
+            "raiseOnError",
         }
         for k, v in kwds.items():
             if k not in allowed_args:
@@ -840,7 +882,9 @@ class FutureButton(FeedbackButton):
     def processing(self, message="Processing..", tip="", processEvents=True):
         """Displays specified message on button to let user know the action is in progress. Threadsafe."""
         # This had to be reimplemented to allow stoppable buttons to remain enabled.
-        isGuiThread = Qt.QtCore.QThread.currentThread() == Qt.QtCore.QCoreApplication.instance().thread()
+        isGuiThread = (
+            Qt.QtCore.QThread.currentThread() == Qt.QtCore.QCoreApplication.instance().thread()
+        )
         if isGuiThread:
             self.setEnabled(self._stoppable)
             self.setText(message, temporary=True)
@@ -854,7 +898,10 @@ class FutureButton(FeedbackButton):
 
     def _controlTheFuture(self):
         if self._future is None:
-            self.processing(self._processing or (f"Cancel {self.text()}" if self._stoppable else "Processing..."))
+            self.processing(
+                self._processing
+                or (f"Cancel {self.text()}" if self._stoppable else "Processing...")
+            )
             try:
                 future = self._future = Future(self._fn)
             except Exception:

--- a/acq4/util/future.py
+++ b/acq4/util/future.py
@@ -278,34 +278,38 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
         """Add a future to the list of futures that will be stopped if this future is stopped."""
         self._stopsToPropagate.append(future)
 
+    propagate_stops_into = propagateStopsInto
+
     def getResult(self, **kwds) -> FUTURE_RETVAL_TYPE:
-        self.wait(**kwds)
-        return self._returnVal
+        return self.wait(**kwds)
+
+    def get_result(self, **kwds) -> FUTURE_RETVAL_TYPE:
+        return self.wait(**kwds)
 
     def currentState(self):
-        """Return the current state of this future.
+        """Return the current state string of this future."""
+        return self._state
 
-        The state can be any string used to indicate the progress this future is making in its task.
-        """
+    def current_state(self):
         return self._state
 
     def setState(self, state):
-        """Set the current state of this future.
-
-        The state can be any string used to indicate the progress this future is making in its task.
-        """
+        """Set the current state string of this future."""
         if state == self._state:
             return
         self.log(f"Future [{self._name}] state changed: {state}")
         self._state = state
         self.sigStateChanged.emit(self, state)
 
-    def percentDone(self):
-        """Return the percent of the task that has completed.
+    def set_state(self, state):
+        return self.setState(state)
 
-        Must be reimplemented in subclasses.
-        """
+    def percentDone(self):
+        """Return the percent of the task completed. Must be reimplemented in subclasses."""
         raise NotImplementedError("method must be reimplemented in subclass")
+
+    def percent_done(self):
+        return self.percentDone()
 
     def stop(self, reason: str | None = "task stop requested", wait=False):
         """Stop the task (nicely).
@@ -401,6 +405,10 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
         """Return True if the task was interrupted before completing (due to an error or a stop request)."""
         return self._wasInterrupted
 
+    @property
+    def was_interrupted(self) -> bool:
+        return self._wasInterrupted
+
     def wasStopped(self):
         """Return True if the task was stopped."""
         return self._stopRequested
@@ -412,13 +420,22 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
             except Exception:
                 self.logger.exception(message)
 
+    def log_errors(self, message=""):
+        return self.logErrors(message)
+
     def exceptionRaised(self):
+        return self._excInfo[1] if self._excInfo is not None else None
+
+    def exception_raised(self):
         return self._excInfo[1] if self._excInfo is not None else None
 
     def isDone(self):
         """Return True if the task has completed successfully or was interrupted."""
         with self._completionLock:
             return self._isDone
+
+    def on_finish(self, callback, *args, inGui: bool = False, **kwargs):
+        return self.onFinish(callback, *args, inGui=inGui, **kwargs)
 
     def onFinish(self, callback, *args, inGui: bool = False, **kwargs):
         """Make sure the callback is called when the future is finished, including if the future is already done."""
@@ -454,6 +471,10 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
         """Return a string description of the reason for a task failure,
         or None if there was no failure (or if the reason is unknown).
         """
+        return self._errorMessage
+
+    @property
+    def error_message(self) -> str | None:
         return self._errorMessage
 
     def wait(self, timeout=None, updates=False, pollInterval=0.1):
@@ -524,15 +545,14 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
         self.finishedEvent.wait(timeout=duration)
 
     def checkStop(self):
-        """Raise self.StopRequested if self.stop() has been called.
-
-        This may be used by subclasses to periodically check for stop requests.
-
-        The optional *delay* argument causes this method to sleep while periodically
-        checking for a stop request.
-        """
+        """Raise self.StopRequested if self.stop() has been called."""
         if self._stopRequested:
             raise self.StopRequested()
+
+    def check_stop(self):
+        """Raise Stopped if stop() has been called on this future."""
+        if self._stopRequested:
+            raise self.Stopped()
 
     def sleep(self, duration, interval=0.2):
         """Sleep for the specified duration (in seconds) while checking for stop requests."""
@@ -545,6 +565,11 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
 
             time.sleep(max(0.0, min(interval, stop - now)))
             self.checkStop()
+
+    def wait_for(
+        self, future: "Future[WAITING_RETVAL_TYPE]", timeout=20.0
+    ) -> "Future[WAITING_RETVAL_TYPE]":
+        return self.waitFor(future, timeout=timeout)
 
     def waitFor(
         self, future: Future[WAITING_RETVAL_TYPE], timeout=20.0
@@ -566,6 +591,9 @@ class Future(Generic[FUTURE_RETVAL_TYPE]):
                 if timeout is not None and time.time() - start > timeout:
                     raise self.Timeout(f"Timed out waiting {timeout}s for {future!r}") from e
         return future
+
+    def raise_errors(self, message, poll_interval=1.0):
+        return self.raiseErrors(message, pollInterval=poll_interval)
 
     def raiseErrors(self, message, pollInterval=1.0):
         """Monitor this future for errors and raise if any occur.
@@ -805,10 +833,16 @@ class MultiFuture(Future):
         return "; ".join(error_messages) if error_messages else None
 
     def getResult(self):
-        return [f.getResult() for f in self.futures]
+        return [f.get_result() for f in self.futures]
+
+    def get_result(self):
+        return [f.get_result() for f in self.futures]
 
     def currentState(self):
         return "; ".join([str(f.currentState()) or "" for f in self.futures])
+
+    def current_state(self):
+        return self.currentState()
 
 
 class FutureButton(FeedbackButton):

--- a/acq4/util/future.py
+++ b/acq4/util/future.py
@@ -838,14 +838,19 @@ class MultiFuture(Future):
 
 
 class FutureButton(FeedbackButton):
-    """A button that starts a Future when clicked and displays feedback based on the Future's state."""
+    """A button that starts a Future when clicked and displays feedback based on the Future's state.
+
+    Pass a zero-arg callable as the first argument. FutureButton wraps it in Future(fn) on click,
+    so the callable runs in a background thread. The callable should do its work synchronously —
+    use sleep() and check_stop() for cooperative cancellation.
+    """
 
     sigFinished = Qt.Signal(object)  # future
     sigStateChanged = Qt.Signal(object, object)  # future, state
 
     def __init__(
             self,
-            future_producer: Optional[Callable[[ParamSpec], Future]] = None,
+            fn: Optional[Callable] = None,
             *args,
             stoppable: bool = False,
             success=None,
@@ -858,24 +863,24 @@ class FutureButton(FeedbackButton):
 
         Parameters
         ----------
-        future_producer : Callable[[], Future]
-            A function that takes no arguments and returns a Future instance.
+        fn : Callable[[], Any]
+            Zero-arg callable that does the work. Runs in a background thread via Future(fn).
         *args
             Arguments to pass to FeedbackButton.__init__.
         stoppable : bool
-            If True, the Future can be stopped by clicking the button while it is in progress.
+            If True, clicking the button while work is in progress stops the Future.
         success : str | None
-            The message to display when the Future completes successfully. If None, the default message is "Success".
+            Message shown on success. Defaults to "Success".
         failure : str | None
-            The message to display when the Future fails. If None, the default message is the error message from the Future.
+            Message shown on failure. Defaults to the Future's error message.
         raiseOnError : bool
-            If True, the Future will raise an exception if the future has one to be raised. Default is True.
+            If True, re-raises any exception from the future. Default is True.
         processing : str | None
-            The message to display while the Future is in progress. If None, the default message is "Processing...".
+            Message shown while work is in progress. Defaults to "Processing...".
         """
         super().__init__(*args)
         self._future = None
-        self._future_producer = future_producer
+        self._fn = fn
         self._stoppable = stoppable
         self._userRequestedStop = False
         self._success = success
@@ -887,7 +892,7 @@ class FutureButton(FeedbackButton):
 
     def setOpts(self, **kwds):
         allowed_args = [
-            "future_producer",
+            "fn",
             "stoppable",
             "success",
             "failure",
@@ -919,7 +924,7 @@ class FutureButton(FeedbackButton):
         if self._future is None:
             self.processing(self._processing or (f"Cancel {self.text()}" if self._stoppable else "Processing..."))
             try:
-                future = self._future = self._future_producer()
+                future = self._future = Future(self._fn)
             except Exception:
                 self.failure("Error!")
                 raise
@@ -939,7 +944,7 @@ class FutureButton(FeedbackButton):
         elif self._userRequestedStop:
             self._userRequestedStop = False
             self.reset()
-        elif future.wasStopped():
+        elif future.is_stopped:
             self.reset()
         else:
             self.failure(self._failure or (future.errorMessage() or "Failed!")[:40])

--- a/acq4/util/geometry.py
+++ b/acq4/util/geometry.py
@@ -1334,7 +1334,7 @@ class GeometryMotionPlanner:
 
             obstacles.append((obst_volume, to_global_from_obst, obst.name))
             if visualizer is not None:
-                visualizer.addObstacle(obst.name, obst_volume, to_global_from_obst).raiseErrors(
+                visualizer.addObstacle(obst.name, obst_volume, to_global_from_obst, _sync="async").raiseErrors(
                     "obstacle failed to render"
                 )
         return obstacles

--- a/acq4/util/geometry.py
+++ b/acq4/util/geometry.py
@@ -1335,7 +1335,7 @@ class GeometryMotionPlanner:
             obstacles.append((obst_volume, to_global_from_obst, obst.name))
             if visualizer is not None:
                 from acq4.util.future import Future
-                Future(visualizer.addObstacle, (obst.name, obst_volume, to_global_from_obst)).raiseErrors(
+                Future(visualizer.addObstacle, (obst.name, obst_volume, to_global_from_obst)).raise_errors(
                     "obstacle failed to render"
                 )
         return obstacles

--- a/acq4/util/geometry.py
+++ b/acq4/util/geometry.py
@@ -1334,7 +1334,8 @@ class GeometryMotionPlanner:
 
             obstacles.append((obst_volume, to_global_from_obst, obst.name))
             if visualizer is not None:
-                visualizer.addObstacle(obst.name, obst_volume, to_global_from_obst, _sync="async").raiseErrors(
+                from acq4.util.future import Future
+                Future(visualizer.addObstacle, (obst.name, obst_volume, to_global_from_obst)).raiseErrors(
                     "obstacle failed to render"
                 )
         return obstacles

--- a/acq4/util/imaging/sequencer.py
+++ b/acq4/util/imaging/sequencer.py
@@ -143,7 +143,7 @@ def _stepped_z_stack(imager, start, end, step, name, future=None) -> list[Frame]
     with imager.ensureRunning(ensureFreshFrames=True):
         for z in np.arange(start, end + step, step):
             _set_focus_depth(imager, z, direction, speed="slow", name=f"{name} step")
-            frames.append(imager.acquireFrames(1).getResult()[0])
+            frames.append(imager.acquireFrames(1).get_result()[0])
     return frames
 
 
@@ -270,7 +270,7 @@ def run_image_sequence(
                         stack = acquire_z_stack(imager, *z_stack, name=name)
                         handle_new_frames(stack, i)
                     else:  # single frame
-                        frame = imager.acquireFrames(1, ensureFreshFrames=True).getResult()[0]
+                        frame = imager.acquireFrames(1, ensureFreshFrames=True).get_result()[0]
                         handle_new_frames(frame, i)
                     check_stop()
                 sleep(interval - (ptime.time() - start))
@@ -396,7 +396,7 @@ def acquire_z_stack(
                     imager.acquireFrames(1).wait()  # just to be sure the camera caught up
                 finally:
                     frames_fut.stop()
-        frames = frames_fut.getResult(timeout=10)
+        frames = frames_fut.get_result(timeout=10)
         try:
             frames = enforce_linear_z_stack(frames, start, stop, step)
         except ValueError:
@@ -546,7 +546,7 @@ class ImageSequencerCtrl(Qt.QWidget):
             prot["storage_dir"] = dh
             self.setRunning(True)
             self._future = Future(run_image_sequence, (), prot)
-            self._future.onFinish(self.threadStopped, inGui=True)
+            self._future.on_finish(self.threadStopped, inGui=True)
             self._future.sigStateChanged.connect(self.threadMessage)
         except Exception:
             self.threadStopped(self._future)

--- a/acq4/util/imaging/sequencer.py
+++ b/acq4/util/imaging/sequencer.py
@@ -275,7 +275,7 @@ def run_image_sequence(
                 for move in movements_to_cover_region(imager, mosaic, name):
                     _future.waitFor(move)
                     if z_stack:
-                        stack = acquire_z_stack(imager, *z_stack, block=True, name=name, checkStopThrough=_future).getResult()
+                        stack = acquire_z_stack(imager, *z_stack, name=name, checkStopThrough=_future)
                         handle_new_frames(stack, i)
                     else:  # single frame
                         frame = _future.waitFor(imager.acquireFrames(1, ensureFreshFrames=True)).getResult()[0]
@@ -554,7 +554,7 @@ class ImageSequencerCtrl(Qt.QWidget):
             dh.setInfo(dhinfo)
             prot["storage_dir"] = dh
             self.setRunning(True)
-            self._future = run_image_sequence(**prot)
+            self._future = run_image_sequence(**prot, _sync="async")
             self._future.onFinish(self.threadStopped, inGui=True)
             self._future.sigStateChanged.connect(self.threadMessage)
         except Exception:

--- a/acq4/util/imaging/sequencer.py
+++ b/acq4/util/imaging/sequencer.py
@@ -12,7 +12,7 @@ import acq4.Manager as Manager
 import pyqtgraph as pg
 from acq4.util import Qt, ptime
 from acq4.util.DataManager import DirHandle
-from acq4.util.future import Future, future_wrap
+from acq4.util.future import Future, check_stop, sleep, current_future
 from acq4.util.imaging import Frame
 from acq4.util.surface import find_surface
 from acq4.util.threadrun import runInGuiThread
@@ -130,26 +130,20 @@ def _set_focus_depth(
     else:
         move = imager.setFocusDepth(depth, speed, name=f"redundant {name}")
 
-    if future is not None:
-        future.waitFor(move, timeout=timeout)
-    else:
-        move.wait(timeout=timeout)
+    move.wait(timeout=timeout)
 
     move = imager.setFocusDepth(depth, speed, name=name)  # maybe redundant
-    if future is not None:
-        future.waitFor(move, timeout=timeout)
-    else:
-        move.wait(timeout=timeout)
+    move.wait(timeout=timeout)
 
 
-def _stepped_z_stack(imager, start, end, step, name, future) -> list[Frame]:
+def _stepped_z_stack(imager, start, end, step, name, future=None) -> list[Frame]:
     direction = np.sign(end - start)
     step = direction * abs(step)
     frames = []
     with imager.ensureRunning(ensureFreshFrames=True):
         for z in np.arange(start, end + step, step):
-            _set_focus_depth(imager, z, direction, speed="slow", name=f"{name} step", future=future)
-            frames.append(future.waitFor(imager.acquireFrames(1)).getResult()[0])
+            _set_focus_depth(imager, z, direction, speed="slow", name=f"{name} step")
+            frames.append(imager.acquireFrames(1).getResult()[0])
     return frames
 
 
@@ -226,7 +220,6 @@ def _save_results(
     return ret_fh
 
 
-@future_wrap(logLevel='debug')
 def run_image_sequence(
     imager,
     count: float = 1,
@@ -236,7 +229,6 @@ def run_image_sequence(
     mosaic: "tuple[float, float, float, float, float] | None" = None,
     storage_dir: "DirHandle | None" = None,
     name: str | None = None,
-    _future: Future = None,
 ) -> "Frame | list[Frame | list[Frame | list[Frame]]]":
     _hold_imager_focus(imager, True)
     _open_shutter(imager, True)  # don't toggle shutter between stack frames
@@ -273,20 +265,21 @@ def run_image_sequence(
                     break
                 start = ptime.time()
                 for move in movements_to_cover_region(imager, mosaic, name):
-                    _future.waitFor(move)
+                    move.wait()
                     if z_stack:
-                        stack = acquire_z_stack(imager, *z_stack, name=name, checkStopThrough=_future)
+                        stack = acquire_z_stack(imager, *z_stack, name=name)
                         handle_new_frames(stack, i)
                     else:  # single frame
-                        frame = _future.waitFor(imager.acquireFrames(1, ensureFreshFrames=True)).getResult()[0]
+                        frame = imager.acquireFrames(1, ensureFreshFrames=True).getResult()[0]
                         handle_new_frames(frame, i)
-                    _future.checkStop()
-                _future.setState(_status_message(i, count))
-                _future.sleep(interval - (ptime.time() - start))
+                    check_stop()
+                sleep(interval - (ptime.time() - start))
         finally:
             _open_shutter(imager, False)
             _hold_imager_focus(imager, False)
-    _future.imagesSavedIn = ret_fh
+    fut = current_future()
+    if fut is not None:
+        fut.imagesSavedIn = ret_fh
     return result
 
 
@@ -342,7 +335,6 @@ def positions_to_cover_region(region, imager_center, imager_region) -> Generator
         x_finished = False
 
 
-@future_wrap(logLevel='debug')
 def acquire_z_stack(
     imager,
     start: float,
@@ -353,7 +345,6 @@ def acquire_z_stack(
     device_reservation_timeout=10.0,
     max_dz_per_frame=5e-6,  # m
     name: str | None = "z stack",
-    _future: Future = None,
 ) -> list[Frame]:
     """Acquire a Z stack from the given imager.
 
@@ -383,7 +374,7 @@ def acquire_z_stack(
     """
     # TODO think about strobing the lighting for clearer images
     direction = stop - start
-    _set_focus_depth(imager, start, direction, "fast", hysteresis_correction, f"{name} start", _future)
+    _set_focus_depth(imager, start, direction, "fast", hysteresis_correction, f"{name} start")
     stage = imager.scopeDev.getFocusDevice()
     exposure = imager.getParam('exposure')
     # todo estimate the depth of field of the objective from its numerical aperture and wavelength
@@ -394,18 +385,18 @@ def acquire_z_stack(
     man = Manager.getManager()
     if dz_per_frame > max_dz_per_frame:
         with man.reserveDevices(imager.devicesToReserve(), timeout=device_reservation_timeout, reserver="acquire_z_stack"):
-            frames = _stepped_z_stack(imager, start, stop, step, name, _future)
+            frames = _stepped_z_stack(imager, start, stop, step, name, None)
     else:
         with man.reserveDevices(imager.devicesToReserve(), timeout=device_reservation_timeout, reserver="acquire_z_stack"):
             with imager.ensureRunning(ensureFreshFrames=True):
                 frames_fut = imager.acquireFrames()
                 try:
-                    _future.waitFor(imager.acquireFrames(1))  # just to be sure the camera's recording
-                    _set_focus_depth(imager, stop, direction, speed, hysteresis_correction=False, name=f"{name} stop", future=_future)
-                    _future.waitFor(imager.acquireFrames(1))  # just to be sure the camera caught up
+                    imager.acquireFrames(1).wait()  # just to be sure the camera's recording
+                    _set_focus_depth(imager, stop, direction, speed, hysteresis_correction=False, name=f"{name} stop")
+                    imager.acquireFrames(1).wait()  # just to be sure the camera caught up
                 finally:
                     frames_fut.stop()
-        frames = _future.waitFor(frames_fut).getResult(timeout=10)
+        frames = frames_fut.getResult(timeout=10)
         try:
             frames = enforce_linear_z_stack(frames, start, stop, step)
         except ValueError:
@@ -413,7 +404,7 @@ def acquire_z_stack(
                 raise
             imager.logger.info("Failed to fast-acquire linear z stack. Retrying with stepwise movement.")
             with man.reserveDevices(imager.devicesToReserve(), timeout=device_reservation_timeout, reserver="acquire_z_stack"):
-                frames = _stepped_z_stack(imager, start, stop, step, name, _future)
+                frames = _stepped_z_stack(imager, start, stop, step, name, None)
     _fix_frame_transforms(frames, step)
     return frames
 
@@ -554,7 +545,7 @@ class ImageSequencerCtrl(Qt.QWidget):
             dh.setInfo(dhinfo)
             prot["storage_dir"] = dh
             self.setRunning(True)
-            self._future = run_image_sequence(**prot, _sync="async")
+            self._future = Future(run_image_sequence, (), prot)
             self._future.onFinish(self.threadStopped, inGui=True)
             self._future.sigStateChanged.connect(self.threadMessage)
         except Exception:

--- a/acq4/util/threadrun.py
+++ b/acq4/util/threadrun.py
@@ -47,10 +47,12 @@ def inGuiThread(func):
     return run_func_in_gui_thread
 
 
-class ThreadCallFuture(Future):
+class ThreadCallFuture(Qt.QObject, Future):
+    """Future that marshals a function call into a target Qt thread."""
     sigRequestCall = Qt.Signal()
 
     def __init__(self, thread, func, *args, **kwds):
+        Qt.QObject.__init__(self)
         Future.__init__(self, name="ThreadCallFuture")
         self.func = func
         self.args = args

--- a/acq4/util/ui/tests/test_ZPositionWidget.py
+++ b/acq4/util/ui/tests/test_ZPositionWidget.py
@@ -1,0 +1,55 @@
+# Tests for ZPositionWidget movement state tracking behavior.
+# Uses a mock plot to avoid requiring a full Qt application.
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+@pytest.fixture
+def mock_plot():
+    """A minimal plot mock that returns InfiniteLine-like objects."""
+    def make_line():
+        line = MagicMock()
+        line._value = 0.0
+        line.value = lambda: line._value
+        line.setValue = lambda v: line.__setattr__('_value', v)
+        return line
+
+    plot = MagicMock()
+    plot.addLine = MagicMock(side_effect=lambda **kwargs: make_line())
+    return plot
+
+
+@pytest.fixture
+def widget(qtbot, mock_plot):
+    from acq4.util.ui.ZPositionWidget import ZPositionWidget
+    w = ZPositionWidget(mock_plot)
+    qtbot.addWidget(w)
+    return w
+
+
+class TestSetMoving:
+    def test_setMoving_false_snaps_target_to_focus(self, widget):
+        widget.setFocusDepth(100e-6)
+        widget.setTargetDepth(200e-6)
+        widget.setMovingToTarget(False)
+        assert widget.targetLine.value() == pytest.approx(100e-6)
+
+    def test_setMoving_true_leaves_target_unchanged(self, widget):
+        widget.setFocusDepth(100e-6)
+        widget.setTargetDepth(200e-6)
+        widget.setMovingToTarget(True)
+        assert widget.targetLine.value() == pytest.approx(200e-6)
+
+    def test_setMoving_false_after_true_snaps_to_updated_focus(self, widget):
+        widget.setTargetDepth(200e-6)
+        widget.setMovingToTarget(True)
+        widget.setFocusDepth(150e-6)  # device moved partway
+        widget.setFocusDepth(200e-6)  # device arrived
+        widget.setMovingToTarget(False)
+        assert widget.targetLine.value() == pytest.approx(200e-6)
+
+    def test_setMoving_false_with_no_prior_target_uses_focus(self, widget):
+        widget.setFocusDepth(50e-6)
+        widget.setMovingToTarget(False)
+        assert widget.targetLine.value() == pytest.approx(50e-6)

--- a/tests/teleprox_queue_worker_helper.py
+++ b/tests/teleprox_queue_worker_helper.py
@@ -1,0 +1,31 @@
+# Helper module imported by the remote teleprox process in test_teleprox_context.py.
+# Simulates a queue-worker that captures task_stack at enqueue time (the SmartStage pattern).
+import logging
+import queue
+import threading
+
+from acq4.util.future import task_stack
+
+_queue = queue.Queue()
+_thread = None
+
+
+def start():
+    global _thread
+    _thread = threading.Thread(target=_worker, daemon=True)
+    _thread.start()
+
+
+def enqueue(msg):
+    """Called from RPC; captures the propagated task_stack as caller_stack."""
+    _queue.put((task_stack.get(), msg))
+
+
+def _worker():
+    while True:
+        item = _queue.get()
+        if item is None:
+            break
+        caller_stack, msg = item
+        with task_stack.push_full(caller_stack):
+            logging.getLogger('acq4').warning(msg)

--- a/tests/test_future.py
+++ b/tests/test_future.py
@@ -354,5 +354,54 @@ class TestEvent(unittest.TestCase):
         self.assertTrue(ev.wait(timeout=0.1))
 
 
+class TestFutureButton(unittest.TestCase):
+    """Tests for the redesigned FutureButton that wraps fn in Future(fn) on click."""
+
+    def _make_button(self, fn, **kwargs):
+        from acq4.util.future import FutureButton
+        return FutureButton(fn, "Test Button", raiseOnError=False, **kwargs)
+
+    def test_click_runs_fn_in_background(self):
+        ran = threading.Event()
+        btn = self._make_button(lambda: ran.set())
+        btn.click()
+        QApplication.processEvents()
+        self.assertTrue(ran.wait(timeout=2))
+
+    def test_success_message_shown_on_completion(self):
+        btn = self._make_button(lambda: None, success="Done!")
+        btn.click()
+        QApplication.processEvents()
+        import time; time.sleep(0.1)
+        QApplication.processEvents()
+        self.assertEqual(btn.text(), "Done!")
+
+    def test_failure_message_shown_on_exception(self):
+        def boom():
+            raise ValueError("oops")
+        btn = self._make_button(boom, failure="Oops!")
+        btn.click()
+        QApplication.processEvents()
+        import time; time.sleep(0.1)
+        QApplication.processEvents()
+        self.assertEqual(btn.text(), "Oops!")
+
+    def test_stop_resets_button(self):
+        from acq4.util.future import sleep
+        started = threading.Event()
+        def task():
+            started.set()
+            sleep(60)
+        btn = self._make_button(task, stoppable=True)
+        btn.click()
+        QApplication.processEvents()
+        started.wait(timeout=2)
+        btn.click()  # second click stops it
+        QApplication.processEvents()
+        import time; time.sleep(0.2)
+        QApplication.processEvents()
+        self.assertEqual(btn.text(), "Test Button")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_future.py
+++ b/tests/test_future.py
@@ -1,1199 +1,357 @@
-import contextlib
-import sys
+# Tests for acq4.util.future — v2 Future API plus TaskStack/task_stack infrastructure.
+# Run with: pytest tests/test_future.py
 import threading
 import time
 import unittest
-from unittest.mock import MagicMock
 
 from PyQt5.QtWidgets import QApplication
 
-from acq4.util.future import Future, FutureButton, MultiFuture, MultiException
-from acq4.util.future import future_wrap
-from acq4.util.future import current_future, task_stack
-
-app = QApplication([])
-
-
-class TestFutureButton(unittest.TestCase):
-    def setUp(self):
-        self._future = Future.immediate("success")
-        self.future_producer = MagicMock(return_value=self._future)
-        self.button = FutureButton(
-            self.future_producer, "Test Button", stoppable=True, success="Completed", failure="Failed",
-            raiseOnError=False,
-        )
-
-    def test_button_initial_state(self):
-        self.assertIsNone(self.button._future)
-        self.assertEqual(self.button.text(), "Test Button")
-
-    def test_button_click_starts_future(self):
-        self.button.click()
-        QApplication.processEvents()
-        self.assertTrue(self.future_producer.called)
-        self.assertTrue(self._future.isDone())
-        self.assertEqual("success", self._future.getResult())
-
-    def test_button_success_message(self):
-        self.button.click()
-        QApplication.processEvents()
-        self.assertEqual("Completed", self.button.text())
-
-    def test_erroring_future(self):
-        @future_wrap
-        def task(_future=None):
-            raise ValueError("error")
-        self.future_producer.return_value = task(_sync="async")
-        self.button.click()
-        QApplication.processEvents()
-        self.assertEqual("Failed", self.button.text())
-
-    def test_stopped_futures_just_reset(self):
-        @future_wrap
-        def so_sleepy(_future):
-            _future.sleep(1e6, interval=0)
-
-        f = so_sleepy(_sync="async")
-        self.future_producer.return_value = f
-        self.button.click()
-        QApplication.processEvents()
-        f.stop("stop")
-        time.sleep(0.01)
-        self.assertTrue(f.isDone())
-        QApplication.processEvents()
-        self.assertEqual("Test Button", self.button.text())
-
-    def test_button_stop(self):
-        f = Future()
-        self.future_producer.return_value = f
-        self.button.click()
-        QApplication.processEvents()
-        self.assertFalse(f._stopRequested)
-        self.button.click()  # second click to stop
-        QApplication.processEvents()
-        self.assertTrue(f._stopRequested)
-
-
-class TestFuture(unittest.TestCase):
-    def test_future_immediate(self):
-        result = "test"
-        fut = Future.immediate(result)
-        self.assertTrue(fut.isDone())
-        self.assertEqual(fut.getResult(), result)
-
-    def test_future_executeInThread(self):
-        def task(_future):
-            return "done"
-
-        fut = Future()
-        fut.executeInThread(task, (), {})
-        fut.wait()
-        self.assertTrue(fut.isDone())
-        self.assertEqual(fut.getResult(), "done")
-
-    def test_future_stop(self):
-        fut = Future()
-        fut.stop("test stop")
-        self.assertTrue(fut._stopRequested)
-        self.assertEqual(fut.errorMessage(), "test stop")
-
-    def test_future_wait_timeout(self):
-        fut = Future()
-        with self.assertRaises(Future.Timeout):
-            fut.wait(timeout=0.1)
-
-    def test_wrapped_on_error(self):
-        @future_wrap
-        def boom(_future):
-            raise ValueError("error")
-
-        called = False
-
-        def on_error(f):
-            nonlocal called
-            called = True
-        fut = boom(_sync="async", onFutureError=on_error)
-        with contextlib.suppress(ValueError):
-            fut.wait()
-        self.assertTrue(called)
-
-    def test_wrapped_on_no_error(self):
-        @future_wrap
-        def boom(_future):
-            return "success"
-
-        called = False
-
-        def on_error(f):
-            nonlocal called
-            called = True
-        fut = boom(_sync="async", onFutureError=on_error)
-        fut.wait()
-        self.assertFalse(called)
-
-    def test_future_checkStop(self):
-        fut = Future()
-        fut.stop()
-        with self.assertRaises(Future.StopRequested):
-            fut.checkStop()
-
-    def test_future_waitFor(self):
-        fut1 = Future.immediate("result1")
-        fut2 = Future.immediate("meow")
-        fut2.waitFor(fut1)
-        self.assertTrue(fut2.isDone())
-        self.assertEqual(fut1.getResult(), "result1")
-
-    def test_future_wrap(self):
-        @future_wrap
-        def task(_future=None):
-            return "wrapped"
-
-        fut = task(_sync="async")
-        fut.wait()
-        self.assertTrue(fut.isDone())
-        self.assertEqual(fut.getResult(), "wrapped")
-
-    def test_future_onFinish_immediate(self):
-        result = "test"
-        called = False
-
-        def on_finish(fut):
-            nonlocal called
-            self.assertTrue(fut.isDone())
-            self.assertEqual(fut.getResult(), result)
-            called = True
-
-        fut = Future.immediate(result)
-        self.assertFalse(called)
-        fut.onFinish(on_finish)
-        self.assertTrue(called)
-
-    def test_future_waitFor_nested_exception(self):
-        outer_future = Future()
-        inner_future = Future()
-
-        def inner_task(_future):
-            raise ValueError("inner task failed")
-
-        inner_future.executeInThread(inner_task, (), {})
-
-        with self.assertRaises(ValueError) as cm:
-            outer_future.waitFor(inner_future)
-        # The enhanced exception should contain the original error message
-        self.assertIn("inner task failed", str(cm.exception))
-        self.assertFalse(outer_future.isDone()) # waitFor raises, outer_future itself is not "done"
-
-    def test_future_waitFor_outer_stop_requested(self):
-        outer_future = Future(name="outer")
-        inner_future = Future(name="inner")
-
-        def inner_task_long(_future):
-            _future.sleep(15) # sleep long enough to be interrupted
-
-        inner_future.executeInThread(inner_task_long, (), {})
-
-        def stop_outer_then_wait():
-            time.sleep(0.05) # give waitFor a chance to start
-            outer_future.stop("outer stop")
-
-        wait_thread = threading.Thread(target=lambda: outer_future.waitFor(inner_future))
-        stopper_thread = threading.Thread(target=stop_outer_then_wait)
-
-        wait_thread.start()
-        stopper_thread.start()
-        wait_thread.join()
-        stopper_thread.join()
-        self.assertTrue(outer_future.wasStopped())
-        self.assertTrue(inner_future.wasStopped(), "Inner future should be stopped by parent's StopRequested")
-        self.assertEqual(inner_future.errorMessage(), "parent task stop requested")
-
-    def test_future_waitFor_timeout_on_inner(self):
-        outer_future = Future()
-        inner_future = Future(name="inner")
-
-        def inner_task_slow(_future):
-            time.sleep(0.5) # longer than timeout
-            return "slow done"
-
-        inner_future.executeInThread(inner_task_slow, (), {})
-
-        with self.assertRaises(Future.Timeout) as cm:
-            outer_future.waitFor(inner_future, timeout=0.1)
-        self.assertIn("Timed out waiting", str(cm.exception)) # Future name might vary
-        self.assertIn(" for <Future inner>", str(cm.exception))
-        self.assertFalse(inner_future.isDone()) # inner_future is still running
-        inner_future.stop() # clean up
-        with contextlib.suppress(Future.Stopped): # wait for it to actually stop
-            inner_future.wait(timeout=1)
-
-    def test_future_propagateStopsInto(self):
-        parent_future = Future()
-        child_future = Future()
-        parent_future.propagateStopsInto(child_future)
-
-        self.assertFalse(child_future.wasStopped())
-        parent_future.stop("parent stopped")
-        self.assertTrue(parent_future.wasStopped())
-        self.assertTrue(child_future.wasStopped())
-        self.assertEqual(child_future.errorMessage(), "parent stopped")
-
-    def test_future_onFinish_called_after_exception(self):
-        fut = Future()
-        callback_called = False
-        exception_in_callback = None
-
-        def on_finish_handler(f):
-            nonlocal callback_called, exception_in_callback
-            callback_called = True
-            exception_in_callback = f.exceptionRaised()
-
-        fut.onFinish(on_finish_handler)
-
-        test_exception = ValueError("Task failed with exception")
-        try:
-            raise test_exception
-        except ValueError:
-            exc_info = sys.exc_info()
-            fut._taskDone(interrupted=True, excInfo=exc_info)
-
-        self.assertTrue(callback_called)
-        self.assertTrue(fut.isDone())
-        self.assertTrue(fut.wasInterrupted())
-        self.assertIs(fut.exceptionRaised(), test_exception)
-        self.assertIs(exception_in_callback, test_exception)
-
-    def test_future_onFinish_multiple_callbacks(self):
-        fut = Future.immediate("done")
-        call_count = [0, 0]
-
-        def callback1(f):
-            call_count[0] += 1
-
-        def callback2(f):
-            call_count[1] += 1
-
-        fut.onFinish(callback1)
-        fut.onFinish(callback2)
-
-        self.assertEqual(call_count, [1, 1])
-
-    def test_future_getResult_raises_if_error_with_excInfo(self):
-        fut = Future()
-        test_exception = TypeError("Specific error")
-        try:
-            raise test_exception
-        except TypeError:
-            fut._taskDone(interrupted=True, excInfo=sys.exc_info())
-
-        with self.assertRaises(TypeError) as cm:
-            fut.getResult()
-        # The enhanced exception should contain the original error message
-        self.assertIn("Specific error", str(cm.exception))
-        # The enhanced exception should have the original as its cause
-        self.assertIs(cm.exception.__cause__, test_exception)
-
-    def test_future_getResult_raises_runtime_error_if_interrupted_no_excInfo(self):
-        fut = Future()
-        fut._taskDone(interrupted=True, error="Some interruption")
-        with self.assertRaisesRegex(RuntimeError, "Task .* did not complete: Some interruption"):
-            fut.getResult()
-
-    def test_future_getResult_raises_if_stopped(self):
-        fut = Future()
-        fut.stop("user requested stop")
-        assert fut.errorMessage() == "user requested stop"
-        # Simulate task acknowledging stop
-        fut._taskDone(interrupted=True) # error message is already set by stop()
-        assert fut.errorMessage() == "user requested stop"
-
-        with self.assertRaises(Future.Stopped) as cm:
-            fut.getResult()
-        assert fut.errorMessage() == "user requested stop"
-        self.assertIn(r"did not complete: user requested stop", str(cm.exception))
-
-    def test_future_double_taskDone_call(self):
-        fut = Future()
-        fut._taskDone(returnValue="first call")
-        self.assertTrue(fut.isDone())
-        with self.assertRaises(ValueError) as cm:
-            fut._taskDone(returnValue="second call")
-        self.assertEqual(str(cm.exception), "Cannot alter future after future is done.")
-
-    def test_future_state_changes_and_signals(self):
-        fut = Future()
-        mock_slot = MagicMock()
-        fut.sigStateChanged.connect(mock_slot)
-
-        fut.setState("processing")
-        mock_slot.assert_called_once_with(fut, "processing")
-        self.assertEqual(fut.currentState(), "processing")
-        mock_slot.reset_mock()
-
-        fut.setState("processing") # same state
-        mock_slot.assert_not_called()
-        mock_slot.reset_mock()
-
-        fut.setState("finalizing")
-        mock_slot.assert_called_once_with(fut, "finalizing")
-        self.assertEqual(fut.currentState(), "finalizing")
-        mock_slot.reset_mock()
-
-        fut._taskDone(returnValue="done")
-        mock_slot.assert_not_called()
-        mock_slot.reset_mock()
-
-        fut2 = Future()
-        fut2.sigStateChanged.connect(mock_slot)
-        fut2._taskDone(interrupted=True, error="failed")
-        mock_slot.assert_not_called()
-
-    def test_future_sleep_interrupt(self):
-        fut = Future()
-
-        def task_with_sleep(_future):
-            try:
-                _future.sleep(5) # Long sleep
-                return "slept"
-            except Future.StopRequested:
-                return "stopped during sleep"
-
-        fut.executeInThread(task_with_sleep, (), {})
-        time.sleep(0.1) # let sleep start
-        self.assertFalse(fut.isDone())
-        fut.stop("interrupt sleep")
-        result = fut.getResult() # This will raise Future.Stopped if sleep doesn't handle it
-        self.assertEqual(result, "stopped during sleep")
-        self.assertTrue(fut.wasStopped())
-
-    def test_future_waitFor_propagates_stop_on_self_stop(self):
-        # This test ensures that if self.checkStop() within waitFor raises,
-        # the future being waited upon (child) is stopped.
-        parent_future = Future(name="parent")
-        child_future = Future(name="child_for_waitFor_prop_stop")
-
-        def child_task(_future):
-            _future.sleep(10) # Keep child busy
-
-        child_future.executeInThread(child_task, (), {})
-
-        # Start waiting in a thread
-        wait_thread_finished_event = threading.Event()
-        exception_in_thread = None
-
-        def wait_for_child():
-            nonlocal exception_in_thread
-            try:
-                parent_future.waitFor(child_future, timeout=20)
-            except Exception as e:
-                exception_in_thread = e
-            finally:
-                wait_thread_finished_event.set()
-
-        wait_thread = threading.Thread(target=wait_for_child)
-        wait_thread.start()
-
-        time.sleep(0.1) # Ensure waitFor has started and child_future is running
-        self.assertFalse(child_future.wasStopped())
-
-        parent_future.stop("Parent was stopped externally")
-        wait_thread_finished_event.wait(timeout=2) # Wait for waitFor to react
-
-        self.assertTrue(wait_thread_finished_event.is_set(), "Wait thread did not finish")
-        self.assertIsInstance(exception_in_thread, Future.StopRequested)
-        self.assertTrue(child_future.wasStopped(), "Child future was not stopped when parent was stopped during waitFor")
-        self.assertEqual(child_future.errorMessage(), "parent task stop requested")
-
-    def test_future_waitFor_propagates_stop_to_grandchildren(self):
-        # This test ensures that if self.checkStop() within waitFor raises,
-        # the future being waited upon (child) is stopped.
-        parent_future = Future(name="parent")
-        child_future = Future(name="child_for_waitFor_prop_stop")
-        grandchild_future = Future(name="grandchild_for_waitFor_prop_stop")
-
-        def grandchild_task(_future):
-            _future.sleep(1000) # Keep child busy
-        grandchild_future.executeInThread(grandchild_task, (), {})
-        wait_child_finished_event = threading.Event()
-        exception_in_child = None
-
-        def child_task(_future):
-            nonlocal exception_in_child
-            try:
-                _future.waitFor(grandchild_future, timeout=2000)
-            except Exception as e:
-                exception_in_child = e
-            finally:
-                wait_child_finished_event.set()
-
-        child_future.executeInThread(child_task, (), {})
-
-        # Start waiting in a thread
-        wait_thread_finished_event = threading.Event()
-        exception_in_thread = None
-
-        def wait_for_child():
-            nonlocal exception_in_thread
-            try:
-                parent_future.waitFor(child_future, timeout=2000)
-            except Exception as e:
-                exception_in_thread = e
-            finally:
-                wait_thread_finished_event.set()
-
-        wait_thread = threading.Thread(target=wait_for_child)
-        wait_thread.start()
-
-        time.sleep(0.1) # Ensure waitFor has started and all futures are running
-        self.assertFalse(child_future.wasStopped())
-        self.assertFalse(grandchild_future.wasStopped())
-
-        parent_future.stop("Parent was stopped externally")
-        wait_thread_finished_event.wait(timeout=2) # Wait for waitFor to react
-        wait_child_finished_event.wait(timeout=2) # Wait for child to react
-
-        self.assertTrue(wait_thread_finished_event.is_set(), "Wait thread did not finish")
-        self.assertIsInstance(exception_in_thread, Future.StopRequested)
-        self.assertTrue(wait_child_finished_event.is_set(), "Child wait thread did not finish")
-        self.assertIsInstance(exception_in_child, Future.StopRequested)
-        self.assertTrue(child_future.wasStopped(), "Child future was not stopped when parent was stopped during waitFor")
-        self.assertEqual(child_future.errorMessage(), "parent task stop requested")
-        self.assertTrue(grandchild_future.wasStopped(), "Grandchild future was not stopped when parent was stopped during waitFor")
-        self.assertEqual(grandchild_future.errorMessage(), "parent task stop requested")
-
-    def test_future_stop_with_wait_parameter(self):
-        """Test the new wait parameter in Future.stop()"""
-        fut = Future()
-        stop_completed = threading.Event()
-        
-        def long_running_task(_future):
-            try:
-                _future.sleep(0.5)  # Sleep for a reasonable time
-                return "completed"
-            except Future.StopRequested:
-                # Simulate some cleanup time
-                time.sleep(0.1)
-                return "stopped"
-            finally:
-                stop_completed.set()
-        
-        fut.executeInThread(long_running_task, (), {})
-        time.sleep(0.05)  # Let task start
-        
-        # Test stop without wait - should return immediately
-        start_time = time.time()
-        fut.stop("test stop", wait=False)
-        elapsed = time.time() - start_time
-        self.assertLess(elapsed, 0.05, "stop(wait=False) should return immediately")
-        self.assertTrue(fut.wasStopped())
-        
-        # Verify task eventually completes
-        self.assertTrue(stop_completed.wait(timeout=1))
-        
-    def test_future_stop_with_wait_blocks_until_done(self):
-        """Test that stop(wait=True) blocks until task completes"""
-        fut = Future()
-        task_finished = threading.Event()
-        
-        def task_with_cleanup(_future):
-            try:
-                _future.sleep(1.0)  # Long sleep
-                return "completed normally"
-            except Future.StopRequested:
-                # Simulate cleanup work
-                time.sleep(0.2)
-                return "stopped after cleanup"
-            finally:
-                task_finished.set()
-        
-        fut.executeInThread(task_with_cleanup, (), {})
-        time.sleep(0.05)  # Let task start
-        
-        # Test stop with wait=True - should block until task finishes
-        start_time = time.time()
-        fut.stop("test stop with wait", wait=True)
-        elapsed = time.time() - start_time
-        
-        self.assertGreaterEqual(elapsed, 0.15, "stop(wait=True) should block for cleanup time")
-        self.assertTrue(fut.isDone())
-        self.assertTrue(task_finished.is_set())
-        
-    def test_future_stop_wait_with_exception(self):
-        """Test stop(wait=True) when task raises an exception"""
-        fut = Future()
-        task_started = threading.Event()
-        
-        def failing_task(_future):
-            task_started.set()
-            try:
-                _future.sleep(0.5)
-                return "should not reach here"
-            except Future.StopRequested:
-                # Simulate cleanup that raises an exception
-                time.sleep(0.1)
-                raise ValueError("cleanup failed")
-        
-        fut.executeInThread(failing_task, (), {})
-        task_started.wait(timeout=1)  # Ensure task has started
-        
-        # stop(wait=True) should still complete even if task raises during cleanup
-        start_time = time.time()
-        fut.stop("test stop with exception", wait=True)
-        elapsed = time.time() - start_time
-        
-        self.assertGreaterEqual(elapsed, 0.05, "Should wait for cleanup even with exception")
-        self.assertTrue(fut.isDone())
-        self.assertTrue(fut.wasInterrupted())
-        
-    def test_future_stop_wait_on_already_done_future(self):
-        """Test stop(wait=True) on an already completed future"""
-        fut = Future.immediate("already done")
-        
-        # Should return immediately without error
-        start_time = time.time()
-        fut.stop("test stop on done", wait=True)
-        elapsed = time.time() - start_time
-        
-        self.assertLess(elapsed, 0.01, "stop() on done future should return immediately")
-        
-    def test_future_stop_wait_race_condition(self):
-        """Test race condition where future completes just as stop() is called"""
-        fut = Future()
-        
-        def quick_task(_future):
-            time.sleep(0.05)  # Very short task
-            return "quick completion"
-        
-        fut.executeInThread(quick_task, (), {})
-        
-        # Try to stop right around when task might complete
-        time.sleep(0.03)  # Partial way through task
-        
-        # This might catch the future in various states
-        fut.stop("race condition test", wait=True)
-        
-        # Should handle gracefully regardless of timing
-        self.assertTrue(fut.isDone())
-        
-    def test_future_stop_wait_with_nested_futures(self):
-        """Test stop(wait=True) with nested futures that propagate stops"""
-        parent_fut = Future()
-        child_fut = Future()
-        parent_fut.propagateStopsInto(child_fut)
-        
-        child_stopped = threading.Event()
-        parent_stopped = threading.Event()
-        
-        def child_task(_future):
-            try:
-                _future.sleep(1.0)
-                return "child completed"
-            except Future.StopRequested:
-                time.sleep(0.1)  # Cleanup time
-                return "child stopped"
-            finally:
-                child_stopped.set()
-        
-        def parent_task(_future):
-            try:
-                _future.waitFor(child_fut)
-                return "parent completed"
-            except Future.StopRequested:
-                time.sleep(0.05)  # Parent cleanup
-                return "parent stopped"
-            finally:
-                parent_stopped.set()
-        
-        child_fut.executeInThread(child_task, (), {})
-        parent_fut.executeInThread(parent_task, (), {})
-        time.sleep(0.05)  # Let tasks start
-        
-        # Stop parent with wait=True should wait for both to complete
-        start_time = time.time()
-        parent_fut.stop("nested stop test", wait=True)
-        elapsed = time.time() - start_time
-        
-        self.assertGreaterEqual(elapsed, 0.05, "Should wait for some cleanup time")
-        self.assertTrue(parent_fut.isDone())
-        self.assertTrue(child_fut.wasStopped())
-        self.assertTrue(parent_stopped.wait(timeout=0.5))
-        self.assertTrue(child_stopped.wait(timeout=0.5))
-        
-    def test_future_stop_wait_timeout_protection(self):
-        """Test that stop(wait=True) waits for cleanup but handles exceptions gracefully"""
-        fut = Future()
-        task_started = threading.Event()
-        
-        def task_with_slow_cleanup(_future):
-            task_started.set()
-            try:
-                _future.sleep(5.0)  # Long sleep that will be interrupted
-                return "should not complete"
-            except Future.StopRequested:
-                # Simulate cleanup that takes some time
-                time.sleep(0.2)  # Reasonable cleanup time
-                return "stopped after cleanup"
-        
-        fut.executeInThread(task_with_slow_cleanup, (), {})
-        task_started.wait(timeout=1)
-        
-        # stop(wait=True) should wait for cleanup to complete
-        start_time = time.time()
-        fut.stop("cleanup test", wait=True)
-        elapsed = time.time() - start_time
-        
-        # Should wait for the cleanup time but not the original sleep time
-        self.assertGreaterEqual(elapsed, 0.15, "Should wait for cleanup time")
-        self.assertLess(elapsed, 1.0, "Should not wait for original long sleep")
-        self.assertTrue(fut.isDone())
-        
-    def test_multifuture_stop_with_wait(self):
-        """Test MultiFuture.stop() with wait parameter"""
-        f1 = Future()
-        f2 = Future()
-        multi = MultiFuture([f1, f2])
-        
-        cleanup_times = []
-        
-        def task_with_cleanup(task_id):
-            def _task(_future):
-                try:
-                    _future.sleep(1.0)
-                    return f"task {task_id} completed"
-                except Future.StopRequested:
-                    cleanup_start = time.time()
-                    time.sleep(0.1)  # Cleanup time
-                    cleanup_times.append(time.time() - cleanup_start)
-                    return f"task {task_id} stopped"
-            return _task
-        
-        f1.executeInThread(task_with_cleanup(1), (), {})
-        f2.executeInThread(task_with_cleanup(2), (), {})
-        time.sleep(0.05)  # Let tasks start
-        
-        # Stop with wait=True should wait for all futures
-        start_time = time.time()
-        multi.stop("multi stop test", wait=True)
-        elapsed = time.time() - start_time
-        
-        self.assertGreaterEqual(elapsed, 0.08, "Should wait for all futures to cleanup")
-        self.assertTrue(f1.wasStopped())
-        self.assertTrue(f2.wasStopped())
-        self.assertEqual(len(cleanup_times), 2, "Both futures should have completed cleanup")
-
-
-class TestMultiFuture(unittest.TestCase):
-    def test_raises_on_one_error(self):
-        f1 = Future.immediate("success")
-        f2 = Future.immediate(excInfo=[ValueError, ValueError("boom"), None])
-        multi = MultiFuture([f1, f2])
-        with self.assertRaises(RuntimeError) as cm:
-            multi.wait()
-        # The original ValueError should be in the cause chain
-        self.assertIsInstance(cm.exception.__cause__, ValueError)
-        # The error message should appear in the enhanced traceback
-        enhanced_exception_str = str(cm.exception.__cause__)
-        self.assertIn("boom", enhanced_exception_str)
-
-    def test_raises_on_multiple_errors(self):
-        f1 = Future.immediate("success")
-        f2 = Future.immediate(excInfo=[ValueError, ValueError("boom"), None])
-        f3 = Future.immediate(excInfo=[ValueError, ValueError("pow"), None])
-        multi = MultiFuture([f1, f2, f3])
-        with self.assertRaises(RuntimeError) as cm:
-            multi.wait()
-        self.assertIsInstance(cm.exception.__cause__, MultiException)
-
-    def test_onFinish(self):
-        result = "test"
-        called = False
-
-        def on_finish(fut):
-            nonlocal called
-            self.assertTrue(fut.isDone())
-            self.assertIn(result, fut.getResult())
-            called = True
-
-        fut = MultiFuture([Future.immediate(result)])
-        self.assertFalse(called)
-        fut.onFinish(on_finish)
-        self.assertTrue(called)
-
-    def test_multi_future_stop_propagates(self):
-        f1 = Future()
-        f2 = Future()
-        multi = MultiFuture([f1, f2])
-        multi.stop("stop multi")
-        self.assertTrue(f1.wasStopped())
-        self.assertTrue(f2.wasStopped())
-        self.assertEqual(f1.errorMessage(), "stop multi")
-        self.assertEqual(f2.errorMessage(), "stop multi")
-        self.assertTrue(multi.wasStopped())
-
-    def test_multi_future_percent_done(self):
-        class MockPercentFuture(Future):
-            def __init__(self, percent):
-                super().__init__()
-                self._percent = percent
-                if percent == 1.0:
-                    self._taskDone()
-
-            def percentDone(self):
-                return self._percent
-
-        f1 = MockPercentFuture(0.5)
-        f2 = MockPercentFuture(0.8)
-        multi = MultiFuture([f1, f2])
-        self.assertEqual(multi.percentDone(), 0.5)
-
-        f3 = MockPercentFuture(1.0)
-        multi_all_done = MultiFuture([f3, MockPercentFuture(1.0)])
-        self.assertEqual(multi_all_done.percentDone(), 1.0)
-        self.assertTrue(multi_all_done.isDone())
-
-    def test_multi_future_current_state(self):
-        f1 = Future.immediate("res1")
-        f1.setState("f1_state")
-        f2 = Future()
-        f2.setState("f2_init_state")
-        f2_event = threading.Event()
-        def f2_task(_future):
-            f2_event.set()
-            _future.setState("f2_running")
-            time.sleep(0.1)
-            _future.setState("f2_done")
-            return "res2"
-        multi = MultiFuture([f1, f2])
-        self.assertIn("f2_init_state", multi.currentState()) # or f2_running depending on timing
-        f2.executeInThread(f2_task, (), {})
-        f2_event.wait(timeout=1)
-        # State can be tricky due to timing, check that it contains individual states
-        self.assertIn("f1_state", multi.currentState())
-        self.assertIn("f2_running", multi.currentState()) # or f2_running depending on timing
-        f2.wait()
-        self.assertIn("f1_state", multi.currentState())
-        self.assertIn("f2_done", multi.currentState())
-
-
-class TestFutureCreationStackTraces(unittest.TestCase):
-    def test_basic_stack_capture(self):
-        """Test that Future captures the creation stack."""
-        def create_nested_future():
-            def level2():
-                def level3():
-                    return Future(name="nested_creation")
-                return level3()
-            return level2()
-        
-        fut = create_nested_future()
-        self.assertIsNotNone(fut._creationStack)
-        self.assertGreater(len(fut._creationStack), 3)  # Should have multiple stack frames
-        
-        # Check that relevant function names are in the stack
-        stack_filenames = [frame.filename for frame in fut._creationStack]
-        stack_names = [frame.name for frame in fut._creationStack]
-        
-        self.assertIn("create_nested_future", stack_names)
-        self.assertIn("level2", stack_names)
-        self.assertIn("level3", stack_names)
-
-    def test_exception_with_creation_context(self):
-        """Test that exceptions include both creation and execution contexts."""
-        def create_failing_future():
-            def nested_creator():
-                fut = Future(name="failing_task")
-                
-                def failing_task(_future):
-                    raise ValueError("Task failed deliberately")
-                
-                fut.executeInThread(failing_task, (), {})
-                return fut
-            return nested_creator()
-        
-        fut = create_failing_future()
-        
-        with self.assertRaises(ValueError) as cm:
-            fut.wait()
-        
-        exception_str = str(cm.exception)
-        
-        # Should include the creation stack
-        self.assertIn("create_failing_future", exception_str)
-        self.assertIn("nested_creator", exception_str)
-        
-        # Should include the execution context
-        self.assertIn("failing_task", exception_str)
-        self.assertIn("Task failed deliberately", exception_str)
-
-    def test_threaded_future_with_thread_boundary(self):
-        """Test that threaded futures show the thread transition."""
-        def create_threaded_future():
-            fut = Future(name="threaded_task")
-            
-            def task_in_thread(_future):
-                raise RuntimeError("Error in thread")
-            
-            fut.executeInThread(task_in_thread, (), {})
-            return fut
-        
-        fut = create_threaded_future()
-        
-        with self.assertRaises(RuntimeError) as cm:
-            fut.wait()
-        
-        exception_str = str(cm.exception)
-        
-        # Should show thread boundary
-        self.assertIn("Thread boundary", exception_str)
-        self.assertIn("execute thread for", exception_str)
-        
-        # Should include both sides of the boundary
-        self.assertIn("create_threaded_future", exception_str)
-        self.assertIn("task_in_thread", exception_str)
-
-    def test_future_wrap_creation_context(self):
-        """Test that future_wrap shows the correct creation point."""
-        @future_wrap
-        def wrapped_failing_function(arg1, _future=None):
-            raise TypeError(f"Wrapped function failed with {arg1}")
-        
-        def call_wrapped_function():
-            return wrapped_failing_function("test_arg", _sync="async")
-
-        fut = call_wrapped_function()
-        
-        with self.assertRaises(TypeError) as cm:
-            fut.wait()
-        
-        exception_str = str(cm.exception)
-        
-        # Should include the call site
-        self.assertIn("call_wrapped_function", exception_str)
-        
-        # Should include the wrapped function
-        self.assertIn("wrapped_failing_function", exception_str)
-        self.assertIn("Wrapped function failed with test_arg", exception_str)
-
-    def test_immediate_future_preserves_excInfo(self):
-        """Test that immediate futures with excInfo preserve the traceback."""
-        def create_immediate_with_exc():
-            try:
-                raise ValueError("Original error")
-            except ValueError:
-                exc_info = sys.exc_info()
-                return Future.immediate(excInfo=exc_info)
-        
-        fut = create_immediate_with_exc()
-        
-        with self.assertRaises(ValueError) as cm:
-            fut.wait()
-        
-        exception_str = str(cm.exception)
-        
-        # Should include creation context
-        self.assertIn("create_immediate_with_exc", exception_str)
-        
-        # Should include original error
-        self.assertIn("Original error", exception_str)
-
-    def test_multifuture_exception_handling(self):
-        """Test that MultiFuture preserves individual future creation stacks."""
-        def create_multi_with_failures():
-            def create_failing_subfuture(name, error_msg):
-                fut = Future(name=name)
-                
-                def failing_task(_future):
-                    raise ValueError(error_msg)
-                
-                fut.executeInThread(failing_task, (), {})
-                return fut
-            
-            f1 = create_failing_subfuture("subfuture1", "Error in first future")
-            f2 = Future.immediate("success")
-            return MultiFuture([f1, f2])
-        
-        multi_fut = create_multi_with_failures()
-        
-        with self.assertRaises(RuntimeError) as cm:
-            multi_fut.wait()
-        
-        # The enhanced exception should be in the __cause__ chain
-        enhanced_exc = cm.exception.__cause__
-        self.assertIsNotNone(enhanced_exc)
-        exception_str = str(enhanced_exc)
-        
-        # Should include the creation context for the MultiFuture
-        self.assertIn("create_multi_with_failures", exception_str)
-        # Should include the original error
-        self.assertIn("Error in first future", exception_str)
-        # Should include the creation path to MultiFuture
-        self.assertIn("MultiFuture", exception_str)
-
-    def test_nested_futures_preserve_stacks(self):
-        """Test that nested futures maintain their individual creation stacks."""
-        def outer_function():
-            def middle_function():
-                def inner_function():
-                    inner_fut = Future(name="inner")
-                    
-                    def inner_task(_future):
-                        raise KeyError("Inner task error")
-                    
-                    inner_fut.executeInThread(inner_task, (), {})
-                    return inner_fut
-                
-                return inner_function()
-            
-            outer_fut = Future(name="outer")
-            
-            def outer_task(_future):
-                inner_fut = middle_function()
-                try:
-                    inner_fut.wait()
-                except Exception as e:
-                    raise RuntimeError("Outer task failed") from e
-            
-            outer_fut.executeInThread(outer_task, (), {})
-            return outer_fut
-        
-        fut = outer_function()
-        
-        with self.assertRaises(RuntimeError) as cm:
-            fut.wait()
-        
-        exception_str = str(cm.exception)
-        
-        # Should show the outer future's creation stack
-        self.assertIn("outer_function", exception_str)
-        
-        # Should include the outer task failure
-        self.assertIn("Outer task failed", exception_str)
-
-    def test_creation_stack_excludes_future_init(self):
-        """Test that the creation stack doesn't include Future.__init__ itself."""
-        def create_future_and_check():
-            fut = Future(name="test_exclusion")
-            return fut
-        
-        fut = create_future_and_check()
-        
-        # Should not include __init__ in the creation stack
-        stack_names = [frame.name for frame in fut._creationStack]
-        self.assertNotIn("__init__", stack_names)
-        
-        # Should include the calling function
-        self.assertIn("create_future_and_check", stack_names)
+app = QApplication.instance() or QApplication([])
 
 
 class TestTaskStack(unittest.TestCase):
+    def setUp(self):
+        from acq4.util.future import task_stack
+        self.task_stack = task_stack
+
     def test_get_returns_empty_tuple_by_default(self):
-        self.assertEqual(task_stack.get(), ())
+        self.assertEqual(self.task_stack.get(), ())
 
     def test_full_stack_returns_empty_string_when_empty(self):
-        self.assertEqual(task_stack.full_stack(), "")
+        self.assertEqual(self.task_stack.full_stack(), "")
 
     def test_push_appends_name_and_restores(self):
-        with task_stack.push("foo"):
-            self.assertEqual(task_stack.get(), ("foo",))
-        self.assertEqual(task_stack.get(), ())
+        with self.task_stack.push("foo"):
+            self.assertEqual(self.task_stack.get(), ("foo",))
+        self.assertEqual(self.task_stack.get(), ())
 
     def test_nested_push_builds_chain(self):
-        with task_stack.push("a"):
-            with task_stack.push("b"):
-                self.assertEqual(task_stack.get(), ("a", "b"))
-                self.assertEqual(task_stack.full_stack(), "a > b")
-            self.assertEqual(task_stack.get(), ("a",))
-        self.assertEqual(task_stack.get(), ())
+        with self.task_stack.push("a"):
+            with self.task_stack.push("b"):
+                self.assertEqual(self.task_stack.get(), ("a", "b"))
+                self.assertEqual(self.task_stack.full_stack(), "a > b")
+            self.assertEqual(self.task_stack.get(), ("a",))
+        self.assertEqual(self.task_stack.get(), ())
 
     def test_push_full_replaces_chain_and_restores(self):
-        with task_stack.push("outer"):
-            with task_stack.push_full(("a", "b")):
-                self.assertEqual(task_stack.get(), ("a", "b"))
-            self.assertEqual(task_stack.get(), ("outer",))
+        with self.task_stack.push("outer"):
+            with self.task_stack.push_full(("a", "b")):
+                self.assertEqual(self.task_stack.get(), ("a", "b"))
+            self.assertEqual(self.task_stack.get(), ("outer",))
 
     def test_push_in_thread_does_not_affect_parent(self):
-        """Thread gets its own copy of the stack and does not bleed into the parent."""
         results = {}
 
         def thread_fn():
-            with task_stack.push("thread_name"):
-                results["in_thread"] = task_stack.get()
+            with self.task_stack.push("thread_name"):
+                results["in_thread"] = self.task_stack.get()
 
         t = threading.Thread(target=thread_fn)
         t.start()
         t.join()
 
-        results["in_parent"] = task_stack.get()
+        results["in_parent"] = self.task_stack.get()
         self.assertEqual(results["in_thread"], ("thread_name",))
         self.assertEqual(results["in_parent"], ())
 
     def test_full_stack_with_single_entry(self):
-        with task_stack.push("only"):
-            self.assertEqual(task_stack.full_stack(), "only")
+        with self.task_stack.push("only"):
+            self.assertEqual(self.task_stack.full_stack(), "only")
 
 
 class TestCurrentFuture(unittest.TestCase):
-    def test_current_future_is_none_by_default(self):
-        self.assertIsNone(current_future.get(None))
+    """Tests for the current_future() ambient accessor and context tracking."""
 
-    def test_current_future_set_during_execute_and_set_return(self):
+    def test_current_future_is_none_by_default(self):
+        from acq4.util.future import current_future
+        self.assertIsNone(current_future())
+
+    def test_current_future_set_while_future_runs(self):
+        from acq4.util.future import Future, current_future
         captured = {}
 
-        def task(_future):
-            captured["during"] = current_future.get(None)
-            return "ok"
+        def task():
+            captured["during"] = current_future()
 
-        fut = Future(name="cf_test")
-        fut.executeInThread(task, (), {})
+        fut = Future(task, name="cf_test")
         fut.wait()
         self.assertIs(captured["during"], fut)
 
-    def test_current_future_restored_after_future_completes(self):
-        def task(_future):
-            return "ok"
+    def test_current_future_is_none_after_future_completes(self):
+        from acq4.util.future import Future, current_future
+        Future(lambda: None, name="cf_cleanup").wait()
+        self.assertIsNone(current_future())
 
-        fut = Future(name="cf_restore_test")
-        fut.executeInThread(task, (), {})
-        fut.wait()
-        # After execution the thread is gone; confirm parent thread is still None
-        self.assertIsNone(current_future.get(None))
-
-    def test_task_stack_pushed_during_execute_and_set_return(self):
+    def test_task_stack_pushed_while_future_runs(self):
+        from acq4.util.future import Future, task_stack
         captured = {}
 
-        def task(_future):
+        def task():
             captured["stack"] = task_stack.get()
-            return "ok"
 
-        fut = Future(name="my_task")
-        fut.executeInThread(task, (), {})
-        fut.wait()
+        Future(task, name="my_task").wait()
         self.assertIn("my_task", captured["stack"])
 
-    def test_task_stack_popped_after_future_completes(self):
-        """Stack in the executing thread is clean after the future finishes."""
-        captured = {}
+    def test_task_stack_includes_parent_then_child(self):
+        from acq4.util.future import Future, task_stack
+        inner_stack = {}
 
-        def task(_future):
-            return "ok"
+        def inner():
+            inner_stack["stack"] = task_stack.get()
 
-        finished = threading.Event()
+        def outer():
+            Future(inner, name="inner").wait()
 
-        def thread_fn():
-            fut = Future(name="pop_test")
-            fut.executeAndSetReturn(task, (), {})
-            captured["after"] = task_stack.get()
-            finished.set()
-
-        t = threading.Thread(target=thread_fn)
-        t.start()
-        finished.wait(timeout=2)
-        self.assertEqual(captured["after"], ())
+        Future(outer, name="outer").wait()
+        self.assertEqual(inner_stack["stack"], ("outer", "inner"))
 
 
-class TestFutureWrapExecutionModel(unittest.TestCase):
-    """Tests for the blocking-by-default / _sync='async' execution model."""
+class TestV2Future(unittest.TestCase):
+    """Tests for the v2 Future(fn) API."""
 
-    def test_default_call_returns_value(self):
-        @future_wrap
-        def task(name=None, _future=None):
-            return 42
+    def test_wait_returns_function_result(self):
+        from acq4.util.future import Future
+        fut = Future(lambda: 42, name="answer")
+        self.assertEqual(fut.wait(), 42)
 
-        result = task()
-        self.assertEqual(result, 42)
+    def test_is_done_after_wait(self):
+        from acq4.util.future import Future
+        fut = Future(lambda: None, name="done_check")
+        fut.wait()
+        self.assertTrue(fut.is_done)
 
-    def test_default_call_propagates_exception(self):
-        @future_wrap
-        def boom(name=None, _future=None):
+    def test_wait_re_raises_exception(self):
+        from acq4.util.future import Future
+
+        def boom():
             raise ValueError("kaboom")
 
+        fut = Future(boom, name="boom")
         with self.assertRaises(ValueError, msg="kaboom"):
-            boom()
+            fut.wait()
 
-    def test_default_call_sets_current_future(self):
-        captured = {}
+    def test_stop_interrupts_sleeping_future(self):
+        from acq4.util.future import Future, sleep, Stopped
+        started = threading.Event()
 
-        @future_wrap
-        def task(name=None, _future=None):
-            captured["fut"] = current_future.get()
+        def task():
+            started.set()
+            sleep(60)
 
-        task()
-        self.assertIsNotNone(captured["fut"])
-        self.assertIsInstance(captured["fut"], Future)
+        fut = Future(task, name="sleeper")
+        started.wait(timeout=2)
+        fut.stop()
+        with self.assertRaises(Stopped):
+            fut.wait()
 
-    def test_default_call_pushes_task_stack(self):
-        captured = {}
+    def test_is_stopped_after_stop(self):
+        from acq4.util.future import Future, sleep
+        started = threading.Event()
 
-        @future_wrap
-        def task(name=None, _future=None):
-            captured["stack"] = task_stack.get()
+        def task():
+            started.set()
+            sleep(60)
 
-        task(name="my_task")
-        self.assertIn("my_task", captured["stack"])
+        fut = Future(task, name="stop_check")
+        started.wait(timeout=2)
+        fut.stop()
+        fut._done.wait(timeout=2)
+        self.assertTrue(fut.is_stopped)
 
-    def test_async_returns_future(self):
-        @future_wrap
-        def task(name=None, _future=None):
-            return "done"
+    def test_stop_cascades_to_child(self):
+        from acq4.util.future import Future, sleep, Stopped
+        child_started = threading.Event()
 
-        fut = task(_sync="async")
-        self.assertIsInstance(fut, Future)
-        self.assertEqual(fut.getResult(), "done")
+        def child():
+            child_started.set()
+            sleep(60)
 
-    def test_name_kwarg_used_as_future_name(self):
-        captured = {}
+        def parent():
+            child_fut = Future(child, name="child")
+            child_started.wait(timeout=2)
+            child_fut.wait()
 
-        @future_wrap
-        def task(name=None, _future=None):
-            captured["name"] = current_future.get().name
+        parent_fut = Future(parent, name="parent")
+        child_started.wait(timeout=2)
+        parent_fut.stop()
+        with self.assertRaises(Stopped):
+            parent_fut.wait()
 
-        task(name="special_name")
-        self.assertEqual(captured["name"], "special_name")
+    def test_add_finish_callback_called_on_completion(self):
+        from acq4.util.future import Future
+        results = []
+        fut = Future(lambda: "done", name="cb_test")
+        fut.add_finish_callback(lambda result, exc: results.append((result, exc)))
+        fut.wait()
+        self.assertEqual(results, [("done", None)])
 
-    def test_name_kwarg_passed_through_to_function(self):
-        captured = {}
+    def test_add_finish_callback_called_immediately_if_already_done(self):
+        from acq4.util.future import Future
+        fut = Future(lambda: "done", name="cb_immediate")
+        fut.wait()
+        results = []
+        fut.add_finish_callback(lambda result, exc: results.append((result, exc)))
+        self.assertEqual(results, [("done", None)])
 
-        @future_wrap
-        def task(name=None, _future=None):
-            captured["name"] = name
+    def test_wait_timeout_raises(self):
+        from acq4.util.future import Future
+        fut = Future(lambda: time.sleep(60), name="slow")
+        with self.assertRaises(TimeoutError):
+            fut.wait(timeout=0.1)
+        fut.stop()
 
-        task(name="passed_through")
-        self.assertEqual(captured["name"], "passed_through")
+    def test_detached_future_not_stopped_by_parent(self):
+        from acq4.util.future import Future, sleep
+        child_done = threading.Event()
 
-    def test_nested_default_calls_build_task_stack(self):
-        outer_stack = {}
-        inner_stack = {}
+        def child():
+            time.sleep(0.2)
+            child_done.set()
+            return "child_result"
 
-        @future_wrap
-        def inner(name=None, _future=None):
-            inner_stack["stack"] = task_stack.get()
+        def parent():
+            child_fut = Future(child, name="detached_child", detach=True)
+            return child_fut
 
-        @future_wrap
-        def outer(name=None, _future=None):
-            outer_stack["stack"] = task_stack.get()
-            inner(name="inner")
+        parent_fut = Future(parent, name="parent_detach")
+        child_fut = parent_fut.wait()
+        parent_fut.stop()
+        child_done.wait(timeout=2)
+        self.assertTrue(child_done.is_set())
+        self.assertEqual(child_fut.wait(), "child_result")
 
-        outer(name="outer")
-        self.assertEqual(outer_stack["stack"], ("outer",))
-        self.assertEqual(inner_stack["stack"], ("outer", "inner"))
 
-    def test_async_call_inherits_parent_task_stack(self):
-        inner_stack = {}
-        done = threading.Event()
+class TestSleep(unittest.TestCase):
+    def test_sleep_outside_future_behaves_like_time_sleep(self):
+        from acq4.util.future import sleep
+        t0 = time.monotonic()
+        sleep(0.05)
+        elapsed = time.monotonic() - t0
+        self.assertGreater(elapsed, 0.04)
 
-        @future_wrap
-        def inner(name=None, _future=None):
-            inner_stack["stack"] = task_stack.get()
-            done.set()
+    def test_sleep_raises_stopped_when_future_is_stopped(self):
+        from acq4.util.future import Future, sleep, Stopped
+        started = threading.Event()
 
-        @future_wrap
-        def outer(name=None, _future=None):
-            fut = inner(name="inner", _sync="async")
-            _future.waitFor(fut)
+        def task():
+            started.set()
+            sleep(60)
 
-        outer(name="outer")
-        done.wait(timeout=2)
-        self.assertEqual(inner_stack["stack"], ("outer", "inner"))
+        fut = Future(task, name="sleep_stop")
+        started.wait(timeout=2)
+        fut.stop()
+        with self.assertRaises(Stopped):
+            fut.wait()
+
+    def test_sleep_completes_normally(self):
+        from acq4.util.future import Future, sleep
+
+        def task():
+            sleep(0.05)
+            return "ok"
+
+        result = Future(task, name="sleep_ok").wait()
+        self.assertEqual(result, "ok")
+
+
+class TestCheckStop(unittest.TestCase):
+    def test_check_stop_raises_stopped_when_future_is_stopped(self):
+        from acq4.util.future import Future, check_stop, Stopped
+        started = threading.Event()
+        stopped = threading.Event()
+
+        def task():
+            started.set()
+            stopped.wait(timeout=2)
+            check_stop()
+
+        fut = Future(task, name="check_stop_test")
+        started.wait(timeout=2)
+        fut.stop()
+        stopped.set()
+        with self.assertRaises(Stopped):
+            fut.wait()
+
+    def test_check_stop_is_noop_outside_future(self):
+        from acq4.util.future import check_stop
+        check_stop()  # should not raise
+
+    def test_check_stop_is_noop_when_not_stopped(self):
+        from acq4.util.future import Future, check_stop
+
+        def task():
+            check_stop()
+            return "fine"
+
+        self.assertEqual(Future(task, name="cs_noop").wait(), "fine")
+
+
+class TestQueue(unittest.TestCase):
+    def test_get_returns_item(self):
+        from acq4.util.future import Future, Queue
+
+        q = Queue()
+        q.put("item")
+
+        def task():
+            return q.get()
+
+        self.assertEqual(Future(task, name="q_get").wait(), "item")
+
+    def test_get_raises_stopped_when_future_is_stopped(self):
+        from acq4.util.future import Future, Queue, Stopped
+        q = Queue()
+        started = threading.Event()
+
+        def task():
+            started.set()
+            q.get()
+
+        fut = Future(task, name="q_stop")
+        started.wait(timeout=2)
+        fut.stop()
+        with self.assertRaises(Stopped):
+            fut.wait()
+
+    def test_get_outside_future_behaves_normally(self):
+        from acq4.util.future import Queue
+        q = Queue()
+        q.put(99)
+        self.assertEqual(q.get(), 99)
+
+
+class TestEvent(unittest.TestCase):
+    def test_wait_returns_when_set(self):
+        from acq4.util.future import Future, Event
+
+        ev = Event()
+        ev.set()
+
+        def task():
+            return ev.wait()
+
+        self.assertTrue(Future(task, name="ev_set").wait())
+
+    def test_wait_raises_stopped_when_future_is_stopped(self):
+        from acq4.util.future import Future, Event, Stopped
+        ev = Event()
+        started = threading.Event()
+
+        def task():
+            started.set()
+            ev.wait()
+
+        fut = Future(task, name="ev_stop")
+        started.wait(timeout=2)
+        fut.stop()
+        with self.assertRaises(Stopped):
+            fut.wait()
+
+    def test_wait_outside_future_behaves_normally(self):
+        from acq4.util.future import Event
+        ev = Event()
+        ev.set()
+        self.assertTrue(ev.wait(timeout=0.1))
 
 
 if __name__ == "__main__":

--- a/tests/test_future.py
+++ b/tests/test_future.py
@@ -9,6 +9,7 @@ from PyQt5.QtWidgets import QApplication
 
 from acq4.util.future import Future, FutureButton, MultiFuture, MultiException
 from acq4.util.future import future_wrap
+from acq4.util.future import current_future, task_stack
 
 app = QApplication([])
 
@@ -18,7 +19,8 @@ class TestFutureButton(unittest.TestCase):
         self._future = Future.immediate("success")
         self.future_producer = MagicMock(return_value=self._future)
         self.button = FutureButton(
-            self.future_producer, "Test Button", stoppable=True, success="Completed", failure="Failed"
+            self.future_producer, "Test Button", stoppable=True, success="Completed", failure="Failed",
+            raiseOnError=False,
         )
 
     def test_button_initial_state(self):
@@ -41,7 +43,7 @@ class TestFutureButton(unittest.TestCase):
         @future_wrap
         def task(_future=None):
             raise ValueError("error")
-        self.future_producer.return_value = task()
+        self.future_producer.return_value = task(_sync="async")
         self.button.click()
         QApplication.processEvents()
         self.assertEqual("Failed", self.button.text())
@@ -51,7 +53,7 @@ class TestFutureButton(unittest.TestCase):
         def so_sleepy(_future):
             _future.sleep(1e6, interval=0)
 
-        f = so_sleepy()
+        f = so_sleepy(_sync="async")
         self.future_producer.return_value = f
         self.button.click()
         QApplication.processEvents()
@@ -110,7 +112,7 @@ class TestFuture(unittest.TestCase):
         def on_error(f):
             nonlocal called
             called = True
-        fut = boom(onFutureError=on_error)
+        fut = boom(_sync="async", onFutureError=on_error)
         with contextlib.suppress(ValueError):
             fut.wait()
         self.assertTrue(called)
@@ -125,7 +127,7 @@ class TestFuture(unittest.TestCase):
         def on_error(f):
             nonlocal called
             called = True
-        fut = boom(onFutureError=on_error)
+        fut = boom(_sync="async", onFutureError=on_error)
         fut.wait()
         self.assertFalse(called)
 
@@ -147,7 +149,7 @@ class TestFuture(unittest.TestCase):
         def task(_future=None):
             return "wrapped"
 
-        fut = task()
+        fut = task(_sync="async")
         fut.wait()
         self.assertTrue(fut.isDone())
         self.assertEqual(fut.getResult(), "wrapped")
@@ -856,8 +858,8 @@ class TestFutureCreationStackTraces(unittest.TestCase):
             raise TypeError(f"Wrapped function failed with {arg1}")
         
         def call_wrapped_function():
-            return wrapped_failing_function("test_arg")
-        
+            return wrapped_failing_function("test_arg", _sync="async")
+
         fut = call_wrapped_function()
         
         with self.assertRaises(TypeError) as cm:
@@ -981,6 +983,217 @@ class TestFutureCreationStackTraces(unittest.TestCase):
         
         # Should include the calling function
         self.assertIn("create_future_and_check", stack_names)
+
+
+class TestTaskStack(unittest.TestCase):
+    def test_get_returns_empty_tuple_by_default(self):
+        self.assertEqual(task_stack.get(), ())
+
+    def test_full_stack_returns_empty_string_when_empty(self):
+        self.assertEqual(task_stack.full_stack(), "")
+
+    def test_push_appends_name_and_restores(self):
+        with task_stack.push("foo"):
+            self.assertEqual(task_stack.get(), ("foo",))
+        self.assertEqual(task_stack.get(), ())
+
+    def test_nested_push_builds_chain(self):
+        with task_stack.push("a"):
+            with task_stack.push("b"):
+                self.assertEqual(task_stack.get(), ("a", "b"))
+                self.assertEqual(task_stack.full_stack(), "a > b")
+            self.assertEqual(task_stack.get(), ("a",))
+        self.assertEqual(task_stack.get(), ())
+
+    def test_push_full_replaces_chain_and_restores(self):
+        with task_stack.push("outer"):
+            with task_stack.push_full(("a", "b")):
+                self.assertEqual(task_stack.get(), ("a", "b"))
+            self.assertEqual(task_stack.get(), ("outer",))
+
+    def test_push_in_thread_does_not_affect_parent(self):
+        """Thread gets its own copy of the stack and does not bleed into the parent."""
+        results = {}
+
+        def thread_fn():
+            with task_stack.push("thread_name"):
+                results["in_thread"] = task_stack.get()
+
+        t = threading.Thread(target=thread_fn)
+        t.start()
+        t.join()
+
+        results["in_parent"] = task_stack.get()
+        self.assertEqual(results["in_thread"], ("thread_name",))
+        self.assertEqual(results["in_parent"], ())
+
+    def test_full_stack_with_single_entry(self):
+        with task_stack.push("only"):
+            self.assertEqual(task_stack.full_stack(), "only")
+
+
+class TestCurrentFuture(unittest.TestCase):
+    def test_current_future_is_none_by_default(self):
+        self.assertIsNone(current_future.get(None))
+
+    def test_current_future_set_during_execute_and_set_return(self):
+        captured = {}
+
+        def task(_future):
+            captured["during"] = current_future.get(None)
+            return "ok"
+
+        fut = Future(name="cf_test")
+        fut.executeInThread(task, (), {})
+        fut.wait()
+        self.assertIs(captured["during"], fut)
+
+    def test_current_future_restored_after_future_completes(self):
+        def task(_future):
+            return "ok"
+
+        fut = Future(name="cf_restore_test")
+        fut.executeInThread(task, (), {})
+        fut.wait()
+        # After execution the thread is gone; confirm parent thread is still None
+        self.assertIsNone(current_future.get(None))
+
+    def test_task_stack_pushed_during_execute_and_set_return(self):
+        captured = {}
+
+        def task(_future):
+            captured["stack"] = task_stack.get()
+            return "ok"
+
+        fut = Future(name="my_task")
+        fut.executeInThread(task, (), {})
+        fut.wait()
+        self.assertIn("my_task", captured["stack"])
+
+    def test_task_stack_popped_after_future_completes(self):
+        """Stack in the executing thread is clean after the future finishes."""
+        captured = {}
+
+        def task(_future):
+            return "ok"
+
+        finished = threading.Event()
+
+        def thread_fn():
+            fut = Future(name="pop_test")
+            fut.executeAndSetReturn(task, (), {})
+            captured["after"] = task_stack.get()
+            finished.set()
+
+        t = threading.Thread(target=thread_fn)
+        t.start()
+        finished.wait(timeout=2)
+        self.assertEqual(captured["after"], ())
+
+
+class TestFutureWrapExecutionModel(unittest.TestCase):
+    """Tests for the blocking-by-default / _sync='async' execution model."""
+
+    def test_default_call_returns_value(self):
+        @future_wrap
+        def task(name=None, _future=None):
+            return 42
+
+        result = task()
+        self.assertEqual(result, 42)
+
+    def test_default_call_propagates_exception(self):
+        @future_wrap
+        def boom(name=None, _future=None):
+            raise ValueError("kaboom")
+
+        with self.assertRaises(ValueError, msg="kaboom"):
+            boom()
+
+    def test_default_call_sets_current_future(self):
+        captured = {}
+
+        @future_wrap
+        def task(name=None, _future=None):
+            captured["fut"] = current_future.get()
+
+        task()
+        self.assertIsNotNone(captured["fut"])
+        self.assertIsInstance(captured["fut"], Future)
+
+    def test_default_call_pushes_task_stack(self):
+        captured = {}
+
+        @future_wrap
+        def task(name=None, _future=None):
+            captured["stack"] = task_stack.get()
+
+        task(name="my_task")
+        self.assertIn("my_task", captured["stack"])
+
+    def test_async_returns_future(self):
+        @future_wrap
+        def task(name=None, _future=None):
+            return "done"
+
+        fut = task(_sync="async")
+        self.assertIsInstance(fut, Future)
+        self.assertEqual(fut.getResult(), "done")
+
+    def test_name_kwarg_used_as_future_name(self):
+        captured = {}
+
+        @future_wrap
+        def task(name=None, _future=None):
+            captured["name"] = current_future.get().name
+
+        task(name="special_name")
+        self.assertEqual(captured["name"], "special_name")
+
+    def test_name_kwarg_passed_through_to_function(self):
+        captured = {}
+
+        @future_wrap
+        def task(name=None, _future=None):
+            captured["name"] = name
+
+        task(name="passed_through")
+        self.assertEqual(captured["name"], "passed_through")
+
+    def test_nested_default_calls_build_task_stack(self):
+        outer_stack = {}
+        inner_stack = {}
+
+        @future_wrap
+        def inner(name=None, _future=None):
+            inner_stack["stack"] = task_stack.get()
+
+        @future_wrap
+        def outer(name=None, _future=None):
+            outer_stack["stack"] = task_stack.get()
+            inner(name="inner")
+
+        outer(name="outer")
+        self.assertEqual(outer_stack["stack"], ("outer",))
+        self.assertEqual(inner_stack["stack"], ("outer", "inner"))
+
+    def test_async_call_inherits_parent_task_stack(self):
+        inner_stack = {}
+        done = threading.Event()
+
+        @future_wrap
+        def inner(name=None, _future=None):
+            inner_stack["stack"] = task_stack.get()
+            done.set()
+
+        @future_wrap
+        def outer(name=None, _future=None):
+            fut = inner(name="inner", _sync="async")
+            _future.waitFor(fut)
+
+        outer(name="outer")
+        done.wait(timeout=2)
+        self.assertEqual(inner_stack["stack"], ("outer", "inner"))
 
 
 if __name__ == "__main__":

--- a/tests/test_teleprox_context.py
+++ b/tests/test_teleprox_context.py
@@ -1,0 +1,117 @@
+# End-to-end tests for task_stack propagation across teleprox remote processes.
+# Verifies that log records emitted in a remote process carry the caller's task context.
+import logging
+import sys
+import time
+
+import pytest
+
+from acq4.util.future import task_stack, setup_teleprox_context_propagation
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _start_acq4_child(name, log_addr):
+    """Start a teleprox child process with the acq4 path and log forwarding."""
+    import teleprox
+    # Use WARNING level so teleprox internal debug logs don't pollute the recorder.
+    proc = teleprox.start_process(name=name, log_addr=log_addr, log_level=logging.WARNING)
+    proc.client._import('sys').path.insert(0, sys.path[0])
+    # Set up context propagation in the remote process
+    proc.client._import('acq4.util.future').setup_teleprox_context_propagation()
+    return proc
+
+
+def _find_app_record(recorder, msg):
+    """Return the first record whose msg is exactly *msg* (not a substring of a debug trace)."""
+    return recorder.find_message(f'^{msg}$')
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_task_stack_in_remote_log_records():
+    """Log records from a remote process carry the caller's task_stack."""
+    import teleprox
+    from teleprox.tests.util import RemoteLogRecorder
+
+    with RemoteLogRecorder('test_remote_task_stack') as recorder:
+        proc = _start_acq4_child('test_child', recorder.address)
+        try:
+            remote_logging = proc.client._import('logging')
+
+            with task_stack.push('Approach'):
+                with task_stack.push('moveToGlobal'):
+                    remote_logging.getLogger('acq4').warning('remote_msg_in_context')
+
+            remote_logging.getLogger('acq4').warning('remote_msg_no_context')
+        finally:
+            proc.stop()
+
+    rec_with = _find_app_record(recorder, 'remote_msg_in_context')
+    rec_without = _find_app_record(recorder, 'remote_msg_no_context')
+
+    assert rec_with is not None, "message with context not received"
+    assert rec_without is not None, "message without context not received"
+
+    assert getattr(rec_with, 'task_stack', None) == 'Approach > moveToGlobal'
+    assert getattr(rec_without, 'task_stack', None) == ''
+
+
+def test_remote_queue_worker_captures_propagated_stack():
+    """A queue-worker pattern captures the propagated task_stack from the RPC caller."""
+    import teleprox
+    from teleprox.tests.util import RemoteLogRecorder
+
+    with RemoteLogRecorder('test_remote_queue_worker') as recorder:
+        proc = _start_acq4_child('test_queue_child', recorder.address)
+        try:
+            # Install a simple queue-worker module in the remote process.
+            proc.client._import('sys').path.insert(0, sys.path[0])
+            remote_worker = proc.client._import('tests.teleprox_queue_worker_helper')
+            remote_worker.start()
+
+            with task_stack.push('PatchPipette'):
+                with task_stack.push('approach'):
+                    # The worker captures task_stack.get() inside the RPC call,
+                    # which has been set to ('PatchPipette', 'approach') by the hook.
+                    remote_worker.enqueue('queued_work_msg')
+        finally:
+            time.sleep(0.4)
+            proc.stop()
+
+    rec = _find_app_record(recorder, 'queued_work_msg')
+    assert rec is not None, "queued message not received"
+    assert getattr(rec, 'task_stack', '') == 'PatchPipette > approach'
+
+
+def test_main_process_log_records_have_task_stack(tmp_path):
+    """Log records written to the JSON log file by the main process include task_stack."""
+    import json
+    from acq4.logging_config import setup_logging
+
+    log_file = str(tmp_path / 'test.log')
+    setup_logging(log_file, gui=False)
+
+    logger = logging.getLogger('acq4.test_task_stack_field')
+    with task_stack.push('TestOp'):
+        logger.warning('main_process_in_context')
+    logger.warning('main_process_no_context')
+
+    records = []
+    with open(log_file) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+
+    in_ctx = next((r for r in records if 'main_process_in_context' in r.get('message', '') + r.get('msg', '')), None)
+    no_ctx = next((r for r in records if 'main_process_no_context' in r.get('message', '') + r.get('msg', '')), None)
+
+    assert in_ctx is not None
+    assert no_ctx is not None
+    assert in_ctx.get('task_stack') == 'TestOp'
+    assert no_ctx.get('task_stack') == ''

--- a/tests/test_worker_thread_context.py
+++ b/tests/test_worker_thread_context.py
@@ -1,0 +1,279 @@
+# Tests for task_stack context propagation in queue-based worker control threads.
+# Verifies that each job carries the caller's task_stack snapshot and restores it during handling.
+
+import sys
+import queue
+import threading
+import unittest
+from unittest.mock import MagicMock, patch, Mock
+
+from acq4.util.future import task_stack
+
+# ---------------------------------------------------------------------------
+# Stub out hardware-dependent modules before importing control threads.
+# - motionsynergy_api requires pythonnet (not available in test env)
+# - acq4.drivers.Scientifica.__init__ auto-imports Scientifica which pulls in
+#   pyserial; stub the package init while leaving control_thread importable.
+# ---------------------------------------------------------------------------
+_motionsynergy_stub = MagicMock()
+_motionsynergy_stub.MotionSynergyException = type('MotionSynergyException', (Exception,), {})
+sys.modules.setdefault('acq4.drivers.dovermotion.motionsynergy_api', _motionsynergy_stub)
+
+# Stub the Scientifica package __init__ so importing the sub-module does not
+# trigger the auto-import of Scientifica (which needs pyserial).
+import importlib.util as _importlib_util
+import os as _os
+import types as _types
+
+# Resolve the real filesystem path for the Scientifica sub-package so that
+# Python's importer can still find acq4.drivers.Scientifica.control_thread.
+_acq4_pkg_dir = _os.path.dirname(_importlib_util.find_spec('acq4').origin)
+_sci_pkg_dir = _os.path.join(_acq4_pkg_dir, 'drivers', 'Scientifica')
+_sci_pkg_stub = _types.ModuleType('acq4.drivers.Scientifica')
+_sci_pkg_stub.__path__ = [_sci_pkg_dir]
+_sci_pkg_stub.__package__ = 'acq4.drivers.Scientifica'
+sys.modules.setdefault('acq4.drivers.Scientifica', _sci_pkg_stub)
+
+
+# ---------------------------------------------------------------------------
+# Helpers to build lightweight test doubles without touching real hardware
+# ---------------------------------------------------------------------------
+
+def _make_mock_axis():
+    """Return a mock axis object that satisfies the SmartStageControlThread API."""
+    axis = MagicMock()
+    axis.GetIsEnabled.return_value = MagicMock(Value=True)
+    axis.GetActualPosition.return_value = MagicMock(Value=0.0)
+    return axis
+
+
+def _make_mock_motionsynergy(num_axes=3):
+    """Return a mock MotionSynergy API object."""
+    ms = MagicMock()
+    ms.GetFirstProduct.return_value = MagicMock(ProductType='SmartStage')
+    ms.AxisList = [_make_mock_axis() for _ in range(num_axes)]
+    return ms
+
+
+# ---------------------------------------------------------------------------
+# SmartStage tests
+# ---------------------------------------------------------------------------
+
+class TestSmartStageRequestFutureCallerStack(unittest.TestCase):
+    """SmartStageRequestFuture captures task_stack at submission time."""
+
+    def _make_future(self, req='position', kwds=None):
+        """Create a SmartStageRequestFuture with a mock control thread."""
+        from acq4.drivers.dovermotion.control_thread import SmartStageRequestFuture
+        mock_ctrl = MagicMock()
+        return SmartStageRequestFuture(mock_ctrl, req, kwds or {})
+
+    def test_caller_stack_captured_on_init(self):
+        """caller_stack attribute is set when a future is created."""
+        fut = self._make_future()
+        self.assertTrue(hasattr(fut, 'caller_stack'))
+
+    def test_caller_stack_is_empty_when_no_task_context(self):
+        """caller_stack is an empty tuple when there is no active task scope."""
+        fut = self._make_future()
+        self.assertEqual(fut.caller_stack, ())
+
+    def test_caller_stack_reflects_active_task_chain(self):
+        """caller_stack matches task_stack at the moment of future creation."""
+        with task_stack.push("outer"):
+            with task_stack.push("inner"):
+                fut = self._make_future()
+        self.assertEqual(fut.caller_stack, ("outer", "inner"))
+
+    def test_caller_stack_is_snapshot_not_live(self):
+        """caller_stack does not change if the active task_stack changes later."""
+        with task_stack.push("first"):
+            fut = self._make_future()
+        # After the 'with' block the outer stack is empty again; snapshot is unchanged.
+        self.assertEqual(fut.caller_stack, ("first",))
+
+
+class TestSmartStageHandleRequestContext(unittest.TestCase):
+    """_handle_request restores caller's task_stack while executing, then reverts."""
+
+    def _make_patched_ctrl(self):
+        """Build a SmartStageControlThread with all hardware calls mocked out."""
+        mock_ms = _make_mock_motionsynergy()
+        mock_settings = MagicMock()
+
+        with patch(
+            'acq4.drivers.dovermotion.control_thread.get_motionsynergyapi',
+            return_value=(mock_ms, mock_settings),
+        ), patch(
+            'acq4.drivers.dovermotion.control_thread.initialize',
+        ):
+            from acq4.drivers.dovermotion.control_thread import SmartStageControlThread
+            ctrl = SmartStageControlThread(
+                pos_callback=None,
+                poll_interval=0.05,
+                callback_threshold=1.0,
+                move_complete_threshold=0.1,
+            )
+        return ctrl
+
+    def test_handle_request_sees_caller_stack_during_execution(self):
+        """While _handle_request runs, task_stack reflects the caller's chain."""
+        ctrl = self._make_patched_ctrl()
+        captured = {}
+
+        from acq4.drivers.dovermotion.control_thread import SmartStageRequestFuture
+
+        class SpyFuture(SmartStageRequestFuture):
+            def set_result(self, result):
+                captured['stack_during'] = task_stack.get()
+                super().set_result(result)
+
+        caller_chain = ("caller_task", "sub_task")
+        spy = SpyFuture(ctrl, 'position', {})
+        spy.caller_stack = caller_chain
+
+        ctrl._handle_request(spy)
+
+        self.assertEqual(captured['stack_during'], caller_chain)
+
+    def test_handle_request_restores_worker_stack_after_execution(self):
+        """After _handle_request completes, task_stack reverts to what it was before."""
+        ctrl = self._make_patched_ctrl()
+
+        from acq4.drivers.dovermotion.control_thread import SmartStageRequestFuture
+
+        fut = SmartStageRequestFuture(ctrl, 'position', {})
+        fut.caller_stack = ("caller_task",)
+
+        # The worker thread here has an empty stack (default).
+        stack_before = task_stack.get()
+        ctrl._handle_request(fut)
+        stack_after = task_stack.get()
+
+        self.assertEqual(stack_before, stack_after)
+
+    def test_handle_request_restores_even_when_inside_worker_scope(self):
+        """Worker's own push_full context is restored correctly after _handle_request."""
+        ctrl = self._make_patched_ctrl()
+
+        from acq4.drivers.dovermotion.control_thread import SmartStageRequestFuture
+
+        fut = SmartStageRequestFuture(ctrl, 'position', {})
+        fut.caller_stack = ("caller_only",)
+
+        with task_stack.push("worker_scope"):
+            ctrl._handle_request(fut)
+            stack_restored = task_stack.get()
+
+        self.assertEqual(stack_restored, ("worker_scope",))
+
+
+# ---------------------------------------------------------------------------
+# Scientifica tests
+# ---------------------------------------------------------------------------
+
+def _make_mock_scientifica_dev():
+    """Return a mock Scientifica device that satisfies ScientificaControlThread's API."""
+    dev = MagicMock()
+    dev.getSpeed.return_value = 1000.0
+    dev.getPos.return_value = [0.0, 0.0, 0.0]
+    dev.isMoving.return_value = False
+    return dev
+
+
+class TestScientificaRequestFutureCallerStack(unittest.TestCase):
+    """ScientificaRequestFuture captures task_stack at submission time."""
+
+    def _make_future(self, req='stop', kwds=None):
+        from acq4.drivers.Scientifica.control_thread import ScientificaRequestFuture
+        mock_ctrl = MagicMock()
+        return ScientificaRequestFuture(mock_ctrl, req, kwds or {'reason': None})
+
+    def test_caller_stack_captured_on_init(self):
+        """caller_stack attribute is set when a future is created."""
+        fut = self._make_future()
+        self.assertTrue(hasattr(fut, 'caller_stack'))
+
+    def test_caller_stack_is_empty_when_no_task_context(self):
+        """caller_stack is an empty tuple when there is no active task scope."""
+        fut = self._make_future()
+        self.assertEqual(fut.caller_stack, ())
+
+    def test_caller_stack_reflects_active_task_chain(self):
+        """caller_stack matches task_stack at the moment of future creation."""
+        with task_stack.push("sci_outer"):
+            with task_stack.push("sci_inner"):
+                fut = self._make_future()
+        self.assertEqual(fut.caller_stack, ("sci_outer", "sci_inner"))
+
+    def test_caller_stack_is_snapshot_not_live(self):
+        """caller_stack does not change if the active task_stack changes later."""
+        with task_stack.push("sci_first"):
+            fut = self._make_future()
+        self.assertEqual(fut.caller_stack, ("sci_first",))
+
+
+class TestScientificaHandleRequestContext(unittest.TestCase):
+    """_handle_request restores caller's task_stack while executing, then reverts."""
+
+    def _make_ctrl(self):
+        """Build a ScientificaControlThread with a mock device."""
+        dev = _make_mock_scientifica_dev()
+        from acq4.drivers.Scientifica.control_thread import ScientificaControlThread
+        ctrl = ScientificaControlThread(dev)
+        return ctrl
+
+    def test_handle_request_sees_caller_stack_during_execution(self):
+        """While _handle_request runs, task_stack reflects the caller's chain."""
+        ctrl = self._make_ctrl()
+        captured = {}
+
+        from acq4.drivers.Scientifica.control_thread import ScientificaRequestFuture
+
+        class SpyFuture(ScientificaRequestFuture):
+            def set_result(self, result):
+                captured['stack_during'] = task_stack.get()
+                super().set_result(result)
+
+        caller_chain = ("sci_caller", "sci_sub")
+        spy = SpyFuture(ctrl, 'stop', {'reason': None})
+        spy.caller_stack = caller_chain
+
+        # _handle_stop calls dev.serial.send which is already mocked on ctrl.dev
+        ctrl._handle_request(spy)
+
+        self.assertEqual(captured['stack_during'], caller_chain)
+
+    def test_handle_request_restores_worker_stack_after_execution(self):
+        """After _handle_request completes, task_stack reverts to what it was before."""
+        ctrl = self._make_ctrl()
+
+        from acq4.drivers.Scientifica.control_thread import ScientificaRequestFuture
+
+        fut = ScientificaRequestFuture(ctrl, 'stop', {'reason': None})
+        fut.caller_stack = ("sci_caller",)
+
+        stack_before = task_stack.get()
+        ctrl._handle_request(fut)
+        stack_after = task_stack.get()
+
+        self.assertEqual(stack_before, stack_after)
+
+    def test_handle_request_restores_even_when_inside_worker_scope(self):
+        """Worker's own push_full context is restored correctly after _handle_request."""
+        ctrl = self._make_ctrl()
+
+        from acq4.drivers.Scientifica.control_thread import ScientificaRequestFuture
+
+        fut = ScientificaRequestFuture(ctrl, 'stop', {'reason': None})
+        fut.caller_stack = ("sci_caller_only",)
+
+        with task_stack.push("sci_worker_scope"):
+            ctrl._handle_request(fut)
+            stack_restored = task_stack.get()
+
+        self.assertEqual(stack_restored, ("sci_worker_scope",))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `TaskStack` and `current_future` ContextVars to `future.py` so every log line automatically carries the full chain of active task names (e.g. `autopatch demo > approach > track cell > z-stack > move focus`) with zero changes at log call sites — just attach a `logging.Filter` that reads `task_stack.full_stack()`
- Fixes `executeInThread` to use `contextvars.copy_context()` + `ctx.run()` — Python's `threading.Thread` does **not** copy ContextVars automatically
- Changes `@future_wrap` default: **no `_sync`** → blocking, returns result value; **`_sync='async'`** → returns Future (old default behavior)
- Adds `name=None` to all 48 `@future_wrap`-decorated function signatures so the task stack entry gets a meaningful name
- Adds `caller_stack` capture + `push_full` dispatch to `SmartStageControlThread` and `ScientificaControlThread` (queue-worker pattern: one thread, many callers)
- Migrates all `@future_wrap` call sites to the new model (`_future.waitFor(device.doThing())` → `device.doThing()`)

Design spec: `playground/context_logging_spec.md`
PoCs: `playground/contextvar_future_poc.py`, `playground/contextvar_worker_poc.py`

## Test plan

- [ ] `python -m pytest tests/test_future.py tests/test_worker_thread_context.py -q` → 87 passed
- [ ] Smoke-test autopatch demo end-to-end and confirm log lines carry task ancestry
- [ ] Confirm `FutureButton`-driven flows (detect neurons, auto-target, calibrate) still work

🤖 Generated with [Claude Code](https://claude.ai/code)