### PR TITLE
Show detected cells' z-stacks in the AutomationDebug cell queue

### DIFF
--- a/acq4/modules/AutomationDebug/AutomationDebug.py
+++ b/acq4/modules/AutomationDebug/AutomationDebug.py
@@ -553,6 +553,22 @@ class AutomationDebugWindow(Qt.QWidget):
         if stack.ndim >= 2:
             stack = np.swapaxes(stack, -2, -1)
         iv.setImage(stack, autoRange=True, autoLevels=True)
+        # Default the z slider to the center frame (the plane the cell was detected
+        # on) rather than the first frame setImage jumps to.
+        center = self._centerFrameIndex(stack)
+        if center is not None:
+            iv.setCurrentIndex(center)
+
+    @staticmethod
+    def _centerFrameIndex(stack):
+        """The z index to display by default: the center frame of a 3D stack.
+
+        Returns None for a 2D image or a single-frame stack, where there is no
+        meaningful center frame to jump to.
+        """
+        if stack.ndim >= 3 and stack.shape[0] > 1:
+            return stack.shape[0] // 2
+        return None
 
     @staticmethod
     def _cellInitialStack(cell):

--- a/acq4/modules/AutomationDebug/detection.py
+++ b/acq4/modules/AutomationDebug/detection.py
@@ -199,6 +199,17 @@ class CellDetector:
         for pos, score in detection_results:
             cell = Cell(pos)
             cell.score = score
+            # Seed each detected cell's tracking reference from the z-stack it was
+            # found in, so its ObjectStack is ready for the cell-queue display and
+            # for later tracking without re-acquiring a stack per cell. Cells too
+            # close to the stack edge can't be extracted; keep them queued anyway.
+            try:
+                cell.initializeTrackerFromStack(win.cameraDevice, detection_stack)
+            except Exception:
+                logger.warning(
+                    f"Could not initialize ObjectStack for detected cell at {pos}",
+                    exc_info=True,
+                )
             win._unranked_cells.append(cell)
         return detection_results
 

--- a/acq4/modules/AutomationDebug/tests/test_cell_objectstack_display.py
+++ b/acq4/modules/AutomationDebug/tests/test_cell_objectstack_display.py
@@ -1,0 +1,61 @@
+"""Tests for detected cells' ObjectStacks and their cell-queue display.
+
+Cover that a detected cell can be seeded with a tracking reference from the
+detection z-stack, that the cell table reads that stack back, and that the image
+view defaults to the stack's center frame.
+"""
+
+import numpy as np
+import coorx
+from acq4.util.imaging import Frame
+from acq4_automation.feature_tracking.cell import Cell
+
+from acq4.modules.AutomationDebug.AutomationDebug import AutomationDebugWindow
+
+
+def _make_stack(n_frames=30, nrows=80, ncols=80, xy_px=1e-6, z_step=1e-6):
+    frames = []
+    for i in range(n_frames):
+        data = np.zeros((nrows, ncols), dtype=np.float32)
+        m = np.eye(4)
+        m[0, 0] = xy_px
+        m[1, 1] = xy_px
+        m[2, 2] = z_step
+        m[2, 3] = i * z_step
+        xform = coorx.AffineTransform.from_matrix(
+            m, from_cs=f"frame_{i}.xyz", to_cs="global"
+        )
+        frames.append(Frame(data, {"transform": xform, "pixelSize": (xy_px, xy_px)}))
+    return frames
+
+
+def test_initializeTrackerFromStack_populates_objectstack():
+    cell = Cell(coorx.Point((40e-6, 40e-6, 15e-6), "global"))
+    cell.initializeTrackerFromStack(None, _make_stack())
+
+    stack = cell._tracker.motion_estimator.original_object_stack.data
+    assert stack.shape == (20, 40, 40)
+
+
+def test_cellInitialStack_returns_stack_for_detected_cell():
+    cell = Cell(coorx.Point((40e-6, 40e-6, 15e-6), "global"))
+    cell.initializeTrackerFromStack(None, _make_stack())
+
+    stack = AutomationDebugWindow._cellInitialStack(cell)
+    assert stack is not None
+    assert stack.shape == (20, 40, 40)
+
+
+def test_cellInitialStack_none_for_uninitialized_cell():
+    cell = Cell(coorx.Point((40e-6, 40e-6, 15e-6), "global"))
+    assert AutomationDebugWindow._cellInitialStack(cell) is None
+
+
+def test_center_frame_index_is_middle_of_stack():
+    stack = np.zeros((20, 40, 40), dtype=np.float32)
+    assert AutomationDebugWindow._centerFrameIndex(stack) == 10
+
+
+def test_center_frame_index_none_for_single_frame():
+    assert AutomationDebugWindow._centerFrameIndex(np.zeros((1, 40, 40))) is None
+    assert AutomationDebugWindow._centerFrameIndex(np.zeros((40, 40))) is None


### PR DESCRIPTION
## Summary
The autopatch/detection module now initializes an `ObjectStack` for **every** cell it detects, built from the initial detection z-stack sent to the healthy-cell detector — and shows those stacks in the cell-queue display.

Previously each detected cell was just `Cell(pos)` + a score, with no tracker/ObjectStack; an ObjectStack was only built later (via a fresh per-cell z-stack acquisition) when a cell was actually being worked. So the cell-queue image view — which reads `cell._tracker.motion_estimator.original_object_stack` — was blank for waiting cells.

Changes:
- `detection.py`: seed each detected cell's tracking reference from the detection z-stack (`Cell.initializeTrackerFromStack`) as it's added to the queue. Cells too close to the stack edge to extract are kept in the queue without a stack (logged, not fatal).
- `AutomationDebug.py`: the cell-queue image view defaults to the **center frame** of the stack (the plane the cell was detected on) rather than the first frame.

Depends on AllenInstitute/acq4-automation#18 (adds `initialize_from_stack` / `initializeTrackerFromStack`).

Based on `_staging_20260714` (needs its "show the cell queue" commit).

## Testing
- `test_cell_objectstack_display.py`: detected cell is seeded from the stack, `_cellInitialStack` returns it, center-frame index is the middle, `None` for uninitialized cells / single frames.
- Offscreen Qt check: the full detection→display path lands the ImageView on the center frame with the tracker correctly positioned.
- Full AutomationDebug test suite passes (19).

🧙 Built with [WOZCODE](https://wozcode.com)