### PR TITLE
feat: scope autopatch analysis to the demo's approached attempts

### DIFF
--- a/tools/autopatch_analysis/README.md
+++ b/tools/autopatch_analysis/README.md
@@ -1,0 +1,51 @@
+# Autopatch demo performance analysis
+
+Tools for analyzing the throughput and efficiency of an extended autopatch demo
+run from its saved `MultiPatch_*.log` files.
+
+## Files
+
+- `autopatch_log.py` — parse one log into per-attempt records; reconstruct the
+  find/seal/break-in funnel from the `state_change` sequence and pull
+  whole-cell quality numbers from `test_pulse` events.
+- `autopatch_metrics.py` — aggregate attempts into funnel / throughput /
+  time-budget / failure-mode / timeline DataFrames.
+- `autopatch_analysis.ipynb` — set `ROOTS`, load a run, and render the graphs.
+- `tests/` — unit tests for the parsing and metrics (`pytest tools/autopatch_analysis/tests`).
+
+## Usage
+
+Open `autopatch_analysis.ipynb`, edit the `ROOTS` list in the first code cell to
+point at the directory(ies) holding the run's logs, and run all cells. Logs are
+found recursively; point each root at a single contiguous demo run for
+meaningful throughput rates.
+
+## What's measured
+
+The analysis is restricted to attempts that actually **approached** a cell.
+Attempts that never got past bath/clean/out are pipette setup and cleaning
+cycles, not real patch attempts, and are excluded (set `ONLY_APPROACHED=False`
+to keep them). This keeps the funnel base and the active time honest: the
+active time is the demo window (first to last approached attempt), not the whole
+recording including pre/post-demo idle.
+
+- **Funnel:** approached → found cell → sealed → whole-cell, with per-stage
+  conversion, based on approached attempts.
+- **Throughput:** attempts/hour, whole-cells/hour, overall yield, active time
+  (demo window, summed per-log).
+- **Time budget:** per-attempt duration and total time spent in each patch state.
+- **Failure modes:** the terminal state each attempt gave up in.
+- **Quality:** peak seal resistance, and access resistance / holding current
+  during whole-cell.
+- **Timeline:** a per-folder Gantt of every device's patch states over
+  wall-clock (using all attempts), with the analyzed demo window shaded.
+
+## Notes
+
+Success is reconstructed from the state machine because the richer `patchRecord`
+(with tidy `detectedCell` / `sealSuccessful` / `breakinSuccessful` flags) is
+emitted as a Qt signal and is **not** written to the log. "Cell found" means the
+attempt reached the `seal` state (only entered on `detectedCell=True`); "sealed"
+means it reached `cell attached`; "broke in" means it reached `whole cell`.
+Cell health scores from the detection model are saved with ranked-cell exports,
+not the logs, so they are not covered here.

