### PR TITLE
feat: add refill patch pipette state

### DIFF
--- a/acq4/devices/PatchPipette/devgui.py
+++ b/acq4/devices/PatchPipette/devgui.py
@@ -22,7 +22,7 @@ class PatchPipetteDeviceGui(Qt.QWidget):
         self.positionBtnLayout = Qt.QHBoxLayout()
         self.positionBtnLayout.addWidget(self.cleanBtn)
 
-        positions = ["clean", "rinse", "extract", "collect"]
+        positions = ["clean", "rinse", "extract", "collect", "refill"]
         self.positionBtns = {}
         for pos in positions:
             btn = pg.FeedbackButton(f"Set {pos.capitalize()} Pos")

--- a/acq4/devices/PatchPipette/statemanager.py
+++ b/acq4/devices/PatchPipette/statemanager.py
@@ -48,6 +48,7 @@ class PatchPipetteStateManager(Qt.QObject):
                 states.CleanState,
                 states.NucleusCollectState,
                 states.MoveNucleusToHomeState,
+                states.RefillState,
             ]
         ]
     )

--- a/acq4/devices/PatchPipette/states/__init__.py
+++ b/acq4/devices/PatchPipette/states/__init__.py
@@ -8,6 +8,7 @@ from .cell_attached import CellAttachedState
 from .cell_detect import CellDetectAnalysis, CellDetectState
 from .contact_cell import ContactCellState
 from .clean import CleanState
+from .refill import RefillState
 from .fouled import FouledState
 from .move_nucleus_to_home import MoveNucleusToHomeState
 from .nucleus_collect import NucleusCollectState
@@ -41,4 +42,5 @@ __all__ = [
     'BlowoutState',
     'CleanState',
     'NucleusCollectState',
+    'RefillState',
 ]

