### PR TITLE
feat: detect whole cell access loss and recover via clear access state

### DIFF
--- a/acq4/devices/PatchClamp/patchclamp.py
+++ b/acq4/devices/PatchClamp/patchclamp.py
@@ -114,7 +114,10 @@ class PatchClamp(Device):
             Duration (seconds) of the zap pulse (default 1 ms).
         amplitude : float
             Amplitude (Volts in VC, Amps in IC) of the zap relative to the holding value
-            (default 1 V).
+            (default 1 V). 1 V is the conventional break-in "zap" amplitude in the patch-clamp
+            literature (e.g. Axon instrumentation); some protocols go higher (up to ~5 V) with
+            correspondingly briefer pulses. The default assumes VC; an IC zap would need a sane
+            current amplitude supplied explicitly.
         sampleRate : float
             Sample rate (Hz) for the command waveform (default 500 kHz).
         """

--- a/acq4/devices/PatchClamp/patchclamp.py
+++ b/acq4/devices/PatchClamp/patchclamp.py
@@ -1,11 +1,15 @@
+import time
+
 import numpy as np
 from typing import Literal
 
+from acq4.Manager import getManager
 from acq4.devices.Device import Device
 from acq4.devices.PatchClamp.gui import PatchClampDeviceGui
 from acq4.devices.PatchClamp.testpulse import TestPulseThread
 from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
 from acq4.util import Qt
+from neuroanalysis.stimuli import SquarePulse
 from neuroanalysis.test_pulse import PatchClampTestPulse
 
 
@@ -104,9 +108,11 @@ class PatchClamp(Device):
             tp.analysis.update(self._testPulseAnalysisOverrides)
         return tp
 
-    def zap(self, duration=1e-3, amplitude=1.0, sampleRate=500000):
+    def zap(self, duration=1e-3, amplitude=1.0):
         """Apply a brief voltage pulse ("zap") on top of the current holding to help clear or
         rupture the membrane.
+
+        The command waveform is generated at the device's own test-pulse sample rate.
 
         Parameters
         ----------
@@ -118,14 +124,8 @@ class PatchClamp(Device):
             literature (e.g. Axon instrumentation); some protocols go higher (up to ~5 V) with
             correspondingly briefer pulses. The default assumes VC; an IC zap would need a sane
             current amplitude supplied explicitly.
