### PR TITLE
fix: exclude InteractionSiteArray from interaction-site detection

### DIFF
--- a/acq4/motion/planner.py
+++ b/acq4/motion/planner.py
@@ -62,10 +62,13 @@ class MotionPlanner:
 
     @staticmethod
     def _is_interaction_site(device) -> bool:
+        # containsPoint distinguishes a single site from an InteractionSiteArray, which shares
+        # the positions/_parentStage attributes but is a container of sites, not a site itself.
         return (
             device is not None
             and hasattr(device, "positions")
             and hasattr(device, "_parentStage")
+            and hasattr(device, "containsPoint")
         )
 
     def _validate_specs(self, specs: list[MoveSpec]) -> None:

--- a/acq4/motion/tests/conftest.py
+++ b/acq4/motion/tests/conftest.py
@@ -110,13 +110,25 @@ class MockInteractionSite(MockDevice):
         global_pos=(0.0, 0.0, 0.0),
         scope_park_pos=None,
         parent_stage=None,
+        radius=1e-3,
+        height=1e-3,
     ):
         super().__init__(name, global_pos)
         self.positions = {}
         self.config = {}
+        self.radius = radius
+        self.height = height
         if scope_park_pos is not None:
             self.config["scopeParkPos"] = np.asarray(scope_park_pos, dtype=float)
         self._parentStage = parent_stage or MockStage(f"{name}_stage", global_pos)
+
+    def containsPoint(self, pt, tolerance=1e-9):
+        """Mirror InteractionSite.containsPoint: True if pt lies within this site's cylinder."""
+        local_pt = self.mapFromGlobal(pt)
+        return (
+            local_pt[0] ** 2 + local_pt[1] ** 2 <= self.radius**2 + tolerance
+            and -tolerance <= local_pt[2] <= self.height + tolerance
+        )
 
     def save_positions_for(self, pip, interact_global):
         """Store the interact position (global) and its site-local equivalent."""
@@ -153,6 +165,31 @@ class MockInteractionSite(MockDevice):
         if "interact local" not in pos_config:
             return None
         return np.asarray(pos_config["interact local"], dtype=float)
+
+
+class MockInteractionSiteArray:
+    """InteractionSiteArray mock: a *container* that manages child sites.
+
+    Mirrors the real array's duck-type surface (positions + _parentStage) but, like the
+    real class, deliberately has no containsPoint -- a pipette interacts with the array's
+    child sites, never with the array itself.
+    """
+
+    def __init__(self, name, sites=None, parent_stage=None):
+        self._name = name
+        self.positions = {}
+        self._parentStage = parent_stage or MockStage(f"{name}_stage")
+        self._sites = list(sites or [])
+
+    def name(self):
+        return self._name
+
+    @property
+    def sites(self):
+        return list(self._sites)
+
+    def getFirstAvailableSite(self):
+        return self._sites[0] if self._sites else None
 
 
 @pytest.fixture

--- a/acq4/motion/tests/test_default_planner.py
+++ b/acq4/motion/tests/test_default_planner.py
@@ -9,7 +9,27 @@ import pytest
 from acq4.motion.plan import AtomicMove, ParallelGroup, SequentialGroup
 from acq4.motion.planner import PlanningError
 from acq4.motion.spec import MoveSpec
-from acq4.motion.tests.conftest import MockDevice, MockInteractionSite, MockPipette, MockScope, MockStage
+from acq4.motion.tests.conftest import (
+    MockDevice,
+    MockInteractionSite,
+    MockInteractionSiteArray,
+    MockPipette,
+    MockScope,
+    MockStage,
+)
+
+
+class _FakeManager:
+    """Minimal Manager stand-in for _find_containing_site: a name->device registry."""
+
+    def __init__(self, devices):
+        self._devices = {d.name(): d for d in devices}
+
+    def listDevices(self):
+        return list(self._devices)
+
+    def getDevice(self, name):
+        return self._devices[name]
 
 
 def make_simplified_planner():