--- a/acq4/devices/PatchPipette/states/refill.py
+++ b/acq4/devices/PatchPipette/states/refill.py
@@ -1,0 +1,125 @@
+# Patch pipette refill state: moves to refill site, sucks in internal solution, returns home.
+# Supports periodic clog mitigation (pressure pulse and/or sonication) interleaved with suction.
+from __future__ import annotations
+
+from acq4.util.future import future_wrap
+from ._base import PatchPipetteState
+
+
+class RefillState(PatchPipetteState):
+    """Pipette refill state.
+
+    Moves pipette to a named refill location, applies negative (suction) pressure to draw in
+    internal solution, then returns home. Optionally interleaves periodic clog mitigation steps
+    (a brief pressure pulse and/or sonication) throughout the refill period.
+
+    Parameters
+    ----------
+    refillPressure : float
+        Pressure (Pa) applied during suction phase. Should be negative (e.g. -20 kPa).
+    refillDuration : float
+        Total time (s) to spend at the refill site applying suction.
+    clogMitigationInterval : float
+        How often (s) to pause suction and run a clog mitigation step. 0 disables periodic
+        mitigation (suction runs uninterrupted for the full refillDuration).
+    clogMitigationPressure : float
+        Pressure (Pa) applied during each clog mitigation step (typically positive).
+    clogMitigationDuration : float
+        Duration (s) of each clog mitigation pressure pulse.
+    sonicationProtocol : str
+        Protocol to pass to sonicatorDevice during each clog mitigation step. Empty string
+        disables sonication.
+    nextState : str
+        State to transition to after refill completes.
+    """
+
+    stateName = 'refill'
+
+    _parameterDefaultOverrides = {
+        'initialPressureSource': 'atmosphere',
+        'initialClampMode': 'VC',
+        'initialVCHolding': 0,
+        'initialTestPulseEnable': False,
+        'fallbackState': 'out',
+        'nextState': 'bath',
+    }
+    _parameterTreeConfig = {
+        'refillPressure': {'type': 'float', 'default': -20e3, 'suffix': 'Pa'},
+        'refillDuration': {'type': 'float', 'default': 5.0, 'suffix': 's'},
+        'clogMitigationInterval': {'type': 'float', 'default': 0.0, 'suffix': 's'},
+        'clogMitigationPressure': {'type': 'float', 'default': 10e3, 'suffix': 'Pa'},
+        'clogMitigationDuration': {'type': 'float', 'default': 0.5, 'suffix': 's'},
+        'sonicationProtocol': {'type': 'str', 'default': ''},
+        'nextState': {'type': 'str', 'default': 'bath'},
+    }
+
+    def __init__(self, *args, **kwds):
+        self._sonication = None
+        super().__init__(*args, **kwds)
+
+    def run(self):
+        config = self.config.copy()
+        dev = self.dev
+        pip = dev.pipetteDevice
+
+        self.setState('refilling pipette')
+        self.waitFor(pip.moveTo('refill', 'fast'), timeout=60)
+
+        refill_pressure = config['refillPressure']
+        refill_duration = config['refillDuration']
+        mitigation_interval = config['clogMitigationInterval']
+        mitigation_pressure = config['clogMitigationPressure']
+        mitigation_duration = config['clogMitigationDuration']
+        sonication_protocol = config['sonicationProtocol']
+
+        # If no interval configured, treat the whole duration as one block.
+        if mitigation_interval <= 0:
+            mitigation_interval = refill_duration
+
+        remaining = refill_duration
+        while remaining > 0:
+            self.checkStop()
+            chunk = min(remaining, mitigation_interval)
+            dev.pressureDevice.setPressure(source='regulator', pressure=refill_pressure)
+            self.sleep(chunk)
+            remaining -= chunk
+
+            if remaining > 0:
+                self._runClogMitigation(dev, sonication_protocol, mitigation_pressure, mitigation_duration)
+
+        dev.pressureDevice.setPressure(source='atmosphere', pressure=0)
+        self.waitFor(pip.goHome())
+        dev.pipetteRecord()['refillCount'] = dev.pipetteRecord().get('refillCount', 0) + 1
+        return {'state': config['nextState']}
+
+    def _runClogMitigation(self, dev, sonication_protocol, pressure, duration):
+        self.setState('clog mitigation')
+        sonication = None
+        if sonication_protocol and dev.sonicatorDevice is not None:
+            sonication = dev.sonicatorDevice.doProtocol(sonication_protocol)
+            self._sonication = sonication
+
+        if pressure != 0:
+            dev.pressureDevice.setPressure(source='regulator', pressure=pressure)
+            self.sleep(duration)
+
+        if sonication is not None and not sonication.isDone():
+            self.waitFor(sonication)
+
+        self.setState('refilling pipette')
+
+    @future_wrap
+    def _cleanup(self, _future):
+        dev = self.dev
+        try:
+            if self._sonication is not None and not self._sonication.isDone():
+                self._sonication.stop("parent task is cleaning up before sonication finished")
+        except Exception:
+            dev.logger.exception("Error stopping sonication during refill cleanup")
+
+        try:
+            dev.pressureDevice.setPressure(source='atmosphere', pressure=0)
+        except Exception:
+            dev.logger.exception("Error resetting pressure after refill")
+
+        _future.waitFor(super()._cleanup(), timeout=None)

