### PR TITLE
P2a: let the Autopatch orchestrator refill its cell queue from a producer

### DIFF
--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -46,14 +46,10 @@ class Orchestrator(Qt.QObject):
         # RetryCurrentCell, or a persistently-failing action). On exhaustion the
         # cell finishes as "retry-exhausted" rather than wedging the queue forever.
         self.maxRetries = maxRetries
-        if targetQueueDepth < 1:
-            raise ValueError(
-                f"targetQueueDepth must be at least 1, got {targetQueueDepth!r}: "
-                f"a target of 0 makes the refill condition unreachable, silently "
-                f"disabling the producer"
-            )
         # Read fresh on every pass of the run loop rather than snapshotted, so
         # the cell-finding config can retune it while a run is in progress.
+        # Routed through the targetQueueDepth property below so the < 1 guard
+        # applies whether it is set here or reassigned mid-run.
         self.targetQueueDepth = targetQueueDepth
         self._cellProducer = cellProducer
         # Per-run: set once the producer reports exhaustion, cleared by
@@ -78,6 +74,24 @@ class Orchestrator(Qt.QObject):
         """
         self._cellProducer = producer
         self._producerExhausted = False
+
+    @property
+    def targetQueueDepth(self) -> int:
+        return self._targetQueueDepth
+
+    @targetQueueDepth.setter
+    def targetQueueDepth(self, value: int) -> None:
+        # Publicly mutable mid-run by design (the cell-finding config owns this
+        # number), so the guard belongs here rather than only at construction:
+        # otherwise `orch.targetQueueDepth = 0` would silently reproduce the
+        # exact misconfiguration the constructor raises on.
+        if value < 1:
+            raise ValueError(
+                f"targetQueueDepth must be at least 1, got {value!r}: "
+                f"a target of 0 makes the refill condition unreachable, silently "
+                f"disabling the producer"
+            )
+        self._targetQueueDepth = value
 
     def _defaultContext(self, cell) -> ExecutionContext:
         return ExecutionContext(cell=cell, manager=self.manager)

--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -32,7 +32,6 @@ class Orchestrator(Qt.QObject):
         contextFactory=None,
         maxRetries=100,
         cellProducer=None,
-        targetQueueDepth=1,
     ):
         Qt.QObject.__init__(self)
         self.protocolFile = protocolFile
@@ -46,11 +45,6 @@ class Orchestrator(Qt.QObject):
         # RetryCurrentCell, or a persistently-failing action). On exhaustion the
         # cell finishes as "retry-exhausted" rather than wedging the queue forever.
         self.maxRetries = maxRetries
-        # Read fresh on every pass of the run loop rather than snapshotted, so
-        # the cell-finding config can retune it while a run is in progress.
-        # Routed through the targetQueueDepth property below so the < 1 guard
-        # applies whether it is set here or reassigned mid-run.
-        self.targetQueueDepth = targetQueueDepth
         self._cellProducer = cellProducer
         # Per-run: set once the producer reports exhaustion, cleared by
         # _runLoopBody's finally. See setCellProducer for why it is not
@@ -74,24 +68,6 @@ class Orchestrator(Qt.QObject):
         """
         self._cellProducer = producer
         self._producerExhausted = False
-
-    @property
-    def targetQueueDepth(self) -> int:
-        return self._targetQueueDepth
-
-    @targetQueueDepth.setter
-    def targetQueueDepth(self, value: int) -> None:
-        # Publicly mutable mid-run by design (the cell-finding config owns this
-        # number), so the guard belongs here rather than only at construction:
-        # otherwise `orch.targetQueueDepth = 0` would silently reproduce the
-        # exact misconfiguration the constructor raises on.
-        if value < 1:
-            raise ValueError(
-                f"targetQueueDepth must be at least 1, got {value!r}: "
-                f"a target of 0 makes the refill condition unreachable, silently "
-                f"disabling the producer"
-            )
-        self._targetQueueDepth = value
 
     def _defaultContext(self, cell) -> ExecutionContext:
         return ExecutionContext(cell=cell, manager=self.manager)
@@ -186,21 +162,19 @@ class Orchestrator(Qt.QObject):
                 self._checkPause()
                 check_stop()
                 if self._shouldRefill():
-                    queueWasEmpty = not self._queue
                     self._refillQueue()
-                    if queueWasEmpty:
-                        # A request that arrived while the producer was working
-                        # had no cell to advance past: nothing was running and
-                        # nothing was queued. Consuming it against the first
-                        # cell the producer then returned would skip a cell the
-                        # operator never saw, without it ever being attempted.
-                        self._nextCellRequested = False
+                    # Refill only ever runs against an empty queue, so a
+                    # request that arrived while the producer was working had
+                    # no cell to advance past: nothing was running and nothing
+                    # was queued. Consuming it against the first cell the
+                    # producer then returned would skip a cell the operator
+                    # never saw, without it ever being attempted.
+                    self._nextCellRequested = False
                     # Back to the top rather than falling through to a cell:
-                    # re-checks the depth target (so a deep queue fills over
-                    # several passes) and, more importantly, re-checks pause
-                    # and stop between refills. Imaging a tile is slow, so an
-                    # operator pressing Stop part-way through filling a deep
-                    # queue must not have to wait out the whole batch.
+                    # re-checks pause and stop between refills, and lets a
+                    # producer returning [] be asked again next pass. Imaging
+                    # a tile is slow, so an operator pressing Stop mid-survey
+                    # must not have to wait out a refill that already started.
                     continue
                 if not self._queue:
                     # Queue empty and nothing left to produce: the run is done.
@@ -251,7 +225,7 @@ class Orchestrator(Qt.QObject):
         return (
             self._cellProducer is not None
             and not self._producerExhausted
-            and len(self._queue) < self.targetQueueDepth
+            and not self._queue
         )
 
     def _refillQueue(self):

--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -25,7 +25,15 @@ class Orchestrator(Qt.QObject):
     sigCurrentCell = Qt.Signal(object)         # cell, or None when idle
     sigCellFinished = Qt.Signal(object, str)   # cell, status
 
-    def __init__(self, protocolFile, manager=None, contextFactory=None, maxRetries=100):
+    def __init__(
+        self,
+        protocolFile,
+        manager=None,
+        contextFactory=None,
+        maxRetries=100,
+        cellProducer=None,
+        targetQueueDepth=1,
+    ):
         Qt.QObject.__init__(self)
         self.protocolFile = protocolFile
         self.manager = manager
@@ -38,10 +46,38 @@ class Orchestrator(Qt.QObject):
         # RetryCurrentCell, or a persistently-failing action). On exhaustion the
         # cell finishes as "retry-exhausted" rather than wedging the queue forever.
         self.maxRetries = maxRetries
+        if targetQueueDepth < 1:
+            raise ValueError(
+                f"targetQueueDepth must be at least 1, got {targetQueueDepth!r}: "
+                f"a target of 0 makes the refill condition unreachable, silently "
+                f"disabling the producer"
+            )
+        # Read fresh on every pass of the run loop rather than snapshotted, so
+        # the cell-finding config can retune it while a run is in progress.
+        self.targetQueueDepth = targetQueueDepth
+        self._cellProducer = cellProducer
+        # Per-run: set once the producer reports exhaustion, cleared by
+        # _runLoopBody's finally. See setCellProducer for why it is not
+        # simply "has the producer ever returned None".
+        self._producerExhausted = False
 
     # ---- queue / context ----
     def enqueue(self, cell):
         self._queue.append(cell)
+
+    def setCellProducer(self, producer):
+        """Install (or clear, with None) the callback that refills the queue.
+
+        `producer()` takes no arguments, runs on the worker thread, and returns
+        either a sequence of new cells -- possibly empty, meaning "made
+        progress, found none here, ask again" -- or None, meaning exhausted.
+
+        Installing a producer clears the exhausted flag: a caller swapping in a
+        fresh producer (a new survey region) is declaring there is more to find,
+        and would otherwise be ignored for the rest of the run.
+        """
+        self._cellProducer = producer
+        self._producerExhausted = False
 
     def _defaultContext(self, cell) -> ExecutionContext:
         return ExecutionContext(cell=cell, manager=self.manager)
@@ -132,9 +168,21 @@ class Orchestrator(Qt.QObject):
     def _runLoopBody(self):
         self.sigStatus.emit("running")
         try:
-            while self._queue:
+            while True:
                 self._checkPause()
                 check_stop()
+                if self._shouldRefill():
+                    self._refillQueue()
+                    # Back to the top rather than falling through to a cell:
+                    # re-checks the depth target (so a deep queue fills over
+                    # several passes) and, more importantly, re-checks pause
+                    # and stop between refills. Imaging a tile is slow, so an
+                    # operator pressing Stop part-way through filling a deep
+                    # queue must not have to wait out the whole batch.
+                    continue
+                if not self._queue:
+                    # Queue empty and nothing left to produce: the run is done.
+                    break
                 cell = self._queue.popleft()
                 self._processCell(cell)
         except Stopped as exc:
@@ -166,6 +214,35 @@ class Orchestrator(Qt.QObject):
             self.sigStatus.emit("paused")
             self._pauseEvent.wait()
             self.sigStatus.emit("running")
+
+    def _shouldRefill(self) -> bool:
+        return (
+            self._cellProducer is not None
+            and not self._producerExhausted
+            and len(self._queue) < self.targetQueueDepth
+        )
+
+    def _refillQueue(self):
+        """Ask the producer for more cells; record exhaustion when it has none."""
+        try:
+            cells = self._cellProducer()
+        except (Stopped, FlowSignal):
+            # Same pass-through as _processCell: a cooperative stop is a normal
+            # end to the run, and a producer that raises AbortExperiment means
+            # it -- neither is a bug to be wrapped by the clause below.
+            raise
+        except Exception as exc:
+            # An unexpected bug in the producer must fail loud rather than
+            # quietly ending the survey and letting the run look complete.
+            # There is no cell to attribute it to, so no sigCellFinished.
+            logger.exception("Cell producer raised while refilling the queue")
+            self.sigStatus.emit("error")
+            raise AbortExperiment(f"cell producer failed: {exc}") from exc
+        if cells is None:
+            self._producerExhausted = True
+            return
+        for cell in cells:
+            self.enqueue(cell)
 
     def _processCell(self, cell):
         """Run the protocol function for one cell. RetryCurrentCell loops in

--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -172,7 +172,15 @@ class Orchestrator(Qt.QObject):
                 self._checkPause()
                 check_stop()
                 if self._shouldRefill():
+                    queueWasEmpty = not self._queue
                     self._refillQueue()
+                    if queueWasEmpty:
+                        # A request that arrived while the producer was working
+                        # had no cell to advance past: nothing was running and
+                        # nothing was queued. Consuming it against the first
+                        # cell the producer then returned would skip a cell the
+                        # operator never saw, without it ever being attempted.
+                        self._nextCellRequested = False
                     # Back to the top rather than falling through to a cell:
                     # re-checks the depth target (so a deep queue fills over
                     # several passes) and, more importantly, re-checks pause

--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -206,6 +206,16 @@ class Orchestrator(Qt.QObject):
             # be silently consumed against an unrelated cell the next time
             # the queue is started.
             self._nextCellRequested = False
+            # Per-run, exactly like the next-cell request above: a producer
+            # that exhausted during this run must not leave the orchestrator
+            # permanently convinced there is nothing left to find. A later run
+            # -- over a new survey region, or over cells still queued after a
+            # stop -- has to ask again. Unlike the next-cell flag, this one
+            # needs no per-exit clears: it is only ever read by the refill
+            # check at the top of this method's own loop, so there is no
+            # equivalent of _processCell's inner retry loop running past the
+            # reach of this finally.
+            self._producerExhausted = False
             self.sigCurrentCell.emit(None)
             self.sigStatus.emit("waiting")
 

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -381,11 +381,13 @@ def test_pause_is_honored_before_refilling(make_pf, qtbot):
 
     released.set()
     task.wait(timeout=5)
-    # wait() returns None on timeout rather than raising (see acq4/util/task.py),
-    # so a loop that failed to terminate would let a bare wait() pass after the
-    # 5-second stall and leak a spinning worker thread into every test that
-    # follows. Assert the run actually finished instead of trusting the wait.
-    assert task.is_done, "run loop did not finish before the wait timed out"
+    # This wait(updates=False) does raise Timeout on expiry, so it is itself a
+    # barrier -- it is wait(updates=True) that returns None instead (the KNOWN
+    # DIVERGENCE in acq4/util/task.py). The assertion pins the loop's own
+    # completion regardless of which wait a later edit reaches for, so a run
+    # that failed to terminate cannot leak a spinning worker thread into every
+    # test that follows.
+    assert task.is_done, "run loop did not finish before the wait returned"
 
 
 def test_stop_between_tiles_ends_a_barren_survey(make_pf, qtbot):

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -1,5 +1,5 @@
-"""Tests for the Orchestrator's cell-producer refill hook: the queue-depth
-target, the empty-vs-exhausted distinction, and end-of-run conditions."""
+"""Tests for the Orchestrator's cell-producer refill hook: the empty-queue
+refill trigger, the empty-vs-exhausted distinction, and end-of-run conditions."""
 import gc
 import weakref
 
@@ -69,52 +69,6 @@ def test_empty_batch_asks_again_rather_than_ending_the_run(make_pf):
     assert producer.calls["n"] == 4  # two empty tiles, one productive, then exhausted
 
 
-def test_queue_is_filled_to_target_depth_before_the_first_cell_runs(make_pf):
-    """With a depth target above 1, the loop keeps asking until the queue
-    reaches it -- so a producer yielding one cell per tile is asked three times
-    before any cell is worked."""
-    pf = make_pf()
-    callsAtFirstRun = {}
-
-    def run(ctx, **kwargs):
-        callsAtFirstRun.setdefault("n", producer.calls["n"])
-
-    pf.run = run
-    producer = make_producer([["c1"], ["c2"], ["c3"], None])
-    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=3)
-    orch.run_sync()
-    assert callsAtFirstRun["n"] == 3
-
-
-def test_depth_target_is_read_fresh_so_it_can_change_mid_run(make_pf):
-    """The cell-finding config owns this number and an operator may change it
-    while a run is in progress, so it must not be snapshotted at start: turning
-    it down from 2 to 1 after the first cell must actually let the queue drain
-    to 0 between the following cells, rather than being kept topped up to the
-    stale higher target. A snapshot taken once at the top of the run loop would
-    still finish all three cells in the same order with the same call count --
-    only the queue depth observed at each cell distinguishes the two."""
-    pf = make_pf()
-    ran = []
-    depths = []
-
-    def run(ctx, **kwargs):
-        depths.append(len(orch._queue))
-        ran.append(ctx.cell)
-        if ctx.cell == "c1":
-            orch.targetQueueDepth = 1  # operator turns it down after the first cell
-
-    pf.run = run
-    producer = make_producer([["c1"], ["c2"], ["c3"], None])
-    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=2)
-    orch.run_sync()
-    assert ran == ["c1", "c2", "c3"]
-    # Before the turn-down (target=2), the queue is kept filled to 2 ahead of
-    # c1. After it (target=1), the queue must be allowed to drain to 0 between
-    # c2 and c3, not stay topped up to the stale target of 2.
-    assert depths == [1, 0, 0]
-
-
 def test_no_producer_drains_the_queue_and_ends(make_pf):
     """The unconfigured case -- every existing caller. Behaviour must be
     exactly the pre-producer queue drain, and in particular the loop must end