-        sampleRate : float
-            Sample rate (Hz) for the command waveform (default 500 kHz).
         """
-        import time
-
-        from acq4.Manager import getManager
-        from neuroanalysis.stimuli import SquarePulse
-
+        sampleRate = self.testPulseConfig.get('sampleRate', 500000)
         mode = self.getMode()
         pad = 1e-3
         total = pad + duration + pad

--- a/acq4/devices/PatchClamp/patchclamp.py
+++ b/acq4/devices/PatchClamp/patchclamp.py
@@ -104,6 +104,46 @@ class PatchClamp(Device):
             tp.analysis.update(self._testPulseAnalysisOverrides)
         return tp
 
+    def zap(self, duration=1e-3, amplitude=1.0, sampleRate=500000):
+        """Apply a brief voltage pulse ("zap") on top of the current holding to help clear or
+        rupture the membrane.
+
+        Parameters
+        ----------
+        duration : float
+            Duration (seconds) of the zap pulse (default 1 ms).
+        amplitude : float
+            Amplitude (Volts in VC, Amps in IC) of the zap relative to the holding value
+            (default 1 V).
+        sampleRate : float
+            Sample rate (Hz) for the command waveform (default 500 kHz).
+        """
+        import time
+
+        from acq4.Manager import getManager
+        from neuroanalysis.stimuli import SquarePulse
+
+        mode = self.getMode()
+        pad = 1e-3
+        total = pad + duration + pad
+        numPts = int(total * sampleRate)
+        square = SquarePulse(start_time=pad, duration=duration, amplitude=amplitude)
+        cmdData = square.eval(n_pts=numPts, t0=0, sample_rate=sampleRate).data + self.getHolding(mode)
+        daqName = self.getDAQName("primary")
+        cmd = {
+            'protocol': {'duration': total},
+            daqName: {'rate': sampleRate, 'numPts': numPts, 'downsample': 1},
+            self.name(): {'mode': mode, 'command': cmdData, 'stimulus': square},
+        }
+        task = getManager().createTask(cmd)
+        task.reserveDevices(reserver=f"{self.name()}.zap")
+        try:
+            task.execute()
+            while not task.isDone():
+                time.sleep(0.01)
+        finally:
+            task.releaseDevices()
+
     def autoPipetteOffset(self):
         """Automatically set the pipette offset.
         """

--- a/acq4/devices/PatchPipette/patchpipette.py
+++ b/acq4/devices/PatchPipette/patchpipette.py
@@ -42,6 +42,7 @@ class PatchPipette(Device):
     sigNewPipetteRequested = Qt.Signal(object)  # self
     sigTipCleanChanged = Qt.Signal(object, object)  # self, clean
     sigTipBrokenChanged = Qt.Signal(object, object)  # self, broken
+    sigAccessWarningChanged = Qt.Signal(object, object, object)  # self, active, message
 
     # catch-all signal for event logging
     sigNewEvent = Qt.Signal(object, object)  # self, event
@@ -72,6 +73,7 @@ class PatchPipette(Device):
         self.clean = False
         self.calibrated = False
         self.waitingForSwap = False
+        self._accessWarning = (False, "")
         self._lastPos = None
         self._emitTestPulseData = False
         self.cell = None
@@ -125,6 +127,23 @@ class PatchPipette(Device):
         self.clean = clean
         self.sigTipCleanChanged.emit(self, clean)
         self.emitNewEvent('tip_clean_changed', {'clean': clean})
+
+    def accessWarning(self):
+        """Return the current (active, message) access-resistance warning tuple."""
+        return self._accessWarning
+
+    def setAccessWarning(self, active, message=""):
+        """Raise or clear a whole-cell access-resistance warning for the UI to display.
+
+        Unlike a state change, this is a passive alert: whole cell stays put and the user decides
+        whether to initiate a 'clear access' attempt. Emitting with the same active flag is a no-op.
+        """
+        active = bool(active)
+        if self._accessWarning[0] == active:
+            return
+        self._accessWarning = (active, message)
+        self.sigAccessWarningChanged.emit(self, active, message)
+        self.emitNewEvent('access_warning_changed', {'active': active, 'info': message})
 
     def isTipBroken(self):
         return self.broken

--- a/acq4/devices/PatchPipette/statemanager.py
+++ b/acq4/devices/PatchPipette/statemanager.py
@@ -40,6 +40,7 @@ class PatchPipetteStateManager(Qt.QObject):
                 states.CellAttachedState,
                 states.BreakInState,
                 states.WholeCellState,
+                states.ClearAccessState,
                 states.ResealState,
                 states.OutsideOutState,
                 states.BlowoutState,

--- a/acq4/devices/PatchPipette/states/__init__.py
+++ b/acq4/devices/PatchPipette/states/__init__.py
@@ -15,7 +15,7 @@ from .move_nucleus_to_home import MoveNucleusToHomeState
 from .nucleus_collect import NucleusCollectState
 from .reseal import ResealAnalysis, ResealState
 from .seal import SealAnalysis, SealState
-from .whole_cell import WholeCellState
+from .whole_cell import WholeCellAnalysis, WholeCellState
 from .out import OutState
 from .outside_out import OutsideOutState
 
@@ -26,6 +26,7 @@ __all__ = [
     'OutsideOutState',
     'ApproachState',
     'ApproachAnalysis',
+    'WholeCellAnalysis',
     'WholeCellState',
     'BrokenState',
     'FouledState',

--- a/acq4/devices/PatchPipette/states/__init__.py
+++ b/acq4/devices/PatchPipette/states/__init__.py
@@ -6,6 +6,7 @@ from .break_in import BreakInState
 from .broken import BrokenState
 from .cell_attached import CellAttachedState
 from .cell_detect import CellDetectAnalysis, CellDetectState
+from .clear_access import ClearAccessAnalysis, ClearAccessState
 from .contact_cell import ContactCellState
 from .clean import CleanState
 from .refill import RefillState
@@ -36,6 +37,8 @@ __all__ = [
     'SealState',
     'CellAttachedState',
     'BreakInState',
+    'ClearAccessAnalysis',
+    'ClearAccessState',
     'ResealAnalysis',
     'ResealState',
     'MoveNucleusToHomeState',

--- a/acq4/devices/PatchPipette/states/clear_access.py
+++ b/acq4/devices/PatchPipette/states/clear_access.py
@@ -1,0 +1,329 @@
+"""Clear access patch state: recover a whole cell recording whose access resistance has climbed.
+
+Applies a sequence of escalating negative pressure pulses (and optionally voltage zaps) to
+re-open access to the cell, while watching input resistance (Ri). If Ri starts dropping the
+pulsing is paused until the membrane repairs; if Ri collapses the cell is considered lost.
+"""
+from __future__ import annotations
+
+import time
+
+import numpy as np
+
+import pyqtgraph as pg
+from acq4.util import ptime
+from acq4.util.debug import log_and_ignore_exception
+from acq4.util.functions import plottable_booleans
+from pyqtgraph import units
+from ._base import PatchPipetteState, SteadyStateAnalysisBase, exponential_decay_avg
+
+
+class ClearAccessAnalysis(SteadyStateAnalysisBase):
+    """Analyze test pulses to drive whole-cell access recovery.
+
+    Emits three flags from rolling averages of access resistance (Ra) and input resistance (Ri):
+
+    - ``recovered``: smoothed Ra has dropped back below ``access_recovered_threshold`` (success).
+    - ``repairing``: smoothed Ri is dropping faster than ``input_resistance_decline_threshold``
+      (a log10 ratio, expected negative), meaning the membrane is being damaged and pulsing
+      should pause until it recovers.
+    - ``lost``: the slow (``repair_tau``) average of Ri has fallen below
+      ``input_resistance_loss_threshold``, meaning the cell is gone.
+    """
+
+    @classmethod
+    def plot_items(cls, *args, **kwargs):
+        representative = cls(*args, **kwargs)
+        return {
+            'Ω': [
+                pg.InfiniteLine(
+                    movable=False, pos=representative._access_recovered_threshold, angle=0, pen=pg.mkPen('g')
+                ),
+                pg.InfiniteLine(
+                    movable=False, pos=representative._input_resistance_loss_threshold, angle=0, pen=pg.mkPen('r')
+                ),
+            ]
+        }
+
+    @classmethod
+    def plots_for_data(cls, data, *args, **kwargs):
+        plots = {'Ω': [], '': []}
+        names = False
+        for d in data:
+            analyzer = cls(*args, **kwargs)
+            analysis = analyzer.process_measurements(d)
+            plots['Ω'].append(
+                dict(x=analysis["time"], y=analysis["access_avg"], pen=pg.mkPen('b'),
+                     name=None if names else 'Access Avg')
+            )
+            plots['Ω'].append(
+                dict(x=analysis["time"], y=analysis["input_repair_avg"], pen=pg.mkPen(90, 140, 255),
+                     name=None if names else 'Input Repair Avg')
+            )
+            plots[''].append(
+                dict(x=analysis["time"], y=analysis["input_ratio"], pen=pg.mkPen('y'),
+                     name=None if names else 'Input Ratio')
+            )
+            plots[''].append(
+                dict(x=analysis["time"], y=plottable_booleans(analysis["recovered"]), pen=pg.mkPen('g'),
+                     symbol='o', name=None if names else 'Recovered')
+            )
+            plots[''].append(
+                dict(x=analysis["time"], y=plottable_booleans(analysis["repairing"]), pen=pg.mkPen('y'),
+                     symbol='x', name=None if names else 'Repairing')
+            )
+            plots[''].append(
+                dict(x=analysis["time"], y=plottable_booleans(analysis["lost"]), pen=pg.mkPen('r'),
+                     symbol='x', name=None if names else 'Lost')
+            )
+            names = True
+        return plots
+
+    def __init__(
+        self,
+        access_recovered_threshold: float,
+        input_resistance_loss_threshold: float,
+        input_resistance_decline_threshold: float,
+        detection_tau: float,
+        repair_tau: float,
+    ):
+        super().__init__()
+        self._access_recovered_threshold = access_recovered_threshold
+        self._input_resistance_loss_threshold = input_resistance_loss_threshold
+        self._input_resistance_decline_threshold = input_resistance_decline_threshold
+        self._detection_tau = detection_tau
+        self._repair_tau = repair_tau
+
+    def access_recovered(self) -> bool:
+        """Return True if the smoothed access resistance has dropped back below threshold."""
+        return bool(self._last_measurement is not None and self._last_measurement['recovered'])
+
+    def is_repairing(self) -> bool:
+        """Return True if the input resistance is dropping and pulsing should pause."""
+        return bool(self._last_measurement is not None and self._last_measurement['repairing'])
+
+    def cell_lost(self) -> bool:
+        """Return True if the input resistance has collapsed below the loss floor."""
+        return bool(self._last_measurement is not None and self._last_measurement['lost'])
+
+    def process_test_pulses(self, tps) -> np.ndarray:
+        return self.process_measurements(
+            np.array([
+                (tp.recording.start_time, tp.analysis['access_resistance'], tp.analysis['input_resistance'])
+                for tp in tps
+            ]))
+
+    def process_measurements(self, measurements: np.ndarray) -> np.ndarray:
+        ret_array = np.zeros(
+            len(measurements),
+            dtype=[
+                ('time', float),
+                ('access_resistance', float),
+                ('input_resistance', float),
+                ('access_avg', float),
+                ('input_detect_avg', float),
+                ('input_repair_avg', float),
+                ('input_ratio', float),
+                ('recovered', bool),
+                ('repairing', bool),
+                ('lost', bool),
+            ],
+        )
+        for i, measurement in enumerate(measurements):
+            start_time, access_resistance, input_resistance = measurement
+            if self._last_measurement is None:
+                access_avg = access_resistance
+                input_detect_avg = input_resistance
+                input_repair_avg = input_resistance
+                input_ratio = 0.0
+            else:
+                last = self._last_measurement
+                dt = start_time - last['time']
+                access_avg, _ = exponential_decay_avg(
+                    dt, last['access_avg'], access_resistance, self._detection_tau)
+                input_detect_avg, detect_ratio = exponential_decay_avg(
+                    dt, last['input_detect_avg'], input_resistance, self._detection_tau)
+                input_ratio = np.log10(detect_ratio) if detect_ratio > 0 else 0.0
+                input_repair_avg, _ = exponential_decay_avg(
+                    dt, last['input_repair_avg'], input_resistance, self._repair_tau)
+
+            recovered = access_avg < self._access_recovered_threshold
+            repairing = input_ratio < self._input_resistance_decline_threshold
+            lost = input_repair_avg < self._input_resistance_loss_threshold
+            ret_array[i] = (
+                start_time, access_resistance, input_resistance,
+                access_avg, input_detect_avg, input_repair_avg, input_ratio,
+                recovered, repairing, lost,
+            )
+            self._last_measurement = ret_array[i]
+        return ret_array
+
+
+class ClearAccessState(PatchPipetteState):
+    """Recover a whole cell recording whose access resistance has climbed too high.
+
+    State name: "clear access"
+
+    The whole cell state hands off here when access resistance (Ra) climbs past its threshold.
+    This state applies a sequence of escalating negative pressure pulses (and, if ``useZaps`` is
+    enabled, brief voltage zaps) to re-open access, like a gentle break-in. It watches input
+    resistance (Ri): while Ri is dropping it pauses pulsing until the membrane repairs, and if
+    Ri collapses below ``inputResistanceLossThreshold`` it gives up and transitions to
+    ``fallbackState`` (default 'fouled'). On success (Ra back below
+    ``accessRecoveredThreshold``) it returns to 'whole cell'.
+
+    Parameters
+    ----------
+    nPulses : list of int
+        Number of pressure pulses to apply on each recovery attempt.
+    pulseDurations : list of float
+        Duration (seconds) of pulses to apply on each recovery attempt.
+    pulsePressures : list of float
+        Pressure (Pascals, expected negative) of pulses to apply on each recovery attempt.
+    pulseInterval : float
+        Minimum delay (seconds) between recovery attempts.
+    accessRecoveredThreshold : float
+        Access resistance (Ohms) below which (smoothed over ``detectionTau``) access is
+        considered recovered and the state returns to 'whole cell' (default 25 MΩ).
+    inputResistanceLossThreshold : float
+        Input resistance (Ohms) below which (smoothed over ``repairTau``) the cell is considered
+        lost and the state transitions to ``fallbackState`` (default 50 MΩ).
+    inputResistanceDeclineThreshold : float
+        Maximum log10 of the input-resistance ratio (expected negative) before the membrane is
+        considered to be tearing, pausing recovery pulses until it repairs (default -0.01).
+    detectionTau : float
+        Time constant (seconds) for smoothing Ra (recovery) and the Ri decline ratio (default 1 s).
+    repairTau : float
+        Time constant (seconds) for the slow Ri average used to detect cell loss (default 10 s).
+    clearTimeout : float
+        Maximum time (seconds) to spend attempting recovery before failing to ``fallbackState``
+        (default 60 s).
+    useZaps : bool
+        If True, fire a brief voltage zap before each pressure pulse (default False).
+    zapDuration : float
+        Duration (seconds) of each voltage zap (default 1 ms).
+    zapAmplitude : float
+        Amplitude (Volts) of each voltage zap, relative to the holding potential (default 1 V).
+    fallbackState : str
+        State to transition to if recovery fails (default 'fouled').
+    """
+    stateName = 'clear access'
+    _parameterDefaultOverrides = {
+        'initialPressureSource': 'atmosphere',
+        'initialClampMode': 'VC',
+        'initialVCHolding': -70e-3,
+        'initialTestPulseEnable': True,
+        'initialAutoBiasEnable': True,
+        'initialAutoBiasTarget': -70e-3,
+        'fallbackState': 'fouled',
+    }
+    _parameterTreeConfig = {
+        'nPulses': {'type': 'str', 'default': "[1, 1, 2, 2, 3]"},
+        'pulseDurations': {'type': 'str', 'default': "[0.2, 0.2, 0.3, 0.5, 0.7]"},
+        'pulsePressures': {'type': 'str', 'default': "[-20e3, -30e3, -40e3, -50e3, -60e3]"},
+        'pulseInterval': {'type': 'float', 'default': 2, 'suffix': 's'},
+        'accessRecoveredThreshold': {'type': 'float', 'default': 25e6, 'suffix': 'Ω'},
+        'inputResistanceLossThreshold': {'type': 'float', 'default': 50e6, 'suffix': 'Ω'},
+        'inputResistanceDeclineThreshold': {'type': 'float', 'default': -0.01, 'suffix': '', 'siPrefix': False},
+        'detectionTau': {'type': 'float', 'default': 1, 'suffix': 's'},
+        'repairTau': {'type': 'float', 'default': 10, 'suffix': 's'},
+        'clearTimeout': {'type': 'float', 'default': 60, 'suffix': 's'},
+        'useZaps': {'type': 'bool', 'default': False},
+        'zapDuration': {'type': 'float', 'default': 1e-3, 'suffix': 's'},
+        'zapAmplitude': {'type': 'float', 'default': 1.0, 'suffix': 'V'},
+    }
+
+    def __init__(self, *args, **kwds):
+        super().__init__(*args, **kwds)
+        self._analysis = None
+
+    def run(self):
+        patchrec = self.dev.patchRecord()
+        self.monitorTestPulse()
+        config = self.config
+        if isinstance(config['nPulses'], str):
+            config['nPulses'] = eval(config['nPulses'], units.__dict__)
+        if isinstance(config['pulseDurations'], str):
+            config['pulseDurations'] = eval(config['pulseDurations'], units.__dict__)
+        if isinstance(config['pulsePressures'], str):
+            config['pulsePressures'] = eval(config['pulsePressures'], units.__dict__)
+
+        self._analysis = ClearAccessAnalysis(
+            access_recovered_threshold=config['accessRecoveredThreshold'],
+            input_resistance_loss_threshold=config['inputResistanceLossThreshold'],
+            input_resistance_decline_threshold=config['inputResistanceDeclineThreshold'],
+            detection_tau=config['detectionTau'],
+            repair_tau=config['repairTau'],
+        )
+
+        patchrec['attemptedClearAccess'] = True
+        patchrec['clearAccessSuccessful'] = False
+
+        start_time = ptime.time()
+        lastPulse = -np.inf
+        attempt = 0
+        while True:
+            self.checkStop()
+
+            if ptime.time() - start_time > config['clearTimeout']:
+                self.setResult(error="Took longer than `clearTimeout` to recover access.")
+                return {"state": config['fallbackState']}
+
+            self._analysis.process_test_pulses(self.processAtLeastOneTestPulse())
+
+            if self._analysis.access_recovered():
+                self.setState("access resistance recovered")
+                patchrec['clearAccessSuccessful'] = True
+                return {"state": 'whole cell'}
+
+            if self._analysis.cell_lost():
+                self.setResult(error="Input resistance collapsed below `inputResistanceLossThreshold`; cell lost.")
+                return {"state": config['fallbackState']}
+
+            if self._analysis.is_repairing():
+                # Ri is dropping; pause pulsing until the membrane repairs.
+                self.setState("input resistance declining; pausing recovery pulses until repair")
+                lastPulse = ptime.time()  # restart the interval timer once repair finishes
+                continue
+
+            if ptime.time() - lastPulse < config['pulseInterval']:
+                continue
+
+            if attempt >= len(config['nPulses']):
+                self.setResult(error=f"Access not recovered after {attempt} clearing attempts.")
+                return {"state": config['fallbackState']}
+
+            self.setState('Clear access attempt %d' % attempt)
+            self.attemptClear(
+                config['nPulses'][attempt],
+                config['pulseDurations'][attempt],
+                config['pulsePressures'][attempt],
+            )
+            attempt += 1
+            lastPulse = ptime.time()
+
+    def attemptClear(self, nPulses, duration, pressure):
+        """Apply a burst of negative pressure pulses (and optional zaps) to re-open access."""
+        for i in range(nPulses):
+            if self.config['useZaps']:
+                self.dev.clampDevice.zap(
+                    duration=self.config['zapDuration'], amplitude=self.config['zapAmplitude'])
+            self.dev.pressureDevice.setPressure(source='regulator', pressure=pressure)
+            stop = ptime.time() + duration
+            try:
+                while True:
+                    remaining = stop - ptime.time()
+                    if remaining <= 0:
+                        break
+                    self.checkStop()
+                    time.sleep(min(0.1, remaining))
+            finally:
+                self.dev.pressureDevice.setPressure(source='atmosphere')
+            if i < nPulses - 1:
+                time.sleep(0.1)  # short delay between pulses
+
+    def _cleanup(self):
+        dev = self.dev
+        with log_and_ignore_exception(Exception, "Error resetting pressure after clear access"):
+            dev.pressureDevice.setPressure(source='atmosphere', pressure=0)
+        return super()._cleanup()

--- a/acq4/devices/PatchPipette/states/clear_access.py
+++ b/acq4/devices/PatchPipette/states/clear_access.py
@@ -23,12 +23,17 @@ class ClearAccessAnalysis(SteadyStateAnalysisBase):
 
     Emits three flags from rolling averages of access resistance (Ra) and input resistance (Ri):
 
-    - ``recovered``: smoothed Ra has dropped back below ``access_recovered_threshold`` (success).
+    - ``recovered``: smoothed Ra has dropped back below ``access_recovered_threshold`` while the
+      cell is not simultaneously being lost (success).
     - ``repairing``: smoothed Ri is dropping faster than ``input_resistance_decline_threshold``
       (a log10 ratio, expected negative), meaning the membrane is being damaged and pulsing
-      should pause until it recovers.
+      should pause until it recovers. Note this ratio is computed *per test pulse step*, so it
+      scales with the test-pulse interval; the threshold's tuning assumes a roughly steady
+      test-pulse cadence and would need rescaling if that cadence changes substantially.
     - ``lost``: the slow (``repair_tau``) average of Ri has fallen below
-      ``input_resistance_loss_threshold``, meaning the cell is gone.
+      ``input_resistance_loss_threshold``, meaning the cell is gone. Only honored after at least
+      one ``repair_tau`` has elapsed since the first measurement, so a transient low Ri reading
+      on entry cannot prematurely declare the cell lost.
     """
 
     @classmethod
