### PR TITLE
feat: InteractionSiteArray — empirical calibration, role colors

### DIFF
--- a/acq4/devices/InteractionSite.py
+++ b/acq4/devices/InteractionSite.py
@@ -15,7 +15,7 @@ VALID_ROLES = ('clean', 'rinse', 'nucleus', 'refill', 'empty')
 ROLE_COLORS = {
     'nucleus': (0.72, 0.52, 1.00, 0.85),   # lavender
     'clean':   (0.00, 0.55, 1.00, 0.90),   # electric blue
-    'rinse':   (0.20, 0.45, 0.70, 0.55),   # faded blue
+    'rinse':   (0.55, 0.80, 1.00, 0.70),   # washed-out light blue
     'refill':  (1.00, 0.95, 0.00, 0.90),   # electric yellow
     'empty':   (0.25, 0.25, 0.25, 0.65),   # dark grey
 }
@@ -97,6 +97,7 @@ class InteractionSite(Device, OptomechDevice):
         self.positions.setdefault(self.name(), {})['used_up'] = value
         self.writeConfigFile(self.positions, "saved_positions")
         self.sigUsedUpChanged.emit(value)
+        self.sigGeometryChanged.emit(self)
 
     def _is_array_child(self) -> bool:
         """Return True if this site is managed by an InteractionSiteArray."""
@@ -113,17 +114,43 @@ class InteractionSite(Device, OptomechDevice):
 
     def getGeometry(self, name=None):
         color = ROLE_COLORS.get(self._role, ROLE_COLORS['empty'])
+        if self._used_up:
+            color = (*color[:3], 0.5)
         if isinstance(self.config.get("geometry"), dict):
             defaults = {"color": color}
             defaults.update(self.config["geometry"])
-            defaults["color"] = color  # role always wins over static config color
+            defaults["color"] = color  # role and used_up always win over static config color
             self.config["geometry"] = defaults
         else:
+            h, r = self.height, self.radius
+            tube_h  = h * 0.50
+            taper_h = h * 0.45
+            tip_h   = h - tube_h - taper_h
+            tip_r   = r * 0.4
             self.config["geometry"] = {
                 "color": color,
-                "type": "cylinder",
-                "radius": self.radius,
-                "height": self.height,
+                "children": {
+                    "tube": {
+                        "type": "cylinder",
+                        "height": tube_h,
+                        "radius": r,
+                        "transform": {"pos": [0, 0, -tube_h]},
+                    },
+                    "taper": {
+                        "type": "cone",
+                        "height": taper_h,
+                        "top_radius": r,
+                        "bottom_radius": tip_r,
+                        "transform": {"pos": [0, 0, -(tube_h + taper_h)]},
+                    },
+                    "tip": {
+                        "type": "cone",
+                        "height": tip_h,
+                        "top_radius": tip_r,
+                        "bottom_radius": 0,
+                        "transform": {"pos": [0, 0, -h]},
+                    },
+                },
             }
         return super().getGeometry(name)
 

--- a/acq4/devices/InteractionSite.py
+++ b/acq4/devices/InteractionSite.py
@@ -12,6 +12,14 @@ from ..util.target import color_for_diff
 
 VALID_ROLES = ('clean', 'rinse', 'nucleus', 'refill', 'empty')
 
+ROLE_COLORS = {
+    'nucleus': (0.72, 0.52, 1.00, 0.85),   # lavender
+    'clean':   (0.00, 0.55, 1.00, 0.90),   # electric blue
+    'rinse':   (0.20, 0.45, 0.70, 0.55),   # faded blue
+    'refill':  (1.00, 0.95, 0.00, 0.90),   # electric yellow
+    'empty':   (0.25, 0.25, 0.25, 0.65),   # dark grey
+}
+
 
 class InteractionSite(Device, OptomechDevice):
     """Describes the location and dimensions of a cylindrical zone of interaction, such as a
@@ -74,6 +82,7 @@ class InteractionSite(Device, OptomechDevice):
         self.positions.setdefault(self.name(), {})['role'] = value
         self.writeConfigFile(self.positions, "saved_positions")
         self.sigRoleChanged.emit(value)
+        self.sigGeometryChanged.emit(self)
 
     @property
     def used_up(self) -> bool:
@@ -103,13 +112,15 @@ class InteractionSite(Device, OptomechDevice):
                 return
 
     def getGeometry(self, name=None):
+        color = ROLE_COLORS.get(self._role, ROLE_COLORS['empty'])
         if isinstance(self.config.get("geometry"), dict):
-            defaults = {"color": (0.3, 0.3, 0.3, 0.7)}
+            defaults = {"color": color}
             defaults.update(self.config["geometry"])
+            defaults["color"] = color  # role always wins over static config color
             self.config["geometry"] = defaults
         else:
             self.config["geometry"] = {
-                "color": (0.3, 0.3, 0.3, 0.7),
+                "color": color,
                 "type": "cylinder",
                 "radius": self.radius,
                 "height": self.height,

--- a/acq4/devices/InteractionSite.py
+++ b/acq4/devices/InteractionSite.py
@@ -97,7 +97,6 @@ class InteractionSite(Device, OptomechDevice):
         self.positions.setdefault(self.name(), {})['used_up'] = value
         self.writeConfigFile(self.positions, "saved_positions")
         self.sigUsedUpChanged.emit(value)
-        self.sigGeometryChanged.emit(self)
 
     def _is_array_child(self) -> bool:
         """Return True if this site is managed by an InteractionSiteArray."""
@@ -114,8 +113,6 @@ class InteractionSite(Device, OptomechDevice):
 
     def getGeometry(self, name=None):
         color = ROLE_COLORS.get(self._role, ROLE_COLORS['empty'])
-        if self._used_up:
-            color = (*color[:3], 0.1)
         if isinstance(self.config.get("geometry"), dict):
             defaults = {"color": color}
             defaults.update(self.config["geometry"])

--- a/acq4/devices/InteractionSite.py
+++ b/acq4/devices/InteractionSite.py
@@ -10,6 +10,8 @@ from .Stage import Stage
 from ..util.future import Future
 from ..util.target import color_for_diff
 
+VALID_ROLES = ('clean', 'rinse', 'nucleus', 'refill', 'empty')
+
 
 class InteractionSite(Device, OptomechDevice):
     """Describes the location and dimensions of a cylindrical zone of interaction, such as a
@@ -24,7 +26,12 @@ class InteractionSite(Device, OptomechDevice):
         for details.
     * parentDevice: Optional name of parent device for coordinate transforms.  E.g. a stage that
         the site is mounted on.
+    * role: (str) Initial role for this site. One of: clean, rinse, nucleus, refill, empty.
+        Default is 'empty'. Also persisted at runtime via saved_positions.
     """
+
+    sigRoleChanged = Qt.Signal(str)
+    sigUsedUpChanged = Qt.Signal(bool)
 
     def __init__(self, dm, config, name):
         Device.__init__(self, dm, config, name)
@@ -47,6 +54,45 @@ class InteractionSite(Device, OptomechDevice):
         offset = self.positions.get(self.name(), {}).get("offset", [0, 0, 0])
         self.setOffset(np.asarray(offset))
         self._guessRotation()
+        site_data = self.positions.get(self.name(), {})
+        cfg_role = config.get('role', 'empty')
+        self._role = site_data.get('role', cfg_role)
+        self._used_up = site_data.get('used_up', False)
+
+    @property
+    def role(self) -> str:
+        """The functional role of this site: one of VALID_ROLES."""
+        return self._role
+
+    @role.setter
+    def role(self, value: str):
+        if value not in VALID_ROLES:
+            raise ValueError(f"Invalid role {value!r}; must be one of {VALID_ROLES}")
+        if value == self._role:
+            return
+        self._role = value
+        self.positions.setdefault(self.name(), {})['role'] = value
+        self.writeConfigFile(self.positions, "saved_positions")
+        self.sigRoleChanged.emit(value)
+
+    @property
+    def used_up(self) -> bool:
+        """True when this site has been consumed and is no longer available."""
+        return self._used_up
+
+    @used_up.setter
+    def used_up(self, value: bool):
+        if value == self._used_up:
+            return
+        self._used_up = value
+        self.positions.setdefault(self.name(), {})['used_up'] = value
+        self.writeConfigFile(self.positions, "saved_positions")
+        self.sigUsedUpChanged.emit(value)
+
+    def _is_array_child(self) -> bool:
+        """Return True if this site is managed by an InteractionSiteArray."""
+        parent = self.parentDevice()
+        return parent is not None and hasattr(parent, 'getFirstAvailableSite')
 
     def _guessRotation(self):
         for other_name, pos_config in self.positions.items():
@@ -101,7 +147,9 @@ class InteractionSite(Device, OptomechDevice):
         return InteractionSiteCameraInterface(self, mod)
 
     def deviceInterface(self, win):
-        """Return a widget with a UI to put in the device rack."""
+        """Return a widget with a UI to put in the device rack, or None for array-managed sites."""
+        if self._is_array_child():
+            return None
         return InteractionSiteDeviceGui(self, win)
 
     def globalPosition(self):
@@ -314,6 +362,23 @@ class InteractionSiteDeviceGui(Qt.QWidget):
         layout.addWidget(self.interactLabel, row, 1)
         row += 1
 
+        # Role display (read-only; set via array UI or config)
+        layout.addWidget(Qt.QLabel("Role:"), row, 0)
+        self.roleLabel = Qt.QLabel(dev.role)
+        layout.addWidget(self.roleLabel, row, 1)
+        row += 1
+
+        # Used-up flag (user-editable)
+        layout.addWidget(Qt.QLabel("Used up:"), row, 0)
+        self.usedUpCheck = Qt.QCheckBox()
+        self.usedUpCheck.setChecked(dev.used_up)
+        self.usedUpCheck.stateChanged.connect(self._onUsedUpChanged)
+        layout.addWidget(self.usedUpCheck, row, 1)
+        row += 1
+
+        dev.sigRoleChanged.connect(self.roleLabel.setText)
+        dev.sigUsedUpChanged.connect(self.usedUpCheck.setChecked)
+
         # layout.addWidget(Qt.QLabel("( for testing )"), row, 0)
         # self.doInteractBtn = FutureButton(
         #     self._doInteractForTest, "Do test interact!", stoppable=True
@@ -357,6 +422,9 @@ class InteractionSiteDeviceGui(Qt.QWidget):
         if pip is not None:
             self.dev.saveInteractPosition(pip)
             self._updatePositionLabels()
+
+    def _onUsedUpChanged(self, state):
+        self.dev.used_up = bool(state)
 
     def _doInteractForTest(self):
         pip = self._selectedPipette()

--- a/acq4/devices/InteractionSite.py
+++ b/acq4/devices/InteractionSite.py
@@ -115,42 +115,18 @@ class InteractionSite(Device, OptomechDevice):
     def getGeometry(self, name=None):
         color = ROLE_COLORS.get(self._role, ROLE_COLORS['empty'])
         if self._used_up:
-            color = (*color[:3], 0.5)
+            color = (*color[:3], 0.1)
         if isinstance(self.config.get("geometry"), dict):
             defaults = {"color": color}
             defaults.update(self.config["geometry"])
             defaults["color"] = color  # role and used_up always win over static config color
             self.config["geometry"] = defaults
         else:
-            h, r = self.height, self.radius
-            tube_h  = h * 0.50
-            taper_h = h * 0.45
-            tip_h   = h - tube_h - taper_h
-            tip_r   = r * 0.4
             self.config["geometry"] = {
                 "color": color,
-                "children": {
-                    "tube": {
-                        "type": "cylinder",
-                        "height": tube_h,
-                        "radius": r,
-                        "transform": {"pos": [0, 0, -tube_h]},
-                    },
-                    "taper": {
-                        "type": "cone",
-                        "height": taper_h,
-                        "top_radius": r,
-                        "bottom_radius": tip_r,
-                        "transform": {"pos": [0, 0, -(tube_h + taper_h)]},
-                    },
-                    "tip": {
-                        "type": "cone",
-                        "height": tip_h,
-                        "top_radius": tip_r,
-                        "bottom_radius": 0,
-                        "transform": {"pos": [0, 0, -h]},
-                    },
-                },
+                "type": "cylinder",
+                "radius": self.radius,
+                "height": self.height,
             }
         return super().getGeometry(name)
 

--- a/acq4/devices/InteractionSiteArray.py
+++ b/acq4/devices/InteractionSiteArray.py
@@ -24,7 +24,7 @@ class InteractionSiteArray(Device, OptomechDevice):
       siteRadius: float (m) — radius of each site cylinder
       siteHeight: float (m) — height of each site cylinder
       parentDevice: str — name of parent stage device
-      siteRoleDefaults: list (optional) — roles in row-major order
+      siteRoleDefaults: list of lists (optional) — roles[row][col], matching the physical grid shape
       childGeometry: dict (optional) — geometry config applied to every child site,
         same format as a standalone InteractionSite geometry block. Use to give the
         array a distinctive shape (e.g. tube + conic tip). The role-based color is
@@ -57,7 +57,10 @@ class InteractionSiteArray(Device, OptomechDevice):
             row = i // self._cols
             col = i % self._cols
             site_name = f"{name}[{i}]"
-            role = role_defaults[i] if i < len(role_defaults) else 'empty'
+            try:
+                role = role_defaults[row][col]
+            except (IndexError, TypeError):
+                role = 'empty'
             site_config = {
                 'radius': siteRadius,
                 'height': siteHeight,

--- a/acq4/devices/InteractionSiteArray.py
+++ b/acq4/devices/InteractionSiteArray.py
@@ -65,6 +65,8 @@ class InteractionSiteArray(Device, OptomechDevice):
                 'height': siteHeight,
                 'role': self._role,
             }
+            if 'scopeParkPos' in config:
+                site_config['scopeParkPos'] = config['scopeParkPos']
             if child_geometry is not None:
                 site_config['geometry'] = child_geometry
             site = InteractionSite(dm, site_config, site_name)

--- a/acq4/devices/InteractionSiteArray.py
+++ b/acq4/devices/InteractionSiteArray.py
@@ -68,6 +68,9 @@ class InteractionSiteArray(Device, OptomechDevice):
             if child_geometry is not None:
                 site_config['geometry'] = child_geometry
             site = InteractionSite(dm, site_config, site_name)
+            # The array's configured role is authoritative; override any stale per-site
+            # role persisted from an earlier configuration so all sites share one role.
+            site._role = self._role
             site.setParentDevice(self)
             dm.declareInterface(site_name, ['device', 'interactionSite'], site)
             self._sites.append(site)
@@ -360,7 +363,9 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
         except Exception as exc:
             self.dev.logger.warning(f"Could not open Visualize3D for array calibration: {exc}")
         self._calibBtn.setEnabled(False)
-        self._calibFlow = InteractionArrayCalibrationFlow(self.dev, pip, parent=self)
+        # parent=None makes this a top-level window, so it can be moved away from the
+        # Manager window to keep the 3D visualizer visible on a small screen.
+        self._calibFlow = InteractionArrayCalibrationFlow(self.dev, pip, parent=None)
         self._calibFlow.finished.connect(self._onCalibrationFinished)
         self._calibFlow.show()
         self._calibFlow.raise_()

--- a/acq4/devices/InteractionSiteArray.py
+++ b/acq4/devices/InteractionSiteArray.py
@@ -117,17 +117,20 @@ class InteractionSiteArray(Device, OptomechDevice):
         self.sigTransformChanged.emit(self)
 
     def saveInteractPosition(self, pip):
-        """Save pip's current global position as the interact position in each site's local frame."""
+        """Save pip's current global position as the interact position in each site's local frame.
+
+        Also stores the site's current global position as 'site global' so that _guessRotation
+        can infer the cylinder axis (approach-to-interact direction) for correct 3D display.
+        """
         for site in self._sites:
-            # Store interact position in each site's local frame so that,
-            # after a stage move, mapToGlobal(local) still gives the right global position.
             site.positions.setdefault(pip.name(), {})
-            # avoid the "only one device per site" guard in InteractionSite.saveInteractPosition
             interact_global = np.asarray(pip.globalPosition(), dtype=float)
             interact_local = site.mapFromGlobal(interact_global)
             site.positions[pip.name()]['interact global'] = interact_global.tolist()
             site.positions[pip.name()]['interact local'] = interact_local.tolist()
+            site.positions[pip.name()]['site global'] = site.globalPosition().tolist()
             site.writeConfigFile(site.positions, "saved_positions")
+            site._guessRotation()
 
     def approachMoveSpec(self, pip, speed='fast'):
         """Return a MoveSpec for the first site that has a saved approach position, or None."""
@@ -152,6 +155,16 @@ class InteractionSiteArray(Device, OptomechDevice):
         return None
 
 
+def _centered(widget):
+    """Wrap a widget in a centered container for use as a QTableWidget cell widget."""
+    container = Qt.QWidget()
+    layout = Qt.QHBoxLayout(container)
+    layout.addWidget(widget)
+    layout.setAlignment(Qt.Qt.AlignCenter)
+    layout.setContentsMargins(0, 0, 0, 0)
+    return container
+
+
 class InteractionSiteArrayDeviceGui(Qt.QWidget):
     def __init__(self, dev: InteractionSiteArray, win):
         Qt.QWidget.__init__(self)
@@ -169,9 +182,12 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
 
         self._role_combos: list[Qt.QComboBox] = []
         self._used_up_checks: list[Qt.QCheckBox] = []
+        cols = dev._cols
 
         for i, site in enumerate(dev.sites):
-            slot_item = Qt.QTableWidgetItem(str(i))
+            row, col = divmod(i, cols)
+            slot_item = Qt.QTableWidgetItem(f"{row},{col}")
+            slot_item.setTextAlignment(Qt.Qt.AlignCenter)
             slot_item.setFlags(Qt.Qt.ItemIsEnabled)
             self._table.setItem(i, 0, slot_item)
 
@@ -180,13 +196,13 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
                 combo.addItem(role)
             combo.setCurrentText(site.role)
             combo.currentTextChanged.connect(self._makeRoleSetter(i))
-            self._table.setCellWidget(i, 1, combo)
+            self._table.setCellWidget(i, 1, _centered(combo))
             self._role_combos.append(combo)
 
             check = Qt.QCheckBox()
             check.setChecked(site.used_up)
             check.stateChanged.connect(self._makeUsedUpSetter(i))
-            self._table.setCellWidget(i, 2, check)
+            self._table.setCellWidget(i, 2, _centered(check))
             self._used_up_checks.append(check)
 
             site.sigRoleChanged.connect(self._makeRoleReceiver(i))
@@ -239,7 +255,7 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
 
     def _makeUsedUpSetter(self, index):
         def setter(state):
-            self.dev.sites[index].used_up = bool(state)
+            self.dev.sites[index].used_up = (state == Qt.Qt.Checked)
         return setter
 
     def _makeRoleReceiver(self, index):

--- a/acq4/devices/InteractionSiteArray.py
+++ b/acq4/devices/InteractionSiteArray.py
@@ -87,10 +87,11 @@ class InteractionSiteArray(Device, OptomechDevice):
     def getSite(self, index: int) -> InteractionSite:
         return self._sites[index]
 
-    def getFirstAvailableSite(self, role: str) -> "InteractionSite | None":
-        """Return the first non-used-up site, or None if *role* does not match this array."""
-        if role != self._role:
-            return None
+    def getFirstAvailableSite(self) -> "InteractionSite | None":
+        """Return the first non-used-up site, or None if all sites are used up.
+
+        Callers are responsible for selecting an array whose role matches their need.
+        """
         for site in self._sites:
             if not site.used_up:
                 return site
@@ -99,82 +100,113 @@ class InteractionSiteArray(Device, OptomechDevice):
     # ------------------------------------------------------------------
     # Calibration
 
-    def calibrateCorner(self, pip, corner: str):
-        """Record stage and pipette positions for a calibration corner.
+    def calibrateApproach(self, pip):
+        """Record the single approach waypoint: stage position and pipette global position.
 
-        corner: 'origin' ([0,0]), 'col_end' ([0,cols-1]), 'row_end' ([rows-1,0])
+        The approach point only needs to be a safe spot above the wells; its position
+        relative to the interact point is shared by every (identical, parallel) site.
+        """
+        if self._parentStage is None:
+            raise RuntimeError(f"{self.name()} has no parent Stage, cannot calibrate")
+        pip_name = pip.name()
+        self.positions.setdefault(pip_name, {})
+        self.positions[pip_name]['approach'] = pip.globalPosition().tolist()
+        self.positions[pip_name]['approach_stage'] = self._parentStage.globalPosition().tolist()
+        self.writeConfigFile(self.positions, "saved_positions")
+
+    def calibrateInteractCorner(self, pip, corner: str):
+        """Record an interact corner: stage position and pipette tip global (deep in the fluid).
+
+        corner: 'origin' ([0,0]), 'col_end' ([0,cols-1]), 'row_end' ([rows-1,0]).
+        These three points define the grid of interact positions, which are the
+        precision-critical targets for fluid interaction.
         """
         if self._parentStage is None:
             raise RuntimeError(f"{self.name()} has no parent Stage, cannot calibrate")
         pip_name = pip.name()
         self.positions.setdefault(pip_name, {})
         self.positions[pip_name][f'{corner}_stage'] = self._parentStage.globalPosition().tolist()
-        self.positions[pip_name]['approach'] = pip.globalPosition().tolist()
+        self.positions[pip_name][f'{corner}_interact'] = pip.globalPosition().tolist()
         self.writeConfigFile(self.positions, "saved_positions")
 
-    def calibrateInteract(self, pip):
-        """Record the pipette interact position (tip inside a reference site) for all sites."""
+    def _commonFrameRef(self, cal):
+        """Return the reference stage position (origin corner) for common-frame conversion."""
+        return np.asarray(cal['origin_stage'], dtype=float)
+
+    def _cornerInCommonFrame(self, cal, corner):
+        """Return one interact corner in the common frame (stage at the origin's stage position).
+
+        A point measured at stage position S maps into the common frame (stage at S_ref) by
+        adding (S_ref - S): moving the stage by that delta shifts the array — and the fluid
+        it carries — by the same amount in global coordinates.
+        """
+        S_ref = self._commonFrameRef(cal)
+        interact = np.asarray(cal[f'{corner}_interact'], dtype=float)
+        stage = np.asarray(cal[f'{corner}_stage'], dtype=float)
+        return interact + (S_ref - stage)
+
+    def applyCalibration(self, pip):
+        """Interpolate per-site interact positions from the three corners and apply them.
+
+        Requires calibrateInteractCorner for 'origin', 'col_end' (and 'row_end' when
+        rows > 1) plus calibrateApproach. Each site gets its own interact global position
+        (interpolated) and an approach position derived from the shared approach-to-interact
+        offset. Site offsets are placed so each site's origin sits at its approach point when
+        the stage is at the reference position.
+        """
         pip_name = pip.name()