@@ -165,15 +119,6 @@ def test_setCellProducer_none_reverts_to_a_plain_queue_drain(make_pf):
     assert ran == ["c1"]
 
 
-def test_target_queue_depth_below_one_is_rejected(make_pf):
-    """A target of 0 would make `len(queue) < target` never true, silently
-    disabling the producer -- a misconfiguration that looks like a hung
-    survey. Fail at construction instead."""
-    pf = make_pf()
-    with pytest.raises(ValueError):
-        Orchestrator(pf, targetQueueDepth=0)
-
-
 def test_exhaustion_does_not_outlive_the_run(make_pf):
     """The scar-tissue test. A producer that exhausted during one run must not
     leave the orchestrator permanently convinced there is nothing to find: the
@@ -202,23 +147,24 @@ def test_exhaustion_cleared_when_the_run_ends_by_raising(make_pf):
     belongs in the finally, not on the return path -- the same mistake that
     left the next-cell flag set on four separate raise paths.
 
-    A target of 1 would let the first batch alone satisfy the depth check,
-    so the producer would never be asked again and never get the chance to
-    return None -- the run would raise before exhaustion ever happened,
-    proving nothing about the clear. A depth of 2 forces a second ask, which
-    is the one that returns None and actually sets the flag before the cell
-    (and its raise) is reached."""
+    Refill only ever runs against an empty queue, so the moment a producer
+    reports exhaustion there is nothing left queued and the run loop ends
+    right there -- there is no way to reach a still-queued, still-raising
+    cell by driving the producer through the normal refill path. The
+    exhausted flag is set directly instead, with a cell already queued from
+    before that point, to pin the same invariant: the finally clears it on
+    this raise path too, not only when the loop ends by returning."""
     pf = make_pf()
 
     def run(ctx, **kwargs):
         raise AttributeError("an ordinary bug, mid-cell")
 
     pf.run = run
-    producer = make_producer([["c1"], None])
-    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=2)
+    orch = Orchestrator(pf, cellProducer=make_producer([]))
+    orch.enqueue("c1")
+    orch._producerExhausted = True
     with pytest.raises(AbortExperiment):
         orch.run_sync()
-    assert producer.calls["n"] == 2  # the batch, then the None that exhausted it
     assert orch._producerExhausted is False
 
 
@@ -227,12 +173,12 @@ def test_exhaustion_cleared_after_a_cooperative_stop(make_pf):
     remain queued, then presses Start again. The remaining cells must be
     worked, and the producer must be re-asked rather than assumed dry.
 
-    The first batch alone (two cells) already meets a target of 1, so with
-    the default depth the producer would never be asked a second time and
-    would never get to return None -- the stop would land with exhaustion
-    never having happened. A target of 3 keeps the refill loop asking past
-    that first batch, so the second call is the one that returns None and
-    sets the flag before c1's Stopped ends the run."""
+    Refill only ever runs against an empty queue, so reaching exhaustion
+    with cells still queued behind it can't be driven through the normal
+    refill path (the moment the producer reports exhaustion, the queue is
+    already empty). The exhausted flag is set directly instead, with two
+    cells already queued, so the first cell's Stopped ends the run while a
+    cell (c2) and the exhausted flag are both still there to check."""
     pf = make_pf()
     ran = []
 
@@ -242,11 +188,12 @@ def test_exhaustion_cleared_after_a_cooperative_stop(make_pf):
             raise Stopped("operator pressed stop")
 
     pf.run = run
-    producer = make_producer([["c1", "c2"], None])
-    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=3)
+    orch = Orchestrator(pf, cellProducer=make_producer([]))
+    orch.enqueue("c1")
+    orch.enqueue("c2")
+    orch._producerExhausted = True
     orch.run_sync()  # a cooperative stop ends the run normally
     assert ran == ["c1"]
-    assert producer.calls["n"] == 2  # the batch, then the None that exhausted it
     assert orch._producerExhausted is False
     assert list(orch._queue) == ["c2"]  # a stop is not a queue drain
 
@@ -323,37 +270,11 @@ def test_nextcell_request_during_refill_of_an_empty_queue_is_discarded(make_pf):
         ran.append(ctx.cell)
 
     pf.run = run
-    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=1)
+    orch = Orchestrator(pf, cellProducer=producer)
     orch.sigCellFinished.connect(lambda c, s: finished.append((c, s)))
     orch.run_sync()
     assert ran == ["c1", "c2"]
     assert finished == [("c1", "done"), ("c2", "done")]
-
-
-def test_nextcell_request_during_refill_of_a_nonempty_queue_is_preserved(make_pf):
-    """The same request, but with a cell already queued when the refill runs,
-    must NOT be discarded: there is a cell it could be about (c1), the same as
-    if the operator had pressed Next before Start. The fix for the empty-queue
-    case above must not over-broadly clear the flag whenever a refill happens
-    to run first."""
-    pf = make_pf()
-    ran = []
-    finished = []
-
-    def producer():
-        orch.requestNextCell()  # arrives mid-produce, c1 is already queued
-        return None  # exhausted immediately -- c1 is the only cell available
-
-    def run(ctx, **kwargs):
-        ran.append(ctx.cell)
-
-    pf.run = run
-    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=2)
-    orch.enqueue("c1")
-    orch.sigCellFinished.connect(lambda c, s: finished.append((c, s)))
-    orch.run_sync()
-    assert ran == []
-    assert finished == [("c1", "skipped")]
 
 
 def test_pause_is_honored_before_refilling(make_pf, qtbot):
@@ -446,7 +367,7 @@ def test_producer_bound_method_cycle_is_freed_once_the_producer_is_released(
     # self._contextFactory attribute does not itself create a self-cycle --
     # this test is targeted at the orch<->panel cycle through the producer
     # specifically, same isolation as the orch<->task cycle test.
-    orch = Orchestrator(pf, contextFactory=lambda cell: None, targetQueueDepth=2)
+    orch = Orchestrator(pf, contextFactory=lambda cell: None)
     panel = FakePanel(orch)
     orch.setCellProducer(panel.produceCells)
     orch.enqueue("c1")

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -184,23 +184,39 @@ def test_exhaustion_cleared_when_the_run_ends_by_raising(make_pf):
     """_runLoopBody can leave by raising as well as returning (an
     OrchestrationError from a cell re-raised as AbortExperiment). The clear
     belongs in the finally, not on the return path -- the same mistake that
-    left the next-cell flag set on four separate raise paths."""
+    left the next-cell flag set on four separate raise paths.
+
+    A target of 1 would let the first batch alone satisfy the depth check,
+    so the producer would never be asked again and never get the chance to
+    return None -- the run would raise before exhaustion ever happened,
+    proving nothing about the clear. A depth of 2 forces a second ask, which
+    is the one that returns None and actually sets the flag before the cell
+    (and its raise) is reached."""
     pf = make_pf()
 
     def run(ctx, **kwargs):
         raise AttributeError("an ordinary bug, mid-cell")
 
     pf.run = run
-    orch = Orchestrator(pf, cellProducer=make_producer([["c1"], None]))
+    producer = make_producer([["c1"], None])
+    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=2)
     with pytest.raises(AbortExperiment):
         orch.run_sync()
+    assert producer.calls["n"] == 2  # the batch, then the None that exhausted it
     assert orch._producerExhausted is False
 
 
 def test_exhaustion_cleared_after_a_cooperative_stop(make_pf):
     """Operator presses Stop after the region is exhausted but while cells
     remain queued, then presses Start again. The remaining cells must be
-    worked, and the producer must be re-asked rather than assumed dry."""
+    worked, and the producer must be re-asked rather than assumed dry.
+
+    The first batch alone (two cells) already meets a target of 1, so with
+    the default depth the producer would never be asked a second time and
+    would never get to return None -- the stop would land with exhaustion
+    never having happened. A target of 3 keeps the refill loop asking past
+    that first batch, so the second call is the one that returns None and
+    sets the flag before c1's Stopped ends the run."""
     pf = make_pf()
     ran = []
 
@@ -211,9 +227,10 @@ def test_exhaustion_cleared_after_a_cooperative_stop(make_pf):
 
     pf.run = run
     producer = make_producer([["c1", "c2"], None])
-    orch = Orchestrator(pf, cellProducer=producer)
+    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=3)
     orch.run_sync()  # a cooperative stop ends the run normally
     assert ran == ["c1"]
+    assert producer.calls["n"] == 2  # the batch, then the None that exhausted it
     assert orch._producerExhausted is False
     assert list(orch._queue) == ["c2"]  # a stop is not a queue drain
 

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -84,19 +84,31 @@ def test_queue_is_filled_to_target_depth_before_the_first_cell_runs(make_pf):
 
 def test_depth_target_is_read_fresh_so_it_can_change_mid_run(make_pf):
     """The cell-finding config owns this number and an operator may change it
-    while a run is in progress, so it must not be snapshotted at start."""
+    while a run is in progress, so it must not be snapshotted at start: turning
+    it down from 2 to 1 after the first cell must actually let the queue drain
+    to 0 between the following cells, rather than being kept topped up to the
+    stale higher target. A snapshot taken once at the top of the run loop would
+    still finish all three cells in the same order with the same call count --
+    only the queue depth observed at each cell distinguishes the two."""
     pf = make_pf()
     ran = []
+    depths = []
 
     def run(ctx, **kwargs):
+        depths.append(len(orch._queue))
         ran.append(ctx.cell)
-        orch.targetQueueDepth = 1  # operator turns it down after the first cell
+        if ctx.cell == "c1":
+            orch.targetQueueDepth = 1  # operator turns it down after the first cell
 
     pf.run = run
     producer = make_producer([["c1"], ["c2"], ["c3"], None])
     orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=2)
     orch.run_sync()
     assert ran == ["c1", "c2", "c3"]
+    # Before the turn-down (target=2), the queue is kept filled to 2 ahead of
+    # c1. After it (target=1), the queue must be allowed to drain to 0 between
+    # c2 and c3, not stay topped up to the stale target of 2.
+    assert depths == [1, 0, 0]
 
 
 def test_no_producer_drains_the_queue_and_ends(make_pf):

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -368,7 +368,7 @@ def test_pause_is_honored_before_refilling(make_pf, qtbot):
 
     orch = Orchestrator(pf, cellProducer=slow_producer)
     orch.pause()
-    orch.start()
+    task = orch.start()
     qtbot.wait(100)
     assert calls["n"] == 0, "producer was asked for a tile while paused"
 
@@ -376,7 +376,12 @@ def test_pause_is_honored_before_refilling(make_pf, qtbot):
     qtbot.waitUntil(lambda: calls["n"] > 0, timeout=5000)
 
     released.set()
-    orch.wait(timeout=5)
+    task.wait(timeout=5)
+    # wait() returns None on timeout rather than raising (see acq4/util/task.py),
+    # so a loop that failed to terminate would let a bare wait() pass after the
+    # 5-second stall and leak a spinning worker thread into every test that
+    # follows. Assert the run actually finished instead of trusting the wait.
+    assert task.is_done, "run loop did not finish before the wait timed out"
 
 
 def test_stop_between_tiles_ends_a_barren_survey(make_pf, qtbot):

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -3,6 +3,8 @@ target, the empty-vs-exhausted distinction, and end-of-run conditions."""
 import pytest
 
 from acq4.experiment.orchestrator import Orchestrator
