### PR TITLE
feat(imaging): record sample surface depth in acquired z-stacks

### DIFF
--- a/acq4/util/imaging/sequencer.py
+++ b/acq4/util/imaging/sequencer.py
@@ -443,6 +443,7 @@ def acquire_z_stack(
             with man.reserveDevices(imager.devicesToReserve(), timeout=device_reservation_timeout, reserver="acquire_z_stack"):
                 frames = _stepped_z_stack(imager, start, stop, step, name)
     _fix_frame_transforms(frames, step)
+    stamp_surface_depth(frames, imager.scopeDev.getSurfaceDepth())
     return frames
 
 
@@ -458,6 +459,18 @@ def _fix_frame_transforms(frames, z_step):
         m[:, 2] = z_vector
         xform.matrix = m  # use the setter so the change is stored
         f.addInfo(transform=xform)
+
+
+def stamp_surface_depth(frames: list[Frame], surface_depth: "float | None") -> None:
+    """Record the sample surface depth on every frame's info dict.
+
+    The surface is the plane along which the sample was cut; storing its global z
+    position (meters) in each acquired stack lets downstream analysis compute a
+    feature's depth below the surface. ``surface_depth`` is whatever the
+    microscope currently reports and may be None if no surface has been marked.
+    """
+    for frame in frames:
+        frame.addInfo(surfaceDepth=surface_depth)
 
 
 class ImageSequencerCtrl(Qt.QWidget):

--- a/tests/test_sequencer.py
+++ b/tests/test_sequencer.py
@@ -2,7 +2,7 @@ import pytest
 import numpy as np
 import pyqtgraph as pg
 
-from acq4.util.imaging.sequencer import enforce_linear_z_stack, calculate_hysteresis
+from acq4.util.imaging.sequencer import enforce_linear_z_stack, calculate_hysteresis, stamp_surface_depth
 from coorx import SRT3DTransform
 
 
@@ -375,3 +375,34 @@ def test_calculate_hysteresis_unreasonable_data():
     center = MockFrame(2, data=100)
     with pytest.raises(ValueError, match="Center frame does not match any frame in the stack"):
         calculate_hysteresis(stack, center)
+
+
+class InfoFrame:
+    """Minimal frame stand-in that records info written via addInfo."""
+    def __init__(self):
+        self._info = {}
+
+    def addInfo(self, info=None, **kwargs):
+        if info is not None:
+            self._info.update(info)
+        self._info.update(kwargs)
+
+    def info(self):
+        return self._info
+
+
+def test_stamp_surface_depth_records_value_on_all_frames():
+    frames = [InfoFrame(), InfoFrame(), InfoFrame()]
+    stamp_surface_depth(frames, -1.5e-4)
+    for f in frames:
+        assert f.info()["surfaceDepth"] == -1.5e-4
+
+
+def test_stamp_surface_depth_stores_none_when_unset():
+    frames = [InfoFrame()]
+    stamp_surface_depth(frames, None)
+    assert frames[0].info()["surfaceDepth"] is None
+
+
+def test_stamp_surface_depth_empty_frames_is_noop():
+    stamp_surface_depth([], -1.5e-4)  # must not raise


### PR DESCRIPTION
Stamp the microscope's surface depth (`imager.scopeDev.getSurfaceDepth()`, global z in meters) onto every frame in `acquire_z_stack`, so it persists in each stack's `.index` alongside `pixelSize`/`exposure`. This lets downstream analysis compute a feature's depth below the cut sample surface — a covariate that is currently unrecoverable retrospectively because surface was only ever written to `MultiPatch.log` (not retained with exported stacks).

Covers all z-stack acquisition paths (GUI Image Sequencer + programmatic approach/pipette/autopatch) since they all funnel through `acquire_z_stack`. Value is `None` when no surface has been marked.

Adds 3 unit tests for the new `stamp_surface_depth` helper. Note: 5 pre-existing `test_sequencer.py` failures (in `enforce_linear_z_stack`/`calculate_hysteresis`) are unrelated to this change and fail identically on the `_reviewed` baseline.

🧙 Built with [WOZCODE](https://wozcode.com)