-        interact_global = np.asarray(pip.globalPosition(), dtype=float)
-        self.positions.setdefault(pip_name, {})
-        self.positions[pip_name]['interact_global'] = interact_global.tolist()
-        self.writeConfigFile(self.positions, "saved_positions")
+        cal = self.positions.get(pip_name, {})
+        S_ref = self._commonFrameRef(cal)
+        J_00 = self._cornerInCommonFrame(cal, 'origin')
 
-        for site in self._sites:
+        if self._cols > 1:
+            J_0N = self._cornerInCommonFrame(cal, 'col_end')
+            col_step = (J_0N - J_00) / (self._cols - 1)
+        else:
+            col_step = np.zeros(3)
+        if self._rows > 1:
+            J_M0 = self._cornerInCommonFrame(cal, 'row_end')
+            row_step = (J_M0 - J_00) / (self._rows - 1)
+        else:
+            row_step = np.zeros(3)
+
+        # Approach point relative to the origin interact, in the common frame; shared by all sites.
+        A_common = np.asarray(cal['approach'], dtype=float) + (
+            S_ref - np.asarray(cal['approach_stage'], dtype=float)
+        )
+        approach_offset = A_common - J_00
+
+        for i, site in enumerate(self._sites):
+            r, c = divmod(i, self._cols)
+            interact_global = J_00 + c * col_step + r * row_step
+            approach_global = interact_global + approach_offset
+            # Place the site origin at its approach point when the stage is at S_ref.
+            site.setOffset(approach_global - S_ref)
             site.positions.setdefault(pip_name, {})
+            site.positions[pip_name]['site global'] = approach_global.tolist()
             site.positions[pip_name]['interact global'] = interact_global.tolist()
             site.writeConfigFile(site.positions, "saved_positions")
             site._guessRotation()
 
-    def applySpacing(self, pip):
-        """Interpolate all site offsets from the calibrated corners and write approach positions.
-
-        Requires calibrateCorner for 'origin', 'col_end' (and 'row_end' when rows > 1).
-        Each site gets its own offset in the parent stage frame so that when the stage moves
-        to bring site [r,c] to the pipette approach position, the site arrives at the correct
-        spot. All sites share the same approach global and interact global.
-        """
-        pip_name = pip.name()
-        cal = self.positions.get(pip_name, {})
-        P = np.asarray(cal['approach'], dtype=float)
-        S_00 = np.asarray(cal['origin_stage'], dtype=float)
-        S_0_N = np.asarray(cal['col_end_stage'], dtype=float)
-
-        col_step = (S_0_N - S_00) / (self._cols - 1) if self._cols > 1 else np.zeros(3)
-        if self._rows > 1:
-            S_M_0 = np.asarray(cal['row_end_stage'], dtype=float)
-            row_step = (S_M_0 - S_00) / (self._rows - 1)
-        else:
-            row_step = np.zeros(3)
-
-        for i, site in enumerate(self._sites):
-            r, c = divmod(i, self._cols)
-            # Stage position when this site will be under the pipette.
-            S_r_c = S_00 + c * col_step + r * row_step
-            # Site offset in parent frame so site.globalPosition() == P when stage is at S_r_c.
-            site_offset = P - S_r_c
-            site.setOffset(site_offset)
-            # Record approach position for the motion planner.
-            site.positions.setdefault(pip_name, {})
-            site.positions[pip_name]['site global'] = P.tolist()
-            site.writeConfigFile(site.positions, "saved_positions")
-            site._guessRotation()
-
     def columnSpacingMm(self, pip_name: str) -> float | None:
-        """Return computed column spacing in mm, or None if not yet calibrated."""
+        """Return computed column spacing in mm (from interact corners), or None."""
         cal = self.positions.get(pip_name, {})
-        if 'origin_stage' not in cal or 'col_end_stage' not in cal or self._cols < 2:
+        needed = ('origin_interact', 'origin_stage', 'col_end_interact', 'col_end_stage')
+        if any(k not in cal for k in needed) or self._cols < 2:
             return None
-        span = np.linalg.norm(np.array(cal['col_end_stage']) - np.array(cal['origin_stage']))
-        return span / (self._cols - 1) * 1e3
+        J_00 = self._cornerInCommonFrame(cal, 'origin')
+        J_0N = self._cornerInCommonFrame(cal, 'col_end')
+        return np.linalg.norm(J_0N - J_00) / (self._cols - 1) * 1e3
 
     def rowSpacingMm(self, pip_name: str) -> float | None:
-        """Return computed row spacing in mm, or None if not yet calibrated."""
+        """Return computed row spacing in mm (from interact corners), or None."""
         cal = self.positions.get(pip_name, {})
-        if 'origin_stage' not in cal or 'row_end_stage' not in cal or self._rows < 2:
+        needed = ('origin_interact', 'origin_stage', 'row_end_interact', 'row_end_stage')
+        if any(k not in cal for k in needed) or self._rows < 2:
             return None
-        span = np.linalg.norm(np.array(cal['row_end_stage']) - np.array(cal['origin_stage']))
-        return span / (self._rows - 1) * 1e3
+        J_00 = self._cornerInCommonFrame(cal, 'origin')
+        J_M0 = self._cornerInCommonFrame(cal, 'row_end')
+        return np.linalg.norm(J_M0 - J_00) / (self._rows - 1) * 1e3
 
     def approachMoveSpec(self, pip, speed='fast'):
         """Return a MoveSpec for the first site that has a saved approach position, or None."""
@@ -248,28 +280,37 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
         calib_layout.addWidget(Qt.QLabel(f"Rows: {dev._rows}   Cols: {dev._cols}"), row, 0, 1, 3)
         row += 1
 
-        # Origin [0,0]
+        # Single approach waypoint
+        self._approachStatus = Qt.QLabel("?")
+        calib_layout.addWidget(self._approachStatus, row, 0)
+        calib_layout.addWidget(Qt.QLabel("Approach waypoint:"), row, 1)
+        self._setApproachBtn = Qt.QPushButton("Set")
+        self._setApproachBtn.clicked.connect(self._calibrateApproach)
+        calib_layout.addWidget(self._setApproachBtn, row, 2)
+        row += 1
+
+        # Origin interact [0,0]
         self._originStatus = Qt.QLabel("?")
         calib_layout.addWidget(self._originStatus, row, 0)
-        calib_layout.addWidget(Qt.QLabel("[0,0] approach:"), row, 1)
+        calib_layout.addWidget(Qt.QLabel("[0,0] interact:"), row, 1)
         self._setOriginBtn = Qt.QPushButton("Set")
         self._setOriginBtn.clicked.connect(self._calibrateOrigin)
         calib_layout.addWidget(self._setOriginBtn, row, 2)
         row += 1
 
-        # Column end [0, cols-1]
+        # Column-end interact [0, cols-1]
         self._colEndStatus = Qt.QLabel("?")
         calib_layout.addWidget(self._colEndStatus, row, 0)
-        self._colSpacingLabel = Qt.QLabel(f"[0,{dev._cols-1}] approach:")
+        self._colSpacingLabel = Qt.QLabel(f"[0,{dev._cols-1}] interact:")
         calib_layout.addWidget(self._colSpacingLabel, row, 1)
         self._setColEndBtn = Qt.QPushButton("Set")
         self._setColEndBtn.clicked.connect(self._calibrateColEnd)
         calib_layout.addWidget(self._setColEndBtn, row, 2)
         row += 1
 
-        # Row end [rows-1, 0] — only shown when rows > 1
+        # Row-end interact [rows-1, 0] — only shown when rows > 1
         self._rowEndStatus = Qt.QLabel("?")
-        self._rowSpacingLabel = Qt.QLabel(f"[{dev._rows-1},0] approach:")
+        self._rowSpacingLabel = Qt.QLabel(f"[{dev._rows-1},0] interact:")
         self._setRowEndBtn = Qt.QPushButton("Set")
         self._setRowEndBtn.clicked.connect(self._calibrateRowEnd)
         if dev._rows > 1:
@@ -278,18 +319,9 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
             calib_layout.addWidget(self._setRowEndBtn, row, 2)
             row += 1
 
-        # Interact depth
-        self._interactStatus = Qt.QLabel("?")
-        calib_layout.addWidget(self._interactStatus, row, 0)
-        calib_layout.addWidget(Qt.QLabel("Interact depth:"), row, 1)
-        self._setInteractBtn = Qt.QPushButton("Set")
-        self._setInteractBtn.clicked.connect(self._calibrateInteract)
-        calib_layout.addWidget(self._setInteractBtn, row, 2)
-        row += 1
-
         # Apply
-        self._applyBtn = Qt.QPushButton("Apply spacing")
-        self._applyBtn.clicked.connect(self._applySpacing)
+        self._applyBtn = Qt.QPushButton("Apply calibration")
+        self._applyBtn.clicked.connect(self._applyCalibration)
         calib_layout.addWidget(self._applyBtn, row, 0, 1, 3)
 
         self._populatePipettes()
@@ -335,8 +367,8 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
             self._pipCombo.addItem(name)
         has_pip = bool(pipettes)
         self._pipCombo.setEnabled(has_pip)
-        for btn in (self._setOriginBtn, self._setColEndBtn, self._setRowEndBtn,
-                    self._setInteractBtn, self._applyBtn):
+        for btn in (self._setApproachBtn, self._setOriginBtn, self._setColEndBtn,
+                    self._setRowEndBtn, self._applyBtn):
             btn.setEnabled(has_pip)
         self._updateCalibStatus()
 
@@ -346,35 +378,37 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
             return None
         return self.dev.dm.getDevice(name)
 
+    def _calibrateApproach(self):
+        pip = self._selectedPipette()
+        if pip is not None:
+            self.dev.calibrateApproach(pip)
+            self._updateCalibStatus()
+
     def _calibrateOrigin(self):
         pip = self._selectedPipette()
         if pip is not None:
-            self.dev.calibrateCorner(pip, 'origin')
+            self.dev.calibrateInteractCorner(pip, 'origin')
             self._updateCalibStatus()
 
     def _calibrateColEnd(self):
         pip = self._selectedPipette()
         if pip is not None:
-            self.dev.calibrateCorner(pip, 'col_end')
+            self.dev.calibrateInteractCorner(pip, 'col_end')
             self._updateCalibStatus()
 
     def _calibrateRowEnd(self):
         pip = self._selectedPipette()
         if pip is not None:
-            self.dev.calibrateCorner(pip, 'row_end')
+            self.dev.calibrateInteractCorner(pip, 'row_end')
             self._updateCalibStatus()
 
-    def _calibrateInteract(self):
+    def _applyCalibration(self):
         pip = self._selectedPipette()
         if pip is not None:
-            self.dev.calibrateInteract(pip)
+            self.dev.applyCalibration(pip)
             self._updateCalibStatus()
-
-    def _applySpacing(self):
-        pip = self._selectedPipette()
-        if pip is not None:
-            self.dev.applySpacing(pip)
-            self._updateCalibStatus()
+            for i in range(len(self.dev.sites)):
+                self._styleSiteButton(self._site_buttons[i], i)
 
     def _updateCalibStatus(self):
         pip = self._selectedPipette()
@@ -386,32 +420,32 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
         def _mark(label, key):
             label.setText("✓" if key in cal else "?")
 
-        _mark(self._originStatus, 'origin_stage')
-        _mark(self._colEndStatus, 'col_end_stage')
-        _mark(self._rowEndStatus, 'row_end_stage')
-        _mark(self._interactStatus, 'interact_global')
+        _mark(self._approachStatus, 'approach')
+        _mark(self._originStatus, 'origin_interact')
+        _mark(self._colEndStatus, 'col_end_interact')
+        _mark(self._rowEndStatus, 'row_end_interact')
 
         # Update spacing labels
         col_mm = self.dev.columnSpacingMm(pip_name)
         if col_mm is not None:
             self._colSpacingLabel.setText(
-                f"[0,{self.dev._cols-1}] approach:  ({col_mm:.2f} mm/col)"
+                f"[0,{self.dev._cols-1}] interact:  ({col_mm:.2f} mm/col)"
             )
         else:
-            self._colSpacingLabel.setText(f"[0,{self.dev._cols-1}] approach:")
+            self._colSpacingLabel.setText(f"[0,{self.dev._cols-1}] interact:")
 
         row_mm = self.dev.rowSpacingMm(pip_name)
         if row_mm is not None:
             self._rowSpacingLabel.setText(
-                f"[{self.dev._rows-1},0] approach:  ({row_mm:.2f} mm/row)"
+                f"[{self.dev._rows-1},0] interact:  ({row_mm:.2f} mm/row)"
             )
         else:
-            self._rowSpacingLabel.setText(f"[{self.dev._rows-1},0] approach:")
+            self._rowSpacingLabel.setText(f"[{self.dev._rows-1},0] interact:")
 
-        # Enable Apply only when all required corners are ready
-        has_cols = 'origin_stage' in cal and 'col_end_stage' in cal
-        has_rows = self.dev._rows == 1 or 'row_end_stage' in cal
-        self._applyBtn.setEnabled(has_cols and has_rows)
+        # Enable Apply only when approach and all required interact corners are ready
+        has_cols = 'origin_interact' in cal and 'col_end_interact' in cal
+        has_rows = self.dev._rows == 1 or 'row_end_interact' in cal
+        self._applyBtn.setEnabled('approach' in cal and has_cols and has_rows)
 
 
 def _fmt_pos(pos):

--- a/acq4/devices/InteractionSiteArray.py
+++ b/acq4/devices/InteractionSiteArray.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from acq4.util import Qt
 from .Device import Device
-from .InteractionSite import InteractionSite, VALID_ROLES
+from .InteractionSite import InteractionSite
 from .OptomechDevice import OptomechDevice
 from .Stage import Stage
 
@@ -18,13 +18,16 @@ class InteractionSiteArray(Device, OptomechDevice):
     Each site stores its own offset in the parent stage frame; positions are calibrated
     empirically by tagging corner sites and interpolating evenly.
 
+    All sites in an array share a single role (set via the *role* config option); roles
+    are not assignable per-site at runtime.
+
     Configuration options:
       rows: int — number of rows in the grid
       cols: int — number of columns in the grid
       siteRadius: float (m) — radius of each site cylinder
       siteHeight: float (m) — height of each site cylinder
       parentDevice: str — name of parent stage device
-      siteRoleDefaults: list of lists (optional) — roles[row][col], matching the physical grid shape
+      role: str — the role shared by every site (clean, rinse, nucleus, refill, empty)
       childGeometry: dict (optional) — geometry config applied to every child site,
         same format as a standalone InteractionSite geometry block. Use to give the
         array a distinctive shape (e.g. tube + conic tip). The role-based color is
@@ -39,7 +42,7 @@ class InteractionSiteArray(Device, OptomechDevice):
         self._cols = config['cols']
         siteRadius = config['siteRadius']
         siteHeight = config['siteHeight']
-        role_defaults = config.get('siteRoleDefaults', [])
+        self._role = config.get('role', 'empty')
         child_geometry = config.get('childGeometry', None)
 
         parent = self
@@ -57,14 +60,10 @@ class InteractionSiteArray(Device, OptomechDevice):
             row = i // self._cols
             col = i % self._cols
             site_name = f"{name}[{i}]"
-            try:
-                role = role_defaults[row][col]
-            except (IndexError, TypeError):
-                role = 'empty'
             site_config = {
                 'radius': siteRadius,
                 'height': siteHeight,
-                'role': role,
+                'role': self._role,
             }
             if child_geometry is not None:
                 site_config['geometry'] = child_geometry
@@ -77,6 +76,11 @@ class InteractionSiteArray(Device, OptomechDevice):
     # Site access
 
     @property
+    def role(self) -> str:
+        """The single role shared by every site in this array."""
+        return self._role
+
+    @property
     def sites(self) -> list[InteractionSite]:
         return list(self._sites)
 
@@ -84,9 +88,11 @@ class InteractionSiteArray(Device, OptomechDevice):
         return self._sites[index]
 
     def getFirstAvailableSite(self, role: str) -> "InteractionSite | None":
-        """Return the first site with *role* that is not used_up, or None."""
+        """Return the first non-used-up site, or None if *role* does not match this array."""
+        if role != self._role:
+            return None
         for site in self._sites:
-            if site.role == role and not site.used_up:
+            if not site.used_up:
                 return site
         return None
 
@@ -191,16 +197,6 @@ class InteractionSiteArray(Device, OptomechDevice):
         return None
 
 
-def _centered(widget):
-    """Wrap a widget in a centered container for use as a QTableWidget cell widget."""
-    container = Qt.QWidget()
-    layout = Qt.QHBoxLayout(container)
-    layout.addWidget(widget)
-    layout.setAlignment(Qt.Qt.AlignCenter)
-    layout.setContentsMargins(0, 0, 0, 0)
-    return container
-
-
 class InteractionSiteArrayDeviceGui(Qt.QWidget):
     def __init__(self, dev: InteractionSiteArray, win):
         Qt.QWidget.__init__(self)
@@ -210,38 +206,26 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
         main_layout = Qt.QVBoxLayout()
         self.setLayout(main_layout)
 
-        # --- Slot table ---
-        self._table = Qt.QTableWidget(len(dev.sites), 3)
-        self._table.setHorizontalHeaderLabels(["Slot", "Role", "Used up"])
-        self._table.horizontalHeader().setStretchLastSection(True)
-        main_layout.addWidget(self._table)
+        # --- Role header ---
+        main_layout.addWidget(Qt.QLabel(f"Role: {dev.role}"))
 
-        self._role_combos: list[Qt.QComboBox] = []
-        self._used_up_checks: list[Qt.QCheckBox] = []
+        # --- Site grid (physical layout; each button toggles used_up) ---
+        grid_widget = Qt.QWidget()
+        grid = Qt.QGridLayout(grid_widget)
+        grid.setSpacing(2)
+        main_layout.addWidget(grid_widget)
+
+        self._site_buttons: list[Qt.QPushButton] = []
         cols = dev._cols
-
         for i, site in enumerate(dev.sites):
             row, col = divmod(i, cols)
-            slot_item = Qt.QTableWidgetItem(f"{row},{col}")
-            slot_item.setTextAlignment(Qt.Qt.AlignCenter)
-            slot_item.setFlags(Qt.Qt.ItemIsEnabled)
-            self._table.setItem(i, 0, slot_item)
-
-            combo = Qt.QComboBox()
-            for role in VALID_ROLES:
-                combo.addItem(role)
-            combo.setCurrentText(site.role)
-            combo.currentTextChanged.connect(self._makeRoleSetter(i))
-            self._table.setCellWidget(i, 1, _centered(combo))
-            self._role_combos.append(combo)
-
-            check = Qt.QCheckBox()
-            check.setChecked(site.used_up)
-            check.stateChanged.connect(self._makeUsedUpSetter(i))
-            self._table.setCellWidget(i, 2, _centered(check))
-            self._used_up_checks.append(check)
-
-            site.sigRoleChanged.connect(self._makeRoleReceiver(i))
+            btn = Qt.QPushButton()
+            btn.setCheckable(True)
+            btn.setChecked(site.used_up)
+            self._styleSiteButton(btn, i)
+            btn.toggled.connect(self._makeUsedUpSetter(i))
+            grid.addWidget(btn, row, col)
+            self._site_buttons.append(btn)
             site.sigUsedUpChanged.connect(self._makeUsedUpReceiver(i))
 
         # --- Mark all unused button ---
@@ -312,32 +296,30 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
         self._pipCombo.currentIndexChanged.connect(self._updateCalibStatus)
 
     # ------------------------------------------------------------------
-    # Slot table handlers
+    # Site grid handlers
 
-    def _makeRoleSetter(self, index):
-        def setter(text):
-            self.dev.sites[index].role = text
-        return setter
+    def _styleSiteButton(self, btn, index):
+        """Set a site button's label and tooltip from its position and used_up state."""
+        row, col = divmod(index, self.dev._cols)
+        site = self.dev.sites[index]
+        offset = np.asarray(site.deviceTransform().offset, dtype=float)
+        used = " (used)" if site.used_up else ""
+        btn.setText(f"{row},{col}{used}")
+        btn.setToolTip(f"site [{row},{col}] offset: {_fmt_pos(offset)}")
 
     def _makeUsedUpSetter(self, index):
-        def setter(state):
-            self.dev.sites[index].used_up = (state == Qt.Qt.Checked)
+        def setter(checked):
+            self.dev.sites[index].used_up = bool(checked)
+            self._styleSiteButton(self._site_buttons[index], index)
         return setter
-
-    def _makeRoleReceiver(self, index):
-        def receiver(value):
-            combo = self._role_combos[index]
-            combo.blockSignals(True)
-            combo.setCurrentText(value)
-            combo.blockSignals(False)
-        return receiver
 
     def _makeUsedUpReceiver(self, index):
         def receiver(value):
-            check = self._used_up_checks[index]
-            check.blockSignals(True)
-            check.setChecked(value)
-            check.blockSignals(False)
+            btn = self._site_buttons[index]
+            btn.blockSignals(True)
+            btn.setChecked(value)
+            btn.blockSignals(False)
+            self._styleSiteButton(btn, index)
         return receiver
 
     def _markAllUnused(self):

--- a/acq4/devices/InteractionSiteArray.py
+++ b/acq4/devices/InteractionSiteArray.py
@@ -24,7 +24,11 @@ class InteractionSiteArray(Device, OptomechDevice):
       site_radius: float (m) — radius of each site cylinder
       site_height: float (m) — height of each site cylinder
       parentDevice: str — name of parent stage device
