### PR TITLE
fix: run moves inline when caller already holds device reservations (#543)

### DIFF
--- a/acq4/Manager.py
+++ b/acq4/Manager.py
@@ -22,7 +22,7 @@ from . import __version__
 from . import modules
 from .Interfaces import InterfaceDirectory
 from .devices import getDeviceClass
-from .devices.Device import Device, DeviceTask, DeviceLocker
+from .devices.Device import Device, DeviceTask, DeviceLocker, get_devices_held_by_thread
 from .logging_config import get_logger, set_log_file
 from .util import DataManager, ptime, Qt
 from .util.DataManager import DirHandle
@@ -481,8 +481,17 @@ class Manager(Qt.QObject):
         """Execute a motion plan for one or more MoveSpec objects.
 
         Returns a Future that resolves when all moves are complete.
+
+        If the calling thread already holds device reservations, the plan is executed
+        inline in this thread rather than on a worker thread. The planner reserves the
+        plan's devices via reserveDevices(); the reservation mutex is recursive only
+        within the holding thread, so a worker thread would block forever waiting on a
+        device this thread already holds (e.g. a focus move inside a z-stack that has
+        reserved the Stage). Running inline re-enters the existing reservation. The
+        returned Future is already resolved in that case.
         """
-        return self.motionPlanner.execute(list(specs), name=name)
+        block = bool(get_devices_held_by_thread())
+        return self.motionPlanner.execute(list(specs), name=name, block=block)
 
     def getOrLoadModule(self, name):
         if name in self.modules:

--- a/acq4/motion/tests/test_move_reservation.py
+++ b/acq4/motion/tests/test_move_reservation.py
@@ -1,0 +1,127 @@
+# Regression tests for Manager.move() under an existing device reservation.
+# Reproduces the nested-move deadlock (acq4/acq4#543): a thread that holds a device
+# reservation issues a move; the planner must re-enter that reservation inline rather
+# than block on a worker thread.
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+import pytest
+
+from acq4.Manager import Manager
+from acq4.devices.Device import Device
+from acq4.motion.plan import AtomicMove, SequentialGroup
+from acq4.motion.planner import MotionPlanner
+from acq4.motion.spec import MoveSpec
+from acq4.util.future import Future
+
+
+class _FakeDM:
+    """Minimal device-manager stub: Device.__init__ only needs declareInterface."""
+
+    def declareInterface(self, name, interfaces, obj):
+        pass
+
+
+class _ReservableDevice(Device):
+    """A real Device (real recursive-mutex reservation machinery) that records the
+    thread each move runs on instead of touching hardware."""
+
+    def __init__(self, dm, name, pos=(0.0, 0.0, 0.0)):
+        Device.__init__(self, dm, {}, name)
+        self._pos = np.asarray(pos, dtype=float)
+        self.move_threads = []
+
+    def globalPosition(self):
+        return self._pos.copy()
+
+    def mapToGlobal(self, local_pos):
+        return np.asarray(local_pos, dtype=float) + self._pos
+
+    def mapFromGlobal(self, global_pos):
+        return np.asarray(global_pos, dtype=float) - self._pos
+
+    def moveToGlobalNoPlanning(self, pos, speed, name=None, **kwargs):
+        self.move_threads.append(threading.current_thread())
+        return Future.immediate()
+
+
+class _TrivialPlanner(MotionPlanner):
+    """Plans each spec as a single AtomicMove to its global target (no geometry)."""
+
+    def plan(self, specs, name=""):
+        steps = [
+            AtomicMove(device=s.device, position=s.position, speed=s.speed, explanation=name or "move")
+            for s in specs
+        ]
+        return steps[0] if len(steps) == 1 else SequentialGroup(steps=steps)
+
+
+class _FakeManager:
+    """Stands in for the real Manager: exposes the real reserveDevices/move and a trivial planner.
+
+    reserveDevices uses a short timeout so that a (buggy) cross-thread reservation
+    attempt fails fast instead of hanging the test for the default 10s.
+    """
+
+    RESERVE_TIMEOUT = 1.0
+
+    def __init__(self, planner, devices):
+        self._planner = planner
+        self._devices = {d.name(): d for d in devices}
+
+    def getDevice(self, name):
+        return self._devices[name]
+
+    def reserveDevices(self, devices, timeout=10.0, reserver=None):
+        # Reuse the real Manager.reserveDevices behaviour but with a short timeout.
+        return Manager.reserveDevices(self, devices, timeout=self.RESERVE_TIMEOUT, reserver=reserver)
+
+    @property
+    def motionPlanner(self):
+        return self._planner
+
+    # The method under test, bound to this stand-in manager.
+    move = Manager.move
+
+
+@pytest.fixture
+def reservation_setup(qtbot, monkeypatch):
+    """A device, a fake manager wired to a trivial planner, with getManager patched."""
+    (qtbot,)  # noqa: F841 -- ensures a QApplication exists for Device's Qt mutex
+    dm = _FakeDM()
+    dev = _ReservableDevice(dm, "stage1")
+    mgr = _FakeManager(_TrivialPlanner(), [dev])
+    # The planner resolves the manager via getManager(); point it at our stand-in.
+    monkeypatch.setattr("acq4.motion.planner.getManager", lambda: mgr)
+    return mgr, dev
+
+
+def test_move_under_held_reservation_runs_inline(reservation_setup):
+    """Regression for #543: moving a device whose reservation this thread already holds
+    must execute inline (re-entering the recursive mutex), not deadlock on a worker thread."""
+    mgr, dev = reservation_setup
+    target = np.array([1.0, 2.0, 3.0])
+    caller_thread = threading.current_thread()
+
+    with mgr.reserveDevices([dev], reserver="run_image_sequence"):
+        fut = mgr.move(MoveSpec(dev, target, speed="fast"))
+        # Already resolved when run inline; would raise TimeoutError before the fix.
+        fut.wait(timeout=5.0)
+
+    assert len(dev.move_threads) == 1
+    assert dev.move_threads[0] is caller_thread, "move should run inline on the reserving thread"
+
+
+def test_move_without_reservation_runs_on_worker_thread(reservation_setup):
+    """When no reservation is held, the move is dispatched to a worker thread as before."""
+    mgr, dev = reservation_setup
+    target = np.array([4.0, 5.0, 6.0])
+    caller_thread = threading.current_thread()
+
+    fut = mgr.move(MoveSpec(dev, target, speed="fast"))
+    fut.wait(timeout=5.0)
+
+    assert len(dev.move_threads) == 1
+    assert dev.move_threads[0] is not caller_thread, "move should run on a worker thread"


### PR DESCRIPTION
## Problem

`run_image_sequence` reserves the Stage on thread A (`with man.reserveDevices(imager.devicesToReserve(), reserver='run_image_sequence')`). A focus move inside the z-stack then routes through `MotionPlanner.execute`, which re-reserves the Stage. Because `execute` is `@future_wrap` it runs on a **worker thread B** by default, and the reservation `Mutex(QMutex.Recursive)` is re-entrant only for the *same* thread — so thread B blocks until timeout:

```
TimeoutError: Timed out waiting for device lock for Stage
  Locked by: run_image_sequence
```

This is independent of the Future/gentletask backend; the deadlock is in the device-locking path itself (see #543).

## Fix

`Manager.move` now detects when the calling thread already holds device reservations (`get_devices_held_by_thread()` non-empty) and runs the plan **inline** (`block=True`) instead of dispatching to a worker thread. Running inline re-enters the existing reservation on the holding thread; the returned `Future` is already resolved.

The decision is made in `Manager.move` (the calling thread) on purpose: `execute` is `@future_wrap`, so by the time its body runs it is already on the worker thread and can no longer observe the caller's locks.

**ParallelGroup sub-moves stay safe**: `_execute_plan` runs them via `moveToGlobalNoPlanning` → `Stage.move()`, which does not reserve devices, so the worker threads it spawns do not contend for the lock held by the inline top-level thread.

## Test

`acq4/motion/tests/test_move_reservation.py` uses real `Device` instances (real recursive-mutex reservation machinery) plus a stand-in manager that reuses the real `Manager.move`/`reserveDevices`:

- `test_move_under_held_reservation_runs_inline` — reserves a device on the main thread, issues a move, asserts it runs inline on the caller's thread. Reverting the fix makes this fail with the exact `TimeoutError` from the issue.
- `test_move_without_reservation_runs_on_worker_thread` — confirms the unchanged worker-thread dispatch when no reservation is held.

Full motion suite: 72 passed.

Fixes #543

🤖 Generated with [Claude Code](https://claude.com/claude-code)