--- a/acq4/devices/PatchPipette/states/refill.py
+++ b/acq4/devices/PatchPipette/states/refill.py
@@ -45,8 +45,8 @@ class RefillState(PatchPipetteState):
     }
     _parameterTreeConfig = {
         'refillPressure': {'type': 'float', 'default': -20e3, 'suffix': 'Pa'},
-        'refillDuration': {'type': 'float', 'default': 5.0, 'suffix': 's'},
-        'clogMitigationInterval': {'type': 'float', 'default': 0.0, 'suffix': 's'},
+        'refillDuration': {'type': 'float', 'default': 180.0, 'suffix': 's'},
+        'clogMitigationInterval': {'type': 'float', 'default': 30.0, 'suffix': 's'},
         'clogMitigationPressure': {'type': 'float', 'default': 10e3, 'suffix': 'Pa'},
         'clogMitigationDuration': {'type': 'float', 'default': 0.5, 'suffix': 's'},
         'sonicationProtocol': {'type': 'str', 'default': ''},

--- a/acq4/modules/MultiPatch/multipatch.py
+++ b/acq4/modules/MultiPatch/multipatch.py
@@ -127,6 +127,7 @@ class MultiPatchWindow(Qt.QWidget):
         self.ui.sealBtn.setOpts(future_producer=self._seal, raiseOnError=False, **common_opts)
         self.ui.reSealBtn.setOpts(future_producer=self._reSeal, raiseOnError=False, **common_opts)
         self.ui.reSealNoNuzzleBtn.setOpts(future_producer=self._reSealNoNuzzle, raiseOnError=False, **common_opts)
+        self.ui.refillBtn.setOpts(future_producer=self._refill, raiseOnError=False, **common_opts)
         self.ui.approachBtn.setOpts(future_producer=self._approach, raiseOnError=False, **common_opts)
         self.ui.cleanBtn.setOpts(future_producer=self._clean, raiseOnError=False, **common_opts)
         self.ui.collectBtn.setOpts(future_producer=self._collect, raiseOnError=False, **common_opts)
@@ -306,6 +307,9 @@ class MultiPatchWindow(Qt.QWidget):
 
     def _reSealNoNuzzle(self):
         return self._setAllSelectedPipettesToState('reseal', extractNucleus=False)
+
+    def _refill(self):
+        return self._setAllSelectedPipettesToState('refill')
 
     def _approach(self):
         futures = []

--- a/acq4/modules/MultiPatch/multipatchTemplate.ui
+++ b/acq4/modules/MultiPatch/multipatchTemplate.ui
@@ -222,6 +222,13 @@
         </property>
        </widget>
       </item>
+      <item row="8" column="1">
+       <widget class="FutureButton" name="refillBtn">
+        <property name="text">
+         <string>Refill</string>
+        </property>
+       </widget>
+      </item>
       <item row="9" column="0">
        <spacer name="verticalSpacer">
         <property name="orientation">


### PR DESCRIPTION
## Summary

- Adds a new `refill` patch pipette state that moves the pipette to a named `'refill'` location, applies configurable suction pressure to draw in internal solution, then returns home
- Supports periodic clog mitigation: every `clogMitigationInterval` seconds, suction is paused and a brief positive-pressure pulse (and optional sonication) is applied before resuming; set to `0` to disable
- Wired into `statemanager.py`; MultiPatch module picks it up automatically via `listStates()`

## Configuration parameters

| Parameter | Default | Description |
|---|---|---|
| `refillPressure` | -20 kPa | Suction pressure during refill |
| `refillDuration` | 180 s | Total time at refill site |
| `clogMitigationInterval` | 30 s | How often to run a clog mitigation step (0 = disabled) |
| `clogMitigationPressure` | 10 kPa | Pressure applied during each mitigation step |
| `clogMitigationDuration` | 0.5 s | Duration of each mitigation pressure pulse |
| `sonicationProtocol` | `''` | Sonication protocol during mitigation (empty = disabled) |
| `nextState` | `'bath'` | State to transition to on completion |

Add a `refill` entry to your `patchProfiles.cfg` to override defaults for your rig.

## Test plan

- [ ] Verify `refill` appears in MultiPatch state menu
- [ ] Confirm pipette moves to `refill` location, applies suction, and returns home
- [ ] Confirm clog mitigation steps fire at the configured interval
- [ ] Confirm `clogMitigationInterval: 0` runs uninterrupted suction
- [ ] Confirm pressure returns to atmosphere on stop/cancel mid-run

🤖 Generated with [Claude Code](https://claude.ai/code)