-      site_role_defaults: list (optional) — roles in row-major order
+      siteRoleDefaults: list (optional) — roles in row-major order
+      childGeometry: dict (optional) — geometry config applied to every child site,
+        same format as a standalone InteractionSite geometry block. Use to give the
+        array a distinctive shape (e.g. tube + conic tip). The role-based color is
+        always applied on top of whatever is configured here.
     """
 
     def __init__(self, dm, config, name):
@@ -35,7 +39,8 @@ class InteractionSiteArray(Device, OptomechDevice):
         self._cols = config['cols']
         site_radius = config['site_radius']
         site_height = config['site_height']
-        role_defaults = config.get('site_role_defaults', [])
+        role_defaults = config.get('siteRoleDefaults', [])
+        child_geometry = config.get('childGeometry', None)
 
         parent = self
         while True:
@@ -58,6 +63,8 @@ class InteractionSiteArray(Device, OptomechDevice):
                 'height': site_height,
                 'role': role,
             }
+            if child_geometry is not None:
+                site_config['geometry'] = child_geometry
             site = InteractionSite(dm, site_config, site_name)
             site.setParentDevice(self)
             dm.declareInterface(site_name, ['device', 'interactionSite'], site)

--- a/acq4/devices/InteractionSiteArray.py
+++ b/acq4/devices/InteractionSiteArray.py
@@ -1,0 +1,309 @@
+# Device class for a grid array of InteractionSite objects (e.g. nucleus deposition tube arrays).
+# Each slot is a real InteractionSite child whose position is offset from the array origin.
+
+from __future__ import annotations
+
+import numpy as np
+
+from acq4.util import Qt
+from .Device import Device
+from .InteractionSite import InteractionSite, VALID_ROLES
+from .OptomechDevice import OptomechDevice
+from .Stage import Stage
+
+
+class InteractionSiteArray(Device, OptomechDevice):
+    """Array of cylindrical interaction sites arranged in a grid.
+
+    Configuration options:
+      rows: int — number of rows in the grid
+      cols: int — number of columns in the grid
+      spacing_x: float (m) — x spacing between adjacent columns
+      spacing_y: float (m) — y spacing between adjacent rows
+      site_radius: float (m) — radius of each site cylinder
+      site_height: float (m) — height of each site cylinder
+      parentDevice: str — name of parent stage device (same as OptomechDevice)
+      transform: dict — optional transform (same as OptomechDevice)
+      site_role_defaults: list (optional) — roles in row-major order; length may be
+        shorter than rows*cols, remaining sites default to 'empty'
+    """
+
+    def __init__(self, dm, config, name):
+        Device.__init__(self, dm, config, name)
+        OptomechDevice.__init__(self, dm, config, name)
+
+        self._rows = config['rows']
+        self._cols = config['cols']
+        self._spacing_x = config['spacing_x']
+        self._spacing_y = config['spacing_y']
+        site_radius = config['site_radius']
+        site_height = config['site_height']
+        role_defaults = config.get('site_role_defaults', [])
+
+        self.positions = self.readConfigFile("saved_positions")
+        array_offset = np.asarray(
+            self.positions.get(self.name(), {}).get("offset", [0, 0, 0]), dtype=float
+        )
+
+        self._sites: list[InteractionSite] = []
+        n = self._rows * self._cols
+        for i in range(n):
+            row = i // self._cols
+            col = i % self._cols
+            site_name = f"{name}[{i}]"
+            role = role_defaults[i] if i < len(role_defaults) else 'empty'
+            site_config = {
+                'radius': site_radius,
+                'height': site_height,
+                'role': role,
+            }
+            site = InteractionSite(dm, site_config, site_name)
+            # attach as child of this array so transforms compose correctly
+            site.setParentDevice(self)
+            # set the site's local offset within the array frame
+            site.setOffset(np.array([col * self._spacing_x, row * self._spacing_y, 0.0]))
+            dm.declareInterface(site_name, ['device', 'interactionSite'], site)
+            self._sites.append(site)
+
+        tr = self.deviceTransform()
+        tr.offset = array_offset
+        self.setDeviceTransform(tr)
+
+    # ------------------------------------------------------------------
+    # Site access
+
+    @property
+    def sites(self) -> list[InteractionSite]:
+        """Return a copy of the list of child InteractionSite objects."""
+        return list(self._sites)
+
+    def getSite(self, index: int) -> InteractionSite:
+        """Return the child site at *index* (row-major order)."""
+        return self._sites[index]
+
+    def getFirstAvailableSite(self, role: str) -> "InteractionSite | None":
+        """Return the first site with *role* that is not used_up, or None."""
+        for site in self._sites:
+            if site.role == role and not site.used_up:
+                return site
+        return None
+
+    # ------------------------------------------------------------------
+    # Calibration
+
+    def setArrayOriginFromPipette(self, pip, reference_slot_index: int):
+        """Position the array so that reference_slot is at the pipette's current position.
+
+        Computes the array's parent-frame offset and saves it to config.
+        """
+        pip_global = np.asarray(pip.globalPosition(), dtype=float)
+        site_in_array = np.array([
+            (reference_slot_index % self._cols) * self._spacing_x,
+            (reference_slot_index // self._cols) * self._spacing_y,
+            0.0,
+        ])
+        desired_array_global = pip_global - site_in_array
+        new_offset = self.mapGlobalToParent(desired_array_global)
+        self._setOffset(new_offset)
+
+    def _setOffset(self, offset):
+        """Set the array's local offset and persist it (same pattern as InteractionSite.setOffset)."""
+        tr = self.deviceTransform()
+        tr.offset = offset
+        self.setDeviceTransform(tr)
+        self.positions.setdefault(self.name(), {})
+        self.positions[self.name()]['offset'] = list(offset)
+        self.writeConfigFile(self.positions, "saved_positions")
+        self.sigTransformChanged.emit(self)
+
+    def saveInteractPosition(self, pip):
+        """Save pip's current global position as the interact position in each site's local frame."""
+        for site in self._sites:
+            # Store interact position in each site's local frame so that,
+            # after a stage move, mapToGlobal(local) still gives the right global position.
+            site.positions.setdefault(pip.name(), {})
+            # avoid the "only one device per site" guard in InteractionSite.saveInteractPosition
+            interact_global = np.asarray(pip.globalPosition(), dtype=float)
+            interact_local = site.mapFromGlobal(interact_global)
+            site.positions[pip.name()]['interact global'] = interact_global.tolist()
+            site.positions[pip.name()]['interact local'] = interact_local.tolist()
+            site.writeConfigFile(site.positions, "saved_positions")
+
+    def approachMoveSpec(self, pip, speed='fast'):
+        """Return a MoveSpec for the first site that has a saved approach position, or None."""
+        for site in self._sites:
+            spec = site.approachMoveSpec(pip, speed=speed)
+            if spec is not None:
+                return spec
+        return None
+
+    def hasApproachPosition(self, pip) -> bool:
+        """Return True if any site has a saved approach position for pip."""
+        return any(site.hasApproachPosition(pip) for site in self._sites)
+
+    # ------------------------------------------------------------------
+    # Device interface
+
+    def deviceInterface(self, win):
+        """Return the array management widget."""
+        return InteractionSiteArrayDeviceGui(self, win)
+
+    def cameraModuleInterface(self, mod):
+        return None
+
+
+class InteractionSiteArrayDeviceGui(Qt.QWidget):
+    def __init__(self, dev: InteractionSiteArray, win):
+        Qt.QWidget.__init__(self)
+        self.dev = dev
+        self.win = win
+
+        main_layout = Qt.QVBoxLayout()
+        self.setLayout(main_layout)
+
+        # --- Slot table ---
+        self._table = Qt.QTableWidget(len(dev.sites), 3)
+        self._table.setHorizontalHeaderLabels(["Slot", "Role", "Used up"])
+        self._table.horizontalHeader().setStretchLastSection(True)
+        main_layout.addWidget(self._table)
+
+        self._role_combos: list[Qt.QComboBox] = []
+        self._used_up_checks: list[Qt.QCheckBox] = []
+
+        for i, site in enumerate(dev.sites):
+            slot_item = Qt.QTableWidgetItem(str(i))
+            slot_item.setFlags(Qt.Qt.ItemIsEnabled)
+            self._table.setItem(i, 0, slot_item)
+
+            combo = Qt.QComboBox()
+            for role in VALID_ROLES:
+                combo.addItem(role)
+            combo.setCurrentText(site.role)
+            combo.currentTextChanged.connect(self._makeRoleSetter(i))
+            self._table.setCellWidget(i, 1, combo)
+            self._role_combos.append(combo)
+
+            check = Qt.QCheckBox()
+            check.setChecked(site.used_up)
+            check.stateChanged.connect(self._makeUsedUpSetter(i))
+            self._table.setCellWidget(i, 2, check)
+            self._used_up_checks.append(check)
+
+            site.sigRoleChanged.connect(self._makeRoleReceiver(i))
+            site.sigUsedUpChanged.connect(self._makeUsedUpReceiver(i))
+
+        # --- Mark all unused button ---
+        self._markAllBtn = Qt.QPushButton("Mark all unused")
+        self._markAllBtn.clicked.connect(self._markAllUnused)
+        main_layout.addWidget(self._markAllBtn)
+
+        # --- Calibration section ---
+        calib_group = Qt.QGroupBox("Calibration")
+        calib_layout = Qt.QGridLayout()
+        calib_group.setLayout(calib_layout)
+        main_layout.addWidget(calib_group)
+
+        calib_layout.addWidget(Qt.QLabel("Pipette:"), 0, 0)
+        self._pipCombo = Qt.QComboBox()
+        calib_layout.addWidget(self._pipCombo, 0, 1)
+
+        calib_layout.addWidget(Qt.QLabel("Reference slot:"), 1, 0)
+        self._refSlotCombo = Qt.QComboBox()
+        for i in range(len(dev.sites)):
+            self._refSlotCombo.addItem(str(i))
+        calib_layout.addWidget(self._refSlotCombo, 1, 1)
+
+        self._setOriginBtn = Qt.QPushButton("Set array origin")
+        self._setOriginBtn.clicked.connect(self._setArrayOrigin)
+        calib_layout.addWidget(self._setOriginBtn, 2, 0, 1, 2)
+
+        self._saveInteractBtn = Qt.QPushButton("Set interact position")
+        self._saveInteractBtn.clicked.connect(self._saveInteractPosition)
+        calib_layout.addWidget(self._saveInteractBtn, 3, 0, 1, 2)
+
+        calib_layout.addWidget(Qt.QLabel("Array origin (global):"), 4, 0)
+        self._originLabel = Qt.QLabel("—")
+        calib_layout.addWidget(self._originLabel, 4, 1)
+
+        calib_layout.addWidget(Qt.QLabel("Interact position (site-local):"), 5, 0)
+        self._interactLabel = Qt.QLabel("—")
+        calib_layout.addWidget(self._interactLabel, 5, 1)
+
+        self._populatePipettes()
+        self._pipCombo.currentIndexChanged.connect(self._updateCalibLabels)
+
+    def _makeRoleSetter(self, index):
+        def setter(text):
+            self.dev.sites[index].role = text
+        return setter
+
+    def _makeUsedUpSetter(self, index):
+        def setter(state):
+            self.dev.sites[index].used_up = bool(state)
+        return setter
+
+    def _makeRoleReceiver(self, index):
+        def receiver(value):
+            combo = self._role_combos[index]
+            combo.blockSignals(True)
+            combo.setCurrentText(value)
+            combo.blockSignals(False)
+        return receiver
+
+    def _makeUsedUpReceiver(self, index):
+        def receiver(value):
+            check = self._used_up_checks[index]
+            check.blockSignals(True)
+            check.setChecked(value)
+            check.blockSignals(False)
+        return receiver
+
+    def _markAllUnused(self):
+        for site in self.dev.sites:
+            site.used_up = False
+
+    def _populatePipettes(self):
+        pipettes = self.dev.dm.listInterfaces('pipette')
+        for name in pipettes:
+            self._pipCombo.addItem(name)
+        has_pip = bool(pipettes)
+        self._pipCombo.setEnabled(has_pip)
+        self._setOriginBtn.setEnabled(has_pip)
+        self._saveInteractBtn.setEnabled(has_pip)
+        self._updateCalibLabels()
+
+    def _selectedPipette(self):
+        name = self._pipCombo.currentText()
+        if not name:
+            return None
+        return self.dev.dm.getDevice(name)
+
+    def _setArrayOrigin(self):
+        pip = self._selectedPipette()
+        if pip is not None:
+            ref = int(self._refSlotCombo.currentText())
+            self.dev.setArrayOriginFromPipette(pip, ref)
+            self._updateCalibLabels()
+
+    def _saveInteractPosition(self):
+        pip = self._selectedPipette()
+        if pip is not None:
+            self.dev.saveInteractPosition(pip)
+            self._updateCalibLabels()
+
+    def _updateCalibLabels(self):
+        origin = self.dev.mapToGlobal(np.zeros(3))
+        self._originLabel.setText(_fmt_pos(origin))
+        pip = self._selectedPipette()
+        if pip is not None and self.dev.sites:
+            local = self.dev.sites[0].interactLocalFor(pip)
+            self._interactLabel.setText(_fmt_pos(local))
+        else:
+            self._interactLabel.setText("—")
+
+
+def _fmt_pos(pos):
+    """Format a 3-element position as a string of mm values."""
+    if pos is None:
+        return "—"
+    return "(%0.3f, %0.3f, %0.3f) mm" % tuple(p * 1e3 for p in pos[:3])

--- a/acq4/devices/InteractionSiteArray.py
+++ b/acq4/devices/InteractionSiteArray.py
@@ -21,8 +21,8 @@ class InteractionSiteArray(Device, OptomechDevice):
     Configuration options:
       rows: int — number of rows in the grid
       cols: int — number of columns in the grid
-      site_radius: float (m) — radius of each site cylinder
-      site_height: float (m) — height of each site cylinder
+      siteRadius: float (m) — radius of each site cylinder
+      siteHeight: float (m) — height of each site cylinder
       parentDevice: str — name of parent stage device
       siteRoleDefaults: list (optional) — roles in row-major order
       childGeometry: dict (optional) — geometry config applied to every child site,
@@ -37,8 +37,8 @@ class InteractionSiteArray(Device, OptomechDevice):
 
         self._rows = config['rows']
         self._cols = config['cols']
-        site_radius = config['site_radius']
-        site_height = config['site_height']
+        siteRadius = config['siteRadius']
+        siteHeight = config['siteHeight']
         role_defaults = config.get('siteRoleDefaults', [])
         child_geometry = config.get('childGeometry', None)
 
@@ -59,8 +59,8 @@ class InteractionSiteArray(Device, OptomechDevice):
             site_name = f"{name}[{i}]"
             role = role_defaults[i] if i < len(role_defaults) else 'empty'
             site_config = {
-                'radius': site_radius,
-                'height': site_height,
+                'radius': siteRadius,
+                'height': siteHeight,
                 'role': role,
             }
             if child_geometry is not None:

--- a/acq4/devices/InteractionSiteArray.py
+++ b/acq4/devices/InteractionSiteArray.py
@@ -271,61 +271,21 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
         calib_group.setLayout(calib_layout)
         main_layout.addWidget(calib_group)
 
-        row = 0
-        calib_layout.addWidget(Qt.QLabel("Pipette:"), row, 0)
+        calib_layout.addWidget(Qt.QLabel("Pipette:"), 0, 0)
         self._pipCombo = Qt.QComboBox()
-        calib_layout.addWidget(self._pipCombo, row, 1, 1, 2)
-        row += 1
+        calib_layout.addWidget(self._pipCombo, 0, 1)
 
-        calib_layout.addWidget(Qt.QLabel(f"Rows: {dev._rows}   Cols: {dev._cols}"), row, 0, 1, 3)
-        row += 1
+        calib_layout.addWidget(Qt.QLabel(f"Grid: {dev._rows} × {dev._cols}"), 1, 0)
+        self._spacingLabel = Qt.QLabel("")
+        calib_layout.addWidget(self._spacingLabel, 1, 1)
 
-        # Single approach waypoint
-        self._approachStatus = Qt.QLabel("?")
-        calib_layout.addWidget(self._approachStatus, row, 0)
-        calib_layout.addWidget(Qt.QLabel("Approach waypoint:"), row, 1)
-        self._setApproachBtn = Qt.QPushButton("Set")
-        self._setApproachBtn.clicked.connect(self._calibrateApproach)
-        calib_layout.addWidget(self._setApproachBtn, row, 2)
-        row += 1
+        self._calibBtn = Qt.QPushButton("Calibrate…")
+        self._calibBtn.clicked.connect(self._startCalibration)
+        calib_layout.addWidget(self._calibBtn, 2, 0, 1, 2)
 
-        # Origin interact [0,0]
-        self._originStatus = Qt.QLabel("?")
-        calib_layout.addWidget(self._originStatus, row, 0)
-        calib_layout.addWidget(Qt.QLabel("[0,0] interact:"), row, 1)
-        self._setOriginBtn = Qt.QPushButton("Set")
-        self._setOriginBtn.clicked.connect(self._calibrateOrigin)
-        calib_layout.addWidget(self._setOriginBtn, row, 2)
-        row += 1
-
-        # Column-end interact [0, cols-1]
-        self._colEndStatus = Qt.QLabel("?")
-        calib_layout.addWidget(self._colEndStatus, row, 0)
-        self._colSpacingLabel = Qt.QLabel(f"[0,{dev._cols-1}] interact:")
-        calib_layout.addWidget(self._colSpacingLabel, row, 1)
-        self._setColEndBtn = Qt.QPushButton("Set")
-        self._setColEndBtn.clicked.connect(self._calibrateColEnd)
-        calib_layout.addWidget(self._setColEndBtn, row, 2)
-        row += 1
-
-        # Row-end interact [rows-1, 0] — only shown when rows > 1
-        self._rowEndStatus = Qt.QLabel("?")
-        self._rowSpacingLabel = Qt.QLabel(f"[{dev._rows-1},0] interact:")
-        self._setRowEndBtn = Qt.QPushButton("Set")
-        self._setRowEndBtn.clicked.connect(self._calibrateRowEnd)
-        if dev._rows > 1:
-            calib_layout.addWidget(self._rowEndStatus, row, 0)
-            calib_layout.addWidget(self._rowSpacingLabel, row, 1)
-            calib_layout.addWidget(self._setRowEndBtn, row, 2)
-            row += 1
-
-        # Apply
-        self._applyBtn = Qt.QPushButton("Apply calibration")
-        self._applyBtn.clicked.connect(self._applyCalibration)
-        calib_layout.addWidget(self._applyBtn, row, 0, 1, 3)
-
+        self._calibFlow = None
         self._populatePipettes()
-        self._pipCombo.currentIndexChanged.connect(self._updateCalibStatus)
+        self._pipCombo.currentIndexChanged.connect(self._updateSpacingLabel)
 
     # ------------------------------------------------------------------
     # Site grid handlers
@@ -359,7 +319,7 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
             site.used_up = False
 
     # ------------------------------------------------------------------
-    # Calibration handlers
+    # Calibration
 
     def _populatePipettes(self):
         pipettes = self.dev.dm.listInterfaces('pipette')
@@ -367,10 +327,8 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
             self._pipCombo.addItem(name)
         has_pip = bool(pipettes)
         self._pipCombo.setEnabled(has_pip)
-        for btn in (self._setApproachBtn, self._setOriginBtn, self._setColEndBtn,
-                    self._setRowEndBtn, self._applyBtn):
-            btn.setEnabled(has_pip)
-        self._updateCalibStatus()
+        self._calibBtn.setEnabled(has_pip)
+        self._updateSpacingLabel()
 
     def _selectedPipette(self):
         name = self._pipCombo.currentText()
@@ -378,74 +336,148 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
             return None
         return self.dev.dm.getDevice(name)
 
-    def _calibrateApproach(self):
+    def _updateSpacingLabel(self):
         pip = self._selectedPipette()
-        if pip is not None:
-            self.dev.calibrateApproach(pip)
-            self._updateCalibStatus()
+        if pip is None:
+            self._spacingLabel.setText("")
+            return
+        parts = []
+        col_mm = self.dev.columnSpacingMm(pip.name())
+        if col_mm is not None:
+            parts.append(f"{col_mm:.2f} mm/col")
+        row_mm = self.dev.rowSpacingMm(pip.name())
+        if row_mm is not None:
+            parts.append(f"{row_mm:.2f} mm/row")
+        self._spacingLabel.setText("  ".join(parts) if parts else "uncalibrated")
 
-    def _calibrateOrigin(self):
-        pip = self._selectedPipette()
-        if pip is not None:
-            self.dev.calibrateInteractCorner(pip, 'origin')
-            self._updateCalibStatus()
-
-    def _calibrateColEnd(self):
-        pip = self._selectedPipette()
-        if pip is not None:
-            self.dev.calibrateInteractCorner(pip, 'col_end')
-            self._updateCalibStatus()
-
-    def _calibrateRowEnd(self):
-        pip = self._selectedPipette()
-        if pip is not None:
-            self.dev.calibrateInteractCorner(pip, 'row_end')
-            self._updateCalibStatus()
-
-    def _applyCalibration(self):
-        pip = self._selectedPipette()
-        if pip is not None:
-            self.dev.applyCalibration(pip)
-            self._updateCalibStatus()
-            for i in range(len(self.dev.sites)):
-                self._styleSiteButton(self._site_buttons[i], i)
-
-    def _updateCalibStatus(self):
+    def _startCalibration(self):
         pip = self._selectedPipette()
         if pip is None:
             return
-        pip_name = pip.name()
-        cal = self.dev.positions.get(pip_name, {})
+        # Make sure the 3D visualizer is up so the user can see the sites move.
+        try:
+            self.dev.dm.getModule("Visualize3D")
+        except Exception as exc:
+            self.dev.logger.warning(f"Could not open Visualize3D for array calibration: {exc}")
+        self._calibBtn.setEnabled(False)
+        self._calibFlow = InteractionArrayCalibrationFlow(self.dev, pip, parent=self)
+        self._calibFlow.finished.connect(self._onCalibrationFinished)
+        self._calibFlow.show()
+        self._calibFlow.raise_()
 
-        def _mark(label, key):
-            label.setText("✓" if key in cal else "?")
+    def _onCalibrationFinished(self, _result):
+        self._calibFlow = None
+        self._calibBtn.setEnabled(self._selectedPipette() is not None)
+        self._updateSpacingLabel()
+        for i in range(len(self.dev.sites)):
+            self._styleSiteButton(self._site_buttons[i], i)
 
-        _mark(self._approachStatus, 'approach')
-        _mark(self._originStatus, 'origin_interact')
-        _mark(self._colEndStatus, 'col_end_interact')
-        _mark(self._rowEndStatus, 'row_end_interact')
 