@@ -93,6 +98,10 @@ class ClearAccessAnalysis(SteadyStateAnalysisBase):
         self._input_resistance_decline_threshold = input_resistance_decline_threshold
         self._detection_tau = detection_tau
         self._repair_tau = repair_tau
+        # Time of the first measurement, so cell loss is only honored once the slow repair
+        # average has had at least one repair tau to settle (a single low Ri reading on entry
+        # must not be enough to declare the cell lost).
+        self._first_time = None
 
     def access_recovered(self) -> bool:
         """Return True if the smoothed access resistance has dropped back below threshold."""
@@ -131,6 +140,8 @@ class ClearAccessAnalysis(SteadyStateAnalysisBase):
         )
         for i, measurement in enumerate(measurements):
             start_time, access_resistance, input_resistance = measurement
+            if self._first_time is None:
+                self._first_time = start_time
             if self._last_measurement is None:
                 access_avg = access_resistance
                 input_detect_avg = input_resistance
@@ -147,9 +158,13 @@ class ClearAccessAnalysis(SteadyStateAnalysisBase):
                 input_repair_avg, _ = exponential_decay_avg(
                     dt, last['input_repair_avg'], input_resistance, self._repair_tau)
 
-            recovered = access_avg < self._access_recovered_threshold
+            # Only trust the loss verdict once the slow repair average has had at least one
+            # repair tau to settle, so a transient low Ri reading on entry can't declare loss.
+            settled = (start_time - self._first_time) >= self._repair_tau
+            lost = settled and input_repair_avg < self._input_resistance_loss_threshold
             repairing = input_ratio < self._input_resistance_decline_threshold
