### PR TITLE
feat: save tracking history after each autopatch demo cell

### DIFF
--- a/acq4/modules/AutomationDebug/autopatch.py
+++ b/acq4/modules/AutomationDebug/autopatch.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from acq4.devices.PatchPipette import PatchPipette
@@ -72,6 +73,7 @@ class Autopatcher:
                     )
                     return
                 cell_dir = run_in_gui_thread(data_manager.createNewFolder, "Cell")
+                cell_to_save = None
                 try:
                     started_clean = ppip.isTipClean()
                     if not started_clean:
@@ -92,6 +94,7 @@ class Autopatcher:
                         set_state("No cells found; quitting demo")
                         logger.info("Autopatch: no cell to work on; quitting demo")
                         return
+                    cell_to_save = cell
                     set_state("Autopatch: cell found")
                     ppip.newPatchAttempt()
                     run_in_gui_thread(multipatch_win.ui.recordBtn.setChecked, True)
@@ -202,6 +205,7 @@ class Autopatcher:
                         win.setCellStatus(win._cell, "error during patching", "bad")
                     continue
                 finally:
+                    self._saveTrackingHistory(cell_to_save, cell_dir)
                     man.setCurrentDir(cell_dir.parent())
                     run_in_gui_thread(multipatch_win.ui.recordBtn.setChecked, False)
         finally:
@@ -346,6 +350,25 @@ class Autopatcher:
             timeout=max(30, expected_duration * 20),
         )
         logger.warning("Autopatch: Task runner sequence completed.")
+
+    def _saveTrackingHistory(self, cell, cell_dir) -> None:
+        """Save the cell's tracking history to an .acqtrack file in cell_dir.
+
+        Silently skips when there is nothing to save (no cell, no tracker, or no
+        recorded tracking results). Exceptions from the save are logged and
+        swallowed so a failed save never aborts the demo loop.
+        """
+        if cell is None:
+            return
+        tracker = getattr(cell, "_tracker", None)
+        if tracker is None or not tracker.tracking_results:
+            return
+        path = Path(cell_dir.name()) / "tracking_history.acqtrack"
+        try:
+            tracker.save_history(path)
+            logger.info(f"Saved tracking history to {path}")
+        except Exception:
+            logger.exception("Failed to save tracking history")
 
     def _saveStack(self, name):
         ppip = self._window.patchPipetteDevice

--- a/acq4/modules/AutomationDebug/tests/test_save_tracking_history.py
+++ b/acq4/modules/AutomationDebug/tests/test_save_tracking_history.py
@@ -1,0 +1,59 @@
+# Tests for Autopatcher._saveTrackingHistory — saving cell tracker history to cell_dir.
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import pytest
+
+from acq4.modules.AutomationDebug.autopatch import Autopatcher
+
+
+@pytest.fixture
+def autopatcher():
+    win = MagicMock()
+    return Autopatcher(win)
+
+
+@pytest.fixture
+def cell_dir(tmp_path):
+    d = tmp_path / "Cell_001"
+    d.mkdir()
+    mock = MagicMock()
+    mock.name.return_value = str(d)
+    return mock
+
+
+def _make_cell(tracking_results=None):
+    cell = MagicMock()
+    cell._tracker = MagicMock()
+    cell._tracker.tracking_results = tracking_results if tracking_results is not None else [MagicMock()]
+    return cell
+
+
+class TestSaveTrackingHistory:
+    def test_skips_when_cell_is_none(self, autopatcher, cell_dir):
+        autopatcher._saveTrackingHistory(None, cell_dir)
+        cell_dir.name.assert_not_called()
+
+    def test_skips_when_tracker_is_none(self, autopatcher, cell_dir):
+        cell = MagicMock()
+        cell._tracker = None
+        autopatcher._saveTrackingHistory(cell, cell_dir)
+        cell_dir.name.assert_not_called()
+
+    def test_skips_when_no_tracking_results(self, autopatcher, cell_dir):
+        cell = _make_cell(tracking_results=[])
+        autopatcher._saveTrackingHistory(cell, cell_dir)
+        cell._tracker.save_history.assert_not_called()
+
+    def test_saves_to_cell_dir(self, autopatcher, cell_dir, tmp_path):
+        cell = _make_cell()
+        autopatcher._saveTrackingHistory(cell, cell_dir)
+        expected = Path(cell_dir.name()) / "tracking_history.acqtrack"
+        cell._tracker.save_history.assert_called_once_with(expected)
+
+    def test_logs_and_continues_on_save_error(self, autopatcher, cell_dir, caplog):
+        cell = _make_cell()
+        cell._tracker.save_history.side_effect = OSError("disk full")
+        import logging
+        with caplog.at_level(logging.ERROR):
+            autopatcher._saveTrackingHistory(cell, cell_dir)
+        assert any("tracking history" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
## Summary

- Adds `Autopatcher._saveTrackingHistory(cell, cell_dir)` — saves the cell's tracker history to `tracking_history.acqtrack` in the per-cell data directory using the new `CellTracker.save_history()` API from `feature/tracking-history-save-format`.
- Wires it into `_autopatchDemo()` via a `cell_to_save` sentinel in the per-cell `finally` block, so the save always happens regardless of patch outcome (whole cell, fouled, exception, or user stop).
- Guards against `None` cell, missing tracker, or empty `tracking_results`; save failures are logged and never abort the demo loop.

## Test plan

- [ ] All 5 new unit tests in `test_save_tracking_history.py` pass
- [ ] All 27 AutomationDebug tests pass
- [ ] Run a mock autopatch demo and confirm a `tracking_history.acqtrack` file appears in each cell's directory

🤖 Generated with [Claude Code](https://claude.ai/code)