-        # Update spacing labels
-        col_mm = self.dev.columnSpacingMm(pip_name)
-        if col_mm is not None:
-            self._colSpacingLabel.setText(
-                f"[0,{self.dev._cols-1}] interact:  ({col_mm:.2f} mm/col)"
+class InteractionArrayCalibrationFlow(Qt.QDialog):
+    """Modeless step-by-step calibration wizard for an InteractionSiteArray.
+
+    Walks the user through (in order): the [0,0] interact point, the [0,0] approach
+    waypoint, the [rows-1,0] interact corner, and the [0,cols-1] interact corner.
+    Each step lets the user capture the current pipette position or keep a previously
+    saved one. The calibration is applied automatically after the last step.
+    """
+
+    def __init__(self, dev: InteractionSiteArray, pip, parent=None):
+        Qt.QDialog.__init__(self, parent)
+        self.dev = dev
+        self.pip = pip
+        self.setWindowTitle(f"Calibrate {dev.name()}")
+        self.setModal(False)
+
+        # Build the ordered step list, skipping degenerate corners.
+        self._steps = [
+            ('origin', 'interact', "Site [0,0] — interact point",
+             "Drive the pipette tip into the fluid at the bottom of site [0,0]."),
+            ('origin', 'approach', "Site [0,0] — approach waypoint",
+             "Raise the pipette to a safe waypoint above site [0,0]."),
+        ]
+        if dev._rows > 1:
+            self._steps.append(
+                ('row_end', 'interact', f"Site [{dev._rows-1},0] — interact point",
+                 f"Drive the pipette tip into the fluid at the bottom of site [{dev._rows-1},0].")
             )
-        else:
-            self._colSpacingLabel.setText(f"[0,{self.dev._cols-1}] interact:")
-
-        row_mm = self.dev.rowSpacingMm(pip_name)
-        if row_mm is not None:
-            self._rowSpacingLabel.setText(
-                f"[{self.dev._rows-1},0] interact:  ({row_mm:.2f} mm/row)"
+        if dev._cols > 1:
+            self._steps.append(
+                ('col_end', 'interact', f"Site [0,{dev._cols-1}] — interact point",
+                 f"Drive the pipette tip into the fluid at the bottom of site [0,{dev._cols-1}].")
             )
-        else:
-            self._rowSpacingLabel.setText(f"[{self.dev._rows-1},0] interact:")
+        self._index = 0
 
-        # Enable Apply only when approach and all required interact corners are ready
-        has_cols = 'origin_interact' in cal and 'col_end_interact' in cal
-        has_rows = self.dev._rows == 1 or 'row_end_interact' in cal
-        self._applyBtn.setEnabled('approach' in cal and has_cols and has_rows)
+        layout = Qt.QVBoxLayout()
+        self.setLayout(layout)
+
+        self._stepLabel = Qt.QLabel()
+        f = self._stepLabel.font()
+        f.setBold(True)
+        self._stepLabel.setFont(f)
+        layout.addWidget(self._stepLabel)
+
+        self._instructionLabel = Qt.QLabel()
+        self._instructionLabel.setWordWrap(True)
+        layout.addWidget(self._instructionLabel)
+
+        self._savedLabel = Qt.QLabel()
+        layout.addWidget(self._savedLabel)
+
+        btn_row = Qt.QHBoxLayout()
+        layout.addLayout(btn_row)
+        self._useBtn = Qt.QPushButton("Use current position")
+        self._useBtn.clicked.connect(self._useCurrent)
+        btn_row.addWidget(self._useBtn)
+        self._keepBtn = Qt.QPushButton("Keep existing")
+        self._keepBtn.clicked.connect(self._keepExisting)
+        btn_row.addWidget(self._keepBtn)
+        self._cancelBtn = Qt.QPushButton("Cancel")
+        self._cancelBtn.clicked.connect(self.reject)
+        btn_row.addWidget(self._cancelBtn)
+
+        self._showStep()
+
+    def _currentSaved(self):
+        """Return the saved value for the current step, or None."""
+        corner, kind, _, _ = self._steps[self._index]
+        cal = self.dev.positions.get(self.pip.name(), {})
+        key = 'approach' if kind == 'approach' else f'{corner}_interact'
+        return cal.get(key)
+
+    def _showStep(self):
+        corner, kind, title, instruction = self._steps[self._index]
+        self._stepLabel.setText(f"Step {self._index + 1} of {len(self._steps)}: {title}")
+        self._instructionLabel.setText(instruction)
+        saved = self._currentSaved()
+        if saved is not None:
+            self._savedLabel.setText(f"Saved: {_fmt_pos(np.asarray(saved, dtype=float))}")
+            self._keepBtn.setEnabled(True)
+        else:
+            self._savedLabel.setText("Saved: none yet")
+            self._keepBtn.setEnabled(False)
+
+    def _capture(self):
+        corner, kind, _, _ = self._steps[self._index]
+        if kind == 'approach':
+            self.dev.calibrateApproach(self.pip)
+        else:
+            self.dev.calibrateInteractCorner(self.pip, corner)
+
+    def _useCurrent(self):
+        self._capture()
+        self._advance()
+
+    def _keepExisting(self):
+        self._advance()
+
+    def _advance(self):
+        self._index += 1
+        if self._index >= len(self._steps):
+            self.dev.applyCalibration(self.pip)
+            self.accept()
+        else:
+            self._showStep()
 
 
 def _fmt_pos(pos):

--- a/acq4/devices/InteractionSiteArray.py
+++ b/acq4/devices/InteractionSiteArray.py
@@ -1,5 +1,5 @@
 # Device class for a grid array of InteractionSite objects (e.g. nucleus deposition tube arrays).
-# Each slot is a real InteractionSite child whose position is offset from the array origin.
+# Each slot holds its own offset in the parent stage frame, calibrated empirically from corner sites.
 
 from __future__ import annotations
 
@@ -15,17 +15,16 @@ from .Stage import Stage
 class InteractionSiteArray(Device, OptomechDevice):
     """Array of cylindrical interaction sites arranged in a grid.
 
+    Each site stores its own offset in the parent stage frame; positions are calibrated
+    empirically by tagging corner sites and interpolating evenly.
+
     Configuration options:
       rows: int — number of rows in the grid
       cols: int — number of columns in the grid
-      spacing_x: float (m) — x spacing between adjacent columns
-      spacing_y: float (m) — y spacing between adjacent rows
       site_radius: float (m) — radius of each site cylinder
       site_height: float (m) — height of each site cylinder
-      parentDevice: str — name of parent stage device (same as OptomechDevice)
-      transform: dict — optional transform (same as OptomechDevice)
-      site_role_defaults: list (optional) — roles in row-major order; length may be
-        shorter than rows*cols, remaining sites default to 'empty'
+      parentDevice: str — name of parent stage device
+      site_role_defaults: list (optional) — roles in row-major order
     """
 
     def __init__(self, dm, config, name):
@@ -34,16 +33,18 @@ class InteractionSiteArray(Device, OptomechDevice):
 
         self._rows = config['rows']
         self._cols = config['cols']
-        self._spacing_x = config['spacing_x']
-        self._spacing_y = config['spacing_y']
         site_radius = config['site_radius']
         site_height = config['site_height']
         role_defaults = config.get('site_role_defaults', [])
 
+        parent = self
+        while True:
+            parent = parent.parentDevice()
+            if parent is None or isinstance(parent, Stage):
+                break
+        self._parentStage: Stage | None = parent
+
         self.positions = self.readConfigFile("saved_positions")
-        array_offset = np.asarray(
-            self.positions.get(self.name(), {}).get("offset", [0, 0, 0]), dtype=float
-        )
 
         self._sites: list[InteractionSite] = []
         n = self._rows * self._cols
@@ -58,27 +59,18 @@ class InteractionSiteArray(Device, OptomechDevice):
                 'role': role,
             }
             site = InteractionSite(dm, site_config, site_name)
-            # attach as child of this array so transforms compose correctly
             site.setParentDevice(self)
-            # set the site's local offset within the array frame
-            site.setOffset(np.array([col * self._spacing_x, row * self._spacing_y, 0.0]))
             dm.declareInterface(site_name, ['device', 'interactionSite'], site)
             self._sites.append(site)
-
-        tr = self.deviceTransform()
-        tr.offset = array_offset
-        self.setDeviceTransform(tr)
 
     # ------------------------------------------------------------------
     # Site access
 
     @property
     def sites(self) -> list[InteractionSite]:
-        """Return a copy of the list of child InteractionSite objects."""
         return list(self._sites)
 
     def getSite(self, index: int) -> InteractionSite:
-        """Return the child site at *index* (row-major order)."""
         return self._sites[index]
 
     def getFirstAvailableSite(self, role: str) -> "InteractionSite | None":
@@ -91,46 +83,82 @@ class InteractionSiteArray(Device, OptomechDevice):
     # ------------------------------------------------------------------
     # Calibration
 
-    def setArrayOriginFromPipette(self, pip, reference_slot_index: int):
-        """Position the array so that reference_slot is at the pipette's current position.
+    def calibrateCorner(self, pip, corner: str):
+        """Record stage and pipette positions for a calibration corner.
 
-        Computes the array's parent-frame offset and saves it to config.
+        corner: 'origin' ([0,0]), 'col_end' ([0,cols-1]), 'row_end' ([rows-1,0])
         """
-        pip_global = np.asarray(pip.globalPosition(), dtype=float)
-        site_in_array = np.array([
-            (reference_slot_index % self._cols) * self._spacing_x,
-            (reference_slot_index // self._cols) * self._spacing_y,
-            0.0,
-        ])
-        desired_array_global = pip_global - site_in_array
-        new_offset = self.mapGlobalToParent(desired_array_global)
-        self._setOffset(new_offset)
-
-    def _setOffset(self, offset):
-        """Set the array's local offset and persist it (same pattern as InteractionSite.setOffset)."""
-        tr = self.deviceTransform()
-        tr.offset = offset
-        self.setDeviceTransform(tr)
-        self.positions.setdefault(self.name(), {})
-        self.positions[self.name()]['offset'] = list(offset)
+        if self._parentStage is None:
+            raise RuntimeError(f"{self.name()} has no parent Stage, cannot calibrate")
+        pip_name = pip.name()
+        self.positions.setdefault(pip_name, {})
+        self.positions[pip_name][f'{corner}_stage'] = self._parentStage.globalPosition().tolist()
+        self.positions[pip_name]['approach'] = pip.globalPosition().tolist()
         self.writeConfigFile(self.positions, "saved_positions")
-        self.sigTransformChanged.emit(self)
 
-    def saveInteractPosition(self, pip):
-        """Save pip's current global position as the interact position in each site's local frame.
+    def calibrateInteract(self, pip):
+        """Record the pipette interact position (tip inside a reference site) for all sites."""
+        pip_name = pip.name()
+        interact_global = np.asarray(pip.globalPosition(), dtype=float)
+        self.positions.setdefault(pip_name, {})
+        self.positions[pip_name]['interact_global'] = interact_global.tolist()
+        self.writeConfigFile(self.positions, "saved_positions")
 
-        Also stores the site's current global position as 'site global' so that _guessRotation
-        can infer the cylinder axis (approach-to-interact direction) for correct 3D display.
-        """
         for site in self._sites:
-            site.positions.setdefault(pip.name(), {})
-            interact_global = np.asarray(pip.globalPosition(), dtype=float)
-            interact_local = site.mapFromGlobal(interact_global)
-            site.positions[pip.name()]['interact global'] = interact_global.tolist()
-            site.positions[pip.name()]['interact local'] = interact_local.tolist()
-            site.positions[pip.name()]['site global'] = site.globalPosition().tolist()
+            site.positions.setdefault(pip_name, {})
+            site.positions[pip_name]['interact global'] = interact_global.tolist()
             site.writeConfigFile(site.positions, "saved_positions")
             site._guessRotation()
+
+    def applySpacing(self, pip):
+        """Interpolate all site offsets from the calibrated corners and write approach positions.
+
+        Requires calibrateCorner for 'origin', 'col_end' (and 'row_end' when rows > 1).
+        Each site gets its own offset in the parent stage frame so that when the stage moves
+        to bring site [r,c] to the pipette approach position, the site arrives at the correct
+        spot. All sites share the same approach global and interact global.
+        """
+        pip_name = pip.name()
+        cal = self.positions.get(pip_name, {})
+        P = np.asarray(cal['approach'], dtype=float)
+        S_00 = np.asarray(cal['origin_stage'], dtype=float)
+        S_0_N = np.asarray(cal['col_end_stage'], dtype=float)
+
+        col_step = (S_0_N - S_00) / (self._cols - 1) if self._cols > 1 else np.zeros(3)
+        if self._rows > 1:
+            S_M_0 = np.asarray(cal['row_end_stage'], dtype=float)
+            row_step = (S_M_0 - S_00) / (self._rows - 1)
+        else:
+            row_step = np.zeros(3)
+
+        for i, site in enumerate(self._sites):
+            r, c = divmod(i, self._cols)
+            # Stage position when this site will be under the pipette.
+            S_r_c = S_00 + c * col_step + r * row_step
+            # Site offset in parent frame so site.globalPosition() == P when stage is at S_r_c.
+            site_offset = P - S_r_c
+            site.setOffset(site_offset)
+            # Record approach position for the motion planner.
+            site.positions.setdefault(pip_name, {})
+            site.positions[pip_name]['site global'] = P.tolist()
+            site.writeConfigFile(site.positions, "saved_positions")
+            site._guessRotation()
+
+    def columnSpacingMm(self, pip_name: str) -> float | None:
+        """Return computed column spacing in mm, or None if not yet calibrated."""
+        cal = self.positions.get(pip_name, {})
+        if 'origin_stage' not in cal or 'col_end_stage' not in cal or self._cols < 2:
+            return None
+        span = np.linalg.norm(np.array(cal['col_end_stage']) - np.array(cal['origin_stage']))
+        return span / (self._cols - 1) * 1e3
+
+    def rowSpacingMm(self, pip_name: str) -> float | None:
+        """Return computed row spacing in mm, or None if not yet calibrated."""
+        cal = self.positions.get(pip_name, {})
+        if 'origin_stage' not in cal or 'row_end_stage' not in cal or self._rows < 2:
+            return None
+        span = np.linalg.norm(np.array(cal['row_end_stage']) - np.array(cal['origin_stage']))
+        return span / (self._rows - 1) * 1e3
 
     def approachMoveSpec(self, pip, speed='fast'):
         """Return a MoveSpec for the first site that has a saved approach position, or None."""
@@ -141,14 +169,12 @@ class InteractionSiteArray(Device, OptomechDevice):
         return None
 
     def hasApproachPosition(self, pip) -> bool:
-        """Return True if any site has a saved approach position for pip."""
         return any(site.hasApproachPosition(pip) for site in self._sites)
 
     # ------------------------------------------------------------------
     # Device interface
 
     def deviceInterface(self, win):
-        """Return the array management widget."""
         return InteractionSiteArrayDeviceGui(self, win)
 
     def cameraModuleInterface(self, mod):
@@ -219,34 +245,64 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
         calib_group.setLayout(calib_layout)
         main_layout.addWidget(calib_group)
 
-        calib_layout.addWidget(Qt.QLabel("Pipette:"), 0, 0)
+        row = 0
+        calib_layout.addWidget(Qt.QLabel("Pipette:"), row, 0)
         self._pipCombo = Qt.QComboBox()
-        calib_layout.addWidget(self._pipCombo, 0, 1)
+        calib_layout.addWidget(self._pipCombo, row, 1, 1, 2)
+        row += 1
 
-        calib_layout.addWidget(Qt.QLabel("Reference slot:"), 1, 0)
-        self._refSlotCombo = Qt.QComboBox()
-        for i in range(len(dev.sites)):
-            self._refSlotCombo.addItem(str(i))
-        calib_layout.addWidget(self._refSlotCombo, 1, 1)
+        calib_layout.addWidget(Qt.QLabel(f"Rows: {dev._rows}   Cols: {dev._cols}"), row, 0, 1, 3)
+        row += 1
 
-        self._setOriginBtn = Qt.QPushButton("Set array origin")
-        self._setOriginBtn.clicked.connect(self._setArrayOrigin)
-        calib_layout.addWidget(self._setOriginBtn, 2, 0, 1, 2)
+        # Origin [0,0]
+        self._originStatus = Qt.QLabel("?")
+        calib_layout.addWidget(self._originStatus, row, 0)
+        calib_layout.addWidget(Qt.QLabel("[0,0] approach:"), row, 1)
+        self._setOriginBtn = Qt.QPushButton("Set")
+        self._setOriginBtn.clicked.connect(self._calibrateOrigin)
+        calib_layout.addWidget(self._setOriginBtn, row, 2)
+        row += 1
 
-        self._saveInteractBtn = Qt.QPushButton("Set interact position")
-        self._saveInteractBtn.clicked.connect(self._saveInteractPosition)
-        calib_layout.addWidget(self._saveInteractBtn, 3, 0, 1, 2)
+        # Column end [0, cols-1]
+        self._colEndStatus = Qt.QLabel("?")
+        calib_layout.addWidget(self._colEndStatus, row, 0)
+        self._colSpacingLabel = Qt.QLabel(f"[0,{dev._cols-1}] approach:")
+        calib_layout.addWidget(self._colSpacingLabel, row, 1)
+        self._setColEndBtn = Qt.QPushButton("Set")
+        self._setColEndBtn.clicked.connect(self._calibrateColEnd)
+        calib_layout.addWidget(self._setColEndBtn, row, 2)
+        row += 1
 
-        calib_layout.addWidget(Qt.QLabel("Array origin (global):"), 4, 0)
-        self._originLabel = Qt.QLabel("—")
-        calib_layout.addWidget(self._originLabel, 4, 1)
+        # Row end [rows-1, 0] — only shown when rows > 1
+        self._rowEndStatus = Qt.QLabel("?")
+        self._rowSpacingLabel = Qt.QLabel(f"[{dev._rows-1},0] approach:")
+        self._setRowEndBtn = Qt.QPushButton("Set")
+        self._setRowEndBtn.clicked.connect(self._calibrateRowEnd)
+        if dev._rows > 1:
+            calib_layout.addWidget(self._rowEndStatus, row, 0)
+            calib_layout.addWidget(self._rowSpacingLabel, row, 1)
+            calib_layout.addWidget(self._setRowEndBtn, row, 2)
+            row += 1
 
-        calib_layout.addWidget(Qt.QLabel("Interact position (site-local):"), 5, 0)
-        self._interactLabel = Qt.QLabel("—")
-        calib_layout.addWidget(self._interactLabel, 5, 1)
+        # Interact depth
+        self._interactStatus = Qt.QLabel("?")
+        calib_layout.addWidget(self._interactStatus, row, 0)
+        calib_layout.addWidget(Qt.QLabel("Interact depth:"), row, 1)
+        self._setInteractBtn = Qt.QPushButton("Set")
+        self._setInteractBtn.clicked.connect(self._calibrateInteract)
+        calib_layout.addWidget(self._setInteractBtn, row, 2)
+        row += 1
+
+        # Apply
+        self._applyBtn = Qt.QPushButton("Apply spacing")
+        self._applyBtn.clicked.connect(self._applySpacing)
+        calib_layout.addWidget(self._applyBtn, row, 0, 1, 3)
 
         self._populatePipettes()
-        self._pipCombo.currentIndexChanged.connect(self._updateCalibLabels)
+        self._pipCombo.currentIndexChanged.connect(self._updateCalibStatus)
+
+    # ------------------------------------------------------------------
+    # Slot table handlers
 
     def _makeRoleSetter(self, index):
         def setter(text):
@@ -278,15 +334,19 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
         for site in self.dev.sites:
             site.used_up = False
 
+    # ------------------------------------------------------------------
+    # Calibration handlers
+
     def _populatePipettes(self):
         pipettes = self.dev.dm.listInterfaces('pipette')
         for name in pipettes:
             self._pipCombo.addItem(name)
         has_pip = bool(pipettes)
         self._pipCombo.setEnabled(has_pip)
-        self._setOriginBtn.setEnabled(has_pip)
-        self._saveInteractBtn.setEnabled(has_pip)
-        self._updateCalibLabels()
+        for btn in (self._setOriginBtn, self._setColEndBtn, self._setRowEndBtn,
+                    self._setInteractBtn, self._applyBtn):
+            btn.setEnabled(has_pip)
+        self._updateCalibStatus()
 
     def _selectedPipette(self):
         name = self._pipCombo.currentText()
@@ -294,28 +354,72 @@ class InteractionSiteArrayDeviceGui(Qt.QWidget):
             return None
         return self.dev.dm.getDevice(name)
 
-    def _setArrayOrigin(self):
+    def _calibrateOrigin(self):
         pip = self._selectedPipette()
         if pip is not None:
-            ref = int(self._refSlotCombo.currentText())
-            self.dev.setArrayOriginFromPipette(pip, ref)
-            self._updateCalibLabels()
+            self.dev.calibrateCorner(pip, 'origin')
+            self._updateCalibStatus()
 
-    def _saveInteractPosition(self):
+    def _calibrateColEnd(self):
         pip = self._selectedPipette()
         if pip is not None:
-            self.dev.saveInteractPosition(pip)
-            self._updateCalibLabels()
+            self.dev.calibrateCorner(pip, 'col_end')
+            self._updateCalibStatus()
 
-    def _updateCalibLabels(self):
-        origin = self.dev.mapToGlobal(np.zeros(3))
-        self._originLabel.setText(_fmt_pos(origin))
+    def _calibrateRowEnd(self):
         pip = self._selectedPipette()
-        if pip is not None and self.dev.sites:
-            local = self.dev.sites[0].interactLocalFor(pip)
-            self._interactLabel.setText(_fmt_pos(local))
+        if pip is not None:
+            self.dev.calibrateCorner(pip, 'row_end')
+            self._updateCalibStatus()
+
+    def _calibrateInteract(self):
+        pip = self._selectedPipette()
+        if pip is not None:
+            self.dev.calibrateInteract(pip)
+            self._updateCalibStatus()
+
+    def _applySpacing(self):
+        pip = self._selectedPipette()
+        if pip is not None:
+            self.dev.applySpacing(pip)
+            self._updateCalibStatus()
+
+    def _updateCalibStatus(self):
+        pip = self._selectedPipette()
+        if pip is None:
+            return
+        pip_name = pip.name()
+        cal = self.dev.positions.get(pip_name, {})
+
+        def _mark(label, key):
+            label.setText("✓" if key in cal else "?")
+
+        _mark(self._originStatus, 'origin_stage')
+        _mark(self._colEndStatus, 'col_end_stage')
+        _mark(self._rowEndStatus, 'row_end_stage')
+        _mark(self._interactStatus, 'interact_global')
+
+        # Update spacing labels
+        col_mm = self.dev.columnSpacingMm(pip_name)
+        if col_mm is not None:
+            self._colSpacingLabel.setText(
+                f"[0,{self.dev._cols-1}] approach:  ({col_mm:.2f} mm/col)"
+            )
         else:
-            self._interactLabel.setText("—")
+            self._colSpacingLabel.setText(f"[0,{self.dev._cols-1}] approach:")
+
+        row_mm = self.dev.rowSpacingMm(pip_name)
+        if row_mm is not None:
+            self._rowSpacingLabel.setText(
+                f"[{self.dev._rows-1},0] approach:  ({row_mm:.2f} mm/row)"
+            )
+        else:
+            self._rowSpacingLabel.setText(f"[{self.dev._rows-1},0] approach:")
+
+        # Enable Apply only when all required corners are ready
+        has_cols = 'origin_stage' in cal and 'col_end_stage' in cal
+        has_rows = self.dev._rows == 1 or 'row_end_stage' in cal
+        self._applyBtn.setEnabled(has_cols and has_rows)
 
 
 def _fmt_pos(pos):

--- a/acq4/devices/PatchPipette/states/clean.py
+++ b/acq4/devices/PatchPipette/states/clean.py
@@ -63,7 +63,11 @@ class CleanState(PatchPipetteState):
             if len(sequence) == 0:
                 continue
 
-            self.waitFor(pip.moveTo(stage, "fast"), timeout=60)
+            site = pip.getSiteFor(stage)
+            if site is not None:
+                self.waitFor(site.moveToInteract(pip, speed='fast'), timeout=60)
+            else:
+                self.waitFor(pip.moveTo(stage, 'fast'), timeout=60)
 
             if dev.sonicatorDevice is not None:
                 self.sonication = dev.sonicatorDevice.doProtocol(config['sonicationProtocol'])

--- a/acq4/devices/PatchPipette/states/nucleus_collect.py
+++ b/acq4/devices/PatchPipette/states/nucleus_collect.py
@@ -50,7 +50,7 @@ class NucleusCollectState(PatchPipetteState):
         self.setState('nucleus collection')
 
         self.startPos = pip.globalPosition()
-        well = pip.getNucleusDepositionWell()
+        well = pip.getSiteFor('nucleus')
         if well is not None:
             self.waitFor(well.moveToInteract(pip), timeout=60)
         else:

--- a/acq4/devices/PatchPipette/states/refill.py
+++ b/acq4/devices/PatchPipette/states/refill.py
@@ -63,7 +63,11 @@ class RefillState(PatchPipetteState):
         pip = dev.pipetteDevice
 
         self.setState('refilling pipette')
-        self.waitFor(pip.moveTo('refill', 'fast'), timeout=60)
+        site = pip.getSiteFor('refill')
+        if site is not None:
+            self.waitFor(site.moveToInteract(pip, speed='fast'), timeout=60)
+        else:
+            self.waitFor(pip.moveTo('refill', 'fast'), timeout=60)
 
         refill_pressure = config['refillPressure']
         refill_duration = config['refillDuration']

--- a/acq4/devices/Pipette/pipette.py
+++ b/acq4/devices/Pipette/pipette.py
@@ -175,6 +175,9 @@ class Pipette(Device, OptomechDevice):
 
         deviceManager.sigAbortAll.connect(self.stop)
 
+        self._site_assignments: dict[str, str | None] = {}
+        self._loadSiteAssignments()
+
     def getGeometry(self, name=None):
         if isinstance(self.config.get("geometry"), dict):
             defaults = {'color': (0, 1, 0.2, 1)}
@@ -209,12 +212,11 @@ class Pipette(Device, OptomechDevice):
             'target': self.goTarget,
             'aboveTarget': self.goAboveTarget,
         }