--- a/tools/autopatch_analysis/autopatch_analysis.ipynb
+++ b/tools/autopatch_analysis/autopatch_analysis.ipynb
@@ -1,0 +1,471 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f4261cc6",
+   "metadata": {},
+   "source": [
+    "# Autopatch demo performance\n",
+    "\n",
+    "Analyze the saved MultiPatch logs from an extended autopatch demo run: the\n",
+    "find → seal → break-in funnel, throughput/efficiency, where time goes, why\n",
+    "attempts fail, and the electrical quality of the cells that made it to whole-cell.\n",
+    "\n",
+    "Metrics are reconstructed from the `state_change` sequence and `test_pulse`\n",
+    "events in each `MultiPatch_*.log` (the tidy `patchRecord` is emitted as a Qt\n",
+    "signal, not written to the log). Parsing/aggregation live in `autopatch_log.py`\n",
+    "and `autopatch_metrics.py` (unit-tested under `tests/`)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02234adb",
+   "metadata": {},
+   "source": [
+    "## 1. Configure & load\n",
+    "\n",
+    "Point `ROOTS` at the directory (or directories) holding the demo's\n",
+    "`MultiPatch_*.log` files. They're found recursively, one attempt-set per file.\n",
+    "\n",
+    "The analysis is restricted to attempts that actually approached a cell\n",
+    "(`ONLY_APPROACHED`); setup/cleaning cycles that never engaged a cell are\n",
+    "excluded so the funnel and active-time reflect only real patch attempts."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e9d9215",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T05:01:49.771505Z",
+     "iopub.status.busy": "2026-07-07T05:01:49.771152Z",
+     "iopub.status.idle": "2026-07-07T05:01:50.194044Z",
+     "shell.execute_reply": "2026-07-07T05:01:50.193483Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os, sys\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "sys.path.insert(0, os.path.abspath('.'))\n",
+    "import autopatch_log as al\n",
+    "import autopatch_metrics as am\n",
+    "\n",
+    "# ---- EDIT ME: directories containing the demo's MultiPatch_*.log files ----\n",
+    "# One extended-demo run per root works best (throughput assumes contiguous time).\n",
+    "ROOTS = [\n",
+    "    '/home/martin/src/acq4/junk_data/2024.08.29_000',\n",
+    "]\n",
+    "\n",
+    "# Restrict the analysis to attempts that actually engaged a cell (reached the\n",
+    "# approach stage). Attempts that never got past bath/clean/out are pipette\n",
+    "# setup and cleaning cycles, not real patch attempts -- keeping them would\n",
+    "# inflate the funnel base and pad the active time with pre/post-demo idle.\n",
+    "ONLY_APPROACHED = True\n",
+    "\n",
+    "plt.rcParams.update({'figure.figsize': (9, 4.5), 'axes.grid': True,\n",
+    "                     'grid.alpha': 0.25, 'axes.axisbelow': True})\n",
+    "# Consistent funnel palette (dark→light single hue reads as a progression).\n",
+    "FUNNEL_COLORS = ['#1a4a73', '#2d6ca8', '#4a90d9', '#8bc0f0', '#2e8b57']\n",
+    "OK, BAD = '#2e8b57', '#c0392b'\n",
+    "\n",
+    "def si(val, unit):\n",
+    "    if val is None or (isinstance(val, float) and np.isnan(val)):\n",
+    "        return 'n/a'\n",
+    "    for p, s in [(1e9, 'G'), (1e6, 'M'), (1e3, 'k'), (1, ''), (1e-3, 'm'), (1e-6, 'µ'), (1e-9, 'n'), (1e-12, 'p')]:\n",
+    "        if abs(val) >= p:\n",
+    "            return f'{val / p:.2f} {s}{unit}'\n",
+    "    return f'{val:.2e} {unit}'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e064541c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T05:01:50.195625Z",
+     "iopub.status.busy": "2026-07-07T05:01:50.195464Z",
+     "iopub.status.idle": "2026-07-07T05:01:50.562794Z",
+     "shell.execute_reply": "2026-07-07T05:01:50.561915Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# raw_attempts keeps every attempt (incl. setup/cleaning idle) for the timeline;\n",
+    "# `attempts` is the analysis population -- approached attempts only by default.\n",
+    "raw_attempts = al.load_run(ROOTS)\n",
+    "attempts = al.approached_attempts(raw_attempts) if ONLY_APPROACHED else raw_attempts\n",
+    "df = am.attempts_to_dataframe(attempts)\n",
+    "assert len(df), 'No approached attempts found. Check ROOTS, or set ONLY_APPROACHED=False.'\n",
+    "n_excluded = len(raw_attempts) - len(attempts)\n",
+    "print(f'{len(al.find_logs(ROOTS))} log files, {len(raw_attempts)} raw attempts, '\n",
+    "      f'{len(df)} approached (analyzed), {n_excluded} setup/cleaning excluded, '\n",
+    "      f\"{df['device'].nunique()} device(s)\")\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8173debf",
+   "metadata": {},
+   "source": [
+    "## 2. Headline throughput & efficiency"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "809fe972",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T05:01:50.565186Z",
+     "iopub.status.busy": "2026-07-07T05:01:50.564965Z",
+     "iopub.status.idle": "2026-07-07T05:01:50.595592Z",
+     "shell.execute_reply": "2026-07-07T05:01:50.594816Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "tp = am.throughput(df)\n",
+    "print('Logs                :', int(tp['n_logs']))\n",
+    "print('Approached attempts :', int(tp['n_attempts']))\n",
+    "print('Cells found         :', int(tp['n_found']))\n",
+    "print('Seals formed        :', int(tp['n_sealed']))\n",
+    "print('Whole-cell recordings:', int(tp['n_whole_cell']))\n",
+    "print('Overall yield       : {:.1f} %  (whole-cell / approached)'.format(tp['overall_yield_pct']))\n",
+    "print('Active time         : {:.2f} h  (demo window, summed per-log)'.format(tp['active_hours']))\n",
+    "print('Attempts / hour     : {:.1f}'.format(tp['attempts_per_hour']))\n",
+    "print('Whole-cells / hour  : {:.2f}'.format(tp['whole_cells_per_hour']))\n",
+    "print('Mean attempt length : {:.1f} min'.format(tp['mean_attempt_minutes']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ff04e092",
+   "metadata": {},
+   "source": [
+    "## 3. The funnel: approached → found → sealed → whole-cell\n",
+    "\n",
+    "How many *approached* attempts survive each stage, and the conversion rate\n",
+    "between stages. Attempts that never engaged a cell (setup/cleaning cycles) are\n",
+    "excluded, so the base of the funnel is the cells we actually tried to patch."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2fd3e0bd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T05:01:50.597935Z",
+     "iopub.status.busy": "2026-07-07T05:01:50.597740Z",
+     "iopub.status.idle": "2026-07-07T05:01:50.662353Z",
+     "shell.execute_reply": "2026-07-07T05:01:50.661823Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "funnel = am.funnel_counts(df)\n",
+    "labels = ['Approached', 'Found\\ncell', 'Sealed', 'Whole\\ncell']\n",
+    "colors = [FUNNEL_COLORS[1], FUNNEL_COLORS[2], FUNNEL_COLORS[3], FUNNEL_COLORS[4]]\n",
+    "fig, ax = plt.subplots(figsize=(9, 5))\n",
+    "bars = ax.bar(labels, funnel['count'], color=colors, width=0.72)\n",
+    "for bar, (_, row) in zip(bars, funnel.iterrows()):\n",
+    "    ax.text(bar.get_x() + bar.get_width() / 2, bar.get_height(),\n",
+    "            f\"{int(row['count'])}\\n{row['pct_of_approached']:.0f}%\",\n",
+    "            ha='center', va='bottom', fontsize=10)\n",
+    "    if row['stage'] not in ('approached',):\n",
+    "        ax.text(bar.get_x() + bar.get_width() / 2, bar.get_height() / 2,\n",
+    "                f\"→{row['conversion_from_prev']:.0f}%\", ha='center', va='center',\n",
+    "                color='white', fontsize=9, fontweight='bold')\n",
+    "ax.set_ylabel('approached attempts')\n",
+    "ax.set_title('Autopatch funnel (bar height = count, mid-bar = conversion from previous stage)')\n",
+    "ax.margins(y=0.15)\n",
+    "plt.tight_layout(); plt.show()\n",
+    "funnel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16e0425a",
+   "metadata": {},
+   "source": [
+    "## 4. Throughput over the run\n",
+    "\n",
+    "Cumulative whole-cell recordings against elapsed time — the slope is the\n",
+    "effective yield rate."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dfb3d2cb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T05:01:50.663622Z",
+     "iopub.status.busy": "2026-07-07T05:01:50.663509Z",
+     "iopub.status.idle": "2026-07-07T05:01:50.692015Z",
+     "shell.execute_reply": "2026-07-07T05:01:50.691616Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "cum = am.cumulative_whole_cells(df)\n",
+    "fig, ax = plt.subplots()\n",
+    "if len(cum):\n",
+    "    ax.step(cum['minutes'], cum['cumulative_whole_cells'], where='post', color=OK, lw=2)\n",
+    "    ax.scatter(cum['minutes'], cum['cumulative_whole_cells'], color=OK, zorder=3)\n",
+    "ax.set_xlabel('minutes since first attempt')\n",
+    "ax.set_ylabel('cumulative whole-cell recordings')\n",
+    "ax.set_title('Whole-cell yield over the run')\n",
+    "plt.tight_layout(); plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "da4cb342",
+   "metadata": {},
+   "source": [
+    "## 5. Where the time goes\n",
+    "\n",
+    "Per-attempt duration, and total time spent in each patch state across the run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2e6426e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T05:01:50.693492Z",
+     "iopub.status.busy": "2026-07-07T05:01:50.693381Z",
+     "iopub.status.idle": "2026-07-07T05:01:50.760722Z",
+     "shell.execute_reply": "2026-07-07T05:01:50.760443Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "dwell = am.state_dwell_times(attempts)\n",
+    "fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4.5))\n",
+    "\n",
+    "ax1.hist(df['duration_s'] / 60.0, bins=20, color=FUNNEL_COLORS[1], edgecolor='white')\n",
+    "ax1.set_xlabel('attempt duration (min)'); ax1.set_ylabel('attempts')\n",
+    "ax1.set_title('Per-attempt duration')\n",
+    "\n",
+    "ax2.barh(dwell['state'], dwell['total_s'] / 60.0, color=FUNNEL_COLORS[2])\n",
+    "ax2.invert_yaxis()\n",
+    "ax2.set_xlabel('total minutes in state (all attempts)')\n",
+    "ax2.set_title('Time budget by state')\n",
+    "plt.tight_layout(); plt.show()\n",
+    "dwell"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "861a09ae",
+   "metadata": {},
+   "source": [
+    "## 6. Where attempts fail\n",
+    "\n",
+    "Terminal outcome of every attempt. `whole cell` is success; the rest are the\n",
+    "state the attempt gave up in."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da16b174",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T05:01:50.762401Z",
+     "iopub.status.busy": "2026-07-07T05:01:50.762283Z",
+     "iopub.status.idle": "2026-07-07T05:01:50.795112Z",
+     "shell.execute_reply": "2026-07-07T05:01:50.794782Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "fm = am.failure_mode_counts(df)\n",
+    "colors = [OK if o == 'whole cell' else BAD for o in fm['outcome']]\n",
+    "fig, ax = plt.subplots()\n",
+    "bars = ax.bar(fm['outcome'], fm['count'], color=colors, width=0.7)\n",
+    "for bar, c, p in zip(bars, fm['count'], fm['pct']):\n",
+    "    ax.text(bar.get_x() + bar.get_width() / 2, bar.get_height(),\n",
+    "            f'{int(c)}\\n{p:.0f}%', ha='center', va='bottom', fontsize=9)\n",
+    "ax.set_ylabel('attempts'); ax.set_title('Attempt outcomes')\n",
+    "ax.margins(y=0.15)\n",
+    "plt.xticks(rotation=20, ha='right')\n",
+    "plt.tight_layout(); plt.show()\n",
+    "fm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4d91a630",
+   "metadata": {},
+   "source": [
+    "## 7. Quality of the whole-cell recordings\n",
+    "\n",
+    "For attempts that broke in: peak seal resistance, and access resistance /\n",
+    "holding current during whole-cell (from the test pulses). Lower access\n",
+    "resistance and smaller holding current are healthier."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec4f356d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T05:01:50.796549Z",
+     "iopub.status.busy": "2026-07-07T05:01:50.796432Z",
+     "iopub.status.idle": "2026-07-07T05:01:50.882235Z",
+     "shell.execute_reply": "2026-07-07T05:01:50.881709Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "wc = df[df['broke_in']].copy()\n",
+    "if len(wc):\n",
+    "    fig, axes = plt.subplots(1, 3, figsize=(13, 4))\n",
+    "    axes[0].hist(wc['max_seal_resistance'].dropna() / 1e9, bins=12, color=FUNNEL_COLORS[0], edgecolor='white')\n",
+    "    axes[0].set_xlabel('peak seal resistance (GΩ)'); axes[0].set_title('Seal quality')\n",
+    "    axes[0].axvline(1.0, color=BAD, ls='--', lw=1, label='1 GΩ')\n",
+    "    axes[0].legend()\n",
+    "    axes[1].hist(wc['access_resistance'].dropna() / 1e6, bins=12, color=FUNNEL_COLORS[1], edgecolor='white')\n",
+    "    axes[1].set_xlabel('access resistance (MΩ)'); axes[1].set_title('Access resistance')\n",
+    "    axes[2].hist(wc['holding_current'].dropna() / 1e-12, bins=12, color=FUNNEL_COLORS[2], edgecolor='white')\n",
+    "    axes[2].set_xlabel('holding current (pA)'); axes[2].set_title('Holding current')\n",
+    "    plt.tight_layout(); plt.show()\n",
+    "    print('median peak seal R :', si(wc['max_seal_resistance'].median(), 'Ω'))\n",
+    "    print('median access R    :', si(wc['access_resistance'].median(), 'Ω'))\n",
+    "    print('median holding I   :', si(wc['holding_current'].median(), 'A'))\n",
+    "else:\n",
+    "    print('No whole-cell recordings in this dataset.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3e33fee",
+   "metadata": {},
+   "source": [
+    "## 8. Per-attempt drill-down\n",
+    "\n",
+    "One row per attempt with outcome and key numbers. Sort/filter as needed — e.g.\n",
+    "`table[table['found_cell'] & ~table['broke_in']]` to inspect attempts that found\n",
+    "a cell but never reached whole-cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae877758",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-07-07T05:01:50.884006Z",
+     "iopub.status.busy": "2026-07-07T05:01:50.883883Z",
+     "iopub.status.idle": "2026-07-07T05:01:50.902181Z",
+     "shell.execute_reply": "2026-07-07T05:01:50.901563Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "table = df[['cell_dir', 'device', 'attempt_index', 'best_stage_name', 'outcome',\n",
+    "            'duration_s', 'max_seal_resistance', 'access_resistance',\n",
+    "            'holding_current', 'n_test_pulses']].copy()\n",
+    "table['duration_min'] = (table.pop('duration_s') / 60.0).round(1)\n",
+    "for col, unit in [('max_seal_resistance', 'Ω'), ('access_resistance', 'Ω'), ('holding_current', 'A')]:\n",
+    "    table[col] = table[col].map(lambda v: si(v, unit))\n",
+    "table"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "zdh53rwd",
+   "source": [
+    "## 9. Full timeline per folder\n",
+    "\n",
+    "One Gantt chart per analyzed folder: every device's patch states over wall-clock,\n",
+    "using **all** attempts (including the setup/cleaning idle that the rest of the\n",
+    "analysis excludes). The shaded span is the analyzed demo window — first to last\n",
+    "approached attempt — so you can see the idle before and after that is trimmed\n",
+    "from the active time."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "mpoanwn1",
+   "source": [
+    "tl = am.state_timeline(raw_attempts)\n",
+    "\n",
+    "# Analyzed demo window per folder = span of the approached attempts we keep.\n",
+    "window_by_folder = {}\n",
+    "for a in attempts:\n",
+    "    f = os.path.dirname(a.source)\n",
+    "    lo, hi = window_by_folder.get(f, (a.start_time, a.end_time))\n",
+    "    window_by_folder[f] = (min(lo, a.start_time), max(hi, a.end_time))\n",
+    "\n",
+    "# Stable color per state across all folders.\n",
+    "states_seen = list(dict.fromkeys(tl['state']))\n",
+    "cmap = plt.get_cmap('tab20')\n",
+    "state_color = {s: cmap(i % 20) for i, s in enumerate(states_seen)}\n",
+    "\n",
+    "for folder, g in tl.groupby('folder'):\n",
+    "    t0 = g['t_start'].min()\n",
+    "    devices = sorted(g['device'].unique())\n",
+    "    ypos = {d: i for i, d in enumerate(devices)}\n",
+    "    fig, ax = plt.subplots(figsize=(12, 0.6 * len(devices) + 2))\n",
+    "    if folder in window_by_folder:\n",
+    "        lo, hi = window_by_folder[folder]\n",
+    "        ax.axvspan((lo - t0) / 60.0, (hi - t0) / 60.0, color='0.5', alpha=0.15,\n",
+    "                   zorder=0, label='analyzed demo window')\n",
+    "    for _, r in g.iterrows():\n",
+    "        width = max((r['t_end'] - r['t_start']) / 60.0, 1e-3)\n",
+    "        ax.broken_barh([((r['t_start'] - t0) / 60.0, width)],\n",
+    "                       (ypos[r['device']] - 0.4, 0.8),\n",
+    "                       facecolors=state_color[r['state']], edgecolor='none')\n",
+    "    ax.set_yticks(range(len(devices)))\n",
+    "    ax.set_yticklabels(devices)\n",
+    "    ax.set_ylim(-0.6, len(devices) - 0.4)\n",
+    "    ax.set_xlabel('minutes since first event in folder')\n",
+    "    ax.set_title(f'{os.path.basename(folder)}  —  shaded = analyzed demo window')\n",
+    "    ax.grid(True, axis='x', alpha=0.25)\n",
+    "    handles = [plt.Rectangle((0, 0), 1, 1, color=state_color[s]) for s in states_seen]\n",
+    "    ax.legend(handles, states_seen, ncol=min(len(states_seen), 6), fontsize=7,\n",
+    "              loc='upper center', bbox_to_anchor=(0.5, -0.3), frameon=False)\n",
+    "    plt.tight_layout()\n",
+    "    plt.show()"
+   ],
+   "metadata": {},
+   "outputs": [],
+   "execution_count": null
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tools/autopatch_analysis/autopatch_log.py
+++ b/tools/autopatch_analysis/autopatch_log.py
@@ -1,0 +1,301 @@
+"""Parse MultiPatch autopatch logs into per-attempt records.
+
+Reads the newline-delimited JSON ``MultiPatch_*.log`` files written by the
+MultiPatch module and reconstructs one :class:`Attempt` per patch attempt,
+deriving how far each attempt progressed through the find/seal/break-in funnel.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+# Fields carried on every ``test_pulse`` event (see MultiPatchLog.TEST_PULSE_METAARRAY_INFO).
+TEST_PULSE_FIELDS = (
+    "baseline_potential",
+    "baseline_current",
+    "input_resistance",
+    "access_resistance",
+    "steady_state_resistance",
+    "capacitance",
+    "time_constant",
+)
+
+# Gigaseal threshold used to cross-check the state machine's seal claim.
+GIGASEAL_OHMS = 1e9
+
+# Ordered funnel stages an attempt can reach. Higher index == further progress.
+STAGE_NAMES = ("attempted", "approached", "found", "sealed", "whole_cell")
+ATTEMPTED, APPROACHED, FOUND, SEALED, WHOLE_CELL = range(len(STAGE_NAMES))
+
+# Minimum funnel stage implied by entering a given patch state. States that do
+# not represent forward progress (idle/reset/failure) map to ATTEMPTED so they
+# never inflate an attempt's best stage.
+#   - approach/cell detect/contact cell: hunting for a cell membrane
+#   - seal: a cell was detected/contacted (you only enter seal on detectedCell)
+#   - cell attached: gigaseal formed
+#   - break in: sealed, now rupturing the membrane
+#   - whole cell (and post-success reseal/collect/home): broke in
+STATE_STAGE = {
+    "out": ATTEMPTED,
+    "bath": ATTEMPTED,
+    "clean": ATTEMPTED,
+    "fouled": ATTEMPTED,
+    "broken": ATTEMPTED,
+    "blowout": ATTEMPTED,
+    "approach": APPROACHED,
+    "cell detect": APPROACHED,
+    "contact cell": APPROACHED,
+    "seal": FOUND,
+    "cell attached": SEALED,
+    "break in": SEALED,
+    "whole cell": WHOLE_CELL,
+    "reseal": WHOLE_CELL,
+    "home with nucleus": WHOLE_CELL,
+    "collect": WHOLE_CELL,
+}
+
+# States that indicate an attempt has ended without a live whole-cell recording.
+FAILURE_STATES = frozenset({"broken", "fouled", "clean", "out", "bath", "blowout"})
+
+
+def parse_log_events(path: str) -> list[dict[str, Any]]:
+    """Read a MultiPatch log file into a list of event dicts.
+
+    Each non-blank line is a JSON object with a trailing comma (as written by
+    the MultiPatch module). Blank lines and unparseable lines are skipped.
+    """
+    events: list[dict[str, Any]] = []
+    with open(path, "rb") as fh:
+        for line in fh:
+            line = line.rstrip(b",\r\n")
+            if not line.strip():
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return events
+
+
+@dataclass
+class Attempt:
+    """One patch attempt on one device, reconstructed from a log's events."""
+
+    source: str
+    device: str
+    index: int
+    start_time: float
+    end_time: float
+    # ordered (time, state) pairs from state_change events (state entered)
+    states: list[tuple[float, str]] = field(default_factory=list)
+    # test_pulse events as dicts (each has 'event_time' plus TEST_PULSE_FIELDS)
+    test_pulses: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def duration(self) -> float:
+        return self.end_time - self.start_time
+
+    @property
+    def best_stage(self) -> int:
+        """Furthest funnel stage this attempt reached (see STAGE_NAMES)."""
+        if not self.states:
+            return ATTEMPTED
+        return max(STATE_STAGE.get(state, ATTEMPTED) for _, state in self.states)
+
+    @property
+    def best_stage_name(self) -> str:
+        return STAGE_NAMES[self.best_stage]
+
+    @property
+    def attempted_find(self) -> bool:
+        return self.best_stage >= APPROACHED
+
+    @property
+    def found_cell(self) -> bool:
+        return self.best_stage >= FOUND
+
+    @property
+    def sealed(self) -> bool:
+        return self.best_stage >= SEALED
+
+    @property
+    def broke_in(self) -> bool:
+        return self.best_stage >= WHOLE_CELL
+
+    @property
+    def final_state(self) -> str | None:
+        """The last patch state entered during this attempt."""
+        return self.states[-1][1] if self.states else None
+
+    @property
+    def outcome(self) -> str:
+        """'whole cell' on success, else the state the attempt gave up in."""
+        if self.broke_in:
+            return "whole cell"
+        # last failure/reset state entered, else the final state, else 'no states'
+        for _, state in reversed(self.states):
+            if state in FAILURE_STATES:
+                return state
+        return self.final_state or "no states"
+
+    def state_intervals(self) -> list[tuple[str, float, float]]:
+        """(state, t_enter, t_exit) spans; the last span runs to end_time."""
+        spans = []
+        for i, (t, state) in enumerate(self.states):
+            t_end = self.states[i + 1][0] if i + 1 < len(self.states) else self.end_time
+            spans.append((state, t, t_end))
+        return spans
+
+    def test_pulses_in_states(self, states: Iterable[str]) -> list[dict[str, Any]]:
+        """Test pulses recorded while the pipette was in any of ``states``."""
+        wanted = set(states)
+        spans = [s for s in self.state_intervals() if s[0] in wanted]
+        if not spans:
+            return []
+        hits = []
+        for tp in self.test_pulses:
+            t = tp.get("event_time")
+            if t is None:
+                continue
+            # Spans are half-open [t0, t1) so boundary pulses aren't double-counted,
+            # except the span ending at end_time includes its final pulse.
+            if any(t0 <= t < t1 or (t == t1 == self.end_time) for _, t0, t1 in spans):
+                hits.append(tp)
+        return hits
+
+    @property
+    def max_seal_resistance(self) -> float | None:
+        """Peak steady-state resistance reached while sealing (ohms)."""
+        tps = self.test_pulses_in_states({"seal", "cell attached"})
+        vals = [
+            tp["steady_state_resistance"]
+            for tp in tps
+            if tp.get("steady_state_resistance") is not None
+        ]
+        return max(vals) if vals else None
+
+    @property
+    def gigaseal(self) -> bool:
+        """Whether a gigaohm seal was measured (cross-check on the state claim)."""
+        r = self.max_seal_resistance
+        return r is not None and r >= GIGASEAL_OHMS
+
+    def _whole_cell_stat(self, field_name: str) -> float | None:
+        tps = self.test_pulses_in_states({"whole cell"})
+        vals = [tp[field_name] for tp in tps if tp.get(field_name) is not None]
+        if not vals:
+            return None
+        vals.sort()
+        return vals[len(vals) // 2]  # median
+
+    @property
+    def access_resistance(self) -> float | None:
+        """Median access resistance during whole-cell (ohms)."""
+        return self._whole_cell_stat("access_resistance")
+
+    @property
+    def input_resistance(self) -> float | None:
+        """Median input resistance during whole-cell (ohms)."""
+        return self._whole_cell_stat("input_resistance")
+
+    @property
+    def holding_current(self) -> float | None:
+        """Median baseline (holding) current during whole-cell (amps)."""
+        return self._whole_cell_stat("baseline_current")
+
+    @property
+    def capacitance(self) -> float | None:
+        """Median membrane capacitance during whole-cell (farads)."""
+        return self._whole_cell_stat("capacitance")
+
+
+def _attempts_from_device_events(
+    events: list[dict[str, Any]], source: str, device: str
+) -> list[Attempt]:
+    """Split one device's event stream into attempts on ``new_patch_attempt``.
+
+    A log with no ``new_patch_attempt`` markers is treated as a single attempt.
+    """
+    # indices of new_patch_attempt markers
+    starts = [
+        i for i, ev in enumerate(events) if ev.get("event") == "new_patch_attempt"
+    ]
+    if not starts:
+        chunks = [events]
+    else:
+        # a preamble before the first marker (if any) is its own attempt
+        bounds = ([0] if starts[0] != 0 else []) + starts + [len(events)]
+        chunks = [events[a:b] for a, b in zip(bounds, bounds[1:]) if b > a]
+
+    attempts = []
+    for index, chunk in enumerate(chunks):
+        times = [ev["event_time"] for ev in chunk if "event_time" in ev]
+        if not times:
+            continue
+        att = Attempt(
+            source=source,
+            device=device,
+            index=index,
+            start_time=min(times),
+            end_time=max(times),
+        )
+        for ev in chunk:
+            etype = ev.get("event")
+            if etype == "state_change":
+                att.states.append((ev["event_time"], ev["state"]))
+            elif etype == "test_pulse":
+                att.test_pulses.append(ev)
+        attempts.append(att)
+    return attempts
+
+
+def load_log(path: str) -> list[Attempt]:
+    """Parse one log file into attempts, split per device and per attempt."""
+    events = parse_log_events(path)
+    by_device: dict[str, list[dict[str, Any]]] = {}
+    for ev in events:
+        dev = ev.get("device")
+        if dev is None:
+            continue  # global events (profiles, surface depth) carry no device
+        by_device.setdefault(dev, []).append(ev)
+    attempts = []
+    for device, dev_events in by_device.items():
+        attempts.extend(_attempts_from_device_events(dev_events, path, device))
+    return attempts
+
+
+def approached_attempts(attempts: Iterable[Attempt]) -> list[Attempt]:
+    """Keep only attempts that actually engaged a cell (reached the approach stage).
+
+    Attempts that never progress past out/bath/clean/fouled (``best_stage ==
+    ATTEMPTED``) are pipette setup and cleaning cycles, not real patch attempts
+    on a cell. They are excluded so the demo analysis (funnel, throughput,
+    active time) reflects only cells the rig actually tried to patch.
+    """
+    return [a for a in attempts if a.attempted_find]
+
+
+def find_logs(roots: Iterable[str]) -> list[str]:
+    """Recursively find MultiPatch_*.log files under ``roots`` (case-insensitive)."""
+    found = []
+    for root in roots:
+        if os.path.isfile(root):
+            found.append(root)
+            continue
+        for dirpath, _dirs, files in os.walk(root):
+            for name in files:
+                low = name.lower()
+                if low.startswith("multipatch_") and low.endswith(".log"):
+                    found.append(os.path.join(dirpath, name))
+    return sorted(found)
+
+
+def load_run(roots: Iterable[str]) -> list[Attempt]:
+    """Load every attempt from every MultiPatch log found under ``roots``."""
+    attempts = []
+    for path in find_logs(roots):
+        attempts.extend(load_log(path))
+    return attempts

--- a/tools/autopatch_analysis/autopatch_metrics.py
+++ b/tools/autopatch_analysis/autopatch_metrics.py
@@ -1,0 +1,246 @@
+"""Aggregate parsed autopatch attempts into throughput/efficiency tables.
+
+Turns a list of :class:`autopatch_log.Attempt` into pandas DataFrames for the
+funnel (find/seal/break-in conversion), throughput, per-state time budget, and
+failure-mode breakdown consumed by the analysis notebook.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterable
+
+import pandas as pd
+
+from autopatch_log import STAGE_NAMES, Attempt
+
+# Funnel stages in order, as (display stage, Attempt-boolean DataFrame column).
+# The funnel is rooted at ``approached`` -- attempts that never engaged a cell
+# (setup/cleaning cycles) are not real patch attempts and are excluded, so the
+# base of the funnel is the count of approached attempts, not all attempts.
+FUNNEL_STAGES = [
+    ("approached", "attempted_find"),
+    ("found_cell", "found_cell"),
+    ("sealed", "sealed"),
+    ("broke_in", "broke_in"),
+]
+
+
+# Columns of the per-attempt table, in order. Declared so an empty run still
+# yields a well-formed (column-bearing) DataFrame instead of a bare one.
+ATTEMPT_COLUMNS = [
+    "source",
+    "cell_dir",
+    "device",
+    "attempt_index",
+    "start_time",
+    "end_time",
+    "duration_s",
+    "best_stage",
+    "best_stage_name",
+    "attempted_find",
+    "found_cell",
+    "sealed",
+    "broke_in",
+    "gigaseal",
+    "outcome",
+    "final_state",
+    "max_seal_resistance",
+    "access_resistance",
+    "input_resistance",
+    "holding_current",
+    "capacitance",
+    "n_test_pulses",
+    "n_state_changes",
+]
+
+
+def attempts_to_dataframe(attempts: Iterable[Attempt]) -> pd.DataFrame:
+    """One row per attempt with outcome flags and whole-cell quality numbers."""
+    rows = []
+    for a in attempts:
+        rows.append(
+            {
+                "source": a.source,
+                "cell_dir": os.path.basename(os.path.dirname(a.source)),
+                "device": a.device,
+                "attempt_index": a.index,
+                "start_time": a.start_time,
+                "end_time": a.end_time,
+                "duration_s": a.duration,
+                "best_stage": a.best_stage,
+                "best_stage_name": a.best_stage_name,
+                "attempted_find": a.attempted_find,
+                "found_cell": a.found_cell,
+                "sealed": a.sealed,
+                "broke_in": a.broke_in,
+                "gigaseal": a.gigaseal,
+                "outcome": a.outcome,
+                "final_state": a.final_state,
+                "max_seal_resistance": a.max_seal_resistance,
+                "access_resistance": a.access_resistance,
+                "input_resistance": a.input_resistance,
+                "holding_current": a.holding_current,
+                "capacitance": a.capacitance,
+                "n_test_pulses": len(a.test_pulses),
+                "n_state_changes": len(a.states),
+            }
+        )
+    return pd.DataFrame(rows, columns=ATTEMPT_COLUMNS)
+
+
+def funnel_counts(df: pd.DataFrame) -> pd.DataFrame:
+    """Counts and conversion percentages at each funnel stage.
+
+    The funnel is rooted at ``approached`` (attempts that engaged a cell), so
+    never-approached attempts are excluded even if they are present in ``df``.
+    ``pct_of_approached`` is the share of approached attempts reaching a stage;
+    ``conversion_from_prev`` is the share of the previous stage that advanced.
+    """
+    approached = int(df["attempted_find"].sum()) if len(df) else 0
+    rows = []
+    prev = None
+    for stage, column in FUNNEL_STAGES:
+        count = int(df[column].sum()) if len(df) else 0
+        rows.append(
+            {
+                "stage": stage,
+                "count": count,
+                "pct_of_approached": (
+                    (100.0 * count / approached) if approached else 0.0
+                ),
+                "conversion_from_prev": (100.0 * count / prev) if prev else 100.0,
+            }
+        )
+        prev = count
+    return pd.DataFrame(rows)
+
+
+def failure_mode_counts(df: pd.DataFrame) -> pd.DataFrame:
+    """How many attempts ended in each outcome, most common first."""
+    counts = df["outcome"].value_counts()
+    return (
+        counts.rename_axis("outcome")
+        .reset_index(name="count")
+        .assign(pct=lambda d: 100.0 * d["count"] / len(df) if len(df) else 0.0)
+    )
+
+
+def state_dwell_times(attempts: Iterable[Attempt]) -> pd.DataFrame:
+    """Total/mean seconds spent in each patch state across all attempts."""
+    rows = []
+    for a in attempts:
+        for state, t0, t1 in a.state_intervals():
+            rows.append({"state": state, "seconds": t1 - t0})
+    if not rows:
+        return pd.DataFrame(columns=["state", "total_s", "mean_s", "n"])
+    df = pd.DataFrame(rows)
+    agg = (
+        df.groupby("state")["seconds"]
+        .agg(total_s="sum", mean_s="mean", n="count")
+        .reset_index()
+        .sort_values("total_s", ascending=False)
+        .reset_index(drop=True)
+    )
+    return agg
+
+
+# Columns of the state-timeline table, so an empty run still yields a
+# well-formed (column-bearing) DataFrame.
+TIMELINE_COLUMNS = [
+    "folder",
+    "cell_dir",
+    "device",
+    "attempt_index",
+    "state",
+    "t_start",
+    "t_end",
+]
+
+
+def state_timeline(attempts: Iterable[Attempt]) -> pd.DataFrame:
+    """Long-form (folder, device, state, t_start, t_end) spans for a Gantt view.
+
+    One row per state interval of every attempt, keyed by ``folder`` (the
+    directory holding the log). Times are absolute (epoch seconds); the notebook
+    rebases them per folder. This intentionally includes non-approached attempts
+    so the idle time trimmed from the active-time window stays visible.
+    """
+    rows = []
+    for a in attempts:
+        folder = os.path.dirname(a.source)
+        cell_dir = os.path.basename(folder)
+        for state, t0, t1 in a.state_intervals():
+            rows.append(
+                {
+                    "folder": folder,
+                    "cell_dir": cell_dir,
+                    "device": a.device,
+                    "attempt_index": a.index,
+                    "state": state,
+                    "t_start": t0,
+                    "t_end": t1,
+                }
+            )
+    return pd.DataFrame(rows, columns=TIMELINE_COLUMNS)
+
+
+def throughput(df: pd.DataFrame) -> pd.Series:
+    """Run-level throughput: active time, attempt and whole-cell rates.
+
+    Rates use ``active_hours`` -- the summed per-log span of the attempts in
+    ``df`` -- rather than the global first-to-last span, so pointing at logs
+    recorded on different days doesn't count the idle gaps between runs against
+    the rate. Pass the approached attempts (see ``approached_attempts``) so this
+    span covers only the autopatch demo's active window and not the pipette
+    setup/cleaning idle before the first cell or after the last.
+    """
+    if df.empty:
+        return pd.Series(dtype=float)
+    per_log = df.groupby("source").agg(t0=("start_time", "min"), t1=("end_time", "max"))
+    active_h = (per_log["t1"] - per_log["t0"]).sum() / 3600.0
+    span_h = (df["end_time"].max() - df["start_time"].min()) / 3600.0
+    n_attempts = len(df)
+    n_whole = int(df["broke_in"].sum())
+    return pd.Series(
+        {
+            "n_logs": df["source"].nunique(),
+            "n_attempts": n_attempts,
+            "n_found": int(df["found_cell"].sum()),
+            "n_sealed": int(df["sealed"].sum()),
+            "n_whole_cell": n_whole,
+            "active_hours": active_h,
+            "span_hours": span_h,
+            "attempts_per_hour": (n_attempts / active_h) if active_h else float("nan"),
+            "whole_cells_per_hour": (n_whole / active_h) if active_h else float("nan"),
+            "overall_yield_pct": 100.0 * n_whole / n_attempts if n_attempts else 0.0,
+            "mean_attempt_minutes": df["duration_s"].mean() / 60.0,
+        }
+    )
+
+
+def cumulative_whole_cells(df: pd.DataFrame) -> pd.DataFrame:
+    """Whole-cell successes over wall-clock, for a cumulative-yield plot."""
+    if df.empty:
+        return pd.DataFrame(columns=["minutes", "cumulative_whole_cells"])
+    t0 = df["start_time"].min()
+    wc = df[df["broke_in"]].sort_values("end_time")
+    return pd.DataFrame(
+        {
+            "minutes": (wc["end_time"] - t0) / 60.0,
+            "cumulative_whole_cells": range(1, len(wc) + 1),
+        }
+    )
+
+
+# Re-export for notebook convenience.
+__all__ = [
+    "STAGE_NAMES",
+    "attempts_to_dataframe",
+    "funnel_counts",
+    "failure_mode_counts",
+    "state_dwell_times",
+    "state_timeline",
+    "throughput",
+    "cumulative_whole_cells",
+]

--- a/tools/autopatch_analysis/tests/__init__.py
+++ b/tools/autopatch_analysis/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the autopatch analysis tooling."""

--- a/tools/autopatch_analysis/tests/test_autopatch_log.py
+++ b/tools/autopatch_analysis/tests/test_autopatch_log.py
@@ -1,0 +1,208 @@
+"""Tests for parsing MultiPatch logs into per-attempt funnel records.
+
+Fixtures use real event-line shapes copied from actual MultiPatch_*.log files.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import autopatch_log as al  # noqa: E402
+
+
+def _write(tmp_path, lines, name="MultiPatch_000.log"):
+    p = tmp_path / name
+    p.write_text("".join(line + ",\n" for line in lines))
+    return str(p)
+
+
+# --- real-shaped event lines --------------------------------------------------
+
+
+def _state(t, state, old, dev="PatchPipette1"):
+    return (
+        f'{{"device": "{dev}", "event_time": {t}, "event": "state_change", '
+        f'"state": "{state}", "old_state": "{old}"}}'
+    )
+
+
+def _attempt_marker(t, dev="PatchPipette1"):
+    return f'{{"device": "{dev}", "event_time": {t}, "event": "new_patch_attempt"}}'
+
+
+def _tp(t, ssr, access=10e6, rin=200e6, cap=10e-12, ibase=5e-13, dev="PatchPipette1"):
+    return (
+        f'{{"device": "{dev}", "event_time": {t}, "event": "test_pulse", '
+        f'"start_time": {t}, "steady_state_resistance": {ssr}, '
+        f'"input_resistance": {rin}, "access_resistance": {access}, '
+        f'"capacitance": {cap}, "time_constant": 0.001, "fit_yoffset": -1e-11, '
+        f'"fit_xoffset": 0.005, "fit_amplitude": -7e-10, "baseline_potential": 0.0, '
+        f'"baseline_current": {ibase}}}'
+    )
+
+
+def test_parse_log_events_strips_trailing_commas_and_blanks(tmp_path):
+    path = _write(
+        tmp_path, [_state(100.0, "bath", "out"), "", _state(101.0, "seal", "bath")]
+    )
+    events = al.parse_log_events(path)
+    assert [e["state"] for e in events] == ["bath", "seal"]
+
+
+def test_single_attempt_reaching_whole_cell(tmp_path):
+    # bath -> seal -> cell attached -> break in -> whole cell (no attempt marker)
+    path = _write(
+        tmp_path,
+        [
+            _state(0.0, "bath", "out"),
+            _state(10.0, "seal", "bath"),
+            _tp(15.0, ssr=1.2e9),  # gigaseal during seal
+            _state(20.0, "cell attached", "seal"),
+            _state(25.0, "break in", "cell attached"),
+            _state(30.0, "whole cell", "break in"),
+            _tp(35.0, ssr=3e8, access=12e6, rin=250e6, ibase=-1e-10),
+        ],
+    )
+    attempts = al.load_log(path)
+    assert len(attempts) == 1
+    a = attempts[0]
+    assert a.device == "PatchPipette1"
+    assert a.found_cell and a.sealed and a.broke_in
+    assert a.best_stage_name == "whole_cell"
+    assert a.outcome == "whole cell"
+    assert a.duration == pytest.approx(35.0)
+    assert a.gigaseal is True
+    assert a.max_seal_resistance == pytest.approx(1.2e9)
+    assert a.access_resistance == pytest.approx(12e6)
+    assert a.holding_current == pytest.approx(-1e-10)
+
+
+def test_attempt_markers_split_attempts(tmp_path):
+    path = _write(
+        tmp_path,
+        [
+            _attempt_marker(0.0),
+            _state(1.0, "bath", "out"),
+            _state(2.0, "seal", "bath"),
+            _state(3.0, "fouled", "seal"),
+            _attempt_marker(10.0),
+            _state(11.0, "bath", "out"),
+            _state(12.0, "seal", "bath"),
+            _state(13.0, "cell attached", "seal"),
+            _state(14.0, "break in", "cell attached"),
+            _state(15.0, "whole cell", "break in"),
+        ],
+    )
+    attempts = al.load_log(path)
+    assert len(attempts) == 2
+    first, second = attempts
+    assert first.found_cell and not first.sealed
+    assert first.outcome == "fouled"
+    assert second.broke_in
+    assert second.outcome == "whole cell"
+
+
+def test_preamble_before_first_marker_is_its_own_attempt(tmp_path):
+    path = _write(
+        tmp_path,
+        [
+            _state(0.0, "bath", "out"),
+            _attempt_marker(5.0),
+            _state(6.0, "seal", "bath"),
+        ],
+    )
+    attempts = al.load_log(path)
+    assert len(attempts) == 2
+    assert attempts[0].best_stage_name == "attempted"
+    assert attempts[1].found_cell
+
+
+def test_never_found_cell(tmp_path):
+    path = _write(
+        tmp_path,
+        [
+            _state(0.0, "bath", "out"),
+            _state(5.0, "fouled", "bath"),
+            _state(9.0, "clean", "fouled"),
+        ],
+    )
+    a = al.load_log(path)[0]
+    assert not a.attempted_find
+    assert not a.found_cell
+    assert a.outcome == "clean"
+
+
+def test_approached_attempts_filters_out_never_approached(tmp_path):
+    # idx0 never gets past bath/clean; idx1 seals (so it approached a cell)
+    path = _write(
+        tmp_path,
+        [
+            _attempt_marker(0.0),
+            _state(1.0, "bath", "out"),
+            _state(2.0, "clean", "bath"),
+            _attempt_marker(10.0),
+            _state(11.0, "bath", "out"),
+            _state(12.0, "seal", "bath"),
+            _state(13.0, "fouled", "seal"),
+        ],
+    )
+    attempts = al.load_log(path)
+    assert len(attempts) == 2
+    approached = al.approached_attempts(attempts)
+    assert [a.index for a in approached] == [1]
+    assert all(a.attempted_find for a in approached)
+
+
+def test_multiple_devices_are_separated(tmp_path):
+    path = _write(
+        tmp_path,
+        [
+            _state(0.0, "bath", "out", dev="PatchPipette1"),
+            _state(1.0, "seal", "bath", dev="PatchPipette2"),
+            _state(2.0, "whole cell", "break in", dev="PatchPipette1"),
+        ],
+    )
+    attempts = al.load_log(path)
+    devs = {a.device for a in attempts}
+    assert devs == {"PatchPipette1", "PatchPipette2"}
+
+
+def test_global_events_without_device_are_ignored(tmp_path):
+    path = _write(
+        tmp_path,
+        [
+            '{"device": "Microscope", "event_time": 0.0, "event": "surface_depth_changed", "surface_depth": 0.0001}',
+            '{"event_time": 0.5, "device": null, "event": "global patch profiles changed", "profile": "{}"}',
+            _state(1.0, "bath", "out"),
+            _state(2.0, "seal", "bath"),
+        ],
+    )
+    attempts = al.load_log(path)
+    # Microscope has no patch states; only PatchPipette1 yields a real attempt
+    patch_attempts = [a for a in attempts if a.device == "PatchPipette1"]
+    assert len(patch_attempts) == 1
+    assert patch_attempts[0].found_cell
+
+
+def test_find_logs_is_recursive_and_case_insensitive(tmp_path):
+    (tmp_path / "cell_000").mkdir()
+    (tmp_path / "cell_001").mkdir()
+    p1 = _write(tmp_path / "cell_000", [_state(0.0, "bath", "out")])
+    p2 = _write(
+        tmp_path / "cell_001", [_state(0.0, "bath", "out")], name="multipatch_000.log"
+    )
+    (tmp_path / "unrelated.log").write_text("nope")
+    found = al.find_logs([str(tmp_path)])
+    assert set(found) == {p1, p2}
+
+
+def test_load_run_tags_source(tmp_path):
+    d = tmp_path / "cell_000"
+    d.mkdir()
+    path = _write(d, [_state(0.0, "bath", "out"), _state(1.0, "seal", "bath")])
+    attempts = al.load_run([str(tmp_path)])
+    assert len(attempts) == 1
+    assert attempts[0].source == path

--- a/tools/autopatch_analysis/tests/test_autopatch_metrics.py
+++ b/tools/autopatch_analysis/tests/test_autopatch_metrics.py
@@ -1,0 +1,151 @@
+"""Tests for aggregating autopatch attempts into funnel/throughput tables."""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import autopatch_log as al  # noqa: E402
+import autopatch_metrics as am  # noqa: E402
+
+
+def _attempt(
+    index, states, source="/run/cell_000/MultiPatch_000.log", start=0.0, tps=None
+):
+    end = states[-1][0] if states else start
+    if tps:
+        end = max(end, max(t["event_time"] for t in tps))
+    return al.Attempt(
+        source=source,
+        device="PatchPipette1",
+        index=index,
+        start_time=start,
+        end_time=end,
+        states=states,
+        test_pulses=tps or [],
+    )
+
+
+def _sample_attempts():
+    return [
+        # whole cell success
+        _attempt(
+            0,
+            [
+                (0.0, "bath"),
+                (10.0, "seal"),
+                (20.0, "cell attached"),
+                (25.0, "break in"),
+                (30.0, "whole cell"),
+            ],
+        ),
+        # found + sealed but lost it
+        _attempt(
+            1,
+            [(40.0, "bath"), (50.0, "seal"), (60.0, "cell attached"), (70.0, "fouled")],
+        ),
+        # found only
+        _attempt(2, [(80.0, "bath"), (90.0, "seal"), (100.0, "fouled")]),
+        # never found a cell
+        _attempt(3, [(110.0, "bath"), (120.0, "clean")]),
+    ]
+
+
+def test_dataframe_has_row_per_attempt():
+    df = am.attempts_to_dataframe(_sample_attempts())
+    assert len(df) == 4
+    assert df["cell_dir"].iloc[0] == "cell_000"
+    assert list(df["broke_in"]) == [True, False, False, False]
+
+
+def test_funnel_is_based_on_approached_not_all_attempts():
+    # The 4th sample attempt (bath -> clean) never approached a cell and must
+    # not count toward the funnel, even if the full df is passed in.
+    df = am.attempts_to_dataframe(_sample_attempts())
+    funnel = am.funnel_counts(df).set_index("stage")
+    # base of the funnel is the 3 approached attempts, not all 4
+    assert funnel.loc["approached", "count"] == 3
+    assert "attempted" not in funnel.index
+    assert funnel.loc["found_cell", "count"] == 3
+    assert funnel.loc["sealed", "count"] == 2
+    assert funnel.loc["broke_in", "count"] == 1
+    # conversions/percentages are relative to approached attempts
+    assert funnel.loc["found_cell", "pct_of_approached"] == pytest.approx(100.0)
+    assert funnel.loc["sealed", "pct_of_approached"] == pytest.approx(200.0 / 3)
+    # 1 of 2 sealed attempts broke in
+    assert funnel.loc["broke_in", "conversion_from_prev"] == pytest.approx(50.0)
+
+
+def test_state_timeline_spans_per_folder():
+    attempts = _sample_attempts()
+    tl = am.state_timeline(attempts)
+    # one row per state interval across all attempts
+    n_intervals = sum(len(a.states) for a in attempts)
+    assert len(tl) == n_intervals
+    assert set(["folder", "cell_dir", "device", "state", "t_start", "t_end"]) <= set(
+        tl.columns
+    )
+    # spans are ordered and non-negative in duration
+    assert (tl["t_end"] >= tl["t_start"]).all()
+    # folder is the directory holding the log
+    assert tl["folder"].iloc[0].endswith("cell_000")
+
+
+def test_state_timeline_empty_is_well_formed():
+    tl = am.state_timeline([])
+    assert list(tl.columns) == [
+        "folder",
+        "cell_dir",
+        "device",
+        "attempt_index",
+        "state",
+        "t_start",
+        "t_end",
+    ]
+    assert len(tl) == 0
+
+
+def test_failure_mode_counts():
+    df = am.attempts_to_dataframe(_sample_attempts())
+    fm = am.failure_mode_counts(df).set_index("outcome")
+    assert fm.loc["fouled", "count"] == 2
+    assert fm.loc["whole cell", "count"] == 1
+    assert fm.loc["clean", "count"] == 1
+
+
+def test_state_dwell_times():
+    dwell = am.state_dwell_times(_sample_attempts()).set_index("state")
+    # attempt 0: bath spans 0->10 = 10s; attempt 1: bath 40->50 = 10s; etc.
+    assert dwell.loc["bath", "total_s"] == pytest.approx(40.0)
+    assert dwell.loc["bath", "n"] == 4
+    assert dwell.loc["seal", "total_s"] == pytest.approx(30.0)  # 10 + 10 + 10
+
+
+def test_throughput():
+    df = am.attempts_to_dataframe(_sample_attempts())
+    tp = am.throughput(df)
+    assert tp["n_attempts"] == 4
+    assert tp["n_whole_cell"] == 1
+    assert tp["overall_yield_pct"] == pytest.approx(25.0)
+    # single log spanning 0 -> 120 s = 1/30 hour of active time
+    assert tp["active_hours"] == pytest.approx(120.0 / 3600.0)
+    assert tp["attempts_per_hour"] == pytest.approx(4.0 / (120.0 / 3600.0))
+
+
+def test_cumulative_whole_cells():
+    df = am.attempts_to_dataframe(_sample_attempts())
+    cum = am.cumulative_whole_cells(df)
+    assert list(cum["cumulative_whole_cells"]) == [1]
+    assert cum["minutes"].iloc[0] == pytest.approx(0.5)  # 30 s
+
+
+def test_empty_inputs_do_not_crash():
+    df = am.attempts_to_dataframe([])
+    # even with no rows the expected columns exist, so downstream lookups don't KeyError
+    assert "device" in df.columns and "broke_in" in df.columns
+    assert df["device"].nunique() == 0
+    assert am.throughput(df).empty
+    assert am.state_dwell_times([]).empty
+    assert am.cumulative_whole_cells(df).empty


### PR DESCRIPTION
## What

Fixes two sources of extraneous data in `tools/autopatch_analysis/`:

**a) Active time now covers only while the demo is running.** Throughput's `active_hours` was the full per-log span, including pipette setup/cleaning idle before the first cell and after the last. It now spans only the first-to-last *approached* attempt per log (the demo window). On a sample run this drops active time from 3.94 h → 3.38 h.

**b) The funnel no longer counts cells we never approached.** Attempts that never got past bath/clean/out are pipette setup and cleaning cycles, not real patch attempts. The analysis population is now filtered to approached attempts (`ONLY_APPROACHED`, default on), and `funnel_counts()` is rooted at the approached count (`pct_of_approached`). On the sample run: 34 raw attempts → 13 approached (21 excluded).

**Plus** (requested mid-task): a per-folder timeline cell — a Gantt of every device's patch states over wall-clock, drawn from *all* attempts so the trimmed idle stays visible, with the analyzed demo window shaded.

## How it's verified

- `pytest tools/autopatch_analysis/tests` — 19 passing (new tests for `approached_attempts`, the approached-based funnel, and `state_timeline`).
- End-to-end smoke run over real logs: funnel/throughput/timeline all render; `active_hours < span_hours` confirms the trim.

## Note

This tool was untracked in the working checkout (not on `main` or `_working`), so this branch introduces it along with the fix.

🧙 Built with [WOZCODE](https://wozcode.com)