@@ -304,6 +324,49 @@ def test_non_strict_exit_skips_approach_waypoint(pip, site_without_strict_path):
     approach_global = np.array(site_without_strict_path.globalPosition())
     assert not any(np.allclose(m.position, approach_global) for m in pip_moves)
     np.testing.assert_array_almost_equal(pip_moves[-1].position, home_pos)
+
+
+# ---------------------------------------------------------------------------
+# _find_containing_site / _is_interaction_site — InteractionSiteArray must not
+# be mistaken for a single site (it manages child sites and has no containsPoint)
+# ---------------------------------------------------------------------------
+
+def test_is_interaction_site_true_for_single_site(site):
+    """A single InteractionSite (with containsPoint) is an interaction site."""
+    planner = make_simplified_planner()
+    assert planner._is_interaction_site(site) is True
+
+
+def test_is_interaction_site_false_for_site_array():
+    """An InteractionSiteArray container is not itself an interaction site."""
+    planner = make_simplified_planner()
+    array = MockInteractionSiteArray("nucleus_array")
+    assert planner._is_interaction_site(array) is False
+
+
+def test_find_containing_site_ignores_site_array(pip, monkeypatch):
+    """An InteractionSiteArray in the device list must be skipped, not have containsPoint
+    called on it (it has none). The real child site is returned instead."""
+    import acq4.motion.default_planner as dp
+
+    site = MockInteractionSite("cleanwell", global_pos=(0.0, 0.0, 0.0))  # contains pip at origin
+    array = MockInteractionSiteArray("nucleus_array", sites=[site])
+    monkeypatch.setattr(dp, "getManager", lambda: _FakeManager([array, site]))
+
+    planner = make_simplified_planner()
+    assert planner._find_containing_site(pip) is site
+
+
+def test_find_containing_site_returns_none_when_pip_outside(pip, monkeypatch):
+    """No site contains the pip → None (and the array is still skipped without error)."""
+    import acq4.motion.default_planner as dp
+
+    far_site = MockInteractionSite("cleanwell", global_pos=(50e-3, 0.0, 0.0))
+    array = MockInteractionSiteArray("nucleus_array", sites=[far_site])
+    monkeypatch.setattr(dp, "getManager", lambda: _FakeManager([array, far_site]))
+
+    planner = make_simplified_planner()
+    assert planner._find_containing_site(pip) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

A pipette move triggered an unhandled crash:

```
AttributeError: 'InteractionSiteArray' object has no attribute 'containsPoint'
  File "acq4/motion/default_planner.py", line 78, in _find_containing_site
    if self._is_interaction_site(dev) and dev.containsPoint(pip_pos):
```

`MotionPlanner._is_interaction_site()` identified a site by duck-typing on just two attributes:

```python
hasattr(device, "positions") and hasattr(device, "_parentStage")
```

But `InteractionSiteArray.__init__` sets **both** of those, so the array *container* was misclassified as a single site. `_find_containing_site()` iterates every device from the Manager and calls `containsPoint()` on each candidate — the array has no such method (correctly; it manages child sites, it isn't a site itself), so it raised.

## Fix

Require `containsPoint` as the discriminator in `_is_interaction_site()` — that capability is what actually defines "a zone a pipette can be inside." Nothing is lost by skipping the array: its child sites are registered independently (`declareInterface(site_name, ['device', 'interactionSite'], site)`), so `listDevices()` still yields them and they get checked directly.

One-line behavioral change; the shared helper covers all three call sites (`_find_containing_site`, `_plan_one` dispatch, `_validate_*`).

## Tests (TDD)

- Faithful `containsPoint` on `MockInteractionSite` and a new `MockInteractionSiteArray` mock mirroring the real class's deliberate absence of `containsPoint`.
- New tests reproduce the exact production `AttributeError` before the fix, plus `_is_interaction_site` true/false coverage and a "pip outside → None" case.

`pytest acq4/motion/tests/` → 76 passed.

🧙 Built with [WOZCODE](https://wozcode.com)