+        _site_roles = {'clean': 'clean', 'rinse': 'rinse', 'refill': 'refill'}
         if position in go_methods:
             future = go_methods[position](speed=speed, **kwds)
-        elif position == 'clean' and self.getCleaningWell():
-            future = self.getCleaningWell().moveToInteract(self, speed=speed)
-        elif position == 'rinse' and self.getElectrodeSolutionWell():
-            future = self.getElectrodeSolutionWell().moveToInteract(self, speed=speed)
+        elif position in _site_roles and self.getSiteFor(_site_roles[position]) is not None:
+            future = self.getSiteFor(_site_roles[position]).moveToInteract(self, speed=speed)
         else:
             saved_pos = self.loadPosition(position)
             if saved_pos is None:
@@ -876,31 +878,72 @@ class Pipette(Device, OptomechDevice):
         return [self.dm.getDevice(d) for d in self.config.get('recordingChambers', [])]
 
     def getCleaningWell(self) -> InteractionSite | None:
-        """Return the RecordingChamber instance that is associated with this Pipette for cleaning
-        (see 'cleaningWell' config option).
+        """Return the site associated with this Pipette for cleaning.
+
+        Delegates to getSiteFor('clean'). Legacy config key 'cleaningWell' is
+        automatically migrated on startup.
         """
-        name = self.config.get('cleaningWell', None)
-        if name is None:
-            return None
-        return self.dm.getDevice(name)
+        return self.getSiteFor('clean')
 
     def getNucleusDepositionWell(self) -> InteractionSite | None:
-        """Return the RecordingChamber instance that is associated with this Pipette for nucleus expulsion
-        (see 'nucleusExpulsionWell' config option).
+        """Return the site associated with this Pipette for nucleus expulsion.
+
+        Delegates to getSiteFor('nucleus'). Legacy config key 'nucleusExpulsionWell'
+        is automatically migrated on startup.
         """
-        name = self.config.get('nucleusExpulsionWell', None)
-        if name is None:
-            return None
-        return self.dm.getDevice(name)
+        return self.getSiteFor('nucleus')
 
     def getElectrodeSolutionWell(self) -> InteractionSite | None:
-        """Return the RecordingChamber instance that is associated with this Pipette for electrode solution
-        (see 'electrodeSolutionWell' config option).
+        """Return the site associated with this Pipette for electrode solution refill.
+
+        Delegates to getSiteFor('refill'). Legacy config key 'electrodeSolutionWell' is
+        automatically migrated on startup.
         """
-        name = self.config.get('electrodeSolutionWell', None)
+        return self.getSiteFor('refill')
+
+    def _loadSiteAssignments(self):
+        saved = self.readConfigFile("saved_sites")
+        self._site_assignments = saved if saved else {}
+        compat_map = {
+            'clean': self.config.get('cleaningWell'),
+            'nucleus': self.config.get('nucleusExpulsionWell'),
+            'refill': self.config.get('electrodeSolutionWell'),
+        }
+        for role, name in compat_map.items():
+            if name is not None and role not in self._site_assignments:
+                self._site_assignments[role] = name
+
+    def getSiteFor(self, role: str) -> "InteractionSite | None":
+        """Return the interaction site assigned to this pipette for *role*.
+
+        If the assigned device supports getFirstAvailableSite() (i.e. is an
+        InteractionSiteArray), that is called and the result returned.
+        Returns None if no site is assigned or if the assigned device no longer exists.
+        """
+        name = self._site_assignments.get(role)
         if name is None:
             return None
-        return self.dm.getDevice(name)
+        try:
+            device = self.dm.getDevice(name)
+        except Exception:
+            return None
+        if device is None:
+            return None
+        if hasattr(device, 'getFirstAvailableSite'):
+            return device.getFirstAvailableSite(role)
+        return device
+
+    def setSiteFor(self, role: str, device_or_none):
+        """Assign an interaction site (or None) for *role* and persist the choice.
+
+        Accepts either a device object (with a .name() method) or a bare string device name.
+        """
+        if device_or_none is None:
+            self._site_assignments.pop(role, None)
+        else:
+            n = device_or_none if isinstance(device_or_none, str) else device_or_none.name()
+            self._site_assignments[role] = n
+        self.writeConfigFile(self._site_assignments, "saved_sites")
 
     def startRecording(self):
         """Return an object that records all motion updates from this pipette"""

--- a/acq4/devices/Pipette/pipette.py
+++ b/acq4/devices/Pipette/pipette.py
@@ -916,8 +916,8 @@ class Pipette(Device, OptomechDevice):
     def getSiteFor(self, role: str) -> "InteractionSite | None":
         """Return the interaction site assigned to this pipette for *role*.
 
-        If the assigned device supports getFirstAvailableSite() (i.e. is an
-        InteractionSiteArray), that is called and the result returned.
+        If the assigned device is an InteractionSiteArray (has getFirstAvailableSite),
+        its role must match *role* and the first available site is returned.
         Returns None if no site is assigned or if the assigned device no longer exists.
         """
         name = self._site_assignments.get(role)
@@ -930,7 +930,9 @@ class Pipette(Device, OptomechDevice):
         if device is None:
             return None
         if hasattr(device, 'getFirstAvailableSite'):
-            return device.getFirstAvailableSite(role)
+            if getattr(device, 'role', None) != role:
+                return None
+            return device.getFirstAvailableSite()
         return device
 
     def setSiteFor(self, role: str, device_or_none):

--- a/acq4/devices/Pipette/tests/test_pipette_site_assignment.py
+++ b/acq4/devices/Pipette/tests/test_pipette_site_assignment.py
@@ -155,23 +155,37 @@ class TestSetSiteFor:
 
 
 class TestArrayDelegation:
-    def test_getSiteFor_calls_getFirstAvailableSite_on_array(self, qt_app):
+    def test_getSiteFor_calls_getFirstAvailableSite_on_matching_array(self, qt_app):
         mock_site = MagicMock()
         mock_site.name.return_value = 'ActualSite'
         mock_array = MagicMock()
         mock_array.name.return_value = 'Array1'
+        mock_array.role = 'nucleus'
         mock_array.getFirstAvailableSite.return_value = mock_site
 
         pip, _, _ = _make_pipette(devices={'Array1': mock_array})
         pip.setSiteFor('nucleus', mock_array)
         result = pip.getSiteFor('nucleus')
 
-        mock_array.getFirstAvailableSite.assert_called_once_with('nucleus')
+        mock_array.getFirstAvailableSite.assert_called_once_with()
         assert result is mock_site
+
+    def test_getSiteFor_returns_none_when_array_role_mismatches(self, qt_app):
+        mock_array = MagicMock()
+        mock_array.name.return_value = 'Array1'
+        mock_array.role = 'clean'
+        mock_site = MagicMock()
+        mock_array.getFirstAvailableSite.return_value = mock_site
+
+        pip, _, _ = _make_pipette(devices={'Array1': mock_array})
+        pip.setSiteFor('nucleus', mock_array)
+        assert pip.getSiteFor('nucleus') is None
+        mock_array.getFirstAvailableSite.assert_not_called()
 
     def test_getSiteFor_returns_none_when_array_has_no_available_site(self, qt_app):
         mock_array = MagicMock()
         mock_array.name.return_value = 'Array1'
+        mock_array.role = 'nucleus'
         mock_array.getFirstAvailableSite.return_value = None
 
         pip, _, _ = _make_pipette(devices={'Array1': mock_array})

--- a/acq4/devices/Pipette/tests/test_pipette_site_assignment.py
+++ b/acq4/devices/Pipette/tests/test_pipette_site_assignment.py
@@ -1,0 +1,209 @@
+# Tests for Pipette runtime site assignment: getSiteFor / setSiteFor.
+# Verifies backward-compat config migration, duck-typed array delegation, and persistence.
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch, call
+
+import numpy as np
+import pytest
+
+
+def _make_pipette(config=None, saved_sites=None, devices=None):
+    """Create a minimal stub that exercises site-assignment code from the real Pipette class.
+
+    Pipette inherits from Qt.QObject and requires full hardware init; this helper
+    borrows just the methods under test (getSiteFor, setSiteFor, _loadSiteAssignments)
+    onto a plain Python stub that provides the Device infrastructure they depend on.
+    """
+    import os
+    from acq4.devices.Pipette.pipette import Pipette
+
+    storage = {}
+    if saved_sites:
+        storage["devices/TestPip_config/saved_sites"] = saved_sites.copy()
+
+    dm = MagicMock()
+    dm.readConfigFile.side_effect = lambda path: storage.get(path, {})
+    dm.writeConfigFile.side_effect = lambda data, path: storage.update({path: data.copy()})
+    dm.getDevice.side_effect = lambda name: (devices or {}).get(name)
+
+    base_config = {}
+    if config:
+        base_config.update(config)
+
+    class _StubPipette:
+        """Minimal Device-like infrastructure for site assignment unit tests."""
+
+        def name(self_):
+            return 'TestPip'
+
+        def configPath(self_):
+            return os.path.join('devices', f'{self_.name()}_config')
+
+        def readConfigFile(self_, filename):
+            return self_.dm.readConfigFile(os.path.join(self_.configPath(), filename))
+
+        def writeConfigFile(self_, data, filename):
+            self_.dm.writeConfigFile(data, os.path.join(self_.configPath(), filename))
+
+    # Attach the actual Pipette methods under test.
+    _StubPipette._loadSiteAssignments = Pipette._loadSiteAssignments
+    _StubPipette.getSiteFor = Pipette.getSiteFor
+    _StubPipette.setSiteFor = Pipette.setSiteFor
+    _StubPipette.getCleaningWell = Pipette.getCleaningWell
+    _StubPipette.getNucleusDepositionWell = Pipette.getNucleusDepositionWell
+    _StubPipette.getElectrodeSolutionWell = Pipette.getElectrodeSolutionWell
+
+    pip = _StubPipette()
+    pip.dm = dm
+    pip.config = base_config
+    pip._site_assignments = {}
+    pip._loadSiteAssignments()
+    return pip, dm, storage
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    from acq4.util import Qt
+    app = Qt.QApplication.instance()
+    if app is None:
+        app = Qt.QApplication(sys.argv)
+    return app
+
+
+class TestGetSiteForDefaults:
+    def test_returns_none_with_no_config_and_no_saved_state(self, qt_app):
+        pip, _, _ = _make_pipette()
+        assert pip.getSiteFor('clean') is None
+
+    def test_returns_none_for_unknown_role(self, qt_app):
+        pip, _, _ = _make_pipette()
+        assert pip.getSiteFor('nucleus') is None
+
+
+class TestBackwardCompatMigration:
+    def test_cleaningWell_config_migrates_to_clean_role(self, qt_app):
+        mock_well = MagicMock(spec=['name'])
+        mock_well.name.return_value = 'CleaningWell1'
+        pip, _, _ = _make_pipette(
+            config={'cleaningWell': 'CleaningWell1'},
+            devices={'CleaningWell1': mock_well},
+        )
+        assert pip.getSiteFor('clean') is mock_well
+
+    def test_nucleusExpulsionWell_config_migrates_to_nucleus_role(self, qt_app):
+        mock_well = MagicMock(spec=['name'])
+        mock_well.name.return_value = 'NucleusWell1'
+        pip, _, _ = _make_pipette(
+            config={'nucleusExpulsionWell': 'NucleusWell1'},
+            devices={'NucleusWell1': mock_well},
+        )
+        assert pip.getSiteFor('nucleus') is mock_well
+
+    def test_electrodeSolutionWell_config_migrates_to_refill_role(self, qt_app):
+        mock_well = MagicMock(spec=['name'])
+        mock_well.name.return_value = 'ElecWell1'
+        pip, _, _ = _make_pipette(
+            config={'electrodeSolutionWell': 'ElecWell1'},
+            devices={'ElecWell1': mock_well},
+        )
+        assert pip.getSiteFor('refill') is mock_well
+
+    def test_saved_state_takes_precedence_over_config_migration(self, qt_app):
+        runtime_well = MagicMock(spec=['name'])
+        runtime_well.name.return_value = 'RuntimeWell'
+        pip, _, _ = _make_pipette(
+            config={'cleaningWell': 'OldWell'},
+            saved_sites={'clean': 'RuntimeWell'},
+            devices={'RuntimeWell': runtime_well},
+        )
+        assert pip.getSiteFor('clean') is runtime_well
+
+
+class TestSetSiteFor:
+    def test_set_then_get_returns_device(self, qt_app):
+        mock_well = MagicMock(spec=['name'])
+        mock_well.name.return_value = 'Well1'
+        pip, dm, _ = _make_pipette(devices={'Well1': mock_well})
+        pip.setSiteFor('clean', mock_well)
+        assert pip.getSiteFor('clean') is mock_well
+
+    def test_set_none_clears_assignment(self, qt_app):
+        mock_well = MagicMock(spec=['name'])
+        mock_well.name.return_value = 'Well1'
+        pip, _, _ = _make_pipette(devices={'Well1': mock_well})
+        pip.setSiteFor('clean', mock_well)
+        pip.setSiteFor('clean', None)
+        assert pip.getSiteFor('clean') is None
+
+    def test_set_persists_to_config_file(self, qt_app):
+        mock_well = MagicMock(spec=['name'])
+        mock_well.name.return_value = 'Well1'
+        pip, dm, storage = _make_pipette(devices={'Well1': mock_well})
+        pip.setSiteFor('clean', mock_well)
+        saved = storage.get('devices/TestPip_config/saved_sites', {})
+        assert saved.get('clean') == 'Well1'
+
+    def test_set_accepts_string_name(self, qt_app):
+        mock_well = MagicMock(spec=['name'])
+        mock_well.name.return_value = 'Well1'
+        pip, _, _ = _make_pipette(devices={'Well1': mock_well})
+        pip.setSiteFor('clean', 'Well1')
+        assert pip.getSiteFor('clean') is mock_well
+
+
+class TestArrayDelegation:
+    def test_getSiteFor_calls_getFirstAvailableSite_on_array(self, qt_app):
+        mock_site = MagicMock()
+        mock_site.name.return_value = 'ActualSite'
+        mock_array = MagicMock()
+        mock_array.name.return_value = 'Array1'
+        mock_array.getFirstAvailableSite.return_value = mock_site
+
+        pip, _, _ = _make_pipette(devices={'Array1': mock_array})
+        pip.setSiteFor('nucleus', mock_array)
+        result = pip.getSiteFor('nucleus')
+
+        mock_array.getFirstAvailableSite.assert_called_once_with('nucleus')
+        assert result is mock_site
+
+    def test_getSiteFor_returns_none_when_array_has_no_available_site(self, qt_app):
+        mock_array = MagicMock()
+        mock_array.name.return_value = 'Array1'
+        mock_array.getFirstAvailableSite.return_value = None
+
+        pip, _, _ = _make_pipette(devices={'Array1': mock_array})
+        pip.setSiteFor('nucleus', mock_array)
+        assert pip.getSiteFor('nucleus') is None
+
+
+class TestRobustness:
+    def test_getSiteFor_returns_none_when_device_name_no_longer_exists(self, qt_app):
+        pip, _, _ = _make_pipette(saved_sites={'clean': 'GoneWell'})
+        # dm.getDevice returns None for unknown names (no devices dict provided)
+        assert pip.getSiteFor('clean') is None
+
+
+class TestBackwardCompatAliases:
+    def test_getCleaningWell_delegates_to_getSiteFor_clean(self, qt_app):
+        mock_well = MagicMock(spec=['name'])
+        mock_well.name.return_value = 'Well1'
+        pip, _, _ = _make_pipette(devices={'Well1': mock_well})
+        pip.setSiteFor('clean', mock_well)
+        assert pip.getCleaningWell() is mock_well
+
+    def test_getNucleusDepositionWell_delegates_to_getSiteFor_nucleus(self, qt_app):
+        mock_well = MagicMock(spec=['name'])
+        mock_well.name.return_value = 'Well1'
+        pip, _, _ = _make_pipette(devices={'Well1': mock_well})
+        pip.setSiteFor('nucleus', mock_well)
+        assert pip.getNucleusDepositionWell() is mock_well
+
+    def test_getElectrodeSolutionWell_delegates_to_getSiteFor_refill(self, qt_app):
+        mock_well = MagicMock(spec=['name'])
+        mock_well.name.return_value = 'Well1'
+        pip, _, _ = _make_pipette(devices={'Well1': mock_well})
+        pip.setSiteFor('refill', mock_well)
+        assert pip.getElectrodeSolutionWell() is mock_well

--- a/acq4/devices/tests/test_interaction_site.py
+++ b/acq4/devices/tests/test_interaction_site.py
@@ -1,0 +1,174 @@
+# Tests for InteractionSite role/used_up tracking and array-child UI suppression.
+# Uses a real InteractionSite with a mock DeviceManager to avoid hardware dependencies.
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_dm(saved_positions=None):
+    """Create a mock device manager that simulates per-device config file storage."""
+    storage = {}
+    if saved_positions:
+        # store under the canonical path prefix matching configPath()
+        storage["devices/TestSite_config/saved_positions"] = saved_positions.copy()
+
+    dm = MagicMock()
+    dm.readConfigFile.side_effect = lambda path: storage.get(path, {})
+    dm.writeConfigFile.side_effect = lambda data, path: storage.update({path: data.copy()})
+    dm.configFileName.side_effect = lambda path: path
+    dm.listDevices.return_value = []
+    return dm
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    from acq4.util import Qt
+    app = Qt.QApplication.instance()
+    if app is None:
+        app = Qt.QApplication(sys.argv)
+    return app
+
+
+@pytest.fixture
+def make_site(qt_app):
+    """Factory fixture: make_site(saved_positions=None, parent=None)."""
+    from acq4.devices.InteractionSite import InteractionSite
+
+    def _factory(saved_positions=None, parent=None):
+        dm = _make_dm(saved_positions)
+        config = {'radius': 1e-3, 'height': 5e-3}
+        site = InteractionSite(dm, config, 'TestSite')
+        if parent is not None:
+            site.parentDevice = lambda: parent
+        return site
+
+    return _factory
+
+
+class TestRoleDefault:
+    def test_role_defaults_to_empty(self, make_site):
+        site = make_site()
+        assert site.role == 'empty'
+
+
+class TestRoleValidation:
+    def test_valid_roles_accepted(self, make_site):
+        site = make_site()
+        for role in ('clean', 'rinse', 'nucleus', 'refill', 'empty'):
+            site.role = role  # should not raise
+
+    def test_invalid_role_raises(self, make_site):
+        site = make_site()
+        with pytest.raises(ValueError):
+            site.role = 'invalid_role'
+
+
+class TestRolePersistence:
+    def test_role_setter_writes_to_config(self, make_site):
+        site = make_site()
+        site.role = 'clean'
+        assert site.dm.writeConfigFile.called
+        args = site.dm.writeConfigFile.call_args[0]
+        data = args[0]
+        assert data.get('TestSite', {}).get('role') == 'clean'
+
+    def test_role_loaded_from_saved_positions(self, make_site):
+        site = make_site(saved_positions={'TestSite': {'role': 'nucleus', 'offset': [0, 0, 0]}})
+        assert site.role == 'nucleus'
+
+
+class TestRoleSignal:
+    def test_role_change_emits_signal(self, make_site, qt_app):
+        site = make_site()
+        emitted = []
+        site.sigRoleChanged.connect(emitted.append)
+        site.role = 'clean'
+        Qt_app = qt_app
+        from acq4.util import Qt
+        Qt.QApplication.processEvents()
+        assert emitted == ['clean']
+
+    def test_role_signal_not_emitted_if_unchanged(self, make_site, qt_app):
+        site = make_site()
+        site.role = 'rinse'
+        emitted = []
+        site.sigRoleChanged.connect(emitted.append)
+        site.role = 'rinse'
+        from acq4.util import Qt
+        Qt.QApplication.processEvents()
+        assert emitted == []
+
+
+class TestUsedUp:
+    def test_used_up_defaults_to_false(self, make_site):
+        site = make_site()
+        assert site.used_up is False
+
+    def test_used_up_loaded_from_saved_positions(self, make_site):
+        site = make_site(saved_positions={'TestSite': {'used_up': True, 'offset': [0, 0, 0]}})
+        assert site.used_up is True
+
+    def test_used_up_setter_writes_to_config(self, make_site):
+        site = make_site()
+        site.used_up = True
+        assert site.dm.writeConfigFile.called
+        args = site.dm.writeConfigFile.call_args[0]
+        data = args[0]
+        assert data.get('TestSite', {}).get('used_up') is True
+
+    def test_used_up_signal_emitted(self, make_site, qt_app):
+        site = make_site()
+        emitted = []
+        site.sigUsedUpChanged.connect(emitted.append)
+        site.used_up = True
+        from acq4.util import Qt
+        Qt.QApplication.processEvents()
+        assert emitted == [True]
+
+    def test_used_up_signal_not_emitted_if_unchanged(self, make_site, qt_app):
+        site = make_site()
+        site.used_up = True
+        emitted = []
+        site.sigUsedUpChanged.connect(emitted.append)
+        site.used_up = True
+        from acq4.util import Qt
+        Qt.QApplication.processEvents()
+        assert emitted == []
+
+
+class TestIsArrayChild:
+    def test_is_array_child_false_with_no_parent(self, make_site):
+        site = make_site()
+        assert site._is_array_child() is False
+
+    def test_is_array_child_false_with_regular_parent(self, make_site):
+        parent = MagicMock(spec=[])  # no getFirstAvailableSite
+        site = make_site(parent=parent)
+        assert site._is_array_child() is False
+
+    def test_is_array_child_true_with_array_parent(self, make_site):
+        parent = MagicMock()
+        parent.getFirstAvailableSite = MagicMock()
+        site = make_site(parent=parent)
+        assert site._is_array_child() is True
+
+
+class TestDeviceInterface:
+    def test_device_interface_returns_widget_for_standalone(self, make_site, qt_app):
+        from acq4.devices.InteractionSite import InteractionSiteDeviceGui
+        site = make_site()
+        win = MagicMock()
+        result = site.deviceInterface(win)
+        assert isinstance(result, InteractionSiteDeviceGui)
+
+    def test_device_interface_returns_none_for_array_child(self, make_site, qt_app):
+        parent = MagicMock()
+        parent.getFirstAvailableSite = MagicMock()
+        site = make_site(parent=parent)
+        win = MagicMock()
+        result = site.deviceInterface(win)
+        assert result is None

--- a/acq4/devices/tests/test_interaction_site_array.py
+++ b/acq4/devices/tests/test_interaction_site_array.py
@@ -81,9 +81,11 @@ def _calibrate(arr, col_spacing=2e-3, row_spacing=3e-3,
     pip.globalPosition.return_value = I
     arr.calibrateInteractCorner(pip, 'origin')
 
-    arr._parentStage.globalPosition = MagicMock(return_value=S_0N)
-    pip.globalPosition.return_value = I
-    arr.calibrateInteractCorner(pip, 'col_end')
+    # Only calibrate the corners the array actually has, mirroring the wizard.
+    if arr._cols > 1:
+        arr._parentStage.globalPosition = MagicMock(return_value=S_0N)
+        pip.globalPosition.return_value = I
+        arr.calibrateInteractCorner(pip, 'col_end')
 
     if arr._rows > 1:
         arr._parentStage.globalPosition = MagicMock(return_value=S_M0)
@@ -368,3 +370,54 @@ class TestCalibrationFlow:
 def Qt_accepted():
     from acq4.util import Qt
     return Qt.QDialog.Accepted
+
+
+class TestDegenerateGrids:
+    """Single-row, single-column, and single-site arrays must calibrate and display
+    using only the dimensions they actually have."""
+
+    def test_single_row_calibrates_along_columns(self, make_array, qt_app):
+        arr = make_array(rows=1, cols=4, role='nucleus')
+        I = np.array([0., 0., -5e-3])
+        _calibrate(arr, col_spacing=2e-3, interact=I, approach_offset=(0., 0., 5e-3))
+        for c, site in enumerate(arr.sites):
+            expected = I + c * np.array([2e-3, 0, 0])
+            np.testing.assert_allclose(site.positions['pip1']['interact global'], expected, atol=1e-12)
+        assert abs(arr.columnSpacingMm('pip1') - 2.0) < 0.01
+        assert arr.rowSpacingMm('pip1') is None  # no row dimension to report
+
+    def test_single_col_calibrates_along_rows(self, make_array, qt_app):
+        arr = make_array(rows=4, cols=1, role='nucleus')
+        I = np.array([0., 0., -5e-3])
+        _calibrate(arr, row_spacing=3e-3, interact=I, approach_offset=(0., 0., 5e-3))
+        for r, site in enumerate(arr.sites):
+            expected = I + r * np.array([0, 3e-3, 0])
+            np.testing.assert_allclose(site.positions['pip1']['interact global'], expected, atol=1e-12)
+        assert abs(arr.rowSpacingMm('pip1') - 3.0) < 0.01
+        assert arr.columnSpacingMm('pip1') is None  # no column dimension to report
+
+    def test_single_row_wizard_skips_row_corner(self, make_array, qt_app):
+        from acq4.devices.InteractionSiteArray import InteractionArrayCalibrationFlow
+        arr = make_array(rows=1, cols=4, role='nucleus')
+        pip = MagicMock(spec=['name', 'globalPosition'])
+        pip.name.return_value = 'pip1'
+        flow = InteractionArrayCalibrationFlow(arr, pip)
+        corners = [(s[0], s[1]) for s in flow._steps]
+        assert corners == [('origin', 'interact'), ('origin', 'approach'), ('col_end', 'interact')]
+
+    def test_single_site_applies_without_corners(self, make_array, qt_app):
+        arr = make_array(rows=1, cols=1, role='nucleus')
+        I = np.array([1e-3, 1e-3, -5e-3])
+        _calibrate(arr, interact=I, approach_offset=(0., 0., 5e-3))
+        np.testing.assert_allclose(arr.sites[0].positions['pip1']['interact global'], I, atol=1e-12)
+        assert arr.columnSpacingMm('pip1') is None
+        assert arr.rowSpacingMm('pip1') is None
+
+    def test_single_site_wizard_has_only_origin_and_approach(self, make_array, qt_app):
+        from acq4.devices.InteractionSiteArray import InteractionArrayCalibrationFlow
+        arr = make_array(rows=1, cols=1, role='nucleus')
+        pip = MagicMock(spec=['name', 'globalPosition'])
+        pip.name.return_value = 'pip1'
+        flow = InteractionArrayCalibrationFlow(arr, pip)
+        corners = [(s[0], s[1]) for s in flow._steps]
+        assert corners == [('origin', 'interact'), ('origin', 'approach')]

--- a/acq4/devices/tests/test_interaction_site_array.py
+++ b/acq4/devices/tests/test_interaction_site_array.py
@@ -148,24 +148,24 @@ class TestChildSiteOffsets:
 
 class TestGetFirstAvailableSite:
     def test_returns_first_matching_role(self, make_array):
-        arr = make_array(rows=1, cols=3, siteRoleDefaults=['nucleus', 'nucleus', 'empty'])
+        arr = make_array(rows=1, cols=3, siteRoleDefaults=[['nucleus', 'nucleus', 'empty']])
         site = arr.getFirstAvailableSite('nucleus')
         assert site is arr.sites[0]
 
     def test_skips_used_up_sites(self, make_array):
-        arr = make_array(rows=1, cols=3, siteRoleDefaults=['nucleus', 'nucleus', 'empty'])
+        arr = make_array(rows=1, cols=3, siteRoleDefaults=[['nucleus', 'nucleus', 'empty']])
         arr.sites[0].used_up = True
         site = arr.getFirstAvailableSite('nucleus')
         assert site is arr.sites[1]
 
     def test_returns_none_when_all_used_up(self, make_array):
-        arr = make_array(rows=1, cols=2, siteRoleDefaults=['nucleus', 'nucleus'])
+        arr = make_array(rows=1, cols=2, siteRoleDefaults=[['nucleus', 'nucleus']])
         arr.sites[0].used_up = True
         arr.sites[1].used_up = True
         assert arr.getFirstAvailableSite('nucleus') is None
 
     def test_returns_none_when_no_matching_role(self, make_array):
-        arr = make_array(rows=1, cols=2, siteRoleDefaults=['nucleus', 'empty'])
+        arr = make_array(rows=1, cols=2, siteRoleDefaults=[['nucleus', 'empty']])
         assert arr.getFirstAvailableSite('clean') is None
 
 
@@ -176,13 +176,13 @@ class TestSiteRoleDefaults:
         assert arr.sites[1].role == 'empty'
 
     def test_siteRoleDefaults_applied(self, make_array):
-        arr = make_array(rows=1, cols=3, siteRoleDefaults=['clean', 'nucleus', 'rinse'])
+        arr = make_array(rows=1, cols=3, siteRoleDefaults=[['clean', 'nucleus', 'rinse']])
         assert arr.sites[0].role == 'clean'
         assert arr.sites[1].role == 'nucleus'
         assert arr.sites[2].role == 'rinse'
 
     def test_siteRoleDefaults_shorter_than_sites(self, make_array):
-        arr = make_array(rows=1, cols=3, siteRoleDefaults=['clean'])
+        arr = make_array(rows=1, cols=3, siteRoleDefaults=[['clean']])
         assert arr.sites[0].role == 'clean'
         assert arr.sites[1].role == 'empty'
         assert arr.sites[2].role == 'empty'

--- a/acq4/devices/tests/test_interaction_site_array.py
+++ b/acq4/devices/tests/test_interaction_site_array.py
@@ -178,6 +178,29 @@ class TestRole:
         assert arr.role == 'clean'
         assert all(site.role == 'clean' for site in arr.sites)
 
+    def test_config_role_overrides_stale_persisted_site_role(self, qt_app):
+        """A per-site role left over from an earlier config must not override the array role."""
+        from acq4.devices.InteractionSiteArray import InteractionSiteArray
+        from acq4.devices.MockStage import MockStage
+
+        storage = {
+            "devices/TestArray[1]_config/saved_positions": {'TestArray[1]': {'role': 'rinse'}},
+        }
+        dm = MagicMock()
+        dm.readConfigFile.side_effect = lambda p: storage.get(p, {})
+        dm.writeConfigFile.side_effect = lambda d, p: storage.update({p: d.copy()})
+        dm.configFileName.side_effect = lambda p: p
+        dm.listDevices.return_value = []
+        dm.listInterfaces.return_value = []
+        stage = MockStage(dm, {'nAxes': 3}, 'TestStage')
+        dm.getDevice.side_effect = lambda n: stage if n == 'TestStage' else None
+
+        arr = InteractionSiteArray(dm, {
+            'rows': 1, 'cols': 3, 'siteRadius': 1e-3, 'siteHeight': 5e-3,
+            'parentDevice': 'TestStage', 'role': 'nucleus',
+        }, 'TestArray')
+        assert all(site.role == 'nucleus' for site in arr.sites)
+
 
 class TestChildSiteDeviceInterface:
     def test_child_sites_return_none_from_device_interface(self, make_array, qt_app):

--- a/acq4/devices/tests/test_interaction_site_array.py
+++ b/acq4/devices/tests/test_interaction_site_array.py
@@ -48,8 +48,8 @@ def make_array(qt_app):
         config = {
             'rows': rows,
             'cols': cols,
-            'site_radius': 1e-3,
-            'site_height': 5e-3,
+            'siteRadius': 1e-3,
+            'siteHeight': 5e-3,
             'parentDevice': 'TestStage',
         }
         if siteRoleDefaults is not None:

--- a/acq4/devices/tests/test_interaction_site_array.py
+++ b/acq4/devices/tests/test_interaction_site_array.py
@@ -59,39 +59,42 @@ def make_array(qt_app):
     return _factory
 
 
-def _make_pip(approach, stage_pos, interact=None):
-    """Make a mock pipette at *approach* position with a mock stage at *stage_pos*."""
+def _calibrate(arr, col_spacing=2e-3, row_spacing=3e-3,
+               interact=(0., 0., -5e-3), approach_offset=(0., 0., 5e-3)):
+    """Apply a synthetic calibration in the realistic fixed-pipette / moving-stage scenario.
+
+    The pipette tip stays at a fixed global interact point while the stage moves to bring
+    each corner under it; the stage deltas encode the grid spacing. This exercises the
+    common-frame correction in the array math. The approach is one measurement offset from
+    the origin interact by *approach_offset*.
+    """
     pip = MagicMock(spec=['name', 'globalPosition'])
     pip.name.return_value = 'pip1'
-    pip.globalPosition.return_value = np.asarray(approach, dtype=float)
-    return pip, np.asarray(stage_pos, dtype=float)
+    I = np.asarray(interact, dtype=float)
 
-
-def _calibrate(arr, col_spacing=2e-3, row_spacing=3e-3, approach=(0., 0., 0.)):
-    """Apply a synthetic calibration so tests can verify site positions."""
-    from unittest.mock import MagicMock
-    P = np.asarray(approach, dtype=float)
-
-    pip = MagicMock(spec=['name', 'globalPosition'])
-    pip.name.return_value = 'pip1'
-    pip.globalPosition.return_value = P
-
-    # Stage positions for each corner: stage moves negatively to bring sites right/down.
+    # Stage positions: moving the stage by -delta brings the next site under the fixed pipette.
     S_00 = np.array([0., 0., 0.])
-    S_0_N = S_00 + (arr._cols - 1) * np.array([-col_spacing, 0., 0.])
-    S_M_0 = S_00 + (arr._rows - 1) * np.array([0., -row_spacing, 0.])
+    S_0N = S_00 - (arr._cols - 1) * np.array([col_spacing, 0., 0.])
+    S_M0 = S_00 - (arr._rows - 1) * np.array([0., row_spacing, 0.])
 
     arr._parentStage.globalPosition = MagicMock(return_value=S_00)
-    arr.calibrateCorner(pip, 'origin')
+    pip.globalPosition.return_value = I
+    arr.calibrateInteractCorner(pip, 'origin')
 
-    arr._parentStage.globalPosition = MagicMock(return_value=S_0_N)
-    arr.calibrateCorner(pip, 'col_end')
+    arr._parentStage.globalPosition = MagicMock(return_value=S_0N)
+    pip.globalPosition.return_value = I
+    arr.calibrateInteractCorner(pip, 'col_end')
 
     if arr._rows > 1:
-        arr._parentStage.globalPosition = MagicMock(return_value=S_M_0)
-        arr.calibrateCorner(pip, 'row_end')
+        arr._parentStage.globalPosition = MagicMock(return_value=S_M0)
+        pip.globalPosition.return_value = I
+        arr.calibrateInteractCorner(pip, 'row_end')
 
-    arr.applySpacing(pip)
+    arr._parentStage.globalPosition = MagicMock(return_value=S_00)
+    pip.globalPosition.return_value = I + np.asarray(approach_offset, dtype=float)
+    arr.calibrateApproach(pip)
+
+    arr.applyCalibration(pip)
     return pip
 
 
@@ -147,26 +150,20 @@ class TestChildSiteOffsets:
 
 
 class TestGetFirstAvailableSite:
-    def test_returns_first_site_for_matching_role(self, make_array):
+    def test_returns_first_site(self, make_array):
         arr = make_array(rows=1, cols=3, role='nucleus')
-        site = arr.getFirstAvailableSite('nucleus')
-        assert site is arr.sites[0]
+        assert arr.getFirstAvailableSite() is arr.sites[0]
 
     def test_skips_used_up_sites(self, make_array):
         arr = make_array(rows=1, cols=3, role='nucleus')
         arr.sites[0].used_up = True
-        site = arr.getFirstAvailableSite('nucleus')
-        assert site is arr.sites[1]
+        assert arr.getFirstAvailableSite() is arr.sites[1]
 
     def test_returns_none_when_all_used_up(self, make_array):
         arr = make_array(rows=1, cols=2, role='nucleus')
         arr.sites[0].used_up = True
         arr.sites[1].used_up = True
-        assert arr.getFirstAvailableSite('nucleus') is None
-
-    def test_returns_none_when_role_does_not_match(self, make_array):
-        arr = make_array(rows=1, cols=2, role='nucleus')
-        assert arr.getFirstAvailableSite('clean') is None
+        assert arr.getFirstAvailableSite() is None
 
 
 class TestRole:
@@ -202,35 +199,67 @@ class TestGetSite:
             assert arr.getSite(i) is arr.sites[i]
 
 
-class TestCalibrateInteract:
-    def test_interact_position_stored_for_all_sites(self, make_array, qt_app):
-        arr = make_array(rows=1, cols=2)
-        pip = _calibrate(arr, col_spacing=2e-3)
+class TestCalibration:
+    """The array interpolates the three interact corners and transmits a unique interact
+    (and derived approach) position to each child site."""
 
-        # Lower pip to interact depth
-        interact_global = np.array([0., 0., -5e-3])
-        pip.globalPosition.return_value = interact_global
-        arr.calibrateInteract(pip)
+    def test_interact_interpolated_and_transmitted_to_each_child(self, make_array, qt_app):
+        arr = make_array(rows=2, cols=3, role='nucleus')
+        I = np.array([1e-3, 2e-3, -5e-3])
+        col, rowsp = 2e-3, 3e-3
+        _calibrate(arr, col_spacing=col, row_spacing=rowsp, interact=I,
+                   approach_offset=(0., 0., 5e-3))
 
-        # All sites should have the same interact global stored
+        # Each child's stored interact global = I + c*[col,0,0] + r*[0,rowsp,0]
+        for i, site in enumerate(arr.sites):
+            r, c = divmod(i, arr._cols)
+            expected = I + c * np.array([col, 0, 0]) + r * np.array([0, rowsp, 0])
+            stored = site.positions['pip1']['interact global']
+            np.testing.assert_allclose(stored, expected, atol=1e-12)
+
+    def test_approach_derived_from_shared_offset(self, make_array, qt_app):
+        arr = make_array(rows=2, cols=3, role='nucleus')
+        I = np.array([0., 0., -5e-3])
+        approach_off = np.array([0., 0., 5e-3])
+        _calibrate(arr, col_spacing=2e-3, row_spacing=3e-3, interact=I,
+                   approach_offset=approach_off)
+
+        # Each child's approach ('site global') = its interact + the shared approach offset
         for site in arr.sites:
-            stored = site.positions.get('pip1', {}).get('interact global')
-            assert stored is not None
-            np.testing.assert_allclose(stored, interact_global, atol=1e-12)
+            interact = np.asarray(site.positions['pip1']['interact global'])
+            approach = np.asarray(site.positions['pip1']['site global'])
+            np.testing.assert_allclose(approach - interact, approach_off, atol=1e-12)
 
-    def test_interactLocalFor_is_consistent_with_site_position(self, make_array, qt_app):
-        """The interact local position, when mapped back to global, should equal interact_global."""
-        arr = make_array(rows=1, cols=2)
-        pip = _calibrate(arr, col_spacing=2e-3)
+    def test_interactLocalFor_reconstructs_interact_global(self, make_array, qt_app):
+        """After the stage brings a site to its approach pose, the stored interact-local maps
+        back to the calibrated interact global."""
+        arr = make_array(rows=1, cols=3, role='nucleus')
+        I = np.array([0., 0., -5e-3])
+        _calibrate(arr, col_spacing=2e-3, interact=I, approach_offset=(0., 0., 5e-3))
 
-        interact_global = np.array([0., 0., -5e-3])
-        pip.globalPosition.return_value = interact_global
-        arr.calibrateInteract(pip)
+        # At calibration the reference stage position is S_ref = origin stage = 0, so each
+        # site sits at its approach pose with the stage at 0 (the mock's current position).
+        for i, site in enumerate(arr.sites):
+            local = site.interactLocalFor(arr_pip(site))
+            assert local is not None
+            reconstructed = site.mapToGlobal(local)
+            expected = I + i * np.array([2e-3, 0, 0])
+            np.testing.assert_allclose(reconstructed, expected, atol=1e-12)
 
-        # For site[0] (at approach pos [0,0,0]): interact local = interact_global - site.globalPos
-        # When stage moves to approach [0,0], site[0].globalPosition() = approach = [0,0,0]
-        # So interactLocalFor should be [0,0,-5e-3] in site[0]'s frame
-        local0 = arr.sites[0].interactLocalFor(pip)
-        assert local0 is not None
-        reconstructed = arr.sites[0].mapToGlobal(local0)
-        np.testing.assert_allclose(reconstructed, interact_global, atol=1e-12)
+    def test_apply_requires_approach_and_corners(self, make_array, qt_app):
+        arr = make_array(rows=1, cols=2, role='nucleus')
+        pip = MagicMock(spec=['name', 'globalPosition'])
+        pip.name.return_value = 'pip1'
+        pip.globalPosition.return_value = np.zeros(3)
+        arr._parentStage.globalPosition = MagicMock(return_value=np.zeros(3))
+        # Only origin interact calibrated; applyCalibration should raise (missing keys).
+        arr.calibrateInteractCorner(pip, 'origin')
+        with pytest.raises(KeyError):
+            arr.applyCalibration(pip)
+
+
+def arr_pip(site):
+    """Return a mock pipette named 'pip1' for querying a site's saved positions."""
+    pip = MagicMock(spec=['name'])
+    pip.name.return_value = 'pip1'
+    return pip

--- a/acq4/devices/tests/test_interaction_site_array.py
+++ b/acq4/devices/tests/test_interaction_site_array.py
@@ -37,11 +37,11 @@ def qt_app():
 
 @pytest.fixture
 def make_array(qt_app):
-    """Factory: make_array(rows, cols, siteRoleDefaults=None)."""
+    """Factory: make_array(rows, cols, role=None)."""
     from acq4.devices.InteractionSiteArray import InteractionSiteArray
     from acq4.devices.MockStage import MockStage
 
-    def _factory(rows=2, cols=3, siteRoleDefaults=None):
+    def _factory(rows=2, cols=3, role=None):
         dm = _make_dm()
         stage = MockStage(dm, {'nAxes': 3}, 'TestStage')
         dm.getDevice.side_effect = lambda name: stage if name == 'TestStage' else None
@@ -52,8 +52,8 @@ def make_array(qt_app):
             'siteHeight': 5e-3,
             'parentDevice': 'TestStage',
         }
-        if siteRoleDefaults is not None:
-            config['siteRoleDefaults'] = siteRoleDefaults
+        if role is not None:
+            config['role'] = role
         return InteractionSiteArray(dm, config, 'TestArray')
 
     return _factory
@@ -147,45 +147,39 @@ class TestChildSiteOffsets:
 
 
 class TestGetFirstAvailableSite:
-    def test_returns_first_matching_role(self, make_array):
-        arr = make_array(rows=1, cols=3, siteRoleDefaults=[['nucleus', 'nucleus', 'empty']])
+    def test_returns_first_site_for_matching_role(self, make_array):
+        arr = make_array(rows=1, cols=3, role='nucleus')
         site = arr.getFirstAvailableSite('nucleus')
         assert site is arr.sites[0]
 
     def test_skips_used_up_sites(self, make_array):