+from acq4.util.task import Stopped, Event, sleep
+from acq4.experiment.exceptions import AbortExperiment
 
 
 def make_producer(batches):
@@ -154,3 +156,163 @@ def test_target_queue_depth_below_one_is_rejected(make_pf):
     pf = make_pf()
     with pytest.raises(ValueError):
         Orchestrator(pf, targetQueueDepth=0)
+
+
+def test_exhaustion_does_not_outlive_the_run(make_pf):
+    """The scar-tissue test. A producer that exhausted during one run must not
+    leave the orchestrator permanently convinced there is nothing to find: the
+    operator draws a second survey region, presses Start, and the new
+    producer has to actually be asked. This is the same class of leak as the
+    "Next cell" flag surviving its run and silently skipping an unrelated
+    cell."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf, cellProducer=make_producer([["c1"], None]))
+    orch.run_sync()
+    assert ran == ["c1"]
+    assert orch._producerExhausted is False  # cleared on the way out
+
+    second = make_producer([["c2"], None])
+    orch.setCellProducer(second)
+    orch.run_sync()
+    assert ran == ["c1", "c2"]  # the second region was actually surveyed
+    assert second.calls["n"] == 2
+
+
+def test_exhaustion_cleared_when_the_run_ends_by_raising(make_pf):
+    """_runLoopBody can leave by raising as well as returning (an
+    OrchestrationError from a cell re-raised as AbortExperiment). The clear
+    belongs in the finally, not on the return path -- the same mistake that
+    left the next-cell flag set on four separate raise paths."""
+    pf = make_pf()
+
+    def run(ctx, **kwargs):
+        raise AttributeError("an ordinary bug, mid-cell")
+
+    pf.run = run
+    orch = Orchestrator(pf, cellProducer=make_producer([["c1"], None]))
+    with pytest.raises(AbortExperiment):
+        orch.run_sync()
+    assert orch._producerExhausted is False
+
+
+def test_exhaustion_cleared_after_a_cooperative_stop(make_pf):
+    """Operator presses Stop after the region is exhausted but while cells
+    remain queued, then presses Start again. The remaining cells must be
+    worked, and the producer must be re-asked rather than assumed dry."""
+    pf = make_pf()
+    ran = []
+
+    def run(ctx, **kwargs):
+        ran.append(ctx.cell)
+        if ctx.cell == "c1":
+            raise Stopped("operator pressed stop")
+
+    pf.run = run
+    producer = make_producer([["c1", "c2"], None])
+    orch = Orchestrator(pf, cellProducer=producer)
+    orch.run_sync()  # a cooperative stop ends the run normally
+    assert ran == ["c1"]
+    assert orch._producerExhausted is False
+    assert list(orch._queue) == ["c2"]  # a stop is not a queue drain
+
+
+def test_producer_exception_surfaces_as_error_and_aborts(make_pf):
+    """A bug in the producer (a detection crash, a stage move that throws)
+    must not quietly end the survey and let the run report itself complete."""
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+
+    def exploding_producer():
+        raise RuntimeError("detection crashed")
+
+    statuses = []
+    orch = Orchestrator(pf, cellProducer=exploding_producer)
+    orch.sigStatus.connect(statuses.append)
+    with pytest.raises(AbortExperiment) as excinfo:
+        orch.run_sync()
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert "error" in statuses
+
+
+def test_producer_stopped_ends_the_run_normally(make_pf):
+    """Stop pressed while the producer is imaging a tile: check_stop() inside
+    the producer raises Stopped, which is a normal end to the run, not a
+    raise the caller must catch."""
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+
+    def stopping_producer():
+        raise Stopped("operator pressed stop mid-survey")
+
+    orch = Orchestrator(pf, cellProducer=stopping_producer)
+    orch.run_sync()  # must not raise
+
+
+def test_producer_abort_propagates_without_double_wrapping(make_pf):
+    """A producer that raises AbortExperiment means it. It must propagate as
+    itself rather than being caught by the broad clause and re-wrapped in a
+    second AbortExperiment whose __cause__ is the first."""
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+    sentinel = AbortExperiment("region is unusable")
+
+    def aborting_producer():
+        raise sentinel
+
+    orch = Orchestrator(pf, cellProducer=aborting_producer)
+    with pytest.raises(AbortExperiment) as excinfo:
+        orch.run_sync()
+    assert excinfo.value is sentinel
+
+
+def test_pause_is_honored_before_refilling(make_pf, qtbot):
+    """Pause means "start nothing new", and imaging a tile is very much
+    something new -- an operator who pauses must not have the stage move to
+    another tile underneath them."""
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+    calls = {"n": 0}
+    released = Event()
+
+    def slow_producer():
+        calls["n"] += 1
+        sleep(0.005)  # paces tiles out so pause can land between them
+        return [] if not released.is_set() else None
+
+    orch = Orchestrator(pf, cellProducer=slow_producer)
+    orch.pause()
+    orch.start()
+    qtbot.wait(100)
+    assert calls["n"] == 0, "producer was asked for a tile while paused"
+
+    orch.resume()
+    qtbot.waitUntil(lambda: calls["n"] > 0, timeout=5000)
+
+    released.set()
+    orch.wait(timeout=5)
+
+
+def test_stop_between_tiles_ends_a_barren_survey(make_pf, qtbot):
+    """A producer returning [] forever is a wedged survey by construction.
+    check_stop() between refills is what makes it interruptible, so the
+    operator's Stop must end it."""
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+    calls = {"n": 0}
+
+    def barren_producer():
+        calls["n"] += 1
+        sleep(0.005)
+        return []  # never exhausts
+
+    orch = Orchestrator(pf, cellProducer=barren_producer)
+    task = orch.start()
+    qtbot.waitUntil(lambda: calls["n"] >= 2, timeout=5000)
+    orch.stop("test stop")
+    task.wait(timeout=5)  # a cooperative stop is a normal end, not a raise
+    countAtStop = calls["n"]
+    qtbot.wait(100)
+    assert calls["n"] == countAtStop  # genuinely stopped asking
+    assert orch._producerExhausted is False

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -1,0 +1,156 @@
+"""Tests for the Orchestrator's cell-producer refill hook: the queue-depth
+target, the empty-vs-exhausted distinction, and end-of-run conditions."""
+import pytest
+
+from acq4.experiment.orchestrator import Orchestrator
+
+
+def make_producer(batches):
+    """A producer returning each of `batches` in turn, recording its calls.
+
+    Each batch is either a list of cells or None (exhausted). Running past the
+    end of `batches` is a broken test setup, not an implicit exhaustion, so it
+    fails loudly rather than quietly ending the run.
+    """
+    calls = {"n": 0}
+
+    def producer():
+        calls["n"] += 1
+        if not batches:
+            raise AssertionError(
+                "producer called after its last declared batch -- the loop "
+                "asked again past exhaustion"
+            )
+        return batches.pop(0)
+
+    producer.calls = calls
+    return producer
+
+
+def test_producer_fills_an_empty_queue_and_cells_are_processed(make_pf):
+    """The whole point: a run started with nothing queued must still work
+    cells, by asking the producer for them."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf, cellProducer=make_producer([["c1", "c2"], None]))
+    orch.run_sync()  # nothing enqueued up front
+    assert ran == ["c1", "c2"]
+
+
+def test_run_ends_when_queue_empty_and_producer_exhausted(make_pf):
+    pf = make_pf()
+    finished = []
+    pf.run = lambda ctx, **kwargs: None
+    orch = Orchestrator(pf, cellProducer=make_producer([["c1"], None]))
+    orch.sigCellFinished.connect(lambda c, s: finished.append((c, s)))
+    orch.run_sync()  # must return, not spin
+    assert finished == [("c1", "done")]
+
+
+def test_empty_batch_asks_again_rather_than_ending_the_run(make_pf):
+    """An imaged tile with no cells in it returns [] -- "found nothing, ask me
+    again" -- which must NOT end the run the way None does. This is the
+    distinction the whole survey loop rests on: a barren tile in the middle of
+    a region cannot be allowed to stop the experiment."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    producer = make_producer([[], [], ["c1"], None])
+    orch = Orchestrator(pf, cellProducer=producer)
+    orch.run_sync()
+    assert ran == ["c1"]
+    assert producer.calls["n"] == 4  # two empty tiles, one productive, then exhausted
+
+
+def test_queue_is_filled_to_target_depth_before_the_first_cell_runs(make_pf):
+    """With a depth target above 1, the loop keeps asking until the queue
+    reaches it -- so a producer yielding one cell per tile is asked three times
+    before any cell is worked."""
+    pf = make_pf()
+    callsAtFirstRun = {}
+
+    def run(ctx, **kwargs):
+        callsAtFirstRun.setdefault("n", producer.calls["n"])
+
+    pf.run = run
+    producer = make_producer([["c1"], ["c2"], ["c3"], None])
+    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=3)
+    orch.run_sync()
+    assert callsAtFirstRun["n"] == 3
+
+
+def test_depth_target_is_read_fresh_so_it_can_change_mid_run(make_pf):
+    """The cell-finding config owns this number and an operator may change it
+    while a run is in progress, so it must not be snapshotted at start."""
+    pf = make_pf()
+    ran = []
+
+    def run(ctx, **kwargs):
+        ran.append(ctx.cell)
+        orch.targetQueueDepth = 1  # operator turns it down after the first cell
+
+    pf.run = run
+    producer = make_producer([["c1"], ["c2"], ["c3"], None])
+    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=2)
+    orch.run_sync()
+    assert ran == ["c1", "c2", "c3"]
+
+
+def test_no_producer_drains_the_queue_and_ends(make_pf):
+    """The unconfigured case -- every existing caller. Behaviour must be
+    exactly the pre-producer queue drain, and in particular the loop must end
+    rather than spin waiting for a refill that can never come."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf)
+    orch.enqueue("c1")
+    orch.enqueue("c2")
+    orch.run_sync()
+    assert ran == ["c1", "c2"]
+
+
+def test_producer_supplements_cells_seeded_before_start(make_pf):
+    """Seeded cells and produced cells are the same queue: the operator's
+    hand-added cells are worked first, then the producer's."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf, cellProducer=make_producer([["produced"], None]))
+    orch.enqueue("seeded")
+    orch.run_sync()
+    assert ran == ["seeded", "produced"]
+
+
+def test_setCellProducer_installs_a_producer_after_construction(make_pf):
+    """The UI builds the Orchestrator when a protocol is selected, but the
+    producer depends on region/finding config chosen later, so it must be
+    installable after the fact."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf)
+    orch.setCellProducer(make_producer([["c1"], None]))
+    orch.run_sync()
+    assert ran == ["c1"]
+
+
+def test_setCellProducer_none_reverts_to_a_plain_queue_drain(make_pf):
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf, cellProducer=make_producer([["never asked"], None]))
+    orch.setCellProducer(None)
+    orch.enqueue("c1")
+    orch.run_sync()
+    assert ran == ["c1"]
+
+
+def test_target_queue_depth_below_one_is_rejected(make_pf):
+    """A target of 0 would make `len(queue) < target` never true, silently
+    disabling the producer -- a misconfiguration that looks like a hung
+    survey. Fail at construction instead."""
+    pf = make_pf()
+    with pytest.raises(ValueError):
+        Orchestrator(pf, targetQueueDepth=0)

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -1,8 +1,12 @@
 """Tests for the Orchestrator's cell-producer refill hook: the queue-depth
 target, the empty-vs-exhausted distinction, and end-of-run conditions."""
+import gc
+import weakref
+
 import pytest
 
 from acq4.experiment.orchestrator import Orchestrator
+from acq4.util import Qt
 from acq4.util.task import Stopped, Event, sleep
 from acq4.experiment.exceptions import AbortExperiment
 
@@ -406,3 +410,74 @@ def test_stop_between_tiles_ends_a_barren_survey(make_pf, qtbot):
     qtbot.wait(100)
     assert calls["n"] == countAtStop  # genuinely stopped asking
     assert orch._producerExhausted is False
+
+
+def test_producer_bound_method_cycle_is_freed_once_the_producer_is_released(
+    make_pf, qtbot
+):
+    """A realistic producer is a bound method of a UI panel that also holds
+    the orchestrator: orchestrator -> panel (via the bound method's __self__)
+    -> panel._orchestrator -> orchestrator, a QObject reference cycle much
+    like the orch<->task cycle test_finished_task_does_not_leave_qobject_cycle
+    (test_orchestrator_loop.py) guards against. The existing teardown
+    machinery breaks it, but nothing on this branch exercises it with a real
+    producer reference in place. This proves that once the producer is
+    released, plain refcounting -- cyclic GC disabled -- is enough to free
+    both the panel and the orchestrator.
+    """
+    gate = Event()
+    started = Event()
+
+    class FakePanel(Qt.QObject):
+        def __init__(self, orchestrator):
+            super().__init__()
+            self._orchestrator = orchestrator
+
+        def produceCells(self):
+            started.set()
+            gate.wait()
+            return None  # exhausted; nothing more to survey
+
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+    # A plain lambda, not a bound method of orch, so the orchestrator's own
+    # self._contextFactory attribute does not itself create a self-cycle --
+    # this test is targeted at the orch<->panel cycle through the producer
+    # specifically, same isolation as the orch<->task cycle test.
+    orch = Orchestrator(pf, contextFactory=lambda cell: None, targetQueueDepth=2)
+    panel = FakePanel(orch)
+    orch.setCellProducer(panel.produceCells)
+    orch.enqueue("c1")
+
+    task = orch.start()
+    started.wait()  # producer is parked mid-call, definitely not finished
+
+    # Connect to sigFinished BEFORE releasing the gate, so there is no race
+    # between the task starting/finishing and us starting to listen.
+    with qtbot.waitSignal(task.sigFinished, timeout=5000):
+        gate.set()  # let the producer, and the run loop, finish
+
+    # See test_finished_task_does_not_leave_qobject_cycle for why joining the
+    # worker thread directly -- not task.wait() -- is the correct barrier here.
+    task._thread.join(timeout=5)
+    assert not task._thread.is_alive()
+
+    # Release the producer the way real teardown must (P2b/P2c's job, not this
+    # branch's -- see the record-only finding on setCellProducer(None)). This
+    # is what breaks orch -> panel -> panel._orchestrator -> orch.
+    orch.setCellProducer(None)
+    panel._orchestrator = None
+
+    panel_ref = weakref.ref(panel)
+    orch_ref = weakref.ref(orch)
+
+    gc.disable()
+    try:
+        del panel
+        del orch
+        del task
+        assert orch_ref() is None, "Orchestrator survived refcounting alone -- a cycle remains"
+        assert panel_ref() is None, "Panel survived refcounting alone -- a cycle remains"
+    finally:
+        gc.collect()
+        gc.enable()

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -284,6 +284,62 @@ def test_producer_abort_propagates_without_double_wrapping(make_pf):
     assert excinfo.value is sentinel
 
 
+def test_nextcell_request_during_refill_of_an_empty_queue_is_discarded(make_pf):
+    """A "Next cell" request that arrives while the producer is imaging a tile
+    -- itself a slow, seconds-to-minutes operation -- lands on an empty queue:
+    nothing was running and nothing was queued for it to advance past. Consuming
+    it against the first cell the producer then returns would skip a cell the
+    operator never saw, without it ever being attempted, so it must be
+    discarded instead."""
+    pf = make_pf()
+    ran = []
+    finished = []
+    calls = {"n": 0}
+
+    def producer():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            orch.requestNextCell()  # arrives mid-produce, before any cell exists
+            return ["c1", "c2"]
+        return None
+
+    def run(ctx, **kwargs):
+        ran.append(ctx.cell)
+
+    pf.run = run
+    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=1)
+    orch.sigCellFinished.connect(lambda c, s: finished.append((c, s)))
+    orch.run_sync()
+    assert ran == ["c1", "c2"]
+    assert finished == [("c1", "done"), ("c2", "done")]
+
+
+def test_nextcell_request_during_refill_of_a_nonempty_queue_is_preserved(make_pf):
+    """The same request, but with a cell already queued when the refill runs,
+    must NOT be discarded: there is a cell it could be about (c1), the same as
+    if the operator had pressed Next before Start. The fix for the empty-queue
+    case above must not over-broadly clear the flag whenever a refill happens
+    to run first."""
+    pf = make_pf()
+    ran = []
+    finished = []
+
+    def producer():
+        orch.requestNextCell()  # arrives mid-produce, c1 is already queued
+        return None  # exhausted immediately -- c1 is the only cell available
+
+    def run(ctx, **kwargs):
+        ran.append(ctx.cell)
+
+    pf.run = run
+    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=2)
+    orch.enqueue("c1")
+    orch.sigCellFinished.connect(lambda c, s: finished.append((c, s)))
+    orch.run_sync()
+    assert ran == []
+    assert finished == [("c1", "skipped")]
+
+
 def test_pause_is_honored_before_refilling(make_pf, qtbot):
     """Pause means "start nothing new", and imaging a tile is very much
     something new -- an operator who pauses must not have the stage move to

--- a/docs/superpowers/plans/2026-07-29-autopatch-p2a-cell-producer.md
+++ b/docs/superpowers/plans/2026-07-29-autopatch-p2a-cell-producer.md
@@ -1,0 +1,775 @@
+# Autopatch P2a — Orchestrator cell producer / queue-depth refill
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `Orchestrator` an optional cell-producer callback and a queue-depth
+target, so the run loop can refill its queue as it drains instead of exiting the
+moment the queue is momentarily empty — the engine half of design §3.2's
+interleaved find+patch loop.
+
+**Architecture:** `_runLoopBody`'s `while self._queue:` becomes a loop over two
+conditions: refill while the queue is below target and the producer has not
+declared itself exhausted, otherwise process the next queued cell, and end when
+the queue is empty *and* the producer is exhausted. The producer is a plain
+callable returning a sequence of new cells (`[]` meaning "made progress, found
+nothing — ask again") or `None` (meaning "exhausted, never ask again"). Nothing
+about cell processing, dispositions, retries, or the UI model changes. With no
+producer configured the loop's observable behavior is byte-for-byte what it is
+today.
+
+**Tech Stack:** Python 3.12, PyQt (`acq4.util.Qt`), `acq4.util.task` for
+concurrency, pytest + pytest-qt.
+
+## Why this is P2's first task
+
+Design §3.2 describes the interleaved loop as though it exists. It does not:
+`acq4/experiment/orchestrator.py:135` is `while self._queue:`, which exits as
+soon as the deque is momentarily empty. There is no depth target, no refill
+hook, and no outer "regions remain" condition. Areas 1/2 (the survey UI, the
+cell-finding config) cannot be built on top of a loop that stops the instant
+detection hasn't yet produced a cell, so this engine change gates the rest of P2.
+
+Of the three shapes considered, this plan implements the **refill callback**:
+smallest diff, local to one method, headless-testable, and it preserves §3.3's
+one-protocol-per-slice cell-bound context, the per-cell disposition model, and
+Area 5's cell rows exactly as they are.
+
+**Out of scope, deliberately:** the survey/region producer itself (P2c), the
+cell-finding config UI that parameterises it (P2b), and any wall-clock timeout
+on `_drive_fsm`'s poll loop (explicitly deferred — do not add one).
+
+## Global Constraints
+
+- Test runner: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest <path> -v`
+- Verify with a hard timeout so a latent hang fails instead of stalling:
+  `timeout 300 /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/ acq4/modules/Autopatch/ -q`
+- **Baseline: 259 tests passing** across `acq4/experiment/` + `acq4/modules/Autopatch/`,
+  pristine, no skips, no ignores. Every task must leave it green and growing.
+- Concurrency: `check_stop`/`sleep`/`Stopped`/`Event`/`run_in_gui_thread` from
+  `acq4.util.task`. Never `time.sleep`/`threading` in production code.
+- Logging: `from acq4.logging_config import get_logger`. Never stdlib `logging`.
+- `from acq4.util import Qt`. 2-line docstring per new file. No temporal comments —
+  describe the code as it is, never "used to", "now", "was changed".
+- Engine code (`acq4/experiment/`) is **snake_case**; the `modules/Autopatch/` UI
+  layer is camelCase. `Orchestrator`'s existing public methods are camelCase
+  (`requestNextCell`, `run_sync` — it is a `QObject` straddling both); match the
+  neighbouring members you are editing rather than imposing one style.
+- Commit format:
+  `git commit --author="Claude (claude) <noreply@anthropic.com>" -m "<type>: <desc>"`
+  with a trailing `🤖 Generated with [Claude Code](https://claude.ai/code)` line.
+  NEVER `--no-verify`.
+- Branch: `claude/autopatch-orchestration-p2-8d7f8f`.
+
+## Invariants that must not break
+
+These are scar tissue. Each one is a bug this codebase has already shipped once.
+
+- **Per-run state must not outlive the run loop it belongs to.** The existing
+  `_nextCellRequested` needs clears at five per-exit sites *plus* two `finally`
+  blocks, because `_runLoopBody`'s `finally` sits outside its `while` and so
+  never fires between cells. `_producerExhausted` is new per-run state and is
+  subject to exactly the same hazard. Task 3 is where this is proven.
+- **A `FlowSignal` must never be swallowed.** `_processCell` treats
+  `FlowSignal` and `Stopped` as pass-through, distinct from the broad
+  `except Exception` that wraps bugs in `AbortExperiment`. The refill path must
+  do the same, or a producer raising `AbortExperiment` gets double-wrapped.
+- **Engine→UI callbacks are emit-only.** No widget mutation from the worker.
+- `acq4/modules/Autopatch/tests/test_teardown.py`'s assertions are the exit-segfault
+  regression test. **Do not change any assertion in it.** A producer callback is a
+  new reference the `Orchestrator` holds; if you find yourself wanting to relax
+  that file, stop and report instead.
+- Do not add a wall-clock timeout to `_drive_fsm`. Deferred by decision.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `acq4/experiment/orchestrator.py` (modify) | The loop change: `cellProducer`/`targetQueueDepth` config, `_refillQueue`, `_producerExhausted` lifecycle. The only production file this plan touches. |
+| `acq4/experiment/tests/test_orchestrator_producer.py` (create) | All producer tests. A new file rather than growing `test_orchestrator_loop.py` (already ~470 lines) — the producer is its own concern with its own fixtures. |
+| `/home/martin/src/acq4/acq4/autopatch-orchestration-design.md` (modify) | §3.2/§3.3 gain the actual contract. **Absolute path — this file lives in the main checkout, is untracked, and is NOT in the worktree.** Nothing to commit for it. |
+
+---
+
+## Task 1: Specify the refill contract in the design doc
+
+Doc-only, and first: the next two tasks implement what this task writes down, and
+a reviewer needs the contract to review against. §3.2 currently shows pseudocode
+with no producer signature, no exhaustion rule, and no statement of what happens
+when detection yields nothing.
+
+**Files:**
+- Modify: `/home/martin/src/acq4/acq4/autopatch-orchestration-design.md` §3.2, §3.3
+
+**Interfaces:**
+- Produces: the prose contract Tasks 2 and 3 implement. No code.
+
+- [ ] **Step 1: Read the two sections and the current loop**
+
+Read §3.1–§3.3 of the design doc, then `acq4/experiment/orchestrator.py:132-162`
+(`_runLoopBody`). Confirm for yourself that the pseudocode and the code disagree
+in the way this plan's preamble claims — if they do not, stop and report rather
+than writing a contract for a problem that isn't there.
+
+- [ ] **Step 2: Replace §3.2's pseudocode with the real contract**
+
+Keep it terse and in the doc's existing voice. It must state, in this order:
+
+1. The loop ends when the queue is empty **and** the producer is exhausted.
+   With no producer configured, "exhausted" is the initial condition, so the
+   loop is exactly a queue drain.
+2. The producer is a plain callable, `producer() -> Sequence[cell] | None`,
+   called with no arguments on the worker thread.
+3. **`[]` and `None` mean different things.** `[]` is "I made progress and found
+   no cells — ask me again" (an imaged tile that happened to be empty). `None`
+   is "I am exhausted — never ask again" (every tile in the region is imaged).
+   A producer that returns `[]` forever wedges the loop; it is the producer's
+   contract to eventually return `None`. `check_stop()` runs between refills, so
+   the operator's Stop always ends such a run.
+4. Refilling repeats until the queue reaches the depth target or the producer
+   exhausts, and **Pause and Stop are honoured between successive refills** —
+   imaging a tile is slow, so an operator pressing Stop part-way through filling
+   a deep queue must not wait for the whole batch.
+5. The depth target is read fresh each pass, so the cell-finding config may
+   change it mid-run. It must be at least 1.
+6. `Stopped` and `FlowSignal` from the producer propagate untouched; any other
+   exception is a bug, surfaced as `error` status and re-raised as
+   `AbortExperiment`. There is no cell to attribute it to, so no
+   `sigCellFinished` is emitted for it.
+7. Why the depth target exists at all, given a serial orchestrator: detection
+   yields several cells per z-stack, so the target's real job is "don't image a
+   new tile until the queue is nearly drained", and it is the seam a future
+   parallel scheduler needs.
+
+- [ ] **Step 3: Add one line to §3.3**
+
+§3.3 is "One protocol per slice." Add that this is unchanged by the producer:
+cells arriving mid-run run the same slice protocol as cells seeded before Start,
+and the context is still built per cell by the same factory.
+
+- [ ] **Step 4: Remove the "not built" marker**
+
+§3.2 carries a note that the loop is not implemented and is P2's undesigned
+engine change. Tasks 2 and 3 build it, so that note goes — but only once this
+task's contract text is in place, so the section is never simultaneously
+marker-free and contract-free.
+
+Nothing to commit: the file is untracked and outside the worktree. Report the
+sections you edited.
+
+---
+
+## Task 2: The producer, the depth target, and the refill
+
+**Files:**
+- Modify: `acq4/experiment/orchestrator.py` — `__init__`, `_runLoopBody`; add
+  `setCellProducer`, `_refillQueue`
+- Create: `acq4/experiment/tests/test_orchestrator_producer.py`
+
+**Interfaces:**
+- Consumes: Task 1's contract. Existing `Orchestrator.enqueue(cell)`,
+  `_checkPause()`, `_processCell(cell)`, `sigStatus`, `sigCellFinished`.
+- Produces, relied on by Task 3 and by P2b/P2c:
+  - `Orchestrator(protocolFile, manager=None, contextFactory=None, maxRetries=100, cellProducer=None, targetQueueDepth=1)`
+  - `Orchestrator.setCellProducer(producer)` — swap or clear the producer;
+    also clears the exhausted flag so a fresh producer is asked again.
+  - `Orchestrator.targetQueueDepth` — public int attribute, read fresh each pass.
+  - `Orchestrator._producerExhausted` — private bool, per-run.
+  - Producer protocol: `producer() -> Sequence[cell] | None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `acq4/experiment/tests/test_orchestrator_producer.py`:
+
+```python
+"""Tests for the Orchestrator's cell-producer refill hook: the queue-depth
+target, the empty-vs-exhausted distinction, and end-of-run conditions."""
+import pytest
+
+from acq4.experiment.orchestrator import Orchestrator
+
+
+def make_producer(batches):
+    """A producer returning each of `batches` in turn, recording its calls.
+
+    Each batch is either a list of cells or None (exhausted). Running past the
+    end of `batches` is a broken test setup, not an implicit exhaustion, so it
+    fails loudly rather than quietly ending the run.
+    """
+    calls = {"n": 0}
+
+    def producer():
+        calls["n"] += 1
+        if not batches:
+            raise AssertionError(
+                "producer called after its last declared batch -- the loop "
+                "asked again past exhaustion"
+            )
+        return batches.pop(0)
+
+    producer.calls = calls
+    return producer
+
+
+def test_producer_fills_an_empty_queue_and_cells_are_processed(make_pf):
+    """The whole point: a run started with nothing queued must still work
+    cells, by asking the producer for them."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf, cellProducer=make_producer([["c1", "c2"], None]))
+    orch.run_sync()  # nothing enqueued up front
+    assert ran == ["c1", "c2"]
+
+
+def test_run_ends_when_queue_empty_and_producer_exhausted(make_pf):
+    pf = make_pf()
+    finished = []
+    pf.run = lambda ctx, **kwargs: None
+    orch = Orchestrator(pf, cellProducer=make_producer([["c1"], None]))
+    orch.sigCellFinished.connect(lambda c, s: finished.append((c, s)))
+    orch.run_sync()  # must return, not spin
+    assert finished == [("c1", "done")]
+
+
+def test_empty_batch_asks_again_rather_than_ending_the_run(make_pf):
+    """An imaged tile with no cells in it returns [] -- "found nothing, ask me
+    again" -- which must NOT end the run the way None does. This is the
+    distinction the whole survey loop rests on: a barren tile in the middle of
+    a region cannot be allowed to stop the experiment."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    producer = make_producer([[], [], ["c1"], None])
+    orch = Orchestrator(pf, cellProducer=producer)
+    orch.run_sync()
+    assert ran == ["c1"]
+    assert producer.calls["n"] == 4  # two empty tiles, one productive, then exhausted
+
+
+def test_queue_is_filled_to_target_depth_before_the_first_cell_runs(make_pf):
+    """With a depth target above 1, the loop keeps asking until the queue
+    reaches it -- so a producer yielding one cell per tile is asked three times
+    before any cell is worked."""
+    pf = make_pf()
+    callsAtFirstRun = {}
+
+    def run(ctx, **kwargs):
+        callsAtFirstRun.setdefault("n", producer.calls["n"])
+
+    pf.run = run
+    producer = make_producer([["c1"], ["c2"], ["c3"], None])
+    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=3)
+    orch.run_sync()
+    assert callsAtFirstRun["n"] == 3
+
+
+def test_depth_target_is_read_fresh_so_it_can_change_mid_run(make_pf):
+    """The cell-finding config owns this number and an operator may change it
+    while a run is in progress, so it must not be snapshotted at start."""
+    pf = make_pf()
+    ran = []
+
+    def run(ctx, **kwargs):
+        ran.append(ctx.cell)
+        orch.targetQueueDepth = 1  # operator turns it down after the first cell
+
+    pf.run = run
+    producer = make_producer([["c1"], ["c2"], ["c3"], None])
+    orch = Orchestrator(pf, cellProducer=producer, targetQueueDepth=2)
+    orch.run_sync()
+    assert ran == ["c1", "c2", "c3"]
+
+
+def test_no_producer_drains_the_queue_and_ends(make_pf):
+    """The unconfigured case -- every existing caller. Behaviour must be
+    exactly the pre-producer queue drain, and in particular the loop must end
+    rather than spin waiting for a refill that can never come."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf)
+    orch.enqueue("c1")
+    orch.enqueue("c2")
+    orch.run_sync()
+    assert ran == ["c1", "c2"]
+
+
+def test_producer_supplements_cells_seeded_before_start(make_pf):
+    """Seeded cells and produced cells are the same queue: the operator's
+    hand-added cells are worked first, then the producer's."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf, cellProducer=make_producer([["produced"], None]))
+    orch.enqueue("seeded")
+    orch.run_sync()
+    assert ran == ["seeded", "produced"]
+
+
+def test_setCellProducer_installs_a_producer_after_construction(make_pf):
+    """The UI builds the Orchestrator when a protocol is selected, but the
+    producer depends on region/finding config chosen later, so it must be
+    installable after the fact."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf)
+    orch.setCellProducer(make_producer([["c1"], None]))
+    orch.run_sync()
+    assert ran == ["c1"]
+
+
+def test_setCellProducer_none_reverts_to_a_plain_queue_drain(make_pf):
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf, cellProducer=make_producer([["never asked"], None]))
+    orch.setCellProducer(None)
+    orch.enqueue("c1")
+    orch.run_sync()
+    assert ran == ["c1"]
+
+
+def test_target_queue_depth_below_one_is_rejected(make_pf):
+    """A target of 0 would make `len(queue) < target` never true, silently
+    disabling the producer -- a misconfiguration that looks like a hung
+    survey. Fail at construction instead."""
+    pf = make_pf()
+    with pytest.raises(ValueError):
+        Orchestrator(pf, targetQueueDepth=0)
+```
+
+- [ ] **Step 2: Run the tests and confirm they fail for the right reason**
+
+```bash
+timeout 300 /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_orchestrator_producer.py -v
+```
+
+Expected: the `cellProducer`/`targetQueueDepth` tests fail with
+`TypeError: __init__() got an unexpected keyword argument`, `setCellProducer`
+tests with `AttributeError`. `test_no_producer_drains_the_queue_and_ends` should
+**pass already** — it pins existing behaviour. If it fails, stop and report.
+
+- [ ] **Step 3: Add the constructor arguments**
+
+In `Orchestrator.__init__`, after the `maxRetries` assignment:
+
+```python
+        if targetQueueDepth < 1:
+            raise ValueError(
+                f"targetQueueDepth must be at least 1, got {targetQueueDepth!r}: "
+                f"a target of 0 makes the refill condition unreachable, silently "
+                f"disabling the producer"
+            )
+        # Read fresh on every pass of the run loop rather than snapshotted, so
+        # the cell-finding config can retune it while a run is in progress.
+        self.targetQueueDepth = targetQueueDepth
+        self._cellProducer = cellProducer
+        # Per-run: set once the producer reports exhaustion, cleared by
+        # _runLoopBody's finally. See setCellProducer for why it is not
+        # simply "has the producer ever returned None".
+        self._producerExhausted = False
+```
+
+and extend the signature:
+
+```python
+    def __init__(
+        self,
+        protocolFile,
+        manager=None,
+        contextFactory=None,
+        maxRetries=100,
+        cellProducer=None,
+        targetQueueDepth=1,
+    ):
+```
+
+- [ ] **Step 4: Add `setCellProducer`**
+
+Next to `enqueue`, under the `# ---- queue / context ----` heading:
+
+```python
+    def setCellProducer(self, producer):
+        """Install (or clear, with None) the callback that refills the queue.
+
+        `producer()` takes no arguments, runs on the worker thread, and returns
+        either a sequence of new cells -- possibly empty, meaning "made
+        progress, found none here, ask again" -- or None, meaning exhausted.
+
+        Installing a producer clears the exhausted flag: a caller swapping in a
+        fresh producer (a new survey region) is declaring there is more to find,
+        and would otherwise be ignored for the rest of the run.
+        """
+        self._cellProducer = producer
+        self._producerExhausted = False
+```
+
+- [ ] **Step 5: Rewrite the loop and add `_refillQueue`**
+
+Replace `_runLoopBody`'s `while self._queue:` block. Keep the existing
+`except Stopped` clause and the existing `finally` body exactly as they are —
+Task 3 extends the `finally`, this task must not.
+
+```python
+            while True:
+                self._checkPause()
+                check_stop()
+                if self._shouldRefill():
+                    self._refillQueue()
+                    # Back to the top rather than falling through to a cell:
+                    # re-checks the depth target (so a deep queue fills over
+                    # several passes) and, more importantly, re-checks pause
+                    # and stop between refills. Imaging a tile is slow, so an
+                    # operator pressing Stop part-way through filling a deep
+                    # queue must not have to wait out the whole batch.
+                    continue
+                if not self._queue:
+                    # Queue empty and nothing left to produce: the run is done.
+                    break
+                cell = self._queue.popleft()
+                self._processCell(cell)
+```
+
+and add, after `_checkPause`:
+
+```python
+    def _shouldRefill(self) -> bool:
+        return (
+            self._cellProducer is not None
+            and not self._producerExhausted
+            and len(self._queue) < self.targetQueueDepth
+        )
+
+    def _refillQueue(self):
+        """Ask the producer for more cells; record exhaustion when it has none."""
+        try:
+            cells = self._cellProducer()
+        except (Stopped, FlowSignal):
+            # Same pass-through as _processCell: a cooperative stop is a normal
+            # end to the run, and a producer that raises AbortExperiment means
+            # it -- neither is a bug to be wrapped by the clause below.
+            raise
+        except Exception as exc:
+            # An unexpected bug in the producer must fail loud rather than
+            # quietly ending the survey and letting the run look complete.
+            # There is no cell to attribute it to, so no sigCellFinished.
+            logger.exception("Cell producer raised while refilling the queue")
+            self.sigStatus.emit("error")
+            raise AbortExperiment(f"cell producer failed: {exc}") from exc
+        if cells is None:
+            self._producerExhausted = True
+            return
+        for cell in cells:
+            self.enqueue(cell)
+```
+
+- [ ] **Step 6: Run the new tests, then the full suite**
+
+```bash
+timeout 300 /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_orchestrator_producer.py -v
+timeout 300 /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/ acq4/modules/Autopatch/ -q
+```
+
+Expected: all new tests pass; the suite is 259 + 10 = **269 passing**, no skips,
+no warnings. If any pre-existing test fails, the loop rewrite changed behaviour
+it should not have — report rather than adjusting the old test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add acq4/experiment/orchestrator.py acq4/experiment/tests/test_orchestrator_producer.py
+git commit --author="Claude (claude) <noreply@anthropic.com>" -m "$(printf 'feat: let the orchestrator refill its cell queue from a producer\n\n🤖 Generated with [Claude Code](https://claude.ai/code)')"
+```
+
+---
+
+## Task 3: Per-run state hygiene, and the interruption paths
+
+Task 2's loop works. This task proves it is safe against the failure mode this
+codebase produces over and over: state that outlives the run loop it belongs to.
+`_producerExhausted` is exactly the shape of `_nextCellRequested`, whose leak
+needed seven separate clears to close and silently skipped cells until it did.
+
+**Files:**
+- Modify: `acq4/experiment/orchestrator.py` — `_runLoopBody`'s `finally`
+- Modify: `acq4/experiment/tests/test_orchestrator_producer.py`
+
+**Interfaces:**
+- Consumes: everything Task 2 produced.
+- Produces: no new API. The guarantee that `_producerExhausted` is False
+  whenever a run is not in progress.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/experiment/tests/test_orchestrator_producer.py`. Note the new
+imports at the top of the file:
+
+```python
+from acq4.util.task import Stopped, Event, sleep
+from acq4.experiment.exceptions import AbortExperiment
+```
+
+```python
+def test_exhaustion_does_not_outlive_the_run(make_pf):
+    """The scar-tissue test. A producer that exhausted during one run must not
+    leave the orchestrator permanently convinced there is nothing to find: the
+    operator draws a second survey region, presses Start, and the new
+    producer has to actually be asked. This is the same class of leak as the
+    "Next cell" flag surviving its run and silently skipping an unrelated
+    cell."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf, cellProducer=make_producer([["c1"], None]))
+    orch.run_sync()
+    assert ran == ["c1"]
+    assert orch._producerExhausted is False  # cleared on the way out
+
+    second = make_producer([["c2"], None])
+    orch.setCellProducer(second)
+    orch.run_sync()
+    assert ran == ["c1", "c2"]  # the second region was actually surveyed
+    assert second.calls["n"] == 2
+
+
+def test_exhaustion_cleared_when_the_run_ends_by_raising(make_pf):
+    """_runLoopBody can leave by raising as well as returning (an
+    OrchestrationError from a cell re-raised as AbortExperiment). The clear
+    belongs in the finally, not on the return path -- the same mistake that
+    left the next-cell flag set on four separate raise paths."""
+    pf = make_pf()
+
+    def run(ctx, **kwargs):
+        raise AttributeError("an ordinary bug, mid-cell")
+
+    pf.run = run
+    orch = Orchestrator(pf, cellProducer=make_producer([["c1"], None]))
+    with pytest.raises(AbortExperiment):
+        orch.run_sync()
+    assert orch._producerExhausted is False
+
+
+def test_exhaustion_cleared_after_a_cooperative_stop(make_pf):
+    """Operator presses Stop after the region is exhausted but while cells
+    remain queued, then presses Start again. The remaining cells must be
+    worked, and the producer must be re-asked rather than assumed dry."""
+    pf = make_pf()
+    ran = []
+
+    def run(ctx, **kwargs):
+        ran.append(ctx.cell)
+        if ctx.cell == "c1":
+            raise Stopped("operator pressed stop")
+
+    pf.run = run
+    producer = make_producer([["c1", "c2"], None])
+    orch = Orchestrator(pf, cellProducer=producer)
+    orch.run_sync()  # a cooperative stop ends the run normally
+    assert ran == ["c1"]
+    assert orch._producerExhausted is False
+    assert list(orch._queue) == ["c2"]  # a stop is not a queue drain
+
+
+def test_producer_exception_surfaces_as_error_and_aborts(make_pf):
+    """A bug in the producer (a detection crash, a stage move that throws)
+    must not quietly end the survey and let the run report itself complete."""
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+
+    def exploding_producer():
+        raise RuntimeError("detection crashed")
+
+    statuses = []
+    orch = Orchestrator(pf, cellProducer=exploding_producer)
+    orch.sigStatus.connect(statuses.append)
+    with pytest.raises(AbortExperiment) as excinfo:
+        orch.run_sync()
+    assert isinstance(excinfo.value.__cause__, RuntimeError)
+    assert "error" in statuses
+
+
+def test_producer_stopped_ends_the_run_normally(make_pf):
+    """Stop pressed while the producer is imaging a tile: check_stop() inside
+    the producer raises Stopped, which is a normal end to the run, not a
+    raise the caller must catch."""
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+
+    def stopping_producer():
+        raise Stopped("operator pressed stop mid-survey")
+
+    orch = Orchestrator(pf, cellProducer=stopping_producer)
+    orch.run_sync()  # must not raise
+
+
+def test_producer_abort_propagates_without_double_wrapping(make_pf):
+    """A producer that raises AbortExperiment means it. It must propagate as
+    itself rather than being caught by the broad clause and re-wrapped in a
+    second AbortExperiment whose __cause__ is the first."""
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+    sentinel = AbortExperiment("region is unusable")
+
+    def aborting_producer():
+        raise sentinel
+
+    orch = Orchestrator(pf, cellProducer=aborting_producer)
+    with pytest.raises(AbortExperiment) as excinfo:
+        orch.run_sync()
+    assert excinfo.value is sentinel
+
+
+def test_pause_is_honored_before_refilling(make_pf, qtbot):
+    """Pause means "start nothing new", and imaging a tile is very much
+    something new -- an operator who pauses must not have the stage move to
+    another tile underneath them."""
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+    calls = {"n": 0}
+    released = Event()
+
+    def slow_producer():
+        calls["n"] += 1
+        sleep(0.005)  # paces tiles out so pause can land between them
+        return [] if not released.is_set() else None
+
+    orch = Orchestrator(pf, cellProducer=slow_producer)
+    orch.pause()
+    orch.start()
+    qtbot.wait(100)
+    assert calls["n"] == 0, "producer was asked for a tile while paused"
+
+    orch.resume()
+    qtbot.waitUntil(lambda: calls["n"] > 0, timeout=5000)
+
+    released.set()
+    orch.wait(timeout=5)
+
+
+def test_stop_between_tiles_ends_a_barren_survey(make_pf, qtbot):
+    """A producer returning [] forever is a wedged survey by construction.
+    check_stop() between refills is what makes it interruptible, so the
+    operator's Stop must end it."""
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+    calls = {"n": 0}
+
+    def barren_producer():
+        calls["n"] += 1
+        sleep(0.005)
+        return []  # never exhausts
+
+    orch = Orchestrator(pf, cellProducer=barren_producer)
+    task = orch.start()
+    qtbot.waitUntil(lambda: calls["n"] >= 2, timeout=5000)
+    orch.stop("test stop")
+    task.wait(timeout=5)  # a cooperative stop is a normal end, not a raise
+    countAtStop = calls["n"]
+    qtbot.wait(100)
+    assert calls["n"] == countAtStop  # genuinely stopped asking
+    assert orch._producerExhausted is False
+```
+
+- [ ] **Step 2: Run and confirm the failures**
+
+```bash
+timeout 300 /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_orchestrator_producer.py -v
+```
+
+Expected: the three `_producerExhausted is False` assertions fail (the flag
+leaks — nothing clears it yet). The exception-path and pause/stop tests should
+already pass from Task 2's `_refillQueue` and loop ordering. **Confirm which
+fail before implementing** — if the leak tests pass already, Task 2 clears the
+flag somewhere it shouldn't and you must find out where.
+
+- [ ] **Step 3: Clear the flag in the `finally`**
+
+In `_runLoopBody`'s existing `finally`, next to the `_nextCellRequested` clear:
+
+```python
+            # Per-run, exactly like the next-cell request above: a producer
+            # that exhausted during this run must not leave the orchestrator
+            # permanently convinced there is nothing left to find. A later run
+            # -- over a new survey region, or over cells still queued after a
+            # stop -- has to ask again. Unlike the next-cell flag, this one
+            # needs no per-exit clears: it is only ever read by the refill
+            # check at the top of this method's own loop, so there is no
+            # equivalent of _processCell's inner retry loop running past the
+            # reach of this finally.
+            self._producerExhausted = False
+```
+
+- [ ] **Step 4: Run the new tests, then the full suite**
+
+```bash
+timeout 300 /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_orchestrator_producer.py -v
+timeout 300 /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/ acq4/modules/Autopatch/ -q
+```
+
+Expected: **277 passing** (259 baseline + 10 from Task 2 + 8 here), no skips, no
+warnings.
+
+- [ ] **Step 5: Confirm the teardown regression test is untouched**
+
+```bash
+git diff --stat acq4/modules/Autopatch/tests/test_teardown.py
+```
+
+Expected: empty. The `Orchestrator` now holds a producer reference; if that
+introduced a cycle, `test_teardown.py` fails rather than needing edits. If it
+does fail, report it — do not relax an assertion.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add acq4/experiment/orchestrator.py acq4/experiment/tests/test_orchestrator_producer.py
+git commit --author="Claude (claude) <noreply@anthropic.com>" -m "$(printf 'fix: keep producer exhaustion from outliving its run loop\n\n🤖 Generated with [Claude Code](https://claude.ai/code)')"
+```
+
+---
+
+## Self-Review
+
+**Contract coverage** — every numbered clause of Task 1's contract has a test:
+
+| Contract clause | Test |
+|---|---|
+| 1. Ends when queue empty **and** producer exhausted | `test_run_ends_when_queue_empty_and_producer_exhausted`, `test_no_producer_drains_the_queue_and_ends` |
+| 2. `producer() -> Sequence \| None`, no args | `test_producer_fills_an_empty_queue_and_cells_are_processed` |
+| 3. `[]` asks again, `None` exhausts | `test_empty_batch_asks_again_rather_than_ending_the_run` |
+| 4. Fills to target; Pause/Stop honoured between refills | `test_queue_is_filled_to_target_depth_before_the_first_cell_runs`, `test_pause_is_honored_before_refilling`, `test_stop_between_tiles_ends_a_barren_survey` |
+| 5. Depth read fresh, min 1 | `test_depth_target_is_read_fresh_so_it_can_change_mid_run`, `test_target_queue_depth_below_one_is_rejected` |
+| 6. `Stopped`/`FlowSignal` pass through; other exceptions abort | `test_producer_stopped_ends_the_run_normally`, `test_producer_abort_propagates_without_double_wrapping`, `test_producer_exception_surfaces_as_error_and_aborts` |
+| 7. Rationale for the target (prose only) | n/a — doc |
+
+**Landmine coverage** — checked against the bug classes this branch produced:
+
+- *Per-run state outliving its loop* → Task 3 Steps 1/3, three tests covering
+  the return, raise, and cooperative-stop exits. This is the plan's main risk
+  and gets its own task and its own reviewer gate.
+- *Flow signal swallowed* → `_refillQueue`'s `except (Stopped, FlowSignal): raise`
+  mirrors `_processCell`, tested by `test_producer_abort_propagates_without_double_wrapping`.
+- *Shared mutable state read by the worker* → `targetQueueDepth` is a plain int
+  read fresh (atomic; deliberately not snapshotted, and tested as such). The
+  producer *callable* is swappable via `setCellProducer`, which clears the
+  exhausted flag so a swap can't leave incoherent state. The producer's own
+  internal state (ROI geometry, visited tiles) is P2c's problem and is called
+  out there, not here.
+- *Reference cycles across the worker/GUI boundary* → Task 3 Step 5 verifies
+  `test_teardown.py` still passes unmodified with the new producer reference.
+- *Disposition vocabulary drift* → no new dispositions. A producer failure emits
+  `error` **status** and no `sigCellFinished`, since no cell is implicated.
+
+**Type consistency** — `cellProducer` (constructor kwarg) / `setCellProducer`
+(method) / `_cellProducer` (attribute) / `targetQueueDepth` (public attribute
+and kwarg, same spelling in both) / `_producerExhausted` / `_shouldRefill` /
+`_refillQueue`. Used identically in every task. `make_producer` is defined once
+at the top of the test file and used by both tasks' tests.
+
+**Deliberately not here:** the survey/region producer (P2c), the cell-finding
+config UI (P2b), Area 1's ROI ownership, the progress heatmap, and any
+`_drive_fsm` timeout. Task 2's `setCellProducer` is the seam P2b/P2c attach to.
+
+**Ordering:** 1 → 2 → 3, strictly. Task 1 writes the contract the other two are
+reviewed against; Task 3's tests assume Task 2's API exists.

--- a/docs/superpowers/plans/2026-07-29-autopatch-p2a-cell-producer.md
+++ b/docs/superpowers/plans/2026-07-29-autopatch-p2a-cell-producer.md
@@ -1,5 +1,7 @@
 # Autopatch P2a — Orchestrator cell producer / queue-depth refill
 
+> **Superseded:** `targetQueueDepth` (the "keep at least N cells queued" concept this plan built) was removed by owner decision after this plan was executed -- it was conflated with an unrelated notion of z-depth below the tissue surface. Refill now triggers whenever the queue is empty, with no depth target. The code listings and test names below that reference `targetQueueDepth` are superseded by that removal. This document is kept as a historical record and is not updated to match.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Give `Orchestrator` an optional cell-producer callback and a queue-depth

--- a/docs/superpowers/specs/2026-07-24-autopatch-reuse-completed-cells-design.md
+++ b/docs/superpowers/specs/2026-07-24-autopatch-reuse-completed-cells-design.md
@@ -19,12 +19,12 @@ The autopatch orchestration design (`autopatch-orchestration-design.md`, §6 and
 then reuse those same cells for another protocol. Pass 2 inherits pass 1's
 reference stacks because the `Cell` object persists in `CellPanel._cells`.
 
-Today that reuse happens *implicitly and indiscriminately*: every time a
-protocol is loaded or reloaded, `AutopatchWindow._onProtocolLoaded`
-(`Autopatch.py:112`) builds a fresh `Orchestrator`, and
-`CellPanel.bindOrchestrator` (`cell_panel.py:64-76`) flushes **every** held cell
-— completed, skipped, or errored — into the new queue. There is no operator
-control over which cells carry forward.
+Today that reuse happens *implicitly and indiscriminately*: selecting a protocol
+in Area 4 loads it, and every genuine selection change drives
+`AutopatchWindow._onProtocolLoaded` (`Autopatch.py:132`) to build a fresh
+`Orchestrator`, whereupon `CellPanel.bindOrchestrator` (`cell_panel.py:92-103`)
+flushes **every** held cell — completed, abandoned, stopped, or errored — into
+the new queue. There is no operator control over which cells carry forward.
 
 This feature replaces that implicit flush-everything with an explicit,
 operator-controlled reuse action.
@@ -63,7 +63,7 @@ Disposition is tracked in `CellPanel`, not on the `Cell` object and not in the
 Rationale:
 
 - `CellPanel` is already "the authoritative source of truth for seeded cells"
-  (`cell_panel.py:132`) and already outlives every orchestrator — a fresh
+  (`cell_panel.py:167-172`) and already outlives every orchestrator — a fresh
   orchestrator is created and re-bound on each protocol load, but the panel and
   its `_cells` dict persist across passes.
 - The `Orchestrator` is recreated per protocol load, so it cannot remember
@@ -80,26 +80,54 @@ Add to `CellPanel`:
 
 - `self._status: dict[int, str]` — keyed by `id(cell)`, holding the last
   terminal disposition emitted for that cell. Populated in the existing
-  `_onCellFinished` handler. A cell **absent** from this dict is implicitly
-  "queued" (never run to a terminal state).
+  `_onCellFinished` handler (`cell_panel.py:304-307`). A cell **absent** from
+  this dict is implicitly "queued" (never run to a terminal state).
 
-Disposition vocabulary (the statuses `Orchestrator.sigCellFinished` emits):
+Disposition vocabulary — the complete set of statuses
+`Orchestrator.sigCellFinished` emits, one row per emission site:
+
+| Status | Site | Meaning |
+|---|---|---|
+| `"done"` | `orchestrator.py:297` | `run()` returned normally: the protocol ran to completion |
+| `"skipped"` | `orchestrator.py:187`, `:208` | a Next-cell request consumed at the cell/retry boundary, or `AdvanceToNextCell` propagating out of `run()`. **Abandoned without completing.** |
+| `"stopped"` | `orchestrator.py:233` | a cooperative `Stopped`: the operator pressed Stop while this cell was mid-run |
+| `"retry-exhausted"` | `orchestrator.py:217` | `maxRetries` blown against a persistently failing cell |
+| `"error"` | `orchestrator.py:243`, `:255`, `:289` | an uncaught `OrchestrationError`, an unexpected exception, or a flow signal the protocol raised and then swallowed |
+| `"retry"` | `orchestrator.py:219` | transient; superseded by whichever terminal status that cell eventually reaches |
+
+There is no `"handled"` disposition: handler sub-protocols do not exist in the
+engine, so nothing emits one.
 
 ```
-TERMINAL  = {"done", "handled", "skipped", "retry-exhausted", "error"}
-COMPLETED = TERMINAL - {"error"}
-          = {"done", "handled", "skipped", "retry-exhausted"}
+TERMINAL  = {"done", "skipped", "stopped", "retry-exhausted", "error"}
+COMPLETED = {"done"}
 ```
 
 - `TERMINAL` — a cell that finished a pass in any of these states is *not*
   auto-flushed on the next protocol load; it waits for an explicit reuse.
-- `COMPLETED` — the set that "check all completed" ticks. `error` is excluded
-  because it signals an aborted run (possibly a bug); the operator opts an
-  errored cell into reuse manually.
+  `"stopped"` belongs here even though the cell did not finish: silently
+  re-running a cell the operator deliberately interrupted is exactly the
+  indiscriminate behavior §1 exists to remove.
+- `COMPLETED` — the set that "check all completed" ticks. It holds `"done"`
+  alone, so the button means precisely *every cell whose protocol ran to
+  completion*. Every other terminal disposition is a manual opt-in, each for its
+  own reason:
+  - `"error"` signals an aborted run, possibly a bug.
+  - `"retry-exhausted"` is a *persistent* failure (`orchestrator.py:211-218`),
+    not a completion. The rationale for excluding `"error"` applies verbatim.
+  - `"stopped"` and `"skipped"` are both abandonment — the protocol never
+    reached its end. `"skipped"` in particular is what `ctx.next_cell()` reports
+    (`orchestrator.py:208`): the protocol, or the operator's Next-cell press,
+    explicitly giving up on this cell. A protocol that runs to completion
+    reports `"done"`, never `"skipped"` — neither bundled example protocol ends
+    in a flow-control call, and none should. **`"skipped"` therefore does not
+    belong in `COMPLETED`**: ticking it under "check all completed" would offer
+    up cells that never did the work as though they had. If some future protocol
+    ends by abandoning its cell, the thing to fix is that protocol, not this set.
 
-The transient `"retry"` status (`orchestrator.py:172,182`) is not terminal and
-is never stored as a final disposition — it is superseded by the eventual
-terminal status for that cell.
+The transient `"retry"` status (`orchestrator.py:219`) is not terminal and is
+never stored as a final disposition — it is superseded by the eventual terminal
+status for that cell.
 
 ---
 
@@ -146,12 +174,13 @@ different set of cells is checked for reuse.
 
 ### 6.2 Buttons
 
-Two buttons are added to the existing button row (`cell_panel.py:41-48`),
+Two buttons are added to the existing button row (`cell_panel.py:68-75`),
 alongside "Add from target" and "Scatter fake cells":
 
 - **"check all completed"** — sets check state to checked for every row whose
-  `self._status[id(cell)] ∈ COMPLETED`; leaves `error` and never-run rows
-  unchecked. A convenience for the common "reuse everything that worked" case.
+  `self._status[id(cell)] ∈ COMPLETED`; leaves `skipped`, `stopped`,
+  `retry-exhausted`, `error`, and never-run rows unchecked. A convenience for the
+  common "reuse everything that worked" case.
 - **"Reuse checked cells"** — for each checked cell, in list order:
   1. `self._orchestrator.enqueue(cell)` — the *same* `Cell` object.
   2. Reset the row text to `f"cell {id(cell)} — queued"`.
@@ -173,9 +202,14 @@ alongside "Add from target" and "Scatter fake cells":
 - at least one row is checked.
 
 To observe run state, `CellPanel.bindOrchestrator` additionally connects to
-`Orchestrator.sigStatus`; `unbindOrchestrator` disconnects it. The panel caches
-the latest status string and re-evaluates button enablement on status change and
-on checkbox toggle.
+`Orchestrator.sigStatus`. `CellPanel.unbindOrchestrator` (`cell_panel.py:105-123`)
+must disconnect it in the same change: that method disconnects exactly what
+`bindOrchestrator` connects, 1-for-1, and both the rebind path (selecting a
+different protocol) and window teardown go through it. A third connection with no
+matching `Qt.disconnect` leaves a live orchestrator wired into a panel that has
+stopped tracking it — the dangling-connection shape `test_teardown.py` guards
+against. The panel caches the latest status string and re-evaluates button
+enablement on status change and on checkbox toggle.
 
 "check all completed" is enabled whenever ≥1 cell is in a `COMPLETED` state.
 
@@ -183,8 +217,18 @@ on checkbox toggle.
 
 Re-queuing does not start a run. After pressing "Reuse checked cells", the
 operator presses **Start** (Area 3 / `StatusPanel`) to run the current protocol
-over the freshly-queued cells. The implementation must confirm `StatusPanel`
-re-enables Start once a prior run reaches `waiting` (verified under test).
+over the freshly-queued cells.
+
+`StatusPanel` re-enables Start once a prior run reaches `waiting`:
+`_updateButtons` enables Start for `None`/`"waiting"` (`status_panel.py:166-167`),
+and `Orchestrator._runLoopBody`'s `finally` emits `"waiting"` on every exit path
+(`orchestrator.py:152-162`). That holds by inspection, but it hangs on emission
+*order*, not on a final state: the failure path emits `"error"`
+(`orchestrator.py:242`) and only then `"waiting"` from the `finally`, and
+`"error"` on its own disables Start (`status_panel.py:172-173`). So the
+implementation must assert the ordering in a test — drive a run to `error`
+through the real signal path and assert Start ends up enabled — rather than
+assuming the terminal `"waiting"` wins.
 
 ---
 
@@ -198,9 +242,9 @@ The cell's physical continuity is unaffected: the tracker / reference stack live
 on the persistent `Cell` object, not in the panel's log dicts, so pass 2 still
 inherits pass 1's reference stack.
 
-This simplifies the note in `autopatch-orchestration-design.md` §7 (Area 5,
-line 402), which had contemplated keeping per-pass timeline/log segments. That
-line is updated to reflect clear-on-reuse.
+This simplifies the note in `autopatch-orchestration-design.md` §7 (Area 5, the
+"Reuse completed cells" bullet, lines 404-411), which contemplates keeping
+per-pass timeline/log segments. That line is updated to reflect clear-on-reuse.
 
 ---
 
@@ -228,8 +272,10 @@ not printed.
 
 - `_onCellFinished` records each terminal status into `_status` keyed by
   `id(cell)`.
-- "check all completed" checks exactly the `COMPLETED` rows; leaves `error` and
-  never-run rows unchecked.
+- "check all completed" checks exactly the `COMPLETED` rows; leaves `skipped`,
+  `stopped`, `retry-exhausted`, `error`, and never-run rows unchecked. Cover
+  `skipped` explicitly — it is the one status whose name invites being read as a
+  completion.
 - "Reuse checked cells" enqueues each checked `Cell` into the bound orchestrator,
   resets its row text to "queued", clears its `_timelines`/`_logs`, pops its
   `_status`, and unchecks it.
@@ -237,6 +283,11 @@ not printed.
   re-enqueued on rebind; a never-run (queued) cell **is**.
 - Button gating: "Reuse checked cells" disabled with no orchestrator, while
   `running`/`paused`, and with nothing checked; enabled otherwise.
+- Start is enabled again after a run that ends in `error`, driven through the
+  real `"error"`-then-`"waiting"` emission order rather than a single synthetic
+  `sigStatus("waiting")` (§6.4).
+- `unbindOrchestrator` leaves no `sigStatus` connection behind: rebinding to a
+  second orchestrator must not let the first one still drive this panel's gating.
 
 **Integration (mock rig)**
 
@@ -258,8 +309,11 @@ not printed.
   reuse handler, selective-flush change, `sigStatus` subscription, gating.
 - `acq4/modules/Autopatch/tests/` — new unit + integration tests; update
   flush-all regression test.
-- `autopatch-orchestration-design.md` — amend §7 Area 5 (clear-on-reuse; note
-  the selective-flush change).
+- `autopatch-orchestration-design.md` — amend §7 Area 5: clear-on-reuse (§7
+  above), the selective-flush behavior (§5), the disposition vocabulary (Area 5
+  still describes "Completed" as `done / handled` and the reset status as
+  *waiting*; §4 above is the real set, and a cell row's reset text is
+  `queued`).
 
 No changes to `acq4/experiment/` (engine) or the external `acq4_automation`
 package.

--- a/docs/superpowers/specs/2026-07-24-autopatch-reuse-completed-cells-design.md
+++ b/docs/superpowers/specs/2026-07-24-autopatch-reuse-completed-cells-design.md
@@ -88,12 +88,12 @@ Disposition vocabulary — the complete set of statuses
 
 | Status | Site | Meaning |
 |---|---|---|
-| `"done"` | `orchestrator.py:297` | `run()` returned normally: the protocol ran to completion |
-| `"skipped"` | `orchestrator.py:187`, `:208` | a Next-cell request consumed at the cell/retry boundary, or `AdvanceToNextCell` propagating out of `run()`. **Abandoned without completing.** |
-| `"stopped"` | `orchestrator.py:233` | a cooperative `Stopped`: the operator pressed Stop while this cell was mid-run |
-| `"retry-exhausted"` | `orchestrator.py:217` | `maxRetries` blown against a persistently failing cell |
-| `"error"` | `orchestrator.py:243`, `:255`, `:289` | an uncaught `OrchestrationError`, an unexpected exception, or a flow signal the protocol raised and then swallowed |
-| `"retry"` | `orchestrator.py:219` | transient; superseded by whichever terminal status that cell eventually reaches |
+| `"done"` | `orchestrator.py:406` | `run()` returned normally: the protocol ran to completion |
+| `"skipped"` | `orchestrator.py:296`, `:317` | a Next-cell request consumed at the cell/retry boundary, or `AdvanceToNextCell` propagating out of `run()`. **Abandoned without completing.** |
+| `"stopped"` | `orchestrator.py:342` | a cooperative `Stopped`: the operator pressed Stop while this cell was mid-run |
+| `"retry-exhausted"` | `orchestrator.py:326` | `maxRetries` blown against a persistently failing cell |
+| `"error"` | `orchestrator.py:352`, `:364`, `:398` | an uncaught `OrchestrationError`, an unexpected exception, or a flow signal the protocol raised and then swallowed |
+| `"retry"` | `orchestrator.py:328` | transient; superseded by whichever terminal status that cell eventually reaches |
 
 There is no `"handled"` disposition: handler sub-protocols do not exist in the
 engine, so nothing emits one.
@@ -113,11 +113,11 @@ COMPLETED = {"done"}
   completion*. Every other terminal disposition is a manual opt-in, each for its
   own reason:
   - `"error"` signals an aborted run, possibly a bug.
-  - `"retry-exhausted"` is a *persistent* failure (`orchestrator.py:211-218`),
+  - `"retry-exhausted"` is a *persistent* failure (`orchestrator.py:320-327`),
     not a completion. The rationale for excluding `"error"` applies verbatim.
   - `"stopped"` and `"skipped"` are both abandonment — the protocol never
     reached its end. `"skipped"` in particular is what `ctx.next_cell()` reports
-    (`orchestrator.py:208`): the protocol, or the operator's Next-cell press,
+    (`orchestrator.py:317`): the protocol, or the operator's Next-cell press,
     explicitly giving up on this cell. A protocol that runs to completion
     reports `"done"`, never `"skipped"` — neither bundled example protocol ends
     in a flow-control call, and none should. **`"skipped"` therefore does not
@@ -125,7 +125,7 @@ COMPLETED = {"done"}
     up cells that never did the work as though they had. If some future protocol
     ends by abandoning its cell, the thing to fix is that protocol, not this set.
 
-The transient `"retry"` status (`orchestrator.py:219`) is not terminal and is
+The transient `"retry"` status (`orchestrator.py:328`) is not terminal and is
 never stored as a final disposition — it is superseded by the eventual terminal
 status for that cell.
 
@@ -222,9 +222,9 @@ over the freshly-queued cells.
 `StatusPanel` re-enables Start once a prior run reaches `waiting`:
 `_updateButtons` enables Start for `None`/`"waiting"` (`status_panel.py:166-167`),
 and `Orchestrator._runLoopBody`'s `finally` emits `"waiting"` on every exit path
-(`orchestrator.py:152-162`). That holds by inspection, but it hangs on emission
+(`orchestrator.py:222-242`). That holds by inspection, but it hangs on emission
 *order*, not on a final state: the failure path emits `"error"`
-(`orchestrator.py:242`) and only then `"waiting"` from the `finally`, and
+(`orchestrator.py:351`) and only then `"waiting"` from the `finally`, and
 `"error"` on its own disables Start (`status_panel.py:172-173`). So the
 implementation must assert the ordering in a test — drive a run to `error`
 through the real signal path and assert Start ends up enabled — rather than


### PR DESCRIPTION
## P2a — the orchestrator can refill its own cell queue

Design §3.2 described an interleaved find+patch loop as though it existed. It did not: `_runLoopBody` was `while self._queue:`, which exits the instant the deque goes momentarily empty. There was no refill hook and no outer "regions remain" condition — so a survey step that hadn't yet produced a cell would simply end the experiment. Areas 1/2 can't be built on that, which made this the gate on the rest of P2.

`Orchestrator` now takes an optional **cell producer** and refills whenever its queue runs dry.

```python
Orchestrator(pf, cellProducer=survey.next_tile)
orch.setCellProducer(producer)   # or install it later; clears the exhausted flag
```

**Producer contract:** `producer() -> Sequence[cell] | None`, no arguments, called on the worker thread.

- `[]` — "imaged a tile, found no cells here, **ask me again**"
- `None` — "**exhausted**, never ask again"

That distinction is what the whole survey loop rests on: conflating them would let a single barren tile in the middle of a region end the run. A producer returning `[]` forever wedges the loop by construction, so it is the producer's contract to eventually return `None` — and `check_stop()` runs between refills, so the operator's Stop always escapes.

Of the three shapes considered, this is the **refill callback**: smallest diff, local to one method, headless-testable, and it leaves §3.3's one-protocol-per-slice cell-bound context, the per-cell disposition model, and Area 5's cell rows untouched. The alternatives (inverting control into a "slice protocol", or a separate producer thread) each reworked the UI model or added a second thread to the part of this codebase least able to afford one.

**Deliberately not here:** the survey/region producer itself (P2c), the cell-finding config UI that parameterises it (P2b), and any wall-clock timeout on `_drive_fsm`'s poll loop (deferred by decision). `setCellProducer` is the seam P2b/P2c attach to.

## A concept was built and then deleted: `targetQueueDepth`

This branch originally also had a queue-depth target — refill while `len(queue) < targetQueueDepth`, i.e. "keep at least N cells queued before working any of them". **It was removed on review as a concept that should not exist.** A count of cells to accumulate before starting work is not a constraint this system has: detection yields however many cells a tile holds, and the orchestrator should work all of them before asking for more.

It had also quietly collided with the *real* meaning of "depth" in this domain — a **pair of z-depths relative to the tissue surface** in which to search for cells (e.g. −20 µm to −60 µm), which is a cell-finding search constraint and not a queue length. Design §7 Area 2's parameter list had both meanings sitting side by side.

Removing it simplified two things:

- `_shouldRefill()` is now just "a producer is installed, it is not exhausted, and the queue is empty".
- **The Critical fix below became unconditional.** It had needed a `queueWasEmpty` guard to avoid discarding a request that legitimately targeted an already-queued cell; with refill only ever running on an empty queue, that case is unreachable and the guard was dead logic.

It also removed the one test that had been stubbornly hard to make non-vacuous — which, in hindsight, was the signal. A concept with no observable consequence is hard to test because there is nothing there to observe.

## The Critical this branch found — species 2, again

Every Critical on this feature's predecessor branch was one shape: *state, or a signal, shared across or outliving one iteration of the run loop.* This branch produced another, and neither per-task review gate saw it — only the whole-branch review did.

A **Next-cell request arriving while the producer was imaging a tile** stayed set through the refill and was then consumed against the *first cell the producer returned* — a cell that did not exist when the operator pressed the button. It was reported `skipped` and never attempted:

```
ran      = ['c2']
finished = [('c1', 'skipped'), ('c2', 'done')]
```

Live-relevant because imaging a tile takes seconds to minutes, during which `sigStatus` is `running` (so Next stays enabled) and no cell is actually in progress. The skipped cell also falls outside `COMPLETED = {"done"}`, so "reuse completed cells" would never offer it back — the cell is silently lost.

The fix discards a request that arrives during a refill: refill runs only with an empty queue, so nothing is running and nothing is queued, and there is provably no cell the request could have been about.

## Two process notes worth reading

**Three tests in the plan were vacuous.** Not wrong about *what* to assert — unable to reach the state that distinguishes fixed from broken code. Two `_producerExhausted is False` checks never drove the producer to exhaustion, so they passed against code that cleared nothing. A third passed identically against a `targetQueueDepth` snapshotted once at the top of the loop — the exact defect it was named for.

None were caught by reading them. All three were caught by **removing the fix, or applying the defect, and observing the test fail.** Every fix in this branch carries that proof, including the two mutation proofs re-run after the `targetQueueDepth` removal.

**The re-review re-probed rather than re-read** — 22 scenarios constructed and executed against a real `Orchestrator`, plus 4 mutations applied to source and observed. That discipline exists because on the predecessor branch a fix for a review finding introduced two Criticals worse than the finding, caught only the same way.

## Verification

- **276 tests passing** across `acq4/experiment/` + `acq4/modules/Autopatch/` — pristine, no skips, no warnings, no ignores. Baseline at branch point was 259.
- `acq4/modules/Autopatch/tests/test_teardown.py` — the exit-segfault regression test — is **unmodified** (`git diff` against the base is empty). A new engine-level test proves an `Orchestrator` holding a producer that is a **bound method of a QObject** is still freed by plain refcounting with the cyclic GC disabled; it was confirmed to fail when the cycle is left unbroken, so it is sensitive to the thing it claims.
- Termination traced across every reachable combination of (queue empty/non-empty) × (producer absent/present/exhausted) × (pause set/clear) × (stop requested/not). With no producer, the loop is byte-for-byte the old queue drain.
- All seven pre-existing `_nextCellRequested` clears verified intact; `run_sync_cell` confirmed unable to observe or corrupt producer state.

## Also in this branch

Two documentation commits, both correcting docs against landed code rather than changing behaviour:

- **`docs/superpowers/specs/2026-07-24-autopatch-reuse-completed-cells-design.md` §4** — the disposition list needed more than dropping the nonexistent `handled`. `skipped` and `retry-exhausted` both had to **leave** `COMPLETED`, which is now `{"done"}` alone: `skipped` was only ever in there because both bundled example protocols used to end with `next_cell()`, mislabelling a completed run. Every `sigCellFinished` emission is now enumerated with its site.
- The P2a plan, marked superseded where it describes `targetQueueDepth`, and its stale `orchestrator.py:NNN` citations re-derived.

The governing design doc (`autopatch-orchestration-design.md`, untracked in the main checkout) gained §3.2's producer contract, a rewritten §7 Area 2 search-constraint list (z-depth range relative to surface, minimum health prediction in `[0,1]`, maximum cell density before an area counts exhausted, rescans-allowed), and a new **§4.5**: `patch()` and `reseal()`'s details widget is the live steady-state resistance plot, reusing MultiPatch's `PlotWidget` in `'ss resistance'` mode, with the queued-connection and disconnect-on-end rules its cross-module signal binding requires.

## Known, not addressed here

- **The producer↔slice relationship is undesigned, and blocks P2b.** A producer is intimately tied to one *slice*, but `slice` is not an object anywhere in acq4 — it exists only as a data directory in the day → slice → cell hierarchy, and only when the operator configured one. Two things need settling: an explicit binding, and the rule that a producer must not survey one slice twice without operator approval. **`_producerExhausted` is not the place to enforce that** — it is a per-run cache, deliberately cleared at the end of every run so a genuinely new region is asked again, so a once-per-slice rule built on it would silently reset on every Start. The authority has to live with the producer or a slice object. Recorded in §3.2's `Open` block and as a P2b blocker in §10.
- None of the above touches **reuse completed cells**, which re-queues existing `Cell` objects through `enqueue` (two production callers, both in `cell_panel.py`) and never consults the producer. Cell reuse is not the producer's job.
- No `sigStatus` value distinguishes *surveying* from *patching*, and `sigCurrentCell` still holds the just-finished cell during a refill — so the operator sees "current cell = c3" while a tile images. This is what made the Critical above reachable; P2b needs a distinct state.
- No teardown path calls `setCellProducer(None)`. P2b/P2c must add one and route the producer's owner through an unbind.
- `_refillQueue` wraps the producer *call* but not the iteration of its result, so a lazily-evaluated generator producer raising mid-iteration escapes unwrapped. The contract says "sequence", so this is a contract violation rather than a bug — revisit if a real producer is ever lazy.

🤖 Generated with [Claude Code](https://claude.ai/code)