-            lost = input_repair_avg < self._input_resistance_loss_threshold
+            # A falling Ra only counts as recovery if the cell is not simultaneously being lost.
+            recovered = (access_avg < self._access_recovered_threshold) and not lost
             ret_array[i] = (
                 start_time, access_resistance, input_resistance,
                 access_avg, input_detect_avg, input_repair_avg, input_ratio,
@@ -190,7 +205,10 @@ class ClearAccessState(PatchPipetteState):
         lost and the state transitions to ``fallbackState`` (default 50 MΩ).
     inputResistanceDeclineThreshold : float
         Maximum log10 of the input-resistance ratio (expected negative) before the membrane is
-        considered to be tearing, pausing recovery pulses until it repairs (default -0.01).
+        considered to be tearing, pausing recovery pulses until it repairs (default -0.01). This
+        ratio is measured between successive test pulses, so it scales with the test-pulse
+        interval; the default assumes a roughly steady cadence and should be rescaled if the
+        test-pulse rate changes substantially.
     detectionTau : float
         Time constant (seconds) for smoothing Ra (recovery) and the Ri decline ratio (default 1 s).
     repairTau : float
@@ -204,6 +222,9 @@ class ClearAccessState(PatchPipetteState):
         Duration (seconds) of each voltage zap (default 1 ms).
     zapAmplitude : float
         Amplitude (Volts) of each voltage zap, relative to the holding potential (default 1 V).
+        1 V is the conventional break-in "zap" amplitude in the patch-clamp literature (e.g. Axon
+        instrumentation); some protocols go higher (up to ~5 V) with correspondingly briefer
+        pulses to rupture without over-stressing the cell.
     fallbackState : str
         State to transition to if recovery fails (default 'fouled').
     """

--- a/acq4/devices/PatchPipette/states/whole_cell.py
+++ b/acq4/devices/PatchPipette/states/whole_cell.py
@@ -1,7 +1,8 @@
 """Whole cell patch state: hold the recording and watch for access resistance climbing.
 
-When the access resistance (Ra) rises past a threshold the cell is starting to be lost, so
-this state hands off the repair work to the 'clear access' state rather than fixing it here.
+When the access resistance (Ra) rises past a threshold the cell is starting to be lost. The state
+does not act on this itself; it raises a passive warning in the UI so the user can decide whether
+to manually initiate a 'clear access' recovery attempt.
 """
 from __future__ import annotations
 
@@ -9,6 +10,7 @@ import numpy as np
 
 import pyqtgraph as pg
 from acq4.util import ptime
+from acq4.util.debug import log_and_ignore_exception
 from acq4.util.functions import plottable_booleans
 from ._base import PatchPipetteState, SteadyStateAnalysisBase, exponential_decay_avg
 
@@ -16,9 +18,15 @@ from ._base import PatchPipetteState, SteadyStateAnalysisBase, exponential_decay
 class WholeCellAnalysis(SteadyStateAnalysisBase):
     """Track a rolling average of access resistance to detect when whole cell access is being lost.
 
-    The whole cell state only *detects* trouble; the actual recovery is delegated to the
-    'clear access' state. This analysis emits a single ``losing_access`` flag that is True once
-    the smoothed access resistance climbs above ``access_resistance_threshold``.
+    The whole cell state only *detects* trouble; recovery is left to the user (who may manually
+    initiate the 'clear access' state). This analysis emits a single ``losing_access`` flag that is
+    True once the smoothed access resistance climbs above ``access_resistance_threshold``.
+
+    Whole cell holds the actual ephys recording, which reserves the clamp/DAQ and suspends test
+    pulses for extended periods. A gap longer than ``max_test_pulse_gap`` is therefore treated as a
+    fresh start: the rolling average is re-seeded and a new detection window begins, so a single
+    stale reading when test pulses resume cannot trip the warning. The flag is only honored once at
+    least ``detection_tau`` of continuous test pulses have accrued since the last (re)start.
     """
 
     @classmethod
@@ -59,10 +67,14 @@ class WholeCellAnalysis(SteadyStateAnalysisBase):
             names = True
         return plots
 
-    def __init__(self, access_resistance_threshold: float, detection_tau: float):
+    def __init__(self, access_resistance_threshold: float, detection_tau: float, max_test_pulse_gap: float):
         super().__init__()
         self._access_resistance_threshold = access_resistance_threshold
         self._detection_tau = detection_tau
+        self._max_test_pulse_gap = max_test_pulse_gap
+        # Start time of the current continuous detection window; reset whenever test pulses resume
+        # after a gap longer than max_test_pulse_gap, so stale pre-gap data is discarded.
+        self._window_start_time = None
 
     def is_losing_access(self) -> bool:
         """Return True if the smoothed access resistance is above threshold."""
@@ -86,12 +98,22 @@ class WholeCellAnalysis(SteadyStateAnalysisBase):
             start_time, access_resistance = measurement
             if self._last_measurement is None:
                 access_avg = access_resistance
+                self._window_start_time = start_time
             else:
                 dt = start_time - self._last_measurement['time']
-                access_avg, _ = exponential_decay_avg(
-                    dt, self._last_measurement['access_avg'], access_resistance, self._detection_tau
-                )
-            losing_access = access_avg > self._access_resistance_threshold
+                if dt > self._max_test_pulse_gap:
+                    # Test pulses resumed after a long gap (e.g. an ephys recording held the
+                    # clamp): drop the stale average and begin a fresh detection window.
+                    access_avg = access_resistance
+                    self._window_start_time = start_time
+                else:
+                    access_avg, _ = exponential_decay_avg(
+                        dt, self._last_measurement['access_avg'], access_resistance, self._detection_tau
+                    )
+            # Only honor the flag once the window has filled, so a single reading after a gap or
+            # at startup can't trip it before the rolling average is meaningful.
+            settled = (start_time - self._window_start_time) >= self._detection_tau
+            losing_access = settled and access_avg > self._access_resistance_threshold
             ret_array[i] = (start_time, access_resistance, access_avg, losing_access)
             self._last_measurement = ret_array[i]
         return ret_array
@@ -104,23 +126,26 @@ class WholeCellState(PatchPipetteState):
 
     Holds the whole cell recording and monitors access resistance (Ra). When Ra climbs past
     ``accessResistanceThreshold`` for long enough (smoothed over ``detectionTau``) the cell is
-    starting to be lost, and the state hands off to ``troubleState`` (default 'clear access')
-    to attempt recovery. Set ``monitorAccessResistance`` to False to disable the handoff and
-    simply hold the recording.
+    starting to be lost. The state does not switch away on its own; it raises a passive warning on
+    the device (shown with a red border in the MultiPatch window) so the user can decide whether to
+    manually initiate the 'clear access' state. The warning clears automatically if Ra falls back
+    below the threshold. Set ``monitorAccessResistance`` to False to disable monitoring entirely
+    and simply hold the recording.
 
     Parameters
     ----------
     monitorAccessResistance : bool
-        If True (default), monitor access resistance and transition to ``troubleState`` when it
-        climbs past ``accessResistanceThreshold``.
+        If True (default), monitor access resistance and raise a UI warning when it climbs past
+        ``accessResistanceThreshold``.
     accessResistanceThreshold : float
         Access resistance (Ohms) above which (smoothed over ``detectionTau``) the cell is
         considered to be losing access (default 30 MΩ).
     detectionTau : float
         Time constant (seconds) for smoothing the access resistance measurement (default 5 s).
-    troubleState : str
-        Name of the state to transition to when access resistance climbs too high
-        (default 'clear access').
+    maxTestPulseGap : float
+        Gap (seconds) between test pulses beyond which monitoring restarts with a fresh detection
+        window, so a long pause (e.g. during an ephys recording that reserves the clamp) does not
+        leave stale data that trips the warning when test pulses resume (default 5 s).
     """
     stateName = 'whole cell'
     _parameterDefaultOverrides = {
@@ -135,12 +160,13 @@ class WholeCellState(PatchPipetteState):
         'monitorAccessResistance': {'type': 'bool', 'default': True},
         'accessResistanceThreshold': {'type': 'float', 'default': 30e6, 'suffix': 'Ω'},
         'detectionTau': {'type': 'float', 'default': 5, 'suffix': 's'},
-        'troubleState': {'type': 'str', 'default': 'clear access'},
+        'maxTestPulseGap': {'type': 'float', 'default': 5, 'suffix': 's'},
     }
 
     def __init__(self, *args, **kwds):
         super().__init__(*args, **kwds)
         self._analysis = None
+        self._warningActive = False
 
     def run(self):
         patchrec = self.dev.patchRecord()
@@ -153,25 +179,45 @@ class WholeCellState(PatchPipetteState):
             while True:
                 self.sleep(0.1)
 
+        self.dev.setAccessWarning(False)  # clear any stale warning when (re)entering whole cell
         self.monitorTestPulse()
         self._analysis = WholeCellAnalysis(
             access_resistance_threshold=self.config['accessResistanceThreshold'],
             detection_tau=self.config['detectionTau'],
+            max_test_pulse_gap=self.config['maxTestPulseGap'],
         )
         while True:
             self.checkStop()
             tps = self.getTestPulses(timeout=0.2)
             if len(tps) == 0:
                 continue
-            self._analysis.process_test_pulses(tps)
-            if self._analysis.is_losing_access():
-                self.setState(
-                    f"access resistance climbed above `accessResistanceThreshold` "
-                    f"({self.config['accessResistanceThreshold'] / 1e6:.1f}MΩ); attempting recovery"
-                )
-                return {"state": self.config['troubleState']}
+            self.updateAccessWarning(tps)
+
+    def updateAccessWarning(self, tps):
+        """Update the device's access-resistance warning from the latest test pulses.
+
+        Whole cell stays put either way; the warning is purely advisory so the user can choose to
+        manually initiate 'clear access'. The warning clears itself once Ra recovers.
+        """
+        self._analysis.process_test_pulses(tps)
+        losing = self._analysis.is_losing_access()
+        if losing and not self._warningActive:
+            self._warningActive = True
+            message = (
+                f"access resistance climbed above `accessResistanceThreshold` "
+                f"({self.config['accessResistanceThreshold'] / 1e6:.1f}MΩ); "
+                f"consider manually initiating 'clear access'"
+            )
+            self.setState(message)
+            self.dev.setAccessWarning(True, message)
+        elif not losing and self._warningActive:
+            self._warningActive = False
+            self.setState("access resistance recovered")
+            self.dev.setAccessWarning(False)
 
     def _cleanup(self):
         patchrec = self.dev.patchRecord()
         patchrec['wholeCellStopTime'] = ptime.time()
+        with log_and_ignore_exception(Exception, "Error clearing access warning after whole cell"):
+            self.dev.setAccessWarning(False)
         return super()._cleanup()

--- a/acq4/devices/PatchPipette/states/whole_cell.py
+++ b/acq4/devices/PatchPipette/states/whole_cell.py
@@ -1,10 +1,127 @@
+"""Whole cell patch state: hold the recording and watch for access resistance climbing.
+
+When the access resistance (Ra) rises past a threshold the cell is starting to be lost, so
+this state hands off the repair work to the 'clear access' state rather than fixing it here.
+"""
 from __future__ import annotations
 
+import numpy as np
+
+import pyqtgraph as pg
 from acq4.util import ptime
-from ._base import PatchPipetteState
+from acq4.util.functions import plottable_booleans
+from ._base import PatchPipetteState, SteadyStateAnalysisBase, exponential_decay_avg
+
+
+class WholeCellAnalysis(SteadyStateAnalysisBase):
+    """Track a rolling average of access resistance to detect when whole cell access is being lost.
+
+    The whole cell state only *detects* trouble; the actual recovery is delegated to the
+    'clear access' state. This analysis emits a single ``losing_access`` flag that is True once
+    the smoothed access resistance climbs above ``access_resistance_threshold``.
+    """
+
+    @classmethod
+    def plot_items(cls, *args, **kwargs):
+        representative = cls(*args, **kwargs)
+        return {
+            'Ω': [
+                pg.InfiniteLine(
+                    movable=False, pos=representative._access_resistance_threshold, angle=0, pen=pg.mkPen('w')
+                ),
+            ]
+        }
+
+    @classmethod
+    def plots_for_data(cls, data, *args, **kwargs):
+        plots = {'Ω': [], '': []}
+        names = False
+        for d in data:
+            analyzer = cls(*args, **kwargs)
+            analysis = analyzer.process_measurements(d)
+            plots['Ω'].append(
+                dict(
+                    x=analysis["time"],
+                    y=analysis["access_avg"],
+                    pen=pg.mkPen('b'),
+                    name=None if names else 'Access Avg',
+                )
+            )
+            plots[''].append(
+                dict(
+                    x=analysis["time"],
+                    y=plottable_booleans(analysis["losing_access"]),
+                    pen=pg.mkPen('r'),
+                    symbol='x',
+                    name=None if names else 'Losing Access',
+                )
+            )
+            names = True
+        return plots
+
+    def __init__(self, access_resistance_threshold: float, detection_tau: float):
+        super().__init__()
+        self._access_resistance_threshold = access_resistance_threshold
+        self._detection_tau = detection_tau
+
+    def is_losing_access(self) -> bool:
+        """Return True if the smoothed access resistance is above threshold."""
+        return bool(self._last_measurement is not None and self._last_measurement['losing_access'])
+
+    def process_test_pulses(self, tps) -> np.ndarray:
+        return self.process_measurements(
+            np.array([(tp.recording.start_time, tp.analysis['access_resistance']) for tp in tps]))
+
+    def process_measurements(self, measurements: np.ndarray) -> np.ndarray:
+        ret_array = np.zeros(
+            len(measurements),
+            dtype=[
+                ('time', float),
+                ('access_resistance', float),
+                ('access_avg', float),
+                ('losing_access', bool),
+            ],
+        )
+        for i, measurement in enumerate(measurements):
+            start_time, access_resistance = measurement
+            if self._last_measurement is None:
+                access_avg = access_resistance
+            else:
+                dt = start_time - self._last_measurement['time']
+                access_avg, _ = exponential_decay_avg(
+                    dt, self._last_measurement['access_avg'], access_resistance, self._detection_tau
+                )
+            losing_access = access_avg > self._access_resistance_threshold
+            ret_array[i] = (start_time, access_resistance, access_avg, losing_access)
+            self._last_measurement = ret_array[i]
+        return ret_array
 
 
 class WholeCellState(PatchPipetteState):
+    """Pipette in whole cell configuration.
+
+    State name: "whole cell"
+
+    Holds the whole cell recording and monitors access resistance (Ra). When Ra climbs past
+    ``accessResistanceThreshold`` for long enough (smoothed over ``detectionTau``) the cell is
+    starting to be lost, and the state hands off to ``troubleState`` (default 'clear access')
+    to attempt recovery. Set ``monitorAccessResistance`` to False to disable the handoff and
+    simply hold the recording.
+
+    Parameters
+    ----------
+    monitorAccessResistance : bool
+        If True (default), monitor access resistance and transition to ``troubleState`` when it
+        climbs past ``accessResistanceThreshold``.
+    accessResistanceThreshold : float
+        Access resistance (Ohms) above which (smoothed over ``detectionTau``) the cell is
+        considered to be losing access (default 30 MΩ).
+    detectionTau : float
+        Time constant (seconds) for smoothing the access resistance measurement (default 5 s).
+    troubleState : str
+        Name of the state to transition to when access resistance climbs too high
+        (default 'clear access').
+    """
     stateName = 'whole cell'
     _parameterDefaultOverrides = {
         'initialPressureSource': 'atmosphere',
@@ -14,6 +131,16 @@ class WholeCellState(PatchPipetteState):
         'initialAutoBiasEnable': True,
         'initialAutoBiasTarget': -70e-3,
     }
+    _parameterTreeConfig = {
+        'monitorAccessResistance': {'type': 'bool', 'default': True},
+        'accessResistanceThreshold': {'type': 'float', 'default': 30e6, 'suffix': 'Ω'},
+        'detectionTau': {'type': 'float', 'default': 5, 'suffix': 's'},
+        'troubleState': {'type': 'str', 'default': 'clear access'},
+    }
+
+    def __init__(self, *args, **kwds):
+        super().__init__(*args, **kwds)
+        self._analysis = None
 
     def run(self):
         patchrec = self.dev.patchRecord()
@@ -22,9 +149,27 @@ class WholeCellState(PatchPipetteState):
 
         # TODO: Option to switch to I=0 for a few seconds to get initial RMP decay
 
+        if not self.config['monitorAccessResistance']:
+            while True:
+                self.sleep(0.1)
+
+        self.monitorTestPulse()
+        self._analysis = WholeCellAnalysis(
+            access_resistance_threshold=self.config['accessResistanceThreshold'],
+            detection_tau=self.config['detectionTau'],
+        )
         while True:
-            # TODO: monitor for cell loss
-            self.sleep(0.1)
+            self.checkStop()
+            tps = self.getTestPulses(timeout=0.2)
+            if len(tps) == 0:
+                continue
+            self._analysis.process_test_pulses(tps)
+            if self._analysis.is_losing_access():
+                self.setState(
+                    f"access resistance climbed above `accessResistanceThreshold` "
+                    f"({self.config['accessResistanceThreshold'] / 1e6:.1f}MΩ); attempting recovery"
+                )
+                return {"state": self.config['troubleState']}
 
     def _cleanup(self):
         patchrec = self.dev.patchRecord()

--- a/acq4/devices/PatchPipette/tests/test_clear_access_analysis.py
+++ b/acq4/devices/PatchPipette/tests/test_clear_access_analysis.py
@@ -102,6 +102,28 @@ def test_collapsing_input_resistance_is_cell_loss():
     assert analysis.cell_lost()
 
 
+def test_brief_low_input_resistance_does_not_immediately_lose():
+    """A low Ri reading on entry must not trip loss before one repair tau of data has accrued."""
+    analysis = _default_analysis(repair_tau=10.0)
+    # Ri sits below the loss floor, but only a few seconds of data (< repair_tau) so far.
+    times = np.arange(0, 5, 0.5)  # 0..4.5s, well under the 10s repair tau
+    ra = np.full(len(times), 80e6)
+    ri = np.full(len(times), 20e6)
+    analysis.process_measurements(_measurements(times, ra, ri))
+    assert not analysis.cell_lost()
+
+
+def test_recovery_is_blocked_while_cell_is_lost():
+    """Ra dropping back down must not count as recovery if Ri has collapsed (cell lost wins)."""
+    analysis = _default_analysis(repair_tau=10.0)
+    times = np.arange(0, 20, 0.5)  # long enough to pass the loss delay
+    ra = np.full(len(times), 10e6)  # below the recovered threshold
+    ri = np.full(len(times), 20e6)  # below the loss floor
+    analysis.process_measurements(_measurements(times, ra, ri))
+    assert analysis.cell_lost()
+    assert not analysis.access_recovered()
+
+
 def test_process_test_pulses_reads_ra_and_ri():
     analysis = _default_analysis()
     tps = [

--- a/acq4/devices/PatchPipette/tests/test_clear_access_analysis.py
+++ b/acq4/devices/PatchPipette/tests/test_clear_access_analysis.py
@@ -1,0 +1,120 @@
+"""Unit tests for ClearAccessAnalysis, the recovery monitor used by the clear access state.
+
+The clear access state applies recovery pulses (and optional zaps) to drop a climbing access
+resistance back down. This analysis owns the decisions the state acts on:
+ - access recovered (Ra back below threshold -> success, return to whole cell)
+ - repairing (Ri declining -> pause pulsing until the membrane recovers)
+ - cell lost (Ri collapsed below floor -> give up, go to fouled)
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from acq4.devices.PatchPipette.states.clear_access import ClearAccessAnalysis
+
+
+class _FakeTestPulse:
+    """Minimal stand-in for neuroanalysis PatchClampTestPulse with just the fields we read."""
+
+    def __init__(self, start_time, access_resistance, input_resistance):
+        self.recording = type("rec", (), {"start_time": start_time})()
+        self.analysis = {
+            "access_resistance": access_resistance,
+            "input_resistance": input_resistance,
+        }
+
+
+def _measurements(times, ra, ri):
+    return np.array(list(zip(times, ra, ri)), dtype=float)
+
+
+def _default_analysis(**overrides):
+    kwargs = dict(
+        access_recovered_threshold=25e6,
+        input_resistance_loss_threshold=50e6,
+        input_resistance_decline_threshold=-0.01,
+        detection_tau=1.0,
+        repair_tau=10.0,
+    )
+    kwargs.update(overrides)
+    return ClearAccessAnalysis(**kwargs)
+
+
+def test_access_recovery_is_detected():
+    """Ra falling back below the recovered threshold (with healthy Ri) is a success."""
+    analysis = _default_analysis()
+    times = np.arange(0, 20, 0.5)
+    ra = np.linspace(50e6, 10e6, len(times))
+    ri = np.full(len(times), 300e6)
+    result = analysis.process_measurements(_measurements(times, ra, ri))
+    assert not result["recovered"][0]
+    assert analysis.access_recovered()
+    assert not analysis.cell_lost()
+    assert not analysis.is_repairing()
+
+
+def test_healthy_but_high_access_needs_more_pulses():
+    """Steady high Ra with healthy Ri: not recovered, not lost, not repairing (keep pulsing)."""
+    analysis = _default_analysis()
+    times = np.arange(0, 20, 0.5)
+    ra = np.full(len(times), 80e6)
+    ri = np.full(len(times), 300e6)
+    analysis.process_measurements(_measurements(times, ra, ri))
+    assert not analysis.access_recovered()
+    assert not analysis.cell_lost()
+    assert not analysis.is_repairing()
+
+
+def test_declining_input_resistance_triggers_repair_pause():
+    """A steadily dropping Ri should flag repairing so the state pauses pulsing."""
+    analysis = _default_analysis()
+    times = np.arange(0, 10, 0.5)
+    ra = np.full(len(times), 80e6)  # still high, not recovered
+    # ~3% drop per sample stays comfortably above the loss floor but well past the decline threshold.
+    ri = 300e6 * (0.97 ** np.arange(len(times)))
+    result = analysis.process_measurements(_measurements(times, ra, ri))
+    assert result["repairing"][-1]
+    assert analysis.is_repairing()
+    assert not analysis.cell_lost()
+
+
+def test_recovered_input_resistance_clears_repair_pause():
+    """Once Ri stops falling and holds steady, repairing should clear."""
+    analysis = _default_analysis()
+    # First a decline, then a long steady plateau at the last declined value.
+    decline = 300e6 * (0.97 ** np.arange(20))
+    ri = np.concatenate([decline, np.full(20, decline[-1])])
+    times = np.arange(0, len(ri) * 0.5, 0.5)
+    ra = np.full(len(ri), 80e6)
+    analysis.process_measurements(_measurements(times, ra, ri))
+    assert not analysis.is_repairing()
+
+
+def test_collapsing_input_resistance_is_cell_loss():
+    """Ri collapsing below the loss floor (and staying there) means the cell is gone."""
+    analysis = _default_analysis()
+    # Drop quickly to 20 MOhm then hold there for ~2 repair time constants.
+    ri = np.concatenate([np.linspace(300e6, 20e6, 20), np.full(40, 20e6)])
+    times = np.arange(0, len(ri) * 0.5, 0.5)
+    ra = np.full(len(ri), 80e6)
+    analysis.process_measurements(_measurements(times, ra, ri))
+    assert analysis.cell_lost()
+
+
+def test_process_test_pulses_reads_ra_and_ri():
+    analysis = _default_analysis()
+    tps = [
+        _FakeTestPulse(0.0, 40e6, 300e6),
+        _FakeTestPulse(0.5, 35e6, 290e6),
+    ]
+    result = analysis.process_test_pulses(tps)
+    assert result["access_resistance"][0] == pytest.approx(40e6)
+    assert result["input_resistance"][1] == pytest.approx(290e6)
+
+
+def test_flags_default_false_before_any_data():
+    analysis = _default_analysis()
+    assert not analysis.access_recovered()
+    assert not analysis.is_repairing()
+    assert not analysis.cell_lost()

--- a/acq4/devices/PatchPipette/tests/test_clear_access_state.py
+++ b/acq4/devices/PatchPipette/tests/test_clear_access_state.py
@@ -109,8 +109,10 @@ def test_clear_access_fouls_when_cell_is_lost(dev):
         accessRecoveredThreshold=25e6, inputResistanceLossThreshold=50e6,
         detectionTau=1.0, repairTau=10.0, fallbackState='fouled',
     )
-    # Access still high (not recovered), input resistance collapsed -> cell lost.
-    state.testPulseResults.put(_FakeTestPulse(0.0, 80e6, input_resistance=20e6))
+    # Access still high (not recovered) while input resistance collapses and stays down past one
+    # repair tau -> cell lost. A single low reading is intentionally not enough (see analysis tests).
+    for i in range(30):  # 15s of data at 0.5s spacing, well past the 10s repair tau
+        state.testPulseResults.put(_FakeTestPulse(i * 0.5, 80e6, input_resistance=20e6))
     result = state.run()
     assert result == {"state": "fouled"}
     assert dev.patchRecord()['clearAccessSuccessful'] is False

--- a/acq4/devices/PatchPipette/tests/test_clear_access_state.py
+++ b/acq4/devices/PatchPipette/tests/test_clear_access_state.py
@@ -1,15 +1,15 @@
-"""Integration tests for the whole cell -> clear access -> (whole cell | fouled) state wiring.
+"""Integration tests for the whole cell warning and clear access -> (whole cell | fouled) wiring.
 
-These drive the real state ``run()`` methods against a lightweight fake device, feeding test
-pulses through the state's queue and asserting on the returned next-state transition. They cover
-the state machine glue; the rolling-average decision logic itself is unit tested separately.
+These drive the real state logic against a lightweight fake device, feeding test pulses through the
+state's queue and asserting on the resulting warning or next-state transition. They cover the state
+machine glue; the rolling-average decision logic itself is unit tested separately.
 """
 from __future__ import annotations
 
 import numpy as np
 import pytest
 
-from acq4.devices.PatchPipette.states.whole_cell import WholeCellState
+from acq4.devices.PatchPipette.states.whole_cell import WholeCellAnalysis, WholeCellState
 from acq4.devices.PatchPipette.states.clear_access import ClearAccessState
 
 
@@ -54,9 +54,13 @@ class _FakeDev:
         self.pressureDevice = _FakePressure()
         self.pipetteDevice = _FakePipette()
         self._patchrec = {}
+        self.accessWarnings = []
 
     def patchRecord(self):
         return self._patchrec
+
+    def setAccessWarning(self, active, message=""):
+        self.accessWarnings.append((bool(active), message))
 
 
 class _FakeTestPulse:
@@ -79,16 +83,45 @@ def dev(qapp):
     return _FakeDev()
 
 
-def test_whole_cell_hands_off_to_clear_access_when_access_climbs(dev):
-    state = _make_state(
-        WholeCellState, dev,
-        accessResistanceThreshold=30e6, detectionTau=1.0, troubleState='clear access',
+def _wholeCellMonitor(dev, **config):
+    """Build a WholeCellState wired with its analysis the way run() does, ready for
+    updateAccessWarning() without entering the infinite hold loop."""
+    config.setdefault('accessResistanceThreshold', 30e6)
+    config.setdefault('detectionTau', 1.0)
+    config.setdefault('maxTestPulseGap', 5.0)
+    state = _make_state(WholeCellState, dev, **config)
+    state._analysis = WholeCellAnalysis(
+        access_resistance_threshold=config['accessResistanceThreshold'],
+        detection_tau=config['detectionTau'],
+        max_test_pulse_gap=config['maxTestPulseGap'],
     )
+    state._warningActive = False
+    return state
+
+
+def test_whole_cell_warns_but_does_not_switch_when_access_climbs(dev):
+    state = _wholeCellMonitor(dev)
     # A ramp of rising access resistance ending well above threshold.
-    for i, ra in enumerate(np.linspace(10e6, 80e6, 30)):
-        state.testPulseResults.put(_FakeTestPulse(i * 0.5, ra))
-    result = state.run()
-    assert result == {"state": "clear access"}
+    tps = [_FakeTestPulse(i * 0.5, ra) for i, ra in enumerate(np.linspace(10e6, 80e6, 30))]
+    result = state.updateAccessWarning(tps)
+    # Whole cell stays put (no state transition) and raises a warning instead.
+    assert result is None
+    assert state._warningActive
+    active, message = dev.accessWarnings[-1]
+    assert active is True
+    assert "clear access" in message
+
+
+def test_whole_cell_warning_clears_when_access_recovers(dev):
+    state = _wholeCellMonitor(dev)
+    # Climb past threshold -> warn.
+    state.updateAccessWarning([_FakeTestPulse(i * 0.5, ra) for i, ra in enumerate(np.linspace(10e6, 80e6, 30))])
+    assert dev.accessWarnings[-1][0] is True
+    assert state._warningActive
+    # Then Ra falls back down -> the warning clears on its own.
+    state.updateAccessWarning([_FakeTestPulse(15.0 + i * 0.5, 10e6) for i in range(30)])
+    assert dev.accessWarnings[-1][0] is False
+    assert not state._warningActive
 
 
 def test_clear_access_returns_to_whole_cell_on_recovery(dev):

--- a/acq4/devices/PatchPipette/tests/test_clear_access_state.py
+++ b/acq4/devices/PatchPipette/tests/test_clear_access_state.py
@@ -1,0 +1,116 @@
+"""Integration tests for the whole cell -> clear access -> (whole cell | fouled) state wiring.
+
+These drive the real state ``run()`` methods against a lightweight fake device, feeding test
+pulses through the state's queue and asserting on the returned next-state transition. They cover
+the state machine glue; the rolling-average decision logic itself is unit tested separately.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from acq4.devices.PatchPipette.states.whole_cell import WholeCellState
+from acq4.devices.PatchPipette.states.clear_access import ClearAccessState
+
+
+class _FakeSignal:
+    def connect(self, *args, **kwargs):
+        pass
+
+    def disconnect(self, *args, **kwargs):
+        pass
+
+    def emit(self, *args, **kwargs):
+        pass
+
+
+class _FakeClamp:
+    def __init__(self):
+        self.sigTestPulseFinished = _FakeSignal()
+        self.zaps = []
+
+    def zap(self, **kwargs):
+        self.zaps.append(kwargs)
+
+
+class _FakePressure:
+    def __init__(self):
+        self.calls = []
+
+    def setPressure(self, **kwargs):
+        self.calls.append(kwargs)
+
+
+class _FakePipette:
+    def globalPosition(self):
+        return (0.0, 0.0, 0.0)
+
+
+class _FakeDev:
+    def __init__(self):
+        self.active = True
+        self.sigTargetChanged = _FakeSignal()
+        self.clampDevice = _FakeClamp()
+        self.pressureDevice = _FakePressure()
+        self.pipetteDevice = _FakePipette()
+        self._patchrec = {}
+
+    def patchRecord(self):
+        return self._patchrec
+
+
+class _FakeTestPulse:
+    def __init__(self, start_time, access_resistance, input_resistance=300e6):
+        self.recording = type("rec", (), {"start_time": start_time})()
+        self.analysis = {
+            "access_resistance": access_resistance,
+            "input_resistance": input_resistance,
+        }
+
+
+def _make_state(cls, dev, **config):
+    # Skip the base initializePressure/initializeClamp (hardware) and drive run() directly.
+    return cls(dev, config=config)
+
+
+@pytest.fixture
+def dev(qapp):
+    # qapp ensures a QApplication exists for the QObject-based Future base class.
+    return _FakeDev()
+
+
+def test_whole_cell_hands_off_to_clear_access_when_access_climbs(dev):
+    state = _make_state(
+        WholeCellState, dev,
+        accessResistanceThreshold=30e6, detectionTau=1.0, troubleState='clear access',
+    )
+    # A ramp of rising access resistance ending well above threshold.
+    for i, ra in enumerate(np.linspace(10e6, 80e6, 30)):
+        state.testPulseResults.put(_FakeTestPulse(i * 0.5, ra))
+    result = state.run()
+    assert result == {"state": "clear access"}
+
+
+def test_clear_access_returns_to_whole_cell_on_recovery(dev):
+    state = _make_state(
+        ClearAccessState, dev,
+        accessRecoveredThreshold=25e6, detectionTau=1.0,
+    )
+    # Access already back down, input resistance healthy -> immediate success.
+    state.testPulseResults.put(_FakeTestPulse(0.0, 10e6, input_resistance=300e6))
+    result = state.run()
+    assert result == {"state": "whole cell"}
+    assert dev.patchRecord()['clearAccessSuccessful'] is True
+
+
+def test_clear_access_fouls_when_cell_is_lost(dev):
+    state = _make_state(
+        ClearAccessState, dev,
+        accessRecoveredThreshold=25e6, inputResistanceLossThreshold=50e6,
+        detectionTau=1.0, repairTau=10.0, fallbackState='fouled',
+    )
+    # Access still high (not recovered), input resistance collapsed -> cell lost.
+    state.testPulseResults.put(_FakeTestPulse(0.0, 80e6, input_resistance=20e6))
+    result = state.run()
+    assert result == {"state": "fouled"}
+    assert dev.patchRecord()['clearAccessSuccessful'] is False

--- a/acq4/devices/PatchPipette/tests/test_whole_cell_analysis.py
+++ b/acq4/devices/PatchPipette/tests/test_whole_cell_analysis.py
@@ -1,0 +1,71 @@
+"""Unit tests for WholeCellAnalysis, the access-resistance monitor used by the whole cell state.
+
+These tests exercise the pure rolling-average logic that decides when the whole cell
+state is "losing access" and should hand off to the clear access state.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from acq4.devices.PatchPipette.states.whole_cell import WholeCellAnalysis
+
+
+class _FakeTestPulse:
+    """Minimal stand-in for neuroanalysis PatchClampTestPulse with just the fields we read."""
+
+    def __init__(self, start_time, access_resistance):
+        self.recording = type("rec", (), {"start_time": start_time})()
+        self.analysis = {"access_resistance": access_resistance}
+
+
+def _ramp(times, values):
+    return np.array(list(zip(times, values)), dtype=float)
+
+
+def test_stable_low_access_is_not_losing():
+    """A cell with steady, low Ra should never be flagged as losing access."""
+    analysis = WholeCellAnalysis(access_resistance_threshold=30e6, detection_tau=1.0)
+    times = np.arange(0, 10, 0.5)
+    measurements = _ramp(times, np.full(len(times), 10e6))
+    result = analysis.process_measurements(measurements)
+    assert not result["losing_access"].any()
+    assert not analysis.is_losing_access()
+
+
+def test_rising_access_eventually_flags():
+    """Ra climbing well past the threshold should eventually flag losing access."""
+    analysis = WholeCellAnalysis(access_resistance_threshold=30e6, detection_tau=1.0)
+    times = np.arange(0, 20, 0.5)
+    values = np.linspace(10e6, 80e6, len(times))
+    result = analysis.process_measurements(_ramp(times, values))
+    # Early on it is fine, by the end it is clearly losing access.
+    assert not result["losing_access"][0]
+    assert result["losing_access"][-1]
+    assert analysis.is_losing_access()
+
+
+def test_brief_spike_is_smoothed_out():
+    """A single Ra spike should not trip the detector when tau is large."""
+    analysis = WholeCellAnalysis(access_resistance_threshold=30e6, detection_tau=10.0)
+    times = np.arange(0, 5, 0.5)
+    values = np.full(len(times), 10e6)
+    values[3] = 200e6  # one-sample artifact
+    result = analysis.process_measurements(_ramp(times, values))
+    assert not result["losing_access"].any()
+    assert not analysis.is_losing_access()
+
+
+def test_process_test_pulses_reads_access_resistance():
+    """process_test_pulses should pull Ra (access_resistance) out of test pulse analysis."""
+    analysis = WholeCellAnalysis(access_resistance_threshold=30e6, detection_tau=1.0)
+    tps = [_FakeTestPulse(0.0, 10e6), _FakeTestPulse(0.5, 12e6)]
+    result = analysis.process_test_pulses(tps)
+    assert result["access_resistance"][0] == pytest.approx(10e6)
+    assert result["access_resistance"][1] == pytest.approx(12e6)
+
+
+def test_no_measurements_means_no_loss():
+    """Before any data arrives, the detector must not claim loss of access."""
+    analysis = WholeCellAnalysis(access_resistance_threshold=30e6, detection_tau=1.0)
+    assert not analysis.is_losing_access()

--- a/acq4/devices/PatchPipette/tests/test_whole_cell_analysis.py
+++ b/acq4/devices/PatchPipette/tests/test_whole_cell_analysis.py
@@ -1,7 +1,7 @@
 """Unit tests for WholeCellAnalysis, the access-resistance monitor used by the whole cell state.
 
-These tests exercise the pure rolling-average logic that decides when the whole cell
-state is "losing access" and should hand off to the clear access state.
+These tests exercise the pure rolling-average logic that decides when the whole cell state is
+"losing access" and should raise a UI warning so the user can manually initiate 'clear access'.
 """
 from __future__ import annotations
 
@@ -23,9 +23,17 @@ def _ramp(times, values):
     return np.array(list(zip(times, values)), dtype=float)
 
 
+def _analysis(**overrides):
+    # max_test_pulse_gap defaults large so plain ramps aren't treated as gapped unless a test
+    # explicitly exercises gap handling.
+    kwargs = dict(access_resistance_threshold=30e6, detection_tau=1.0, max_test_pulse_gap=1e9)
+    kwargs.update(overrides)
+    return WholeCellAnalysis(**kwargs)
+
+
 def test_stable_low_access_is_not_losing():
     """A cell with steady, low Ra should never be flagged as losing access."""
-    analysis = WholeCellAnalysis(access_resistance_threshold=30e6, detection_tau=1.0)
+    analysis = _analysis()
     times = np.arange(0, 10, 0.5)
     measurements = _ramp(times, np.full(len(times), 10e6))
     result = analysis.process_measurements(measurements)
@@ -35,7 +43,7 @@ def test_stable_low_access_is_not_losing():
 
 def test_rising_access_eventually_flags():
     """Ra climbing well past the threshold should eventually flag losing access."""
-    analysis = WholeCellAnalysis(access_resistance_threshold=30e6, detection_tau=1.0)
+    analysis = _analysis()
     times = np.arange(0, 20, 0.5)
     values = np.linspace(10e6, 80e6, len(times))
     result = analysis.process_measurements(_ramp(times, values))
@@ -47,8 +55,8 @@ def test_rising_access_eventually_flags():
 
 def test_brief_spike_is_smoothed_out():
     """A single Ra spike should not trip the detector when tau is large."""
-    analysis = WholeCellAnalysis(access_resistance_threshold=30e6, detection_tau=10.0)
-    times = np.arange(0, 5, 0.5)
+    analysis = _analysis(detection_tau=10.0)
+    times = np.arange(0, 20, 0.5)  # long enough that the detection window has settled
     values = np.full(len(times), 10e6)
     values[3] = 200e6  # one-sample artifact
     result = analysis.process_measurements(_ramp(times, values))
@@ -56,9 +64,23 @@ def test_brief_spike_is_smoothed_out():
     assert not analysis.is_losing_access()
 
 
+def test_long_gap_restarts_detection_window():
+    """A long pause (ephys held the clamp) must not let a stale reading trip the warning."""
+    analysis = _analysis(detection_tau=1.0, max_test_pulse_gap=3.0)
+    # Healthy run, then test pulses stop for ~60s while a recording reserves the clamp.
+    analysis.process_measurements(_ramp(np.arange(0, 5, 0.5), np.full(10, 10e6)))
+    assert not analysis.is_losing_access()
+    # First reading after the gap is high, but the window restarts so it must not trip yet.
+    analysis.process_measurements(_ramp([65.0], [80e6]))
+    assert not analysis.is_losing_access()
+    # Only after a fresh detection window of sustained high access does it warn.
+    analysis.process_measurements(_ramp(np.arange(65.5, 70, 0.5), np.full(9, 80e6)))
+    assert analysis.is_losing_access()
+
+
 def test_process_test_pulses_reads_access_resistance():
     """process_test_pulses should pull Ra (access_resistance) out of test pulse analysis."""
-    analysis = WholeCellAnalysis(access_resistance_threshold=30e6, detection_tau=1.0)
+    analysis = _analysis()
     tps = [_FakeTestPulse(0.0, 10e6), _FakeTestPulse(0.5, 12e6)]
     result = analysis.process_test_pulses(tps)
     assert result["access_resistance"][0] == pytest.approx(10e6)
@@ -67,5 +89,5 @@ def test_process_test_pulses_reads_access_resistance():
 
 def test_no_measurements_means_no_loss():
     """Before any data arrives, the detector must not claim loss of access."""
-    analysis = WholeCellAnalysis(access_resistance_threshold=30e6, detection_tau=1.0)
+    analysis = _analysis()
     assert not analysis.is_losing_access()

--- a/acq4/filetypes/MultiPatchLog.py
+++ b/acq4/filetypes/MultiPatchLog.py
@@ -885,6 +885,7 @@ class MultiPatchLogWidget(Qt.QWidget):
             fields=('access_resistance',),
             access_resistance_threshold=config['accessResistanceThreshold'],
             detection_tau=config['detectionTau'],
+            max_test_pulse_gap=config['maxTestPulseGap'],
         )
 
     def _toggleClearAccessAnalysis(self, state: bool):

--- a/acq4/filetypes/MultiPatchLog.py
+++ b/acq4/filetypes/MultiPatchLog.py
@@ -700,6 +700,14 @@ class MultiPatchLogWidget(Qt.QWidget):
         self._displayDetectAnalysis = Qt.QCheckBox('Cell Detect Analysis')
         self._displayDetectAnalysis.toggled.connect(self._toggleDetectAnalysis)
         self._ctrl_layout.addWidget(self._displayDetectAnalysis)
+        self._wholeCellAnalysisItems = {}
+        self._displayWholeCellAnalysis = Qt.QCheckBox('Whole Cell Analysis')
+        self._displayWholeCellAnalysis.toggled.connect(self._toggleWholeCellAnalysis)
+        self._ctrl_layout.addWidget(self._displayWholeCellAnalysis)
+        self._clearAccessAnalysisItems = {}
+        self._displayClearAccessAnalysis = Qt.QCheckBox('Clear Access Analysis')
+        self._displayClearAccessAnalysis.toggled.connect(self._toggleClearAccessAnalysis)
+        self._ctrl_layout.addWidget(self._displayClearAccessAnalysis)
         self._displayFullTestPulse = Qt.QCheckBox('Full Test Pulse Data')
         self._displayFullTestPulse.toggled.connect(self._toggleFullTestPulse)
         self._ctrl_layout.addWidget(self._displayFullTestPulse)
@@ -781,14 +789,17 @@ class MultiPatchLogWidget(Qt.QWidget):
         elif 'Pa' in self._plots_by_units:
             self._plots_by_units['Pa'].hide()
 
-    def _toggleAnalysis(self, cls, analysisItems: dict, state: bool, *args, **kwargs):
+    def _toggleAnalysis(
+        self, cls, analysisItems: dict, state: bool, *args,
+        fields: tuple = ('steady_state_resistance',), **kwargs,
+    ):
         if state:
             for units, items in cls.plot_items(*args, **kwargs).items():
                 plot = self.buildPlotForUnits(units)
                 analysisItems.setdefault(units, []).extend(items)
                 for item in items:
                     plot.addItem(item)
-            measurements = self.testPulseAnalysisDataByState('steady_state_resistance')
+            measurements = self.testPulseAnalysisDataByState(*fields)
             for units, plots in cls.plots_for_data(measurements, *args, **kwargs).items():
                 plot = self.buildPlotForUnits(units)
                 analysisItems.setdefault(units, [])
@@ -863,14 +874,43 @@ class MultiPatchLogWidget(Qt.QWidget):
             break_threshold=config['breakThreshold'],
         )
 
-    def testPulseAnalysisDataByState(self, field: str):
+    def _toggleWholeCellAnalysis(self, state: bool):
+        from acq4.devices.PatchPipette.states import WholeCellAnalysis, WholeCellState
+
+        config = WholeCellState.defaultConfig()
+        self._toggleAnalysis(
+            WholeCellAnalysis,
+            self._wholeCellAnalysisItems,
+            state,
+            fields=('access_resistance',),
+            access_resistance_threshold=config['accessResistanceThreshold'],
+            detection_tau=config['detectionTau'],
+        )
+
+    def _toggleClearAccessAnalysis(self, state: bool):
+        from acq4.devices.PatchPipette.states import ClearAccessAnalysis, ClearAccessState
+
+        config = ClearAccessState.defaultConfig()
+        self._toggleAnalysis(
+            ClearAccessAnalysis,
+            self._clearAccessAnalysisItems,
+            state,
+            fields=('access_resistance', 'input_resistance'),
+            access_recovered_threshold=config['accessRecoveredThreshold'],
+            input_resistance_loss_threshold=config['inputResistanceLossThreshold'],
+            input_resistance_decline_threshold=config['inputResistanceDeclineThreshold'],
+            detection_tau=config['detectionTau'],
+            repair_tau=config['repairTau'],
+        )
+
+    def testPulseAnalysisDataByState(self, *fields: str):
         for data in self._devices.values():
             test_pulses = data.get('test_pulse', np.zeros(0, dtype=TEST_PULSE_NUMPY_DTYPE))
             states = data.get('state', [])
             time = test_pulses['event_time'] - self.startTime()
             if len(time) > 0:
-                measurements = np.concatenate(
-                    (time[:, np.newaxis], test_pulses[field][:, np.newaxis]), axis=1)
+                columns = [time[:, np.newaxis]] + [test_pulses[f][:, np.newaxis] for f in fields]
+                measurements = np.concatenate(columns, axis=1)
                 # break the analysis up by state changes
                 state_times = [s[0] - self.startTime() for s in states if s[2] == '']
                 start_indexes = np.searchsorted(time, state_times)

--- a/acq4/modules/MultiPatch/pipetteControl.py
+++ b/acq4/modules/MultiPatch/pipetteControl.py
@@ -57,6 +57,7 @@ class PipetteControl(Qt.QWidget):
             self.pip.sigNewPipetteRequested.connect(self.newPipetteRequested)
             self.pip.sigTipCleanChanged.connect(self.tipCleanChanged)
             self.pip.sigTipBrokenChanged.connect(self.tipBrokenChanged)
+            self.pip.sigAccessWarningChanged.connect(self.accessWarningChanged)
 
         self.ui.vcHoldingSpin.setOpts(
             bounds=[None, None],
@@ -350,6 +351,11 @@ class PipetteControl(Qt.QWidget):
         with pg.SignalBlock(self.ui.brokenCheck.stateChanged, self.brokenCheckChanged):
             self.ui.brokenCheck.setChecked(broken)
         self.ui.brokenCheck.setStyleSheet("" if not broken else "QCheckBox {border: 2px solid #F00;}")
+
+    def accessWarningChanged(self, pip, active, message):
+        """Whole cell flagged (or cleared) an access-resistance warning; show it on the state field."""
+        self.ui.stateText.setStyleSheet("QLineEdit {border: 2px solid #F00;}" if active else "")
+        self.ui.stateText.setToolTip(message if active else "")
 
     def autoOffsetRequested(self):
         self.pip.clampDevice.autoPipetteOffset()


### PR DESCRIPTION
## Summary

Implements [#414](https://github.com/acq4/acq4/issues/414): whole cell can start losing the cell, at which point it needs to recover access (or give up).

Whole cell now *monitors* a rolling average of access resistance (Ra) and, when it climbs past a threshold, hands off to a new **clear access** state instead of silently holding. Clear access *owns the fix*: it applies escalating negative-pressure pulses (and optional voltage zaps) to re-open access, like a gentle break-in, while watching input resistance (Ri). While Ri is dropping it pauses pulsing until the membrane repairs; if Ri collapses it gives up to a fallback state (default `fouled`). On recovery it returns to `whole cell`.

## Changes

- **`WholeCellState`** — detector only: `WholeCellAnalysis` tracks Ra rolling avg; on sustained `Ra > accessResistanceThreshold` (default 30 MΩ) it transitions to `troubleState` (default `clear access`). New `monitorAccessResistance` toggle (default on) preserves the old hold-forever behavior.
- **`ClearAccessState` + `ClearAccessAnalysis`** (new) — config-driven `nPulses`/`pulseDurations`/`pulsePressures` (like break-in), Ri pause-until-repair, and cell-loss detection. Success → `whole cell`; loss/timeout → `fallbackState` (`fouled`, configurable).
- **`PatchClamp.zap()`** — generic brief voltage pulse via the Task/SquarePulse path. Supported on any clamp but **off by default** (`useZaps=False`).
- Registered the new state in `states/__init__.py` and `statemanager.py`.

## Design notes

Per discussion: detector/fixer split (whole cell detects, clear access fixes), **Ra-only handoff with clear access owning Ri**, a dedicated new `clear access` state, `fouled` on loss, and zaps *supported* but pressure-only by default.

## Tests

- `test_whole_cell_analysis.py` (5) + `test_clear_access_analysis.py` (7): pure rolling-average decision logic (TDD red→green).
- `test_clear_access_state.py` (3): drive the real `run()` loops via a fake device — handoff, recovery, loss.

All 15 pass headless (`QT_QPA_PLATFORM=offscreen`).

## Needs rig verification

`zap()` is hardware-coupled and only smoke-checked headlessly; verify on a real rig before relying on `useZaps=True`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)