-        arr = make_array(rows=1, cols=3, siteRoleDefaults=[['nucleus', 'nucleus', 'empty']])
+        arr = make_array(rows=1, cols=3, role='nucleus')
         arr.sites[0].used_up = True
         site = arr.getFirstAvailableSite('nucleus')
         assert site is arr.sites[1]
 
     def test_returns_none_when_all_used_up(self, make_array):
-        arr = make_array(rows=1, cols=2, siteRoleDefaults=[['nucleus', 'nucleus']])
+        arr = make_array(rows=1, cols=2, role='nucleus')
         arr.sites[0].used_up = True
         arr.sites[1].used_up = True
         assert arr.getFirstAvailableSite('nucleus') is None
 
-    def test_returns_none_when_no_matching_role(self, make_array):
-        arr = make_array(rows=1, cols=2, siteRoleDefaults=[['nucleus', 'empty']])
+    def test_returns_none_when_role_does_not_match(self, make_array):
+        arr = make_array(rows=1, cols=2, role='nucleus')
         assert arr.getFirstAvailableSite('clean') is None
 
 
-class TestSiteRoleDefaults:
+class TestRole:
     def test_default_role_is_empty(self, make_array):
         arr = make_array(rows=1, cols=2)
+        assert arr.role == 'empty'
         assert arr.sites[0].role == 'empty'
         assert arr.sites[1].role == 'empty'
 
-    def test_siteRoleDefaults_applied(self, make_array):
-        arr = make_array(rows=1, cols=3, siteRoleDefaults=[['clean', 'nucleus', 'rinse']])
-        assert arr.sites[0].role == 'clean'
-        assert arr.sites[1].role == 'nucleus'
-        assert arr.sites[2].role == 'rinse'
-
-    def test_siteRoleDefaults_shorter_than_sites(self, make_array):
-        arr = make_array(rows=1, cols=3, siteRoleDefaults=[['clean']])
-        assert arr.sites[0].role == 'clean'
-        assert arr.sites[1].role == 'empty'
-        assert arr.sites[2].role == 'empty'
+    def test_role_applied_to_all_sites(self, make_array):
+        arr = make_array(rows=2, cols=3, role='clean')
+        assert arr.role == 'clean'
+        assert all(site.role == 'clean' for site in arr.sites)
 
 
 class TestChildSiteDeviceInterface:

--- a/acq4/devices/tests/test_interaction_site_array.py
+++ b/acq4/devices/tests/test_interaction_site_array.py
@@ -263,3 +263,85 @@ def arr_pip(site):
     pip = MagicMock(spec=['name'])
     pip.name.return_value = 'pip1'
     return pip
+
+
+class TestCalibrationFlow:
+    def _flow(self, arr):
+        from acq4.devices.InteractionSiteArray import InteractionArrayCalibrationFlow
+        pip = MagicMock(spec=['name', 'globalPosition'])
+        pip.name.return_value = 'pip1'
+        pip.globalPosition.return_value = np.zeros(3)
+        return InteractionArrayCalibrationFlow(arr, pip), pip
+
+    def test_step_order_full_grid(self, make_array, qt_app):
+        arr = make_array(rows=2, cols=5, role='nucleus')
+        flow, _ = self._flow(arr)
+        corners = [(s[0], s[1]) for s in flow._steps]
+        assert corners == [
+            ('origin', 'interact'),
+            ('origin', 'approach'),
+            ('row_end', 'interact'),
+            ('col_end', 'interact'),
+        ]
+
+    def test_single_row_skips_row_end(self, make_array, qt_app):
+        arr = make_array(rows=1, cols=4, role='nucleus')
+        flow, _ = self._flow(arr)
+        corners = [(s[0], s[1]) for s in flow._steps]
+        assert ('row_end', 'interact') not in corners
+        assert ('col_end', 'interact') in corners
+
+    def test_single_col_skips_col_end(self, make_array, qt_app):
+        arr = make_array(rows=3, cols=1, role='nucleus')
+        flow, _ = self._flow(arr)
+        corners = [(s[0], s[1]) for s in flow._steps]
+        assert ('col_end', 'interact') not in corners
+        assert ('row_end', 'interact') in corners
+
+    def test_walking_all_steps_applies_calibration(self, make_array, qt_app):
+        arr = make_array(rows=2, cols=3, role='nucleus')
+        flow, pip = self._flow(arr)
+        I = np.array([1e-3, 2e-3, -5e-3])
+        # stage stays at origin for every capture; pipette positions encode the geometry
+        arr._parentStage.globalPosition = MagicMock(return_value=np.zeros(3))
+        captures = {
+            ('origin', 'interact'): I,
+            ('origin', 'approach'): I + np.array([0, 0, 5e-3]),
+            ('row_end', 'interact'): I + np.array([0, 3e-3, 0]),
+            ('col_end', 'interact'): I + np.array([2 * 2e-3, 0, 0]),
+        }
+        results = []
+        flow.finished.connect(results.append)
+        for _ in range(len(flow._steps)):
+            corner, kind, _, _ = flow._steps[flow._index]
+            pip.globalPosition.return_value = captures[(corner, kind)]
+            flow._useCurrent()
+        qt_app.processEvents()
+        # Dialog accepted and calibration applied to children.
+        assert results == [Qt_accepted()]
+        np.testing.assert_allclose(
+            arr.sites[0].positions['pip1']['interact global'], I, atol=1e-12
+        )
+        assert arr.columnSpacingMm('pip1') is not None
+
+    def test_keep_existing_enabled_only_when_saved(self, make_array, qt_app):
+        arr = make_array(rows=1, cols=2, role='nucleus')
+        # Pre-save the origin interact so the first step can keep it.
+        pip = MagicMock(spec=['name', 'globalPosition'])
+        pip.name.return_value = 'pip1'
+        pip.globalPosition.return_value = np.array([0., 0., -5e-3])
+        arr._parentStage.globalPosition = MagicMock(return_value=np.zeros(3))
+        arr.calibrateInteractCorner(pip, 'origin')
+
+        from acq4.devices.InteractionSiteArray import InteractionArrayCalibrationFlow
+        flow = InteractionArrayCalibrationFlow(arr, pip)
+        # Step 1 (origin interact) has a saved value -> keep enabled
+        assert flow._keepBtn.isEnabled()
+        flow._keepExisting()
+        # Step 2 (approach) has no saved value -> keep disabled
+        assert not flow._keepBtn.isEnabled()
+
+
+def Qt_accepted():
+    from acq4.util import Qt
+    return Qt.QDialog.Accepted

--- a/acq4/devices/tests/test_interaction_site_array.py
+++ b/acq4/devices/tests/test_interaction_site_array.py
@@ -1,0 +1,179 @@
+# Tests for InteractionSiteArray: child-site creation, offsets, role selection, and calibration.
+# Uses real InteractionSiteArray/InteractionSite with a mock DeviceManager.
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+
+def _make_dm(extra_storage=None):
+    """Create a mock device manager with per-path config file storage."""
+    storage = {}
+    if extra_storage:
+        storage.update(extra_storage)
+
+    dm = MagicMock()
+    dm.readConfigFile.side_effect = lambda path: storage.get(path, {})
+    dm.writeConfigFile.side_effect = lambda data, path: storage.update({path: data.copy()})
+    dm.configFileName.side_effect = lambda path: path
+    dm.listDevices.return_value = []
+    dm.listInterfaces.return_value = []
+    dm.getDevice.side_effect = lambda name: None
+    return dm
+
+
+@pytest.fixture(scope="module")
+def qt_app():
+    from acq4.util import Qt
+    app = Qt.QApplication.instance()
+    if app is None:
+        app = Qt.QApplication(sys.argv)
+    return app
+
+
+@pytest.fixture
+def make_array(qt_app):
+    """Factory: make_array(rows, cols, spacing_x, spacing_y, site_role_defaults=None)."""
+    from acq4.devices.InteractionSiteArray import InteractionSiteArray
+
+    def _factory(rows=2, cols=3, spacing_x=2e-3, spacing_y=3e-3, site_role_defaults=None):
+        dm = _make_dm()
+        config = {
+            'rows': rows,
+            'cols': cols,
+            'spacing_x': spacing_x,
+            'spacing_y': spacing_y,
+            'site_radius': 1e-3,
+            'site_height': 5e-3,
+        }
+        if site_role_defaults is not None:
+            config['site_role_defaults'] = site_role_defaults
+        return InteractionSiteArray(dm, config, 'TestArray')
+
+    return _factory
+
+
+class TestChildSiteCount:
+    def test_creates_correct_number_of_sites(self, make_array):
+        arr = make_array(rows=2, cols=3)
+        assert len(arr.sites) == 6
+
+    def test_single_row(self, make_array):
+        arr = make_array(rows=1, cols=4)
+        assert len(arr.sites) == 4
+
+    def test_single_col(self, make_array):
+        arr = make_array(rows=3, cols=1)
+        assert len(arr.sites) == 3
+
+
+class TestChildSiteOffsets:
+    def test_first_site_has_zero_offset(self, make_array):
+        arr = make_array(rows=2, cols=3, spacing_x=2e-3, spacing_y=3e-3)
+        pos = arr.sites[0].mapToGlobal(np.zeros(3))
+        np.testing.assert_allclose(pos, [0, 0, 0], atol=1e-12)
+
+    def test_col_offset(self, make_array):
+        arr = make_array(rows=1, cols=3, spacing_x=2e-3, spacing_y=3e-3)
+        # site at col=1 should be 2e-3 in x from site at col=0
+        pos0 = arr.sites[0].mapToGlobal(np.zeros(3))
+        pos1 = arr.sites[1].mapToGlobal(np.zeros(3))
+        np.testing.assert_allclose(pos1 - pos0, [2e-3, 0, 0], atol=1e-12)
+
+    def test_row_offset(self, make_array):
+        arr = make_array(rows=3, cols=1, spacing_x=2e-3, spacing_y=3e-3)
+        # site at row=1 should be 3e-3 in y from site at row=0
+        pos0 = arr.sites[0].mapToGlobal(np.zeros(3))
+        pos1 = arr.sites[1].mapToGlobal(np.zeros(3))
+        np.testing.assert_allclose(pos1 - pos0, [0, 3e-3, 0], atol=1e-12)
+
+    def test_row_major_ordering(self, make_array):
+        arr = make_array(rows=2, cols=3, spacing_x=2e-3, spacing_y=3e-3)
+        # index 3 == row=1, col=0
+        pos0 = arr.sites[0].mapToGlobal(np.zeros(3))
+        pos3 = arr.sites[3].mapToGlobal(np.zeros(3))
+        np.testing.assert_allclose(pos3 - pos0, [0, 3e-3, 0], atol=1e-12)
+
+
+class TestGetFirstAvailableSite:
+    def test_returns_first_matching_role(self, make_array):
+        arr = make_array(rows=1, cols=3, site_role_defaults=['nucleus', 'nucleus', 'empty'])
+        site = arr.getFirstAvailableSite('nucleus')
+        assert site is arr.sites[0]
+
+    def test_skips_used_up_sites(self, make_array):
+        arr = make_array(rows=1, cols=3, site_role_defaults=['nucleus', 'nucleus', 'empty'])
+        arr.sites[0].used_up = True
+        site = arr.getFirstAvailableSite('nucleus')
+        assert site is arr.sites[1]
+
+    def test_returns_none_when_all_used_up(self, make_array):
+        arr = make_array(rows=1, cols=2, site_role_defaults=['nucleus', 'nucleus'])
+        arr.sites[0].used_up = True
+        arr.sites[1].used_up = True
+        assert arr.getFirstAvailableSite('nucleus') is None
+
+    def test_returns_none_when_no_matching_role(self, make_array):
+        arr = make_array(rows=1, cols=2, site_role_defaults=['nucleus', 'empty'])
+        assert arr.getFirstAvailableSite('clean') is None
+
+
+class TestSiteRoleDefaults:
+    def test_default_role_is_empty(self, make_array):
+        arr = make_array(rows=1, cols=2)
+        assert arr.sites[0].role == 'empty'
+        assert arr.sites[1].role == 'empty'
+
+    def test_site_role_defaults_applied(self, make_array):
+        arr = make_array(rows=1, cols=3, site_role_defaults=['clean', 'nucleus', 'rinse'])
+        assert arr.sites[0].role == 'clean'
+        assert arr.sites[1].role == 'nucleus'
+        assert arr.sites[2].role == 'rinse'
+
+    def test_site_role_defaults_shorter_than_sites(self, make_array):
+        arr = make_array(rows=1, cols=3, site_role_defaults=['clean'])
+        assert arr.sites[0].role == 'clean'
+        assert arr.sites[1].role == 'empty'
+        assert arr.sites[2].role == 'empty'
+
+
+class TestChildSiteDeviceInterface:
+    def test_child_sites_return_none_from_device_interface(self, make_array, qt_app):
+        arr = make_array(rows=1, cols=2)
+        win = MagicMock()
+        for site in arr.sites:
+            assert site.deviceInterface(win) is None
+
+    def test_child_site_is_array_child(self, make_array):
+        arr = make_array(rows=1, cols=2)
+        for site in arr.sites:
+            assert site._is_array_child() is True
+
+
+class TestGetSite:
+    def test_get_site_by_index(self, make_array):
+        arr = make_array(rows=2, cols=3)
+        for i in range(6):
+            assert arr.getSite(i) is arr.sites[i]
+
+
+class TestSaveInteractPosition:
+    def test_saves_interact_position_in_each_site_local_frame(self, make_array, qt_app):
+        arr = make_array(rows=1, cols=2, spacing_x=2e-3, spacing_y=0)
+
+        pip = MagicMock()
+        pip.name.return_value = 'pip1'
+        pip.globalPosition.return_value = np.array([1e-3, 0.0, -1e-3])
+
+        arr.saveInteractPosition(pip)
+
+        for site in arr.sites:
+            local = site.interactLocalFor(pip)
+            assert local is not None
+            # reconstruct global from local and verify it matches pip's position
+            reconstructed = site.mapToGlobal(local)
+            np.testing.assert_allclose(reconstructed, [1e-3, 0.0, -1e-3], atol=1e-12)

--- a/acq4/devices/tests/test_interaction_site_array.py
+++ b/acq4/devices/tests/test_interaction_site_array.py
@@ -37,11 +37,11 @@ def qt_app():
 
 @pytest.fixture
 def make_array(qt_app):
-    """Factory: make_array(rows, cols, site_role_defaults=None)."""
+    """Factory: make_array(rows, cols, siteRoleDefaults=None)."""
     from acq4.devices.InteractionSiteArray import InteractionSiteArray
     from acq4.devices.MockStage import MockStage
 
-    def _factory(rows=2, cols=3, site_role_defaults=None):
+    def _factory(rows=2, cols=3, siteRoleDefaults=None):
         dm = _make_dm()
         stage = MockStage(dm, {'nAxes': 3}, 'TestStage')
         dm.getDevice.side_effect = lambda name: stage if name == 'TestStage' else None
@@ -52,8 +52,8 @@ def make_array(qt_app):
             'site_height': 5e-3,
             'parentDevice': 'TestStage',
         }
-        if site_role_defaults is not None:
-            config['site_role_defaults'] = site_role_defaults
+        if siteRoleDefaults is not None:
+            config['siteRoleDefaults'] = siteRoleDefaults
         return InteractionSiteArray(dm, config, 'TestArray')
 
     return _factory
@@ -148,24 +148,24 @@ class TestChildSiteOffsets:
 
 class TestGetFirstAvailableSite:
     def test_returns_first_matching_role(self, make_array):
-        arr = make_array(rows=1, cols=3, site_role_defaults=['nucleus', 'nucleus', 'empty'])
+        arr = make_array(rows=1, cols=3, siteRoleDefaults=['nucleus', 'nucleus', 'empty'])
         site = arr.getFirstAvailableSite('nucleus')
         assert site is arr.sites[0]
 
     def test_skips_used_up_sites(self, make_array):
-        arr = make_array(rows=1, cols=3, site_role_defaults=['nucleus', 'nucleus', 'empty'])
+        arr = make_array(rows=1, cols=3, siteRoleDefaults=['nucleus', 'nucleus', 'empty'])
         arr.sites[0].used_up = True
         site = arr.getFirstAvailableSite('nucleus')
         assert site is arr.sites[1]
 
     def test_returns_none_when_all_used_up(self, make_array):
-        arr = make_array(rows=1, cols=2, site_role_defaults=['nucleus', 'nucleus'])
+        arr = make_array(rows=1, cols=2, siteRoleDefaults=['nucleus', 'nucleus'])
         arr.sites[0].used_up = True
         arr.sites[1].used_up = True
         assert arr.getFirstAvailableSite('nucleus') is None
 
     def test_returns_none_when_no_matching_role(self, make_array):
-        arr = make_array(rows=1, cols=2, site_role_defaults=['nucleus', 'empty'])
+        arr = make_array(rows=1, cols=2, siteRoleDefaults=['nucleus', 'empty'])
         assert arr.getFirstAvailableSite('clean') is None
 
 
@@ -175,14 +175,14 @@ class TestSiteRoleDefaults:
         assert arr.sites[0].role == 'empty'
         assert arr.sites[1].role == 'empty'
 
-    def test_site_role_defaults_applied(self, make_array):
-        arr = make_array(rows=1, cols=3, site_role_defaults=['clean', 'nucleus', 'rinse'])
+    def test_siteRoleDefaults_applied(self, make_array):
+        arr = make_array(rows=1, cols=3, siteRoleDefaults=['clean', 'nucleus', 'rinse'])
         assert arr.sites[0].role == 'clean'
         assert arr.sites[1].role == 'nucleus'
         assert arr.sites[2].role == 'rinse'
 
-    def test_site_role_defaults_shorter_than_sites(self, make_array):
-        arr = make_array(rows=1, cols=3, site_role_defaults=['clean'])
+    def test_siteRoleDefaults_shorter_than_sites(self, make_array):
+        arr = make_array(rows=1, cols=3, siteRoleDefaults=['clean'])
         assert arr.sites[0].role == 'clean'
         assert arr.sites[1].role == 'empty'
         assert arr.sites[2].role == 'empty'

--- a/acq4/devices/tests/test_interaction_site_array.py
+++ b/acq4/devices/tests/test_interaction_site_array.py
@@ -37,24 +37,62 @@ def qt_app():
 
 @pytest.fixture
 def make_array(qt_app):
-    """Factory: make_array(rows, cols, spacing_x, spacing_y, site_role_defaults=None)."""
+    """Factory: make_array(rows, cols, site_role_defaults=None)."""
     from acq4.devices.InteractionSiteArray import InteractionSiteArray
+    from acq4.devices.MockStage import MockStage
 
-    def _factory(rows=2, cols=3, spacing_x=2e-3, spacing_y=3e-3, site_role_defaults=None):
+    def _factory(rows=2, cols=3, site_role_defaults=None):
         dm = _make_dm()
+        stage = MockStage(dm, {'nAxes': 3}, 'TestStage')
+        dm.getDevice.side_effect = lambda name: stage if name == 'TestStage' else None
         config = {
             'rows': rows,
             'cols': cols,
-            'spacing_x': spacing_x,
-            'spacing_y': spacing_y,
             'site_radius': 1e-3,
             'site_height': 5e-3,
+            'parentDevice': 'TestStage',
         }
         if site_role_defaults is not None:
             config['site_role_defaults'] = site_role_defaults
         return InteractionSiteArray(dm, config, 'TestArray')
 
     return _factory
+
+
+def _make_pip(approach, stage_pos, interact=None):
+    """Make a mock pipette at *approach* position with a mock stage at *stage_pos*."""
+    pip = MagicMock(spec=['name', 'globalPosition'])
+    pip.name.return_value = 'pip1'
+    pip.globalPosition.return_value = np.asarray(approach, dtype=float)
+    return pip, np.asarray(stage_pos, dtype=float)
+
+
+def _calibrate(arr, col_spacing=2e-3, row_spacing=3e-3, approach=(0., 0., 0.)):
+    """Apply a synthetic calibration so tests can verify site positions."""
+    from unittest.mock import MagicMock
+    P = np.asarray(approach, dtype=float)
+
+    pip = MagicMock(spec=['name', 'globalPosition'])
+    pip.name.return_value = 'pip1'
+    pip.globalPosition.return_value = P
+
+    # Stage positions for each corner: stage moves negatively to bring sites right/down.
+    S_00 = np.array([0., 0., 0.])
+    S_0_N = S_00 + (arr._cols - 1) * np.array([-col_spacing, 0., 0.])
+    S_M_0 = S_00 + (arr._rows - 1) * np.array([0., -row_spacing, 0.])
+
+    arr._parentStage.globalPosition = MagicMock(return_value=S_00)
+    arr.calibrateCorner(pip, 'origin')
+
+    arr._parentStage.globalPosition = MagicMock(return_value=S_0_N)
+    arr.calibrateCorner(pip, 'col_end')
+
+    if arr._rows > 1:
+        arr._parentStage.globalPosition = MagicMock(return_value=S_M_0)
+        arr.calibrateCorner(pip, 'row_end')
+
+    arr.applySpacing(pip)
+    return pip
 
 
 class TestChildSiteCount:
@@ -72,31 +110,40 @@ class TestChildSiteCount:
 
 
 class TestChildSiteOffsets:
-    def test_first_site_has_zero_offset(self, make_array):
-        arr = make_array(rows=2, cols=3, spacing_x=2e-3, spacing_y=3e-3)
-        pos = arr.sites[0].mapToGlobal(np.zeros(3))
-        np.testing.assert_allclose(pos, [0, 0, 0], atol=1e-12)
+    """After calibration, each site has a unique offset so it arrives at the approach
+    position when the stage is moved to the correct position."""
 
-    def test_col_offset(self, make_array):
-        arr = make_array(rows=1, cols=3, spacing_x=2e-3, spacing_y=3e-3)
-        # site at col=1 should be 2e-3 in x from site at col=0
+    def test_all_sites_at_approach_pos_after_calibration(self, make_array):
+        arr = make_array(rows=1, cols=3)
+        _calibrate(arr, col_spacing=2e-3)
+        # After applySpacing, each site's globalPosition() should equal approach (0,0,0)
+        # only when the stage is at its calibrated position for that site.
+        # We verify indirectly: site offsets differ by col_spacing.
         pos0 = arr.sites[0].mapToGlobal(np.zeros(3))
         pos1 = arr.sites[1].mapToGlobal(np.zeros(3))
+        pos2 = arr.sites[2].mapToGlobal(np.zeros(3))
         np.testing.assert_allclose(pos1 - pos0, [2e-3, 0, 0], atol=1e-12)
+        np.testing.assert_allclose(pos2 - pos0, [4e-3, 0, 0], atol=1e-12)
 
-    def test_row_offset(self, make_array):
-        arr = make_array(rows=3, cols=1, spacing_x=2e-3, spacing_y=3e-3)
-        # site at row=1 should be 3e-3 in y from site at row=0
+    def test_row_offsets_after_calibration(self, make_array):
+        arr = make_array(rows=3, cols=1)
+        _calibrate(arr, row_spacing=3e-3)
         pos0 = arr.sites[0].mapToGlobal(np.zeros(3))
         pos1 = arr.sites[1].mapToGlobal(np.zeros(3))
         np.testing.assert_allclose(pos1 - pos0, [0, 3e-3, 0], atol=1e-12)
 
-    def test_row_major_ordering(self, make_array):
-        arr = make_array(rows=2, cols=3, spacing_x=2e-3, spacing_y=3e-3)
-        # index 3 == row=1, col=0
+    def test_row_major_ordering_after_calibration(self, make_array):
+        arr = make_array(rows=2, cols=3)
+        _calibrate(arr, col_spacing=2e-3, row_spacing=3e-3)
         pos0 = arr.sites[0].mapToGlobal(np.zeros(3))
-        pos3 = arr.sites[3].mapToGlobal(np.zeros(3))
+        pos3 = arr.sites[3].mapToGlobal(np.zeros(3))  # row=1, col=0
         np.testing.assert_allclose(pos3 - pos0, [0, 3e-3, 0], atol=1e-12)
+
+    def test_spacing_mm_helpers(self, make_array):
+        arr = make_array(rows=2, cols=3)
+        _calibrate(arr, col_spacing=2e-3, row_spacing=4e-3)
+        assert abs(arr.columnSpacingMm('pip1') - 2.0) < 0.01
+        assert abs(arr.rowSpacingMm('pip1') - 4.0) < 0.01
 
 
 class TestGetFirstAvailableSite:
@@ -161,19 +208,35 @@ class TestGetSite:
             assert arr.getSite(i) is arr.sites[i]
 
 
-class TestSaveInteractPosition:
-    def test_saves_interact_position_in_each_site_local_frame(self, make_array, qt_app):
-        arr = make_array(rows=1, cols=2, spacing_x=2e-3, spacing_y=0)
+class TestCalibrateInteract:
+    def test_interact_position_stored_for_all_sites(self, make_array, qt_app):
+        arr = make_array(rows=1, cols=2)
+        pip = _calibrate(arr, col_spacing=2e-3)
 
-        pip = MagicMock()
-        pip.name.return_value = 'pip1'
-        pip.globalPosition.return_value = np.array([1e-3, 0.0, -1e-3])
+        # Lower pip to interact depth
+        interact_global = np.array([0., 0., -5e-3])
+        pip.globalPosition.return_value = interact_global
+        arr.calibrateInteract(pip)
 
-        arr.saveInteractPosition(pip)
-
+        # All sites should have the same interact global stored
         for site in arr.sites:
-            local = site.interactLocalFor(pip)
-            assert local is not None
-            # reconstruct global from local and verify it matches pip's position
-            reconstructed = site.mapToGlobal(local)
-            np.testing.assert_allclose(reconstructed, [1e-3, 0.0, -1e-3], atol=1e-12)
+            stored = site.positions.get('pip1', {}).get('interact global')
+            assert stored is not None
+            np.testing.assert_allclose(stored, interact_global, atol=1e-12)
+
+    def test_interactLocalFor_is_consistent_with_site_position(self, make_array, qt_app):
+        """The interact local position, when mapped back to global, should equal interact_global."""
+        arr = make_array(rows=1, cols=2)
+        pip = _calibrate(arr, col_spacing=2e-3)
+
+        interact_global = np.array([0., 0., -5e-3])
+        pip.globalPosition.return_value = interact_global
+        arr.calibrateInteract(pip)
+
+        # For site[0] (at approach pos [0,0,0]): interact local = interact_global - site.globalPos
+        # When stage moves to approach [0,0], site[0].globalPosition() = approach = [0,0,0]
+        # So interactLocalFor should be [0,0,-5e-3] in site[0]'s frame
+        local0 = arr.sites[0].interactLocalFor(pip)
+        assert local0 is not None
+        reconstructed = arr.sites[0].mapToGlobal(local0)
+        np.testing.assert_allclose(reconstructed, interact_global, atol=1e-12)

--- a/acq4/motion/default_planner.py
+++ b/acq4/motion/default_planner.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import numpy as np
 
 from acq4 import getManager
-from acq4.util.future import future_wrap
 from .plan import AtomicMove, ParallelGroup, SequentialGroup
 from .plan import MovePlanStep
 from .planner import MotionPlanner
@@ -46,7 +45,9 @@ class DefaultMotionPlanner(MotionPlanner):
 
     def plan(self, specs, name=""):
         # TODO can this be parallel? (requires at least thread-safe locking)
-        return SequentialGroup([self._plan_one(spec, name) for spec in specs], name or "motion plan")
+        return SequentialGroup(
+            [self._plan_one(spec, name) for spec in specs], name or "motion plan"
+        )
 
     def _plan_one(self, spec: MoveSpec, name: str = "") -> MovePlanStep:
         if self._is_interaction_site(spec.relative_to):
@@ -104,7 +105,11 @@ class DefaultMotionPlanner(MotionPlanner):
         has_approach = site.hasApproachPosition(pip)
         going_inside = not np.allclose(spec.position, 0)
         # target_global is computed from the current transform then corrected for site movement.
-        target_global = np.array(site.mapToGlobal(spec.position)) + site_delta if going_inside else approach_global
+        target_global = (
+            np.array(site.mapToGlobal(spec.position)) + site_delta
+            if going_inside
+            else approach_global
+        )
 
         start = np.array(pip.globalPosition())
 
@@ -122,21 +127,27 @@ class DefaultMotionPlanner(MotionPlanner):
             ]
             safe_z = pip.positionAtDepth(pip.approachDepth(), start=start)
             if safe_z[2] > start[2]:
-                prefix_steps[0].steps.append(
-                    AtomicMove(pip, safe_z, speed, "pip to safe height")
-                )
+                prefix_steps[0].steps.append(AtomicMove(pip, safe_z, speed, "pip to safe height"))
                 start = safe_z
 
         kw = spec.kwargs
         if not going_inside or not has_approach:
             final = approach_global if not going_inside else target_global
             waypoints = self._safe_path(pip, start, final, speed)
-            steps = [AtomicMove(pip, pos, spd, expl, {'linear': lin, **kw}) for pos, spd, lin, expl in waypoints]
+            steps = [
+                AtomicMove(pip, pos, spd, expl, {'linear': lin, **kw})
+                for pos, spd, lin, expl in waypoints
+            ]
             return SequentialGroup(prefix_steps + steps, name or f"approach {site.name()}")
 
         to_approach = self._safe_path(pip, start, approach_global, speed)
-        to_approach_steps = [AtomicMove(pip, pos, spd, expl, {'linear': lin, **kw}) for pos, spd, lin, expl in to_approach]
-        interact_step = AtomicMove(pip, target_global, speed, name or f"interact with {site.name()}", kw)
+        to_approach_steps = [
+            AtomicMove(pip, pos, spd, expl, {'linear': lin, **kw})
+            for pos, spd, lin, expl in to_approach
+        ]
+        interact_step = AtomicMove(
+            pip, target_global, speed, name or f"interact with {site.name()}", kw
+        )
         return SequentialGroup(
             prefix_steps + to_approach_steps + [interact_step],
             name or f"interact with {site.name()}",
@@ -146,7 +157,9 @@ class DefaultMotionPlanner(MotionPlanner):
     # Case 1b: InteractionSite exit
     # ------------------------------------------------------------------
 
-    def _plan_interaction_exit(self, spec: MoveSpec, name: str = "", containing_site=None) -> MovePlanStep:
+    def _plan_interaction_exit(
+        self, spec: MoveSpec, name: str = "", containing_site=None
+    ) -> MovePlanStep:
         """Exit an interaction site and move to the target.
 
         When the site has a saved approach position, the pipette first moves to the
@@ -160,10 +173,15 @@ class DefaultMotionPlanner(MotionPlanner):
         speed = spec.speed or "fast"
 
         kw = spec.kwargs
-        exit_step = AtomicMove(pip, approach_global, speed, f"exit site before {name or 'move'}", kw)
+        exit_step = AtomicMove(
+            pip, approach_global, speed, f"exit site before {name or 'move'}", kw
+        )
         target = np.asarray(spec.position, dtype=float)
         rest_waypoints = self._safe_path(pip, approach_global, target, speed)
-        rest_steps = [AtomicMove(pip, pos, spd, expl, {'linear': lin, **kw}) for pos, spd, lin, expl in rest_waypoints]
+        rest_steps = [
+            AtomicMove(pip, pos, spd, expl, {'linear': lin, **kw})
+            for pos, spd, lin, expl in rest_waypoints
+        ]
         return SequentialGroup(
             [exit_step] + rest_steps,
             name or "exit site and move to target",
@@ -181,7 +199,10 @@ class DefaultMotionPlanner(MotionPlanner):
         start = np.array(pip.globalPosition())
         kw = spec.kwargs
         waypoints = self._safe_path(pip, start, target, speed)
-        steps = [AtomicMove(pip, pos, spd, expl, {'linear': lin, **kw}) for pos, spd, lin, expl in waypoints]
+        steps = [
+            AtomicMove(pip, pos, spd, expl, {'linear': lin, **kw})
+            for pos, spd, lin, expl in waypoints
+        ]
         return SequentialGroup(steps, name or "pipette move")
 
     # ------------------------------------------------------------------
@@ -195,7 +216,9 @@ class DefaultMotionPlanner(MotionPlanner):
             if spec.relative_to is not None
             else spec.position
         )
-        return AtomicMove(spec.device, global_pos, spec.speed or "fast", name or "move to target", spec.kwargs)
+        return AtomicMove(
+            spec.device, global_pos, spec.speed or "fast", name or "move to target", spec.kwargs
+        )
 
     # ------------------------------------------------------------------
     # Path generation — override in subclasses for geometry-aware routing

--- a/acq4/motion/minirig_v1.py
+++ b/acq4/motion/minirig_v1.py
@@ -39,7 +39,9 @@ class MinirigV1MotionPlanner(DefaultMotionPlanner):
     # Override: full approach sequence with scope park
     # ------------------------------------------------------------------
 
-    def _plan_interaction_approach(self, spec: "MoveSpec", name: str = "") -> "MovePlanStep":
+    def _plan_interaction_approach(
+        self, spec: "MoveSpec", name: str = ""
+    ) -> "MovePlanStep":
         site = spec.relative_to
         pip = spec.device
         pip_name = pip.name()
@@ -63,7 +65,9 @@ class MinirigV1MotionPlanner(DefaultMotionPlanner):
         # Step 2: pipette retract to approach depth — pip exits tissue before scope goes lateral
         pip_safe = pip.positionAtDepth(pip.approachDepth(), start=pip_start)
         if pip_safe[2] > pip_start[2]:
-            steps.append(AtomicMove(pip, pip_safe, speed, "pip retract before scope park"))
+            steps.append(
+                AtomicMove(pip, pip_safe, speed, "pip retract before scope park")
+            )
             pip_start = pip_safe
 
         # Step 3: scope lateral to park position
@@ -78,7 +82,10 @@ class MinirigV1MotionPlanner(DefaultMotionPlanner):
         # Step 5: pipette to approach position (safe path from current retracted position)
         kw = spec.kwargs
         pip_to_approach = self._safe_path(pip, pip_start, approach_global, speed)
-        steps.extend(AtomicMove(pip, pos, spd, expl, {'linear': lin, **kw}) for pos, spd, lin, expl in pip_to_approach)
+        steps.extend(
+            AtomicMove(pip, pos, spd, expl, {"linear": lin, **kw})
+            for pos, spd, lin, expl in pip_to_approach
+        )
 
         # Step 6: pipette into site (only when going inside and approach is saved)
         going_inside = not np.allclose(spec.position, 0)
@@ -86,7 +93,13 @@ class MinirigV1MotionPlanner(DefaultMotionPlanner):
             # spec.position is relative to LIVE site, so no need to add site_delta
             target_global = np.array(site.mapToGlobal(spec.position))
             steps.append(
-                AtomicMove(pip, target_global, speed, "pipette into site", {'linear': True, **kw})
+                AtomicMove(
+                    pip,
+                    target_global,
+                    speed,
+                    "pipette into site",
+                    {"linear": True, **kw},
+                )
             )
 
         return SequentialGroup(steps, name or f"approach {site.name()}")
@@ -95,13 +108,17 @@ class MinirigV1MotionPlanner(DefaultMotionPlanner):
     # Shared helper: append scope unwind steps to a plan
     # ------------------------------------------------------------------
 
-    def _append_scope_unwind(self, base: "MovePlanStep", pip_name: str) -> "MovePlanStep":
+    def _append_scope_unwind(
+        self, base: "MovePlanStep", pip_name: str
+    ) -> "MovePlanStep":
         if pip_name not in self._scope_context:
             return base
         scope, forward_path = self._scope_context.pop(pip_name)
         # forward_path = [original, up, park]; return path skips park (already there)
         return_waypoints = list(reversed(forward_path))[1:]
-        scope_steps = [AtomicMove(scope, wp, "fast", "scope return") for wp in return_waypoints]
+        scope_steps = [
+            AtomicMove(scope, wp, "fast", "scope return") for wp in return_waypoints
+        ]
         return SequentialGroup(
             base.steps + [SequentialGroup(scope_steps, "scope unwind")],
             base.explanation,
@@ -111,7 +128,9 @@ class MinirigV1MotionPlanner(DefaultMotionPlanner):
     # Override: append scope unwind when exiting via approach waypoint
     # ------------------------------------------------------------------
 
-    def _plan_interaction_exit(self, spec: "MoveSpec", name: str = "", containing_site=None) -> "MovePlanStep":
+    def _plan_interaction_exit(
+        self, spec: "MoveSpec", name: str = "", containing_site=None
+    ) -> "MovePlanStep":
         base = super()._plan_interaction_exit(spec, name, containing_site)
         return self._append_scope_unwind(base, spec.device.name())
 

--- a/acq4/motion/tests/test_minirig_v1_planner.py
+++ b/acq4/motion/tests/test_minirig_v1_planner.py
@@ -2,11 +2,10 @@
 from __future__ import annotations
 
 import numpy as np
-import pytest
 
 from acq4.motion.plan import AtomicMove, ParallelGroup, SequentialGroup
 from acq4.motion.spec import MoveSpec
-from acq4.motion.tests.conftest import MockDevice, MockInteractionSite, MockPipette, MockScope
+from acq4.motion.tests.conftest import MockPipette, MockScope
 
 
 def make_planner():
@@ -33,6 +32,7 @@ def _flat_moves(plan):
 # ---------------------------------------------------------------------------
 # Interaction approach with microscope park
 # ---------------------------------------------------------------------------
+
 
 def test_no_scope_park_when_not_configured(pip, site):
     """Sites without scopeParkPos produce no scope moves."""
@@ -72,6 +72,7 @@ def test_scope_park_not_repeated_if_already_parked(pip, site_with_scope_park):
 # ---------------------------------------------------------------------------
 # Scope unwind on return home (via _plan_pipette_move fallback)
 # ---------------------------------------------------------------------------
+
 
 def _seed_scope_context(planner, pip):
     scope = pip.scopeDevice()
@@ -131,6 +132,7 @@ def test_no_scope_unwind_when_context_empty(pip):
 # Scope-up-first sequence for approach with scopeParkPos
 # ---------------------------------------------------------------------------
 
+
 def test_scope_up_is_first_move_in_approach(pip, site_with_scope_park):
     """Scope must move up (z-only) as the very first step, before any pip or lateral scope move."""
     planner = make_planner()
@@ -139,11 +141,12 @@ def test_scope_up_is_first_move_in_approach(pip, site_with_scope_park):
     scope_moves = [m for m in moves if isinstance(m.device, MockScope)]
     assert moves[0].device is pip.scopeDevice(), "First move must be scope up"
     park_pos = site_with_scope_park.config["scopeParkPos"]
-    up_pos = np.array([pip.scopeDevice().globalPosition()[0],
-                       pip.scopeDevice().globalPosition()[1],
-                       park_pos[2]])
-    np.testing.assert_array_almost_equal(moves[0].position, up_pos,
-                                         err_msg="First scope move must be z-only (up to park height)")
+    up_pos = np.array(
+        [pip.scopeDevice().globalPosition()[0], pip.scopeDevice().globalPosition()[1], park_pos[2]]
+    )
+    np.testing.assert_array_almost_equal(
+        moves[0].position, up_pos, err_msg="First scope move must be z-only (up to park height)"
+    )
 
 
 def test_pip_retract_before_scope_lateral_when_pip_in_tissue(site_with_scope_park):
@@ -167,8 +170,9 @@ def test_pip_retract_before_scope_lateral_when_pip_in_tissue(site_with_scope_par
     assert len(scope_moves) >= 2, "Expected scope up + scope lateral moves"
     first_pip_idx = all_idxs[id(pip_moves[0])]
     scope_lateral_idx = all_idxs[id(scope_moves[1])]
-    assert first_pip_idx < scope_lateral_idx, \
-        "Pip retract must come before scope lateral move to park position"
+    assert (
+        first_pip_idx < scope_lateral_idx
+    ), "Pip retract must come before scope lateral move to park position"
 
 
 def test_pip_no_retract_step_when_already_at_safe_height(site_with_scope_park):
@@ -193,6 +197,7 @@ def test_pip_no_retract_step_when_already_at_safe_height(site_with_scope_park):
 # ---------------------------------------------------------------------------
 # Scope unwind via interaction exit (_plan_interaction_exit path)
 # ---------------------------------------------------------------------------
+
 
 def test_scope_unwind_appended_after_interaction_exit(pip, site_with_scope_park):
     """When pip exits a site via _plan_interaction_exit, scope unwind is still appended."""

--- a/config/example/devices.cfg
+++ b/config/example/devices.cfg
@@ -346,6 +346,43 @@ CleaningWell:
                     pos: 0, 0, -12*mm
 
 
+
+
+# InteractionSiteArray groups multiple identical interaction sites into a single
+# calibrated grid sharing one role (here: nucleus deposition tubes). The stage moves
+# to bring each site to the pipette approach position; sites are marked used-up
+# individually via the device UI. childGeometry applies to every site in the array.
+InteractionArray:
+    driver: "InteractionSiteArray"
+    parentDevice: "Stage"
+    rows: 2
+    cols: 5
+    siteRadius: 2.5*mm
+    siteHeight: 21*mm
+    role: 'nucleus'
+    childGeometry:
+        children:
+            tube:
+                type: "cylinder"
+                height: 10.5*mm
+                radius: 2.5*mm
+                transform:
+                    pos: 0, 0, -10.5*mm
+            taper:
+                type: "cone"
+                height: 9.45*mm
+                top_radius: 2.5*mm
+                bottom_radius: 1.0*mm
+                transform:
+                    pos: 0, 0, -19.95*mm
+            tip:
+                type: "cone"
+                height: 1.05*mm
+                top_radius: 1.0*mm
+                bottom_radius: 0
+                transform:
+                    pos: 0, 0, -21*mm
+
 # A microscope device, providing a way to inform ACQ4 about the set of
 # objective lenses available and which objective is currently in use. 
 Microscope:


### PR DESCRIPTION
## Summary

Adds a multi-site interaction array (e.g. a nucleus deposition tube rack) plus runtime,
UI-driven assignment of interaction sites to pipettes.

### InteractionSite
- `role` (clean/rinse/nucleus/refill/empty) and `used_up` properties — persisted, with
  Qt signals and validation. Role drives the site's color in the 3D visualizer.
- `deviceInterface` returns `None` when the site is managed by an array (the array's UI
  takes over), detected by duck-typing `_is_array_child()`.

### InteractionSiteArray (new device)
- Creates `rows × cols` child `InteractionSite` objects parented to the array.
- **Single role per array** (`role` config key) shared by all sites — arrays are not
  multi-use, and the array's configured role is authoritative over any stale per-site
  role persisted from an earlier configuration.
- **Calibration measures 3 interact corners + 1 approach** (interact positions are the
  precision-critical fluid targets; approach is a single shared offset). `applyCalibration`
  interpolates each site's interact position in a common frame (correcting for stage
  movement between measurements), derives each approach from the shared approach-to-interact
  offset, and transmits both to every child site.
- `getFirstAvailableSite()` returns the first non-used-up site; `Pipette.getSiteFor(role)`
  verifies the assigned array's role matches before delegating.
- `childGeometry` config key applies one geometry (e.g. tube + conic tip) to every site.

### Calibration UI
- A single **Calibrate…** button opens a guided, **modeless** wizard in its own top-level
  window (so the 3D visualizer stays visible on small screens); the button is disabled while
  a flow is open. Opening the flow ensures Visualize3D is up.
- Wizard steps, in order: `[0,0]` interact → `[0,0]` approach → `[rows-1,0]` interact →
  `[0,cols-1]` interact (degenerate corners skipped for 1×N / N×1). Each step captures the
  current pipette position or keeps a saved one; calibration is applied automatically at the end.
- The device panel shows a physical-layout grid of checkable buttons (one per site, toggling
  `used_up`) and the computed mm/col · mm/row spacing.

### Pipette
- Replaces static `cleaningWell` / `nucleusExpulsionWell` / `electrodeSolutionWell` config
  lookups with runtime `getSiteFor(role)` / `setSiteFor(role, device)`, persisted to
  `saved_sites`. Legacy config keys auto-migrate on startup.
- Fixed `moveTo('rinse')` routing through the electrode well.

### State files
- `clean.py`, `refill.py`, `nucleus_collect.py` use `getSiteFor` with a named-position fallback.

### Config
- `config/example/devices.cfg` gains an `InteractionArray` example with `childGeometry`.
- Config keys are camelCase: `role`, `siteRadius`, `siteHeight`, `childGeometry`.

## Notes on scope changes during review
- Dropped the original "one array, mixed roles" idea — arrays are now single-role; a rig
  with mixed tube types uses separate array devices or standalone `InteractionSite`s.
- Swapped the calibration emphasis from 3 approach + 1 interact to **3 interact + 1 approach**,
  since hitting the few-µL fluid volume precisely matters more than the approach waypoint.
- A per-site `used_up` translucency cue was prototyped and removed (pyqtgraph mesh geometry
  doesn't honor alpha < 1).

## Test plan
- [ ] `python -m pytest acq4/devices/tests/ acq4/devices/Pipette/tests/ acq4/motion/tests/` — 132 tests, all green
- [ ] `python -m acq4 -c config/mock/default.cfg` — existing mock config unaffected
- [ ] `python -m acq4 -c config/array/default.cfg` — InteractionArray starts; 3D visualizer shows 10 same-colored sites; Calibrate… opens a detached wizard that walks 1 approach + 3 interact corners and applies on finish

🤖 Generated with [Claude Code](https://claude.ai/code)