### PR TITLE
Autopatch P2b: the Slice object, Area 2 cell-finding config, and a real cell producer

### DIFF
--- a/acq4/experiment/cell_producer.py
+++ b/acq4/experiment/cell_producer.py
@@ -4,6 +4,7 @@ tile of a slice per call, filtering the cells it returns and skipping crowded ti
 from __future__ import annotations
 
 from acq4.logging_config import get_logger
+from acq4.util.task import Stopped
 
 logger = get_logger(__name__)
 
@@ -58,11 +59,25 @@ class CellProducer:
             return []
         try:
             candidates = self._detector(tile, constraints)
-        finally:
-            # Marked whether or not imaging succeeded: a tile that raises must
-            # not be handed out again, or a producer reused across runs wedges
-            # on the same bad tile forever.
+        except Stopped:
+            # The one exit that leaves the tile uncovered, per Slice.nextTile's
+            # contract: the operator interrupted a tile that would otherwise
+            # have imaged fine, so a later producer over this same slice has to
+            # come back to it rather than report a region 100% surveyed with an
+            # unimaged tile in it. Every other way out of the detector -- an
+            # imaging failure, or a flow signal deciding the experiment's fate
+            # from an arbitrary point mid-tile -- marks the tile below, since
+            # only a cooperative stop is guaranteed to have left nothing
+            # half-done.
+            logger.info("Stopped while imaging tile %r; leaving it uncovered", tile)
+            raise
+        except BaseException:
+            # Marked even though imaging failed: a tile that raises must not be
+            # handed out again, or a producer reused across runs wedges on the
+            # same bad tile forever.
             self._slice.markCovered(tile)
+            raise
+        self._slice.markCovered(tile)
         cells = [c for c in candidates if self._isHealthy(c, constraints)]
         self._slice.registerCells(cells)
         return cells

--- a/acq4/experiment/cell_producer.py
+++ b/acq4/experiment/cell_producer.py
@@ -74,7 +74,18 @@ class CellProducer:
         except BaseException:
             # Marked even though imaging failed: a tile that raises must not be
             # handed out again, or a producer reused across runs wedges on the
-            # same bad tile forever.
+            # same bad tile forever. FlowSignal is deliberately not exempted
+            # alongside Stopped above: it is raised only via
+            # ExecutionContext._raise_flow_signal (next_cell/retry_cell/abort),
+            # and the detector make_tile_detector builds is handed no execution
+            # context, so no FlowSignal can reach this call today -- marking by
+            # default is what stops a tile that fails deterministically from
+            # wedging a producer forever. A detector given context access in
+            # the future would want AbortExperiment treated like Stopped
+            # instead: a slice outlives the single run that aborted, and
+            # marking a tile covered that the operator never actually saw
+            # surveyed would over-report that slice's coverage to every later
+            # run over it.
             self._slice.markCovered(tile)
             raise
         self._slice.markCovered(tile)

--- a/acq4/experiment/cell_producer.py
+++ b/acq4/experiment/cell_producer.py
@@ -1,5 +1,5 @@
 """CellProducer: the callable the orchestrator's refill hook takes, surveying one
-tile of a slice per call and returning the cells found there."""
+tile of a slice per call, filtering the cells it returns and skipping crowded tiles."""
 
 from __future__ import annotations
 

--- a/acq4/experiment/cell_producer.py
+++ b/acq4/experiment/cell_producer.py
@@ -1,0 +1,51 @@
+"""CellProducer: the callable the orchestrator's refill hook takes, surveying one
+tile of a slice per call and returning the cells found there."""
+
+from __future__ import annotations
+
+from acq4.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class CellProducer:
+    """Images one tile of a slice per call and returns the cells found in it.
+
+    Satisfies the orchestrator's producer contract: a call returns either a
+    sequence of cells -- possibly empty, meaning "imaged a tile, found nothing
+    there, ask again" -- or None, meaning "every tile is imaged, never ask
+    again". The distinction is load-bearing: an empty field of view is the
+    common case, and reporting it as exhaustion would end a run on the first
+    barren tile.
+
+    A producer is a **view onto** its slice, not an owner of it. Coverage,
+    regions, and constraints all live on the slice and are shared with every
+    other producer made from it, so a producer built for a second run sees the
+    coverage the first run accumulated. The slice does not hold a reference
+    back (see Slice.makeCellProducer).
+
+    `detector(center, constraints)` is the injected imaging seam: it moves to
+    `center`, finds the surface, acquires a stack across the constrained depth
+    range, and returns candidate objects exposing `.position` (global metres)
+    and `.score` (the health prediction). Keeping it injected is what lets the
+    tile walk and the constraint filtering be tested without a microscope.
+    """
+
+    def __init__(self, slice_, detector):
+        self._slice = slice_
+        self._detector = detector
+
+    def __call__(self) -> list | None:
+        tile = self._slice.nextTile()
+        if tile is None:
+            return None
+        try:
+            candidates = self._detector(tile, self._slice.constraints)
+        finally:
+            # Marked whether or not imaging succeeded: a tile that raises must
+            # not be handed out again, or a producer reused across runs wedges
+            # on the same bad tile forever.
+            self._slice.markCovered(tile)
+        cells = list(candidates)
+        self._slice.registerCells(cells)
+        return cells

--- a/acq4/experiment/cell_producer.py
+++ b/acq4/experiment/cell_producer.py
@@ -29,23 +29,70 @@ class CellProducer:
     range, and returns candidate objects exposing `.position` (global metres)
     and `.score` (the health prediction). Keeping it injected is what lets the
     tile walk and the constraint filtering be tested without a microscope.
+
+    `rescans_allowed` grants exactly one extra pass over the slice's tiles, not
+    unlimited rescanning: a producer that could always find another tile would
+    never return None, and the orchestrator's refill loop would never end.
     """
 
     def __init__(self, slice_, detector):
         self._slice = slice_
         self._detector = detector
+        # Whether this producer has already spent its one rescan pass. Per
+        # producer, not per slice: the allowance mirrors the orchestrator's
+        # per-run _producerExhausted, so a later run over the same slice may
+        # rescan again.
+        self._rescanned = False
 
     def __call__(self) -> list | None:
-        tile = self._slice.nextTile()
+        tile = self._nextTile()
         if tile is None:
             return None
+        constraints = self._slice.constraints
+        if self._isCrowded(tile, constraints):
+            # Nothing is imaged: the point of the density cap is to spend the
+            # imaging time elsewhere. Still marked covered, or this tile is
+            # handed out again on every call.
+            self._slice.markCovered(tile)
+            logger.info("Skipping tile %r: already at the cell-density cap", tile)
+            return []
         try:
-            candidates = self._detector(tile, self._slice.constraints)
+            candidates = self._detector(tile, constraints)
         finally:
             # Marked whether or not imaging succeeded: a tile that raises must
             # not be handed out again, or a producer reused across runs wedges
             # on the same bad tile forever.
             self._slice.markCovered(tile)
-        cells = list(candidates)
+        cells = [c for c in candidates if self._isHealthy(c, constraints)]
         self._slice.registerCells(cells)
         return cells
+
+    def _nextTile(self):
+        """The next tile to image, spending the rescan allowance if needed."""
+        tile = self._slice.nextTile()
+        if tile is not None:
+            return tile
+        if not self._slice.constraints.rescans_allowed or self._rescanned:
+            return None
+        # One extra pass, and only one: an unbounded rescan loop could never
+        # return None, and the orchestrator's refill loop would never end.
+        self._rescanned = True
+        self._slice.resetCoverage()
+        logger.info("Rescanning: every tile was covered and rescans are allowed")
+        return self._slice.nextTile()
+
+    @staticmethod
+    def _isHealthy(candidate, constraints) -> bool:
+        """Whether `candidate` clears the health cutoff.
+
+        An unscored candidate passes: a detector that does not score its output,
+        or a cell seeded by hand, must not be silently discarded by a cutoff it
+        was never measured against.
+        """
+        score = getattr(candidate, "score", None)
+        return score is None or score >= constraints.min_health
+
+    def _isCrowded(self, tile, constraints) -> bool:
+        """Whether `tile` already holds cells at or above the density cap."""
+        density = len(self._slice.cellsNearTile(tile)) / self._slice.tileVolume()
+        return density >= constraints.max_cell_density

--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -277,7 +277,14 @@ class Orchestrator(Qt.QObject):
         # into a TypeError out of calling None. Reading it into a local once
         # makes the two one step for this call: if it is gone by the time
         # this runs, there is simply nothing to ask -- not exhaustion, and not
-        # a bug to report.
+        # a bug to report. The same clear (or a swap to a different producer)
+        # can just as easily land while producer() is off running -- itself
+        # slow, seconds-to-minutes tile imaging -- rather than only before it
+        # starts, so the local is checked against self._cellProducer again
+        # below, right before the batch it returned is queued: a batch called
+        # for under a producer the operator has since moved on from belongs to
+        # tissue already declared gone, and must land nowhere rather than in
+        # the next protocol's queue.
         producer = self._cellProducer
         if producer is None:
             return
@@ -297,6 +304,20 @@ class Orchestrator(Qt.QObject):
             raise AbortExperiment(f"cell producer failed: {exc}") from exc
         if cells is None:
             self._producerExhausted = True
+            return
+        if self._cellProducer is not producer:
+            # The batch is neither "found nothing, ask again" nor exhaustion --
+            # it is real cells this call was in the middle of fetching when the
+            # operator cleared or replaced the producer it was fetching them
+            # for. Dropping it here, rather than setting _producerExhausted or
+            # leaving it to be asked for again, is what keeps this discard from
+            # being mistaken for either of the producer contract's two actual
+            # outcomes.
+            logger.info(
+                "Discarding a batch of %d cell(s): the producer that returned "
+                "them is no longer the installed one",
+                len(cells),
+            )
             return
         # One deque.extend rather than a loop of enqueue() calls: clearQueue()
         # runs on the GUI thread while this runs on the worker thread, and a

--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -257,8 +257,20 @@ class Orchestrator(Qt.QObject):
 
     def _refillQueue(self):
         """Ask the producer for more cells; record exhaustion when it has none."""
+        # setCellProducer() runs on the GUI thread (a "New slice" mid-run, for
+        # instance, clearing it to None) while this loop runs on the worker
+        # thread, so "there is a producer" (_shouldRefill's check, just above)
+        # and "call the producer" cannot be treated as two separate steps -- a
+        # clear landing in between would turn a legitimate operator action
+        # into a TypeError out of calling None. Reading it into a local once
+        # makes the two one step for this call: if it is gone by the time
+        # this runs, there is simply nothing to ask -- not exhaustion, and not
+        # a bug to report.
+        producer = self._cellProducer
+        if producer is None:
+            return
         try:
-            cells = self._cellProducer()
+            cells = producer()
         except (Stopped, FlowSignal):
             # Same pass-through as _processCell: a cooperative stop is a normal
             # end to the run, and a producer that raises AbortExperiment means

--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -55,6 +55,18 @@ class Orchestrator(Qt.QObject):
     def enqueue(self, cell):
         self._queue.append(cell)
 
+    def pendingCells(self) -> list:
+        """Return a snapshot of the cells still waiting in the queue, in the
+        order they will run.
+
+        A copy, not the live deque: the deque is popped from the worker
+        thread as a run proceeds, so a caller salvaging cells from an
+        orchestrator that is about to be replaced (see
+        CellPanel.unbindOrchestrator) must not be able to mutate the run's
+        own queue by holding onto it.
+        """
+        return list(self._queue)
+
     def clearQueue(self) -> None:
         """Drop every cell waiting in the queue, leaving any running cell alone.
 

--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -21,7 +21,7 @@ logger = get_logger(__name__)
 
 
 class Orchestrator(Qt.QObject):
-    sigStatus = Qt.Signal(str)                 # "running"/"waiting"/"paused"/"error"
+    sigStatus = Qt.Signal(str)                 # "running"/"surveying"/"waiting"/"paused"/"error"
     sigCurrentCell = Qt.Signal(object)         # cell, or None when idle
     sigCellFinished = Qt.Signal(object, str)   # cell, status
 
@@ -54,6 +54,17 @@ class Orchestrator(Qt.QObject):
     # ---- queue / context ----
     def enqueue(self, cell):
         self._queue.append(cell)
+
+    def clearQueue(self) -> None:
+        """Drop every cell waiting in the queue, leaving any running cell alone.
+
+        The caller that seeded these cells is discarding them -- the operator
+        has swapped the tissue, so every queued position is a place not to
+        drive a pipette. Clearing the panel's own bookkeeping is not enough:
+        the deque is a separate strong reference and would otherwise keep
+        handing those positions to the protocol.
+        """
+        self._queue.clear()
 
     def setCellProducer(self, producer):
         """Install (or clear, with None) the callback that refills the queue.
@@ -162,6 +173,14 @@ class Orchestrator(Qt.QObject):
                 self._checkPause()
                 check_stop()
                 if self._shouldRefill():
+                    # Surveying is not patching, and the operator watching a
+                    # slow, barren stretch of region must not read a stale
+                    # "running" as "a cell is being worked". Clearing the
+                    # current cell first is the same honesty: leaving the
+                    # just-finished cell named here made Area 5 attribute
+                    # survey time to it.
+                    self.sigCurrentCell.emit(None)
+                    self.sigStatus.emit("surveying")
                     self._refillQueue()
                     # Refill only ever runs against an empty queue, so a
                     # request that arrived while the producer was working had

--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -286,8 +286,14 @@ class Orchestrator(Qt.QObject):
         if cells is None:
             self._producerExhausted = True
             return
-        for cell in cells:
-            self.enqueue(cell)
+        # One deque.extend rather than a loop of enqueue() calls: clearQueue()
+        # runs on the GUI thread while this runs on the worker thread, and a
+        # clear landing part-way through a loop would leave a partial batch of
+        # coordinates queued in tissue the operator has already declared gone.
+        # extend() is a single C-level call, so the whole batch lands either
+        # before or after such a clear, never across it. enqueue() remains the
+        # public single-cell entry point.
+        self._queue.extend(cells)
 
     def _processCell(self, cell):
         """Run the protocol function for one cell. RetryCurrentCell loops in

--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -195,10 +195,18 @@ class Orchestrator(Qt.QObject):
                     # a tile is slow, so an operator pressing Stop mid-survey
                     # must not have to wait out a refill that already started.
                     continue
-                if not self._queue:
-                    # Queue empty and nothing left to produce: the run is done.
+                # clearQueue() runs on the GUI thread while this loop runs on
+                # the worker thread, so the deque's emptiness cannot be
+                # checked and then acted on as two separate steps -- a clear
+                # landing in between would turn a plain empty-queue finish
+                # into an IndexError out of popleft(). Popping directly and
+                # catching that IndexError makes the check and the pop one
+                # step: an empty deque at either the check or the pop means
+                # the same thing, the run is done.
+                try:
+                    cell = self._queue.popleft()
+                except IndexError:
                     break
-                cell = self._queue.popleft()
                 self._processCell(cell)
         except Stopped as exc:
             # An operator-initiated stop is a normal way for the run loop to

--- a/acq4/experiment/search_grid.py
+++ b/acq4/experiment/search_grid.py
@@ -1,0 +1,88 @@
+"""Serpentine field-of-view tiling over a rectangular search region, and
+tracking which of those tiles have already been imaged."""
+
+from __future__ import annotations
+
+import math
+
+
+def _axis_centers(lo: float, hi: float, fov: float, overlap: float) -> list[float]:
+    """Tile centers along one axis whose union covers [lo, hi].
+
+    Step between tiles is ``fov - overlap``; the tile count is the smallest that
+    spans the extent, and the tiles are centered over it so the union fully
+    covers [lo, hi] (the outermost tiles may extend past the edges).
+    """
+    extent = hi - lo
+    step = fov - overlap
+    if step <= 0:
+        # Degrade gracefully if the overlap swallows the whole FOV.
+        step = fov
+    if extent <= fov:
+        return [(lo + hi) / 2.0]
+    n = math.ceil((extent - fov) / step) + 1
+    covered = fov + (n - 1) * step
+    extra = covered - extent
+    start = lo + fov / 2.0 - extra / 2.0
+    return [start + i * step for i in range(n)]
+
+
+def plan_grid(
+    x0: float,
+    y0: float,
+    x1: float,
+    y1: float,
+    fov_w: float,
+    fov_h: float,
+    overlap: float,
+) -> list[tuple[float, float]]:
+    """Serpentine-ordered tile centers whose union fully covers the rectangle.
+
+    The step between adjacent tiles is ``fov - overlap`` (an absolute distance).
+    The grid is centered over the rectangle so no part of it is left uncovered;
+    the outermost tiles may extend past the edges. A single tile at the rect
+    center is returned when the rect is smaller than one FOV. Rows alternate
+    direction (boustrophedon) to minimize stage travel.
+    """
+    xs = _axis_centers(min(x0, x1), max(x0, x1), fov_w, overlap)
+    ys = _axis_centers(min(y0, y1), max(y0, y1), fov_h, overlap)
+    grid: list[tuple[float, float]] = []
+    for j, cy in enumerate(ys):
+        row = xs if j % 2 == 0 else list(reversed(xs))
+        for cx in row:
+            grid.append((cx, cy))
+    return grid
+
+
+def _is_visited(
+    cx: float,
+    cy: float,
+    visited: list[tuple[float, float]],
+    threshold: float,
+) -> bool:
+    """Whether ``(cx, cy)`` lies within ``threshold`` of any visited center."""
+    return any(math.hypot(cx - vx, cy - vy) < threshold for vx, vy in visited)
+
+
+def select_next(
+    grid: list[tuple[float, float]],
+    visited: list[tuple[float, float]],
+    threshold: float,
+) -> tuple[float, float] | None:
+    """First center in ``grid`` not within ``threshold`` of any visited center.
+
+    Returns None when every planned tile has already been imaged.
+    """
+    for cx, cy in grid:
+        if not _is_visited(cx, cy, visited, threshold):
+            return (cx, cy)
+    return None
+
+
+def count_covered(
+    grid: list[tuple[float, float]],
+    visited: list[tuple[float, float]],
+    threshold: float,
+) -> int:
+    """Number of centers in ``grid`` within ``threshold`` of some visited center."""
+    return sum(1 for cx, cy in grid if _is_visited(cx, cy, visited, threshold))

--- a/acq4/experiment/search_grid.py
+++ b/acq4/experiment/search_grid.py
@@ -12,15 +12,32 @@ def _axis_centers(lo: float, hi: float, fov: float, overlap: float) -> list[floa
     Step between tiles is ``fov - overlap``; the tile count is the smallest that
     spans the extent, and the tiles are centered over it so the union fully
     covers [lo, hi] (the outermost tiles may extend past the edges).
+
+    ``extent`` is computed as ``hi - lo``, and ``lo``/``hi`` may be as large as a
+    stage's absolute travel range while ``fov``/``step`` are tiny by comparison,
+    so that subtraction carries rounding error proportional to the magnitude of
+    ``lo``/``hi`` rather than of the extent itself. A tolerance scaled to the
+    largest quantity involved (divided by ``step`` to put it in the same units
+    as the tile-count ratio) absorbs that error so a ratio that is only a
+    rounding error away from an integer is treated as that integer instead of
+    being rounded up to one more tile.
     """
     extent = hi - lo
     step = fov - overlap
     if step <= 0:
         # Degrade gracefully if the overlap swallows the whole FOV.
         step = fov
-    if extent <= fov:
+    scale = max(abs(lo), abs(hi), fov, step)
+    length_tol = scale * 1e-9
+    if extent <= fov + length_tol:
         return [(lo + hi) / 2.0]
-    n = math.ceil((extent - fov) / step) + 1
+    ratio = (extent - fov) / step
+    ratio_tol = length_tol / step
+    rounded_ratio = round(ratio)
+    if abs(ratio - rounded_ratio) <= ratio_tol:
+        n = int(rounded_ratio) + 1
+    else:
+        n = math.ceil(ratio) + 1
     covered = fov + (n - 1) * step
     extra = covered - extent
     start = lo + fov / 2.0 - extra / 2.0

--- a/acq4/experiment/slice.py
+++ b/acq4/experiment/slice.py
@@ -182,3 +182,16 @@ class Slice:
             if abs(pos[0] - cx) <= fov_w / 2 and abs(pos[1] - cy) <= fov_h / 2:
                 found.append(cell)
         return found
+
+    # ---- cell producers ----
+    def makeCellProducer(self, detector) -> "CellProducer":
+        """A producer that surveys this slice, one tile per call.
+
+        This slice keeps no reference to what it hands back. The producer holds
+        the slice, the orchestrator holds the producer, and that one-way chain
+        is refcount-freeable; storing producers here would close it into a cycle
+        only the cyclic GC could reclaim.
+        """
+        from .cell_producer import CellProducer
+
+        return CellProducer(self, detector)

--- a/acq4/experiment/slice.py
+++ b/acq4/experiment/slice.py
@@ -1,0 +1,59 @@
+"""Slice: the search state for one piece of tissue -- the regions to survey, the
+tiles already imaged, the search constraints, and the cell producers it hands out."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SearchConstraints:
+    """The Area 2 search constraints that parameterise a cell producer.
+
+    `depth_range` is a pair of z offsets **relative to the tissue surface**, in
+    metres, negative being deeper: the design's "-20 um through -60 um" is
+    (-20e-6, -60e-6). Surface is found per tile, so the slab follows uneven
+    tissue rather than being absolute stage z. Either ordering is accepted.
+
+    `min_health` is the classification model's score cutoff in [0, 1]; cells
+    scoring below it are not queued. `max_cell_density` is cells per cubic
+    metre, above which a tile counts as already crowded and is skipped rather
+    than having more targets packed into it. `rescans_allowed` permits
+    re-imaging tiles that have already been covered.
+    """
+
+    depth_range: tuple[float, float] = (-20e-6, -60e-6)
+    min_health: float = 0.5
+    # 5e12 cells/m^3 is 5 cells per (100 um)^3 -- dense for cortex, so the
+    # default cap only rejects genuinely crowded tissue.
+    max_cell_density: float = 5e12
+    rescans_allowed: bool = False
+
+    def __post_init__(self):
+        near, far = self.depth_range
+        if near > 0 or far > 0:
+            raise ValueError(
+                f"depth_range offsets must be at or below the surface (<= 0), got {self.depth_range}"
+            )
+        if near == far:
+            raise ValueError(
+                f"depth_range must span a nonzero thickness, got {self.depth_range}"
+            )
+        if not 0.0 <= self.min_health <= 1.0:
+            raise ValueError(
+                f"min_health must be between 0 and 1, got {self.min_health}"
+            )
+        if self.max_cell_density <= 0:
+            raise ValueError(
+                f"max_cell_density must be positive, got {self.max_cell_density}"
+            )
+
+    def z_span(self) -> float:
+        """Thickness of the searched slab, in metres."""
+        near, far = self.depth_range
+        return abs(near - far)
+
+    def z_bounds(self, surface: float) -> tuple[float, float]:
+        """Absolute (shallower, deeper) z for a tile whose surface is at `surface`."""
+        near, far = self.depth_range
+        return surface + max(near, far), surface + min(near, far)

--- a/acq4/experiment/slice.py
+++ b/acq4/experiment/slice.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from .search_grid import count_covered, plan_grid, select_next
+
 
 @dataclass(frozen=True)
 class SearchConstraints:
@@ -57,3 +59,126 @@ class SearchConstraints:
         """Absolute (shallower, deeper) z for a tile whose surface is at `surface`."""
         near, far = self.depth_range
         return surface + max(near, far), surface + min(near, far)
+
+
+class Slice:
+    """The search state for one piece of tissue, and the source of its cell producers.
+
+    Owns the regions to survey (global-coordinate rectangles), the coverage
+    record of which field-of-view tiles have been imaged, the search
+    constraints, and -- once a producer is made from it -- the tiles and cells
+    that producer accumulates. Coverage is shared by every producer this slice
+    makes: that is what stops a second region's survey from re-imaging the
+    first's, and what gives `rescans_allowed` something to decide.
+
+    A slice, its coverage, and its producers persist across orchestrator runs.
+    They are replaced only when the operator starts a new slice. This is
+    deliberately the opposite of Orchestrator._producerExhausted, which is a
+    per-run cache: a producer that reported exhaustion is asked again next run,
+    precisely so a slice that has gained a region can be surveyed further.
+
+    Not a QObject: it holds no widgets, and staying a plain object keeps it
+    refcount-freeable rather than depending on Qt teardown ordering.
+    """
+
+    def __init__(self, fov, constraints=None, overlap=0.0, directory=None):
+        fov_w, fov_h = fov
+        if fov_w <= 0 or fov_h <= 0:
+            raise ValueError(f"fov must be positive in both axes, got {fov}")
+        self._fov = (abs(fov_w), abs(fov_h))
+        self._overlap = overlap
+        self._constraints = (
+            constraints if constraints is not None else SearchConstraints()
+        )
+        self._regions: list[tuple[float, float, float, float]] = []
+        self._covered: list[tuple[float, float]] = []
+        self._cells: list = []
+        # The acq4 slice directory (a DirHandle) this state belongs to, kept so
+        # a caller can write per-slice data alongside it. Not required for the
+        # in-memory search itself.
+        self.directory = directory
+
+    # ---- constraints ----
+    @property
+    def constraints(self) -> SearchConstraints:
+        return self._constraints
+
+    def setConstraints(self, constraints: SearchConstraints) -> None:
+        self._constraints = constraints
+
+    # ---- regions ----
+    @property
+    def regions(self) -> list[tuple[float, float, float, float]]:
+        """The search rectangles, as a copy: mutating the result changes nothing."""
+        return list(self._regions)
+
+    def addRegion(self, x0: float, y0: float, x1: float, y1: float) -> None:
+        """Add a global-coordinate rectangle to survey. Coverage is untouched."""
+        self._regions.append((x0, y0, x1, y1))
+
+    # ---- tiles and coverage ----
+    @property
+    def threshold(self) -> float:
+        """Distance below which two tile centers are the same tile."""
+        fov_w, fov_h = self._fov
+        step = min(fov_w - self._overlap, fov_h - self._overlap)
+        if step <= 0:
+            step = min(fov_w, fov_h)
+        return step / 2
+
+    def tileGrid(self) -> list[tuple[float, float]]:
+        """Every region's tile centers, concatenated in the order regions were added."""
+        grid: list[tuple[float, float]] = []
+        fov_w, fov_h = self._fov
+        for x0, y0, x1, y1 in self._regions:
+            grid.extend(plan_grid(x0, y0, x1, y1, fov_w, fov_h, self._overlap))
+        return grid
+
+    def nextTile(self) -> tuple[float, float] | None:
+        """The next tile center not yet covered, or None when all are.
+
+        Reports only: the caller marks a tile covered once it has actually
+        imaged it, so a tile abandoned by a stop is not silently skipped on the
+        next run.
+        """
+        return select_next(self.tileGrid(), self._covered, self.threshold)
+
+    def markCovered(self, center: tuple[float, float]) -> None:
+        self._covered.append(tuple(center))
+
+    def resetCoverage(self) -> None:
+        """Forget which tiles have been imaged, keeping regions and constraints."""
+        self._covered = []
+
+    @property
+    def coveredTiles(self) -> list[tuple[float, float]]:
+        return list(self._covered)
+
+    def surveyStats(self) -> tuple[int, int, float]:
+        """(total tiles, covered tiles, percent covered) across every region."""
+        grid = self.tileGrid()
+        total = len(grid)
+        covered = count_covered(grid, self._covered, self.threshold)
+        percent = 100.0 * covered / total if total else 0.0
+        return total, covered, percent
+
+    def tileVolume(self) -> float:
+        """The volume one tile searches: FOV area times the constrained depth span."""
+        fov_w, fov_h = self._fov
+        return fov_w * fov_h * self._constraints.z_span()
+
+    # ---- cells found in this tissue ----
+    def registerCells(self, cells) -> None:
+        """Record cells found in this slice, for the density cap's bookkeeping."""
+        self._cells.extend(cells)
+
+    def cellsNearTile(self, center: tuple[float, float]) -> list:
+        """Registered cells whose position falls within `center`'s tile."""
+        cx, cy = center
+        fov_w, fov_h = self._fov
+        found = []
+        for cell in self._cells:
+            pos = cell.position
+            if abs(pos[0] - cx) <= fov_w / 2 and abs(pos[1] - cy) <= fov_h / 2:
+                found.append(cell)
+        return found

--- a/acq4/experiment/slice.py
+++ b/acq4/experiment/slice.py
@@ -81,7 +81,7 @@ class Slice:
     refcount-freeable rather than depending on Qt teardown ordering.
     """
 
-    def __init__(self, fov, constraints=None, overlap=0.0, directory=None):
+    def __init__(self, fov, constraints=None, overlap=0.0):
         fov_w, fov_h = fov
         if fov_w <= 0 or fov_h <= 0:
             raise ValueError(f"fov must be positive in both axes, got {fov}")
@@ -93,10 +93,6 @@ class Slice:
         self._regions: list[tuple[float, float, float, float]] = []
         self._covered: list[tuple[float, float]] = []
         self._cells: list = []
-        # The acq4 slice directory (a DirHandle) this state belongs to, kept so
-        # a caller can write per-slice data alongside it. Not required for the
-        # in-memory search itself.
-        self.directory = directory
 
     # ---- constraints ----
     @property
@@ -127,7 +123,13 @@ class Slice:
         return step / 2
 
     def tileGrid(self) -> list[tuple[float, float]]:
-        """Every region's tile centers, concatenated in the order regions were added."""
+        """Every region's tile centers, concatenated in the order regions were added.
+
+        Within a region the centers keep the serpentine order `plan_grid`
+        produces: alternating the direction of each row roughly halves the stage
+        travel a survey spends getting from one tile to the next, and `nextTile`
+        hands them out in exactly this order.
+        """
         grid: list[tuple[float, float]] = []
         fov_w, fov_h = self._fov
         for x0, y0, x1, y1 in self._regions:

--- a/acq4/experiment/tests/test_cell_producer.py
+++ b/acq4/experiment/tests/test_cell_producer.py
@@ -359,9 +359,9 @@ def test_slice_and_producer_are_freed_by_refcounting_alone():
     """No cycle between a slice and the producers it makes.
 
     Both outlive individual runs and neither is a QObject, so they must be
-    reclaimable without the cyclic collector -- the failure mode that produced
-    P1.5's exit segfault was a graph only gc could break, collected
-    non-deterministically and possibly off the GUI thread.
+    reclaimable without the cyclic collector. A graph only gc can break is
+    collected non-deterministically and possibly off the GUI thread, which is
+    how this module reaches a hard crash on application exit.
     """
     import gc
     import weakref

--- a/acq4/experiment/tests/test_cell_producer.py
+++ b/acq4/experiment/tests/test_cell_producer.py
@@ -215,6 +215,18 @@ def test_a_candidate_without_a_score_passes_the_cutoff():
     assert CellProducer(s, RecordingDetector([[unscored]]))() == [unscored]
 
 
+def test_a_candidate_with_no_score_attribute_at_all_passes_the_cutoff():
+    # The real detector's candidates never carry a `score` attribute until
+    # someone assigns one after the fact, so an unscored candidate is missing
+    # the attribute entirely, not merely holding it as None. Either shape must
+    # be treated as unscored rather than raising or being rejected.
+    s = make_slice(constraints=SearchConstraints(min_health=0.9))
+    tile = s.nextTile()
+    unscored = FakeCandidate((tile[0], tile[1], -30e-6))
+    del unscored.score
+    assert CellProducer(s, RecordingDetector([[unscored]]))() == [unscored]
+
+
 def _crowding_constraints(cells_per_tile):
     """Constraints whose density cap is reached by `cells_per_tile` in one tile.
 
@@ -251,9 +263,22 @@ def test_a_tile_already_at_the_density_cap_is_skipped_without_imaging():
 
 
 def test_a_tile_below_the_density_cap_is_imaged_normally():
-    s = make_slice(constraints=_crowding_constraints(2))
+    # Two tiles so a crowd elsewhere in the slice can be told apart from a
+    # crowd in the tile under test: the cap is a per-tile locality check, not
+    # a slice-wide cell budget, and cells piling up in one tile must not make
+    # every other tile in the slice look crowded too.
+    s = make_slice(
+        constraints=_crowding_constraints(2), regions=((0, 0, 20e-6, 10e-6),)
+    )
     tile = s.nextTile()
+    other_tile = (tile[0] + 10e-6, tile[1])
     s.registerCells([FakeCandidate((tile[0], tile[1], -30e-6))])
+    s.registerCells(
+        [
+            FakeCandidate((other_tile[0], other_tile[1], -30e-6)),
+            FakeCandidate((other_tile[0] + 1e-6, other_tile[1], -30e-6)),
+        ]
+    )
     found = FakeCandidate((tile[0], tile[1], -35e-6))
     detector = RecordingDetector([[found]])
 

--- a/acq4/experiment/tests/test_cell_producer.py
+++ b/acq4/experiment/tests/test_cell_producer.py
@@ -1,0 +1,146 @@
+"""Tests for CellProducer: walking a slice's tiles, the []-versus-None
+exhaustion contract, and the search constraints it filters candidates against."""
+
+import pytest
+
+from acq4.experiment.cell_producer import CellProducer
+from acq4.experiment.slice import SearchConstraints, Slice
+
+FOV = (10e-6, 10e-6)
+
+
+class FakeCandidate:
+    """Stand-in for a detected cell: a global position and a health score."""
+
+    def __init__(self, position, score=1.0):
+        self.position = position
+        self.score = score
+
+    def __repr__(self):
+        return f"FakeCandidate({self.position}, score={self.score})"
+
+
+class RecordingDetector:
+    """A detector seam that returns scripted results and records its calls.
+
+    `results` maps nothing -- it is consumed in order, one entry per call, each
+    entry being the list of candidates that call returns. Running past the end
+    returns an empty list (a barren tile), which is the common real case.
+    """
+
+    def __init__(self, results=()):
+        self._results = list(results)
+        self.calls = []
+
+    def __call__(self, center, constraints):
+        self.calls.append((tuple(center), constraints))
+        return self._results.pop(0) if self._results else []
+
+
+def make_slice(constraints=None, regions=((0, 0, 30e-6, 30e-6),)):
+    s = Slice(fov=FOV, constraints=constraints)
+    for r in regions:
+        s.addRegion(*r)
+    return s
+
+
+def test_a_call_images_one_tile_and_returns_its_cells():
+    s = make_slice()
+    tile = s.nextTile()
+    cell = FakeCandidate((tile[0], tile[1], -30e-6))
+    detector = RecordingDetector([[cell]])
+    producer = CellProducer(s, detector)
+
+    assert producer() == [cell]
+    assert detector.calls[0][0] == tile
+
+
+def test_the_imaged_tile_is_marked_covered_so_the_next_call_advances():
+    s = make_slice()
+    detector = RecordingDetector()
+    producer = CellProducer(s, detector)
+
+    producer()
+    producer()
+
+    assert detector.calls[0][0] != detector.calls[1][0]
+    assert len(s.coveredTiles) == 2
+
+
+def test_a_barren_tile_returns_empty_not_none():
+    # [] is "made progress, found nothing here, ask again"; None would end the
+    # whole run on the first empty field of view.
+    s = make_slice()
+    producer = CellProducer(s, RecordingDetector([[]]))
+    result = producer()
+    assert result == []
+    assert result is not None
+
+
+def test_none_only_once_every_tile_is_imaged():
+    s = make_slice(regions=((0, 0, 10e-6, 10e-6),))  # exactly one tile
+    producer = CellProducer(s, RecordingDetector())
+
+    assert producer() == []
+    assert producer() is None
+
+
+def test_a_slice_with_no_regions_is_exhausted_immediately():
+    s = Slice(fov=FOV)
+    detector = RecordingDetector()
+    producer = CellProducer(s, detector)
+
+    assert producer() is None
+    assert detector.calls == [], "nothing to image, so the detector must not run"
+
+
+def test_the_detector_receives_the_slices_current_constraints():
+    constraints = SearchConstraints(min_health=0.0, depth_range=(-5e-6, -25e-6))
+    s = make_slice(constraints=constraints)
+    detector = RecordingDetector()
+    CellProducer(s, detector)()
+    assert detector.calls[0][1] is constraints
+
+
+def test_found_cells_are_registered_with_the_slice():
+    s = make_slice()
+    tile = s.nextTile()
+    cell = FakeCandidate((tile[0], tile[1], -30e-6))
+    CellProducer(s, RecordingDetector([[cell]]))()
+    assert s.cellsNearTile(tile) == [cell]
+
+
+def test_a_detector_failure_marks_the_tile_covered_rather_than_retrying_it_forever():
+    # A tile that raises must not be handed out again on the next call: the
+    # orchestrator wraps a producer exception into AbortExperiment, but a
+    # producer used across runs would otherwise wedge on the same bad tile.
+    s = make_slice()
+    tile = s.nextTile()
+
+    def exploding(center, constraints):
+        raise RuntimeError("imaging failed")
+
+    producer = CellProducer(s, exploding)
+    with pytest.raises(RuntimeError, match="imaging failed"):
+        producer()
+    assert tile in s.coveredTiles
+
+
+def test_a_populated_tile_returns_a_concrete_list_not_a_lazy_iterator():
+    # The orchestrator's error handling wraps only the producer call, not the
+    # iteration of whatever it returns: a generator that raised partway through
+    # iteration would escape unwrapped and crash the run in a way nothing
+    # handles. __call__ must hand back an already-realized list.
+    s = make_slice()
+    tile = s.nextTile()
+    cell = FakeCandidate((tile[0], tile[1], -30e-6))
+    producer = CellProducer(s, RecordingDetector([[cell]]))
+    result = producer()
+    assert type(result) is list
+
+
+def test_a_barren_tile_also_returns_a_concrete_list():
+    s = make_slice()
+    producer = CellProducer(s, RecordingDetector([[]]))
+    result = producer()
+    assert type(result) is list

--- a/acq4/experiment/tests/test_cell_producer.py
+++ b/acq4/experiment/tests/test_cell_producer.py
@@ -95,11 +95,22 @@ def test_a_slice_with_no_regions_is_exhausted_immediately():
 
 
 def test_the_detector_receives_the_slices_current_constraints():
-    constraints = SearchConstraints(min_health=0.0, depth_range=(-5e-6, -25e-6))
-    s = make_slice(constraints=constraints)
+    # Constraints must be read from the slice at call time, not captured once
+    # when the producer is built: an operator editing a search constraint
+    # mid-experiment has to take effect on the very next tile, or the edit is
+    # silently ignored.
+    first = SearchConstraints(min_health=0.0, depth_range=(-5e-6, -25e-6))
+    s = make_slice(constraints=first)
     detector = RecordingDetector()
-    CellProducer(s, detector)()
-    assert detector.calls[0][1] is constraints
+    producer = CellProducer(s, detector)
+
+    producer()
+    assert detector.calls[0][1] is first
+
+    other = SearchConstraints(min_health=0.9, depth_range=(-5e-6, -25e-6))
+    s.setConstraints(other)
+    producer()
+    assert detector.calls[1][1] is other
 
 
 def test_found_cells_are_registered_with_the_slice():
@@ -130,13 +141,23 @@ def test_a_populated_tile_returns_a_concrete_list_not_a_lazy_iterator():
     # The orchestrator's error handling wraps only the producer call, not the
     # iteration of whatever it returns: a generator that raised partway through
     # iteration would escape unwrapped and crash the run in a way nothing
-    # handles. __call__ must hand back an already-realized list.
+    # handles. __call__ must hand back an already-realized list. The detector
+    # here actually returns a generator, so registering the cells with the
+    # slice and then returning them both have to work from the same run of
+    # the underlying iterator -- proof that nothing was consumed out from
+    # under the caller.
     s = make_slice()
     tile = s.nextTile()
     cell = FakeCandidate((tile[0], tile[1], -30e-6))
-    producer = CellProducer(s, RecordingDetector([[cell]]))
+
+    def detector(center, constraints):
+        return (c for c in [cell])
+
+    producer = CellProducer(s, detector)
     result = producer()
     assert type(result) is list
+    assert result == [cell]
+    assert s.cellsNearTile(tile) == [cell]
 
 
 def test_a_barren_tile_also_returns_a_concrete_list():

--- a/acq4/experiment/tests/test_cell_producer.py
+++ b/acq4/experiment/tests/test_cell_producer.py
@@ -353,3 +353,32 @@ def test_rescan_pass_re_walks_every_tile_not_just_one():
 
     assert producer() is None
     assert len(detector.calls) == 4
+
+
+def test_slice_and_producer_are_freed_by_refcounting_alone():
+    """No cycle between a slice and the producers it makes.
+
+    Both outlive individual runs and neither is a QObject, so they must be
+    reclaimable without the cyclic collector -- the failure mode that produced
+    P1.5's exit segfault was a graph only gc could break, collected
+    non-deterministically and possibly off the GUI thread.
+    """
+    import gc
+    import weakref
+
+    s = Slice(fov=FOV)
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    producer = s.makeCellProducer(RecordingDetector())
+    producer()
+
+    slice_ref = weakref.ref(s)
+    producer_ref = weakref.ref(producer)
+
+    gc.disable()
+    try:
+        del producer
+        assert producer_ref() is None, "producer survived; a cycle holds it"
+        del s
+        assert slice_ref() is None, "slice survived; a cycle holds it"
+    finally:
+        gc.enable()

--- a/acq4/experiment/tests/test_cell_producer.py
+++ b/acq4/experiment/tests/test_cell_producer.py
@@ -1,5 +1,6 @@
 """Tests for CellProducer: walking a slice's tiles, the []-versus-None
-exhaustion contract, and the search constraints it filters candidates against."""
+exhaustion contract, and the search constraints (health cutoff, density cap,
+and rescan policy) it filters candidates and tiles against."""
 
 import pytest
 
@@ -165,3 +166,165 @@ def test_a_barren_tile_also_returns_a_concrete_list():
     producer = CellProducer(s, RecordingDetector([[]]))
     result = producer()
     assert type(result) is list
+
+
+def test_candidates_below_the_health_cutoff_are_not_queued():
+    s = make_slice(constraints=SearchConstraints(min_health=0.6))
+    tile = s.nextTile()
+    good = FakeCandidate((tile[0], tile[1], -30e-6), score=0.9)
+    bad = FakeCandidate((tile[0] + 1e-6, tile[1], -30e-6), score=0.3)
+    producer = CellProducer(s, RecordingDetector([[good, bad]]))
+
+    assert producer() == [good]
+
+
+def test_a_candidate_exactly_at_the_cutoff_is_kept():
+    s = make_slice(constraints=SearchConstraints(min_health=0.6))
+    tile = s.nextTile()
+    borderline = FakeCandidate((tile[0], tile[1], -30e-6), score=0.6)
+    assert CellProducer(s, RecordingDetector([[borderline]]))() == [borderline]
+
+
+def test_a_tile_whose_every_candidate_is_rejected_returns_empty_not_none():
+    # Filtering everything out is still "made progress on a tile"; reporting it
+    # as exhaustion would end the run.
+    s = make_slice(constraints=SearchConstraints(min_health=0.9))
+    tile = s.nextTile()
+    weak = FakeCandidate((tile[0], tile[1], -30e-6), score=0.1)
+    producer = CellProducer(s, RecordingDetector([[weak]]))
+    result = producer()
+    assert result == []
+    assert result is not None
+
+
+def test_rejected_candidates_are_not_registered_with_the_slice():
+    s = make_slice(constraints=SearchConstraints(min_health=0.9))
+    tile = s.nextTile()
+    weak = FakeCandidate((tile[0], tile[1], -30e-6), score=0.1)
+    CellProducer(s, RecordingDetector([[weak]]))()
+    assert s.cellsNearTile(tile) == []
+
+
+def test_a_candidate_without_a_score_passes_the_cutoff():
+    # "Add from target" cells and any detector that does not score its output
+    # must not be silently discarded by a nonzero cutoff.
+    s = make_slice(constraints=SearchConstraints(min_health=0.9))
+    tile = s.nextTile()
+    unscored = FakeCandidate((tile[0], tile[1], -30e-6))
+    unscored.score = None
+    assert CellProducer(s, RecordingDetector([[unscored]]))() == [unscored]
+
+
+def _crowding_constraints(cells_per_tile):
+    """Constraints whose density cap is reached by `cells_per_tile` in one tile.
+
+    The volume is computed through the same `z_span()` used by
+    `Slice.tileVolume()`, rather than a literal depth span, so the cap this
+    produces lands on the same floating-point value the producer compares
+    against: a literal `40e-6` is not bit-identical to `abs(-20e-6 - -60e-6)`,
+    which would make an "exactly at the cap" test actually sit a hair above it.
+    """
+    depth_range = (-20e-6, -60e-6)
+    volume = 10e-6 * 10e-6 * SearchConstraints(depth_range=depth_range).z_span()
+    return SearchConstraints(
+        depth_range=depth_range,
+        min_health=0.0,
+        max_cell_density=cells_per_tile / volume,
+    )
+
+
+def test_a_tile_already_at_the_density_cap_is_skipped_without_imaging():
+    s = make_slice(constraints=_crowding_constraints(2))
+    tile = s.nextTile()
+    s.registerCells(
+        [
+            FakeCandidate((tile[0], tile[1], -30e-6)),
+            FakeCandidate((tile[0] + 1e-6, tile[1], -30e-6)),
+        ]
+    )
+    detector = RecordingDetector([[FakeCandidate((tile[0], tile[1], -30e-6))]])
+    producer = CellProducer(s, detector)
+
+    assert producer() == []
+    assert detector.calls == [], "a crowded tile must not be imaged at all"
+    assert tile in s.coveredTiles, "and it must not be handed out again"
+
+
+def test_a_tile_below_the_density_cap_is_imaged_normally():
+    s = make_slice(constraints=_crowding_constraints(2))
+    tile = s.nextTile()
+    s.registerCells([FakeCandidate((tile[0], tile[1], -30e-6))])
+    found = FakeCandidate((tile[0], tile[1], -35e-6))
+    detector = RecordingDetector([[found]])
+
+    assert CellProducer(s, detector)() == [found]
+    assert len(detector.calls) == 1
+
+
+def test_without_rescans_exhaustion_is_final():
+    s = make_slice(
+        regions=((0, 0, 10e-6, 10e-6),),
+        constraints=SearchConstraints(rescans_allowed=False),
+    )
+    producer = CellProducer(s, RecordingDetector())
+    producer()
+    assert producer() is None
+    assert producer() is None
+
+
+def test_rescans_allowed_grants_exactly_one_more_pass():
+    # Unlimited rescanning could never return None, which would wedge the run
+    # loop; one extra pass makes the switch mean something and keeps the
+    # contract. See CellProducer's docstring.
+    s = make_slice(
+        regions=((0, 0, 10e-6, 10e-6),),
+        constraints=SearchConstraints(rescans_allowed=True),
+    )
+    detector = RecordingDetector()
+    producer = CellProducer(s, detector)
+
+    assert producer() == []  # first pass images the only tile
+    assert producer() == []  # rescan re-images it
+    assert producer() is None  # and then it really is exhausted
+    assert len(detector.calls) == 2
+
+
+def test_a_second_producer_from_the_same_slice_gets_its_own_rescan_allowance():
+    # The allowance is per-producer, matching _producerExhausted's per-run
+    # lifetime, so a later run over the same slice may rescan again.
+    s = make_slice(
+        regions=((0, 0, 10e-6, 10e-6),),
+        constraints=SearchConstraints(rescans_allowed=True),
+    )
+    first = s.makeCellProducer(RecordingDetector())
+    first()
+    first()
+    assert first() is None
+
+    second = s.makeCellProducer(RecordingDetector())
+    assert second() == []
+    assert second() is None
+
+
+def test_rescan_pass_re_walks_every_tile_not_just_one():
+    # The single-tile rescan tests above can't tell a re-walk of the whole
+    # slice apart from a single lucky tile being handed out twice. A
+    # multi-tile region closes that gap: the rescan pass must hand out the
+    # same number of tiles as the first pass before it, too, is exhausted.
+    s = make_slice(
+        regions=((0, 0, 20e-6, 10e-6),),
+        constraints=SearchConstraints(rescans_allowed=True),
+    )
+    detector = RecordingDetector()
+    producer = CellProducer(s, detector)
+
+    assert producer() == []
+    assert producer() == []
+    assert len(detector.calls) == 2, "first pass should walk both tiles"
+
+    assert producer() == []
+    assert producer() == []
+    assert len(detector.calls) == 4, "rescan pass should walk both tiles again"
+
+    assert producer() is None
+    assert len(detector.calls) == 4

--- a/acq4/experiment/tests/test_cell_producer.py
+++ b/acq4/experiment/tests/test_cell_producer.py
@@ -6,6 +6,7 @@ import pytest
 
 from acq4.experiment.cell_producer import CellProducer
 from acq4.experiment.slice import SearchConstraints, Slice
+from acq4.util.task import Stopped
 
 FOV = (10e-6, 10e-6)
 
@@ -136,6 +137,69 @@ def test_a_detector_failure_marks_the_tile_covered_rather_than_retrying_it_forev
     with pytest.raises(RuntimeError, match="imaging failed"):
         producer()
     assert tile in s.coveredTiles
+
+
+def test_a_stop_mid_tile_leaves_that_tile_uncovered():
+    # Slice.nextTile's contract: the caller marks a tile covered once it has
+    # actually imaged it, so a tile the operator abandoned by pressing Stop is
+    # retried rather than silently skipped. tile_detector raises Stopped from
+    # four separate check_stop() points, every one of them before or during the
+    # imaging this tile's coverage is supposed to record.
+    s = make_slice()
+    tile = s.nextTile()
+
+    def stopping(center, constraints):
+        raise Stopped("operator pressed stop mid-tile")
+
+    producer = CellProducer(s, stopping)
+    with pytest.raises(Stopped):
+        producer()
+
+    assert s.coveredTiles == []
+    assert s.nextTile() == tile
+    assert s.surveyStats()[1] == 0
+
+
+def test_a_tile_abandoned_by_a_stop_is_re_imaged_by_a_later_producer():
+    # The slice and its coverage outlive individual runs, so the proof that
+    # matters is the next run's producer -- a fresh CellProducer over the same
+    # persistent slice -- actually returning to the abandoned tile, not merely
+    # that coverage looked right in the moment.
+    s = make_slice()
+    tile = s.nextTile()
+
+    def stopping(center, constraints):
+        raise Stopped("operator pressed stop mid-tile")
+
+    with pytest.raises(Stopped):
+        s.makeCellProducer(stopping)()
+
+    detector = RecordingDetector()
+    s.makeCellProducer(detector)()
+
+    assert detector.calls[0][0] == tile
+    assert tile in s.coveredTiles
+
+
+def test_a_stopped_tile_is_not_counted_as_surveyed():
+    # A region whose every tile but one was imaged, with that one abandoned by a
+    # stop, must not read as 100% surveyed: the readout is what tells the
+    # operator whether the tissue has actually been looked at.
+    s = make_slice(regions=((0, 0, 20e-6, 10e-6),))  # exactly two tiles
+
+    def stopAtTheSecondTile(center, constraints):
+        if len(s.coveredTiles) == 1:
+            raise Stopped("operator pressed stop mid-tile")
+        return []
+
+    producer = CellProducer(s, stopAtTheSecondTile)
+    assert producer() == []
+    with pytest.raises(Stopped):
+        producer()
+
+    total, covered, percent = s.surveyStats()
+    assert (total, covered) == (2, 1)
+    assert percent == pytest.approx(50.0)
 
 
 def test_a_populated_tile_returns_a_concrete_list_not_a_lazy_iterator():

--- a/acq4/experiment/tests/test_detector_producer_seam.py
+++ b/acq4/experiment/tests/test_detector_producer_seam.py
@@ -1,0 +1,142 @@
+"""Integration test for the detector <-> producer seam: a real Slice, a real
+CellProducer, and a real make_tile_detector callable driven end to end against
+fake devices, with only the three device-touching helpers replaced."""
+
+import pytest
+
+from acq4.experiment import tile_detector
+from acq4.experiment.slice import SearchConstraints, Slice
+
+from .test_tile_detector import FakeCamera, FakeCell, FakeScope
+
+# 100x80 um tiles over a 300x80 um region: exactly three tiles in one row, and
+# non-square so a swapped axis cannot pass by coincidence.
+FOV = (100e-6, 80e-6)
+REGION = (0.0, 0.0, 300e-6, 80e-6)
+TILE_COUNT = 3
+# Deliberately nowhere near zero: with the surface at 0 the signed depth offsets
+# would look the same as their own negation, so a sign error in the arithmetic
+# between the constraints and _acquire would not show up.
+SURFACE = -500e-6
+NEAR, FAR = -20e-6, -60e-6
+
+
+@pytest.fixture
+def seam(monkeypatch):
+    """A real Slice/CellProducer/tile detector chain over fake devices.
+
+    Only `_acquire`, `_detect`, and `_newCell` -- the three helpers that reach a
+    real camera, the detection models, and acq4_automation's Cell -- are
+    replaced. The stage moves, the surface search, the depth arithmetic, the tile
+    walk, the coverage bookkeeping, and the constraint filtering are all the
+    genuine articles, which is the point: each half of this chain has its own
+    unit tests, and this is what proves they fit together.
+    """
+    camera = FakeCamera()
+    scope = FakeScope(camera, surface=SURFACE)
+    acquireCalls = []
+
+    def fakeAcquire(cam, start_z, stop_z, step_z):
+        acquireCalls.append((start_z, stop_z, step_z))
+        return ["frame"]
+
+    def fakeDetect(stack, xy_scale, z_scale, models, min_volume_m3, max_candidates):
+        # One candidate per tile, positioned in the tile the stage is parked
+        # over. A real detection is a position inside the field just imaged, and
+        # the density cap is a per-tile locality check, so a candidate has to
+        # land in its own tile for the chain to behave as it does on a rig.
+        cx, cy = scope.moves[-1]
+        return [((cx, cy, SURFACE + (NEAR + FAR) / 2), 0.8)]
+
+    monkeypatch.setattr(tile_detector, "_acquire", fakeAcquire)
+    monkeypatch.setattr(tile_detector, "_detect", fakeDetect)
+    monkeypatch.setattr(tile_detector, "_newCell", FakeCell)
+
+    def build(constraints=None):
+        if constraints is None:
+            constraints = SearchConstraints(depth_range=(NEAR, FAR))
+        sliceState = Slice(fov=FOV, constraints=constraints)
+        sliceState.addRegion(*REGION)
+        return sliceState, sliceState.makeCellProducer(
+            tile_detector.make_tile_detector(camera=camera, scope=scope, manager=None)
+        )
+
+    class Seam:
+        pass
+
+    seam = Seam()
+    seam.camera = camera
+    seam.scope = scope
+    seam.acquireCalls = acquireCalls
+    seam.build = build
+    return seam
+
+
+def test_the_chain_produces_cells_from_the_tile_it_imaged(seam):
+    sliceState, producer = seam.build()
+
+    tile = sliceState.nextTile()
+    cells = producer()
+
+    assert len(cells) == 1
+    cell = cells[0]
+    assert cell.score == pytest.approx(0.8)
+    assert cell.position[:2] == pytest.approx(tile)
+    # The stage actually went there, and the cells reached the slice's own
+    # register (which is what the density cap reads).
+    assert seam.scope.moves == [tile]
+    assert sliceState.cellsNearTile(tile) == [cell]
+
+
+def test_the_depth_range_reaching_acquisition_is_measured_from_this_tiles_surface(seam):
+    _sliceState, producer = seam.build()
+
+    producer()
+
+    start_z, stop_z, _step_z = seam.acquireCalls[0]
+    assert start_z == pytest.approx(SURFACE + NEAR)
+    assert stop_z == pytest.approx(SURFACE + FAR)
+    # Shallow first, then deeper: the stack is acquired travelling into the
+    # tissue, and a swapped pair would drive the objective to the far bound
+    # before imaging anything.
+    assert start_z > stop_z
+
+
+def test_coverage_advances_one_tile_per_call_until_the_producer_is_exhausted(seam):
+    sliceState, producer = seam.build()
+
+    imagedTiles = []
+    for expected in range(1, TILE_COUNT + 1):
+        imagedTiles.append(sliceState.nextTile())
+        assert producer() is not None
+        assert len(sliceState.coveredTiles) == expected
+        assert sliceState.surveyStats() == (
+            TILE_COUNT,
+            expected,
+            pytest.approx(100.0 * expected / TILE_COUNT),
+        )
+
+    # Every tile a distinct one, imaged exactly once.
+    assert len(set(imagedTiles)) == TILE_COUNT
+    assert seam.scope.moves == imagedTiles
+    assert len(seam.acquireCalls) == TILE_COUNT
+
+    assert producer() is None, "a fully covered slice must report exhaustion"
+    assert len(seam.acquireCalls) == TILE_COUNT, "and image nothing more"
+
+
+def test_the_health_cutoff_filters_what_the_real_detector_chain_returns(seam):
+    # The scored candidates come out of _detect, are wrapped into cells by
+    # tile_detector, and are filtered by CellProducer against the slice's
+    # constraints -- three separate objects, so a cutoff that reached none of
+    # them would still look fine in each one's own unit tests.
+    sliceState, producer = seam.build(
+        constraints=SearchConstraints(depth_range=(NEAR, FAR), min_health=0.9)
+    )
+
+    result = producer()
+
+    assert result == [], "a 0.8-scoring candidate must not clear a 0.9 cutoff"
+    # Still a covered tile, and still not exhaustion: the tile was imaged.
+    assert len(sliceState.coveredTiles) == 1
+    assert result is not None

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -583,6 +583,42 @@ def test_clear_queue_race_between_check_and_pop_ends_the_run_cleanly(make_pf):
     assert list(orch._queue) == []
 
 
+def test_producer_cleared_between_shouldrefill_and_refill_ends_the_run_cleanly(make_pf):
+    """setCellProducer(None) runs on the GUI thread (a "New slice" mid-run,
+    say) while this loop runs on the worker thread, so "there is a producer"
+    (_shouldRefill's check) and "call the producer" (_refillQueue, a separate
+    step later) cannot be treated as one atomic check-then-act. A clear
+    landing in between must not turn a legitimate operator action into a
+    TypeError out of calling None -- the run should simply find nothing left
+    to do and end normally, the same as if no producer had ever been asked.
+
+    Deterministic rather than timing-dependent: sigStatus always emits
+    "surveying" between _shouldRefill()'s check and _refillQueue()'s call (see
+    _runLoopBody), so a slot connected to that signal clears the producer at
+    exactly that point on this same thread -- standing in for the concurrent
+    clear the same way RaceyQueue stands in for a concurrent clearQueue()
+    above."""
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+    producer = make_producer([["c1"], None])
+    orch = Orchestrator(pf, cellProducer=producer)
+    statuses = []
+    orch.sigStatus.connect(statuses.append)
+
+    def clear_producer_when_surveying_starts(status):
+        if status == "surveying":
+            orch.setCellProducer(None)
+
+    orch.sigStatus.connect(clear_producer_when_surveying_starts)
+
+    orch.run_sync()  # must not raise
+
+    assert "error" not in statuses
+    assert (
+        producer.calls["n"] == 0
+    ), "producer was called after it had already been cleared"
+
+
 def test_no_producer_never_reports_surveying(make_pf):
     """A plain queue drain (no producer configured) must never emit
     "surveying" -- an operator would misread it as the system looking for

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -96,6 +96,53 @@ def test_producer_supplements_cells_seeded_before_start(make_pf):
     assert ran == ["seeded", "produced"]
 
 
+def test_refill_discards_a_batch_from_a_producer_cleared_during_the_call(make_pf):
+    """The "New slice" hazard: setCellProducer(None) landing between the
+    producer being called and its batch being queued must not let that batch
+    land anyway. A producer that clears itself and then returns cells
+    reproduces the interleaving deterministically -- no thread race needed --
+    since _refillQueue reads self._cellProducer into a local before calling
+    it, and the clear this producer makes on its own way out is exactly the
+    "landed while producer() was running" case that local exists to guard
+    against on the way out too."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf)
+
+    def clears_then_returns_cells():
+        orch.setCellProducer(None)
+        return ["c1", "c2"]
+
+    orch.setCellProducer(clears_then_returns_cells)
+    statuses = []
+    orch.sigStatus.connect(statuses.append)
+    finished = []
+    orch.sigCellFinished.connect(lambda c, s: finished.append((c, s)))
+
+    orch.run_sync()  # must end normally, not error
+
+    assert ran == [], "a cell from a batch discarded on the way out was still processed"
+    assert list(orch._queue) == [], "the discarded batch was left sitting in the queue"
+    assert finished == []
+    assert "error" not in statuses
+
+
+def test_refill_still_queues_a_batch_from_the_still_installed_producer(make_pf):
+    """The ordinary path, pinned alongside the discard above: a producer that
+    is still installed when it returns must still have its cells enqueued and
+    processed -- the new check at the far end of _refillQueue must not turn
+    into a blanket discard."""
+    pf = make_pf()
+    ran = []
+    pf.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    orch = Orchestrator(pf, cellProducer=make_producer([["c1", "c2"], None]))
+
+    orch.run_sync()
+
+    assert ran == ["c1", "c2"]
+
+
 def test_setCellProducer_installs_a_producer_after_construction(make_pf):
     """The UI builds the Orchestrator when a protocol is selected, but the
     producer depends on region/finding config chosen later, so it must be

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -2,6 +2,7 @@
 refill trigger, the empty-vs-exhausted distinction, and end-of-run conditions."""
 import gc
 import weakref
+from collections import deque
 
 import pytest
 
@@ -420,7 +421,26 @@ def test_surveying_status_is_emitted_around_a_refill(make_pf):
     assert statuses.index("surveying") < statuses.index("waiting")
 
 
-def test_a_barren_survey_reports_surveying_without_ever_reporting_running(make_pf):
+def test_current_cell_is_cleared_before_surveying_is_reported(make_pf):
+    """sigCurrentCell(None) and sigStatus("surveying") are same-thread direct
+    connections, so a UI slot genuinely runs between them -- if the status
+    were reported first, that slot would briefly render the just-finished
+    cell as "surveying". Recording both signals into one shared, ordered list
+    pins that the cell is cleared first."""
+    orch = Orchestrator(make_pf())
+    events = []
+    orch.sigCurrentCell.connect(lambda cell: events.append(("cell", cell)))
+    orch.sigStatus.connect(lambda status: events.append(("status", status)))
+    orch.setCellProducer(make_producer([[object()], None]))
+
+    orch.run_sync()
+
+    cell_cleared_index = events.index(("cell", None))
+    surveying_index = events.index(("status", "surveying"))
+    assert cell_cleared_index < surveying_index
+
+
+def test_every_barren_refill_pass_reports_surveying(make_pf):
     # The operator watching a slow, empty stretch of region must see
     # "surveying", not a stale "running" that implies a cell is being patched.
     orch = Orchestrator(make_pf())
@@ -435,8 +455,9 @@ def test_a_barren_survey_reports_surveying_without_ever_reporting_running(make_p
 
 def test_current_cell_is_cleared_before_the_producer_runs(make_pf):
     # sigCurrentCell must not still name the just-finished cell while the
-    # producer images: Area 5 would attribute survey time to that cell, and it
-    # is the state that made P2a's next-cell Critical reachable.
+    # producer images: Area 5 would attribute survey time to that cell, and a
+    # "Next cell" request arriving during the survey would appear to have a
+    # current cell to act against, when none is actually being worked.
     pf = make_pf()
     first = object()
     orch = Orchestrator(pf)
@@ -444,10 +465,17 @@ def test_current_cell_is_cleared_before_the_producer_runs(make_pf):
 
     seen = []
     orch.sigCurrentCell.connect(seen.append)
+    statuses = []
+    orch.sigStatus.connect(statuses.append)
 
     def producer():
         # Whatever the orchestrator last announced must not be `first`.
         assert seen[-1] is None, f"still following {seen[-1]!r} while surveying"
+        # The status the operator sees at this same moment must already be
+        # "surveying", not "running" left over from before the refill.
+        assert (
+            statuses[-1] == "surveying"
+        ), f"status was {statuses[-1]!r} while surveying"
         return None
 
     orch.setCellProducer(producer)
@@ -492,6 +520,7 @@ def test_clear_queue_leaves_a_running_cell_alone(make_pf):
 
     def run(ctx, **kwargs):
         orch.clearQueue()
+        assert orch._nextCellRequested is False
         ran.append(ctx.cell)
 
     orch.protocolFile.run = run
@@ -502,6 +531,49 @@ def test_clear_queue_leaves_a_running_cell_alone(make_pf):
     orch.run_sync_cell(running)
 
     assert ran == [running]
+    assert list(orch._queue) == []
+
+
+def test_clear_queue_race_between_check_and_pop_ends_the_run_cleanly(make_pf):
+    """clearQueue() runs on the GUI thread while _runLoopBody runs on the
+    worker thread. If clearQueue() lands between _runLoopBody deciding the
+    queue is non-empty and it actually popping a cell, that pop must not
+    raise -- an operator clearing the queue mid-run gets a cleanly finished
+    run, not a crashed one.
+
+    Deterministic rather than timing-dependent: RaceyQueue's __bool__ is the
+    same truthiness check _shouldRefill() makes on this deque, and it wipes
+    the deque's own contents -- exactly as a concurrent clearQueue() would --
+    the first time it is consulted while non-empty, reproducing the clear
+    landing between that check and the pop that follows it.
+    """
+
+    class RaceyQueue(deque):
+        def __init__(self, *args):
+            super().__init__(*args)
+            self._consulted = False
+
+        def __bool__(self):
+            was_nonempty = len(self) > 0
+            if was_nonempty and not self._consulted:
+                self._consulted = True
+                self.clear()
+            return was_nonempty
+
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+
+    def poison_producer():
+        raise AssertionError(
+            "producer asked after the race already emptied the queue -- the "
+            "run should have ended instead of trying to refill"
+        )
+
+    orch = Orchestrator(pf, cellProducer=poison_producer)
+    orch._queue = RaceyQueue([object()])
+
+    orch.run_sync()  # must not raise
+
     assert list(orch._queue) == []
 
 

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -404,3 +404,119 @@ def test_producer_bound_method_cycle_is_freed_once_the_producer_is_released(
     finally:
         gc.collect()
         gc.enable()
+
+
+def test_surveying_status_is_emitted_around_a_refill(make_pf):
+    orch = Orchestrator(make_pf())
+    statuses = []
+    orch.sigStatus.connect(statuses.append)
+    orch.setCellProducer(make_producer([[object()], None]))
+
+    orch.run_sync()
+
+    assert "surveying" in statuses
+    # And it must not be the last word: the run reports back to running for the
+    # cell it then works, and waiting once drained.
+    assert statuses.index("surveying") < statuses.index("waiting")
+
+
+def test_a_barren_survey_reports_surveying_without_ever_reporting_running(make_pf):
+    # The operator watching a slow, empty stretch of region must see
+    # "surveying", not a stale "running" that implies a cell is being patched.
+    orch = Orchestrator(make_pf())
+    statuses = []
+    orch.sigStatus.connect(statuses.append)
+    orch.setCellProducer(make_producer([[], [], None]))
+
+    orch.run_sync()
+
+    assert statuses.count("surveying") == 3
+
+
+def test_current_cell_is_cleared_before_the_producer_runs(make_pf):
+    # sigCurrentCell must not still name the just-finished cell while the
+    # producer images: Area 5 would attribute survey time to that cell, and it
+    # is the state that made P2a's next-cell Critical reachable.
+    pf = make_pf()
+    first = object()
+    orch = Orchestrator(pf)
+    orch.enqueue(first)
+
+    seen = []
+    orch.sigCurrentCell.connect(seen.append)
+
+    def producer():
+        # Whatever the orchestrator last announced must not be `first`.
+        assert seen[-1] is None, f"still following {seen[-1]!r} while surveying"
+        return None
+
+    orch.setCellProducer(producer)
+    orch.run_sync()
+
+    assert first in seen
+
+
+def test_clear_queue_drops_pending_cells(make_pf):
+    orch = Orchestrator(make_pf())
+    ran = []
+    orch.protocolFile.run = lambda ctx, **kw: ran.append(ctx.cell)
+    orch.enqueue(object())
+    orch.enqueue(object())
+
+    orch.clearQueue()
+    orch.run_sync()
+
+    assert ran == []
+
+
+def test_clear_queue_leaves_a_later_enqueue_working(make_pf):
+    orch = Orchestrator(make_pf())
+    ran = []
+    orch.protocolFile.run = lambda ctx, **kw: ran.append(ctx.cell)
+    orch.enqueue(object())
+    orch.clearQueue()
+    kept = object()
+    orch.enqueue(kept)
+
+    orch.run_sync()
+
+    assert ran == [kept]
+
+
+def test_clear_queue_leaves_a_running_cell_alone(make_pf):
+    """clearQueue()'s docstring promises it leaves a running cell alone: a
+    cell already in the middle of its protocol must still complete even
+    though the queue behind it is dropped out from under it."""
+    orch = Orchestrator(make_pf())
+    ran = []
+
+    def run(ctx, **kwargs):
+        orch.clearQueue()
+        ran.append(ctx.cell)
+
+    orch.protocolFile.run = run
+    queued = object()
+    orch.enqueue(queued)
+    running = object()
+
+    orch.run_sync_cell(running)
+
+    assert ran == [running]
+    assert list(orch._queue) == []
+
+
+def test_no_producer_never_reports_surveying(make_pf):
+    """A plain queue drain (no producer configured) must never emit
+    "surveying" -- an operator would misread it as the system looking for
+    more cells when it is not."""
+    pf = make_pf()
+    pf.run = lambda ctx, **kwargs: None
+    statuses = []
+    orch = Orchestrator(pf)
+    orch.sigStatus.connect(statuses.append)
+    orch.enqueue("c1")
+    orch.enqueue("c2")
+
+    orch.run_sync()
+
+    assert "surveying" not in statuses

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -542,23 +542,26 @@ def test_clear_queue_race_between_check_and_pop_ends_the_run_cleanly(make_pf):
     run, not a crashed one.
 
     Deterministic rather than timing-dependent: RaceyQueue's __bool__ is the
-    same truthiness check _shouldRefill() makes on this deque, and it wipes
-    the deque's own contents -- exactly as a concurrent clearQueue() would --
-    the first time it is consulted while non-empty, reproducing the clear
-    landing between that check and the pop that follows it.
+    same truthiness check the loop body makes on this deque wherever it asks
+    "is there anything left", and it wipes the deque's own contents the first
+    time it is consulted while non-empty -- exactly as a concurrent
+    clearQueue() would. It then keeps reporting that emptied state as truthy
+    for the rest of the pass, because that is what any later consult in the
+    same iteration actually observes once a clear has landed: a deque that
+    reads as empty when measured by length, but whose iteration is still
+    mid-flight on the assumption a cell is there to take.
     """
 
     class RaceyQueue(deque):
         def __init__(self, *args):
             super().__init__(*args)
-            self._consulted = False
+            self._raced = False
 
         def __bool__(self):
-            was_nonempty = len(self) > 0
-            if was_nonempty and not self._consulted:
-                self._consulted = True
+            if len(self) > 0:
+                self._raced = True
                 self.clear()
-            return was_nonempty
+            return self._raced or len(self) > 0
 
     pf = make_pf()
     pf.run = lambda ctx, **kwargs: None
@@ -572,8 +575,11 @@ def test_clear_queue_race_between_check_and_pop_ends_the_run_cleanly(make_pf):
     orch = Orchestrator(pf, cellProducer=poison_producer)
     orch._queue = RaceyQueue([object()])
 
-    orch.run_sync()  # must not raise
+    completed_without_raising = False
+    orch.run_sync()
+    completed_without_raising = True
 
+    assert completed_without_raising, "run_sync() must end the run cleanly, not raise"
     assert list(orch._queue) == []
 
 

--- a/acq4/experiment/tests/test_search_grid.py
+++ b/acq4/experiment/tests/test_search_grid.py
@@ -68,6 +68,50 @@ def test_grid_centered_over_rect():
     assert math.isclose((ys[0] + ys[-1]) / 2, 65.0)
 
 
+def test_tile_count_stable_across_stage_offsets():
+    # A 30um square needs exactly 9 tiles with a 10um FOV no matter where the
+    # region sits on the stage, including at millimeter-scale offsets where
+    # `hi - lo` picks up floating-point error.
+    fov = 10e-6
+    side = 30e-6
+    for off in (0.0, 500e-6, 1e-3, 2e-3, 5e-3, 1e-2):
+        x0, y0 = off, off
+        x1, y1 = off + side, off + side
+        grid = plan_grid(x0, y0, x1, y1, fov, fov, overlap=0.0)
+        assert len(grid) == 9, off
+        assert _covers(grid, x0, y0, x1, y1, fov, fov), off
+
+
+def test_single_tile_when_rect_is_exactly_one_fov_at_stage_offset():
+    # A rect exactly one FOV wide returns a single tile at the origin and also
+    # at a millimeter-scale offset, where `hi - lo` picks up floating-point
+    # error relative to the FOV.
+    fov = 100e-6
+    for off in (0.0, 1e-3):
+        x0, y0 = off, off
+        x1, y1 = off + fov, off + fov
+        grid = plan_grid(x0, y0, x1, y1, fov, fov, overlap=0.0)
+        assert len(grid) == 1, off
+        assert grid == [((x0 + x1) / 2.0, (y0 + y1) / 2.0)]
+
+
+def test_extra_tile_kept_when_genuinely_needed():
+    # A rect a hair wider than an exact multiple of the step must still get
+    # the extra tile: the excess here (10% of a step) is far larger than any
+    # floating-point error but smaller than a full step, so it must not be
+    # absorbed by the tolerance that protects against rounding error.
+    fov, overlap = 100e-6, 20e-6
+    step = fov - overlap
+    excess = step * 0.1
+    extent = fov + 2 * step + excess
+    off = 1e-3
+    x0, y0 = off, off
+    x1, y1 = off + extent, off + extent
+    grid = plan_grid(x0, y0, x1, y1, fov, fov, overlap)
+    assert len(grid) == 16
+    assert _covers(grid, x0, y0, x1, y1, fov, fov)
+
+
 def test_is_visited_false_when_nothing_visited():
     assert _is_visited(0.0, 0.0, visited=[], threshold=1.0) is False
 

--- a/acq4/experiment/tests/test_search_grid.py
+++ b/acq4/experiment/tests/test_search_grid.py
@@ -1,13 +1,9 @@
-"""Tests for the survey-region grid packing used by the autopatch demo.
-
-Cover plan_grid (serpentine FOV tiling that fully covers a rectangle) and
-select_next (choosing the next un-imaged tile), the pure logic behind surveying
-a user-defined region one z-stack per tile.
-"""
+"""Tests for the search-region grid packing: serpentine FOV tiling that fully
+covers a rectangle, and choosing the next un-imaged tile."""
 
 import math
 
-from acq4.modules.AutomationDebug.survey import (
+from acq4.experiment.search_grid import (
     _is_visited,
     count_covered,
     plan_grid,

--- a/acq4/experiment/tests/test_search_grid.py
+++ b/acq4/experiment/tests/test_search_grid.py
@@ -112,6 +112,22 @@ def test_extra_tile_kept_when_genuinely_needed():
     assert _covers(grid, x0, y0, x1, y1, fov, fov)
 
 
+def test_tile_count_holds_at_a_coordinate_whose_magnitude_dwarfs_the_tile_geometry():
+    # hi - lo carries rounding error proportional to the magnitude of lo/hi
+    # themselves, not to the (much smaller) tile geometry, so at a large
+    # enough coordinate that error outgrows a tolerance fixed to a bare
+    # nanometre. The tolerance must scale with the coordinate to keep
+    # absorbing it, which this offset is large enough to require.
+    fov = 1e-3
+    step = fov
+    n_tiles = 50
+    off = 4e7
+    x0, y0 = off, off
+    x1, y1 = off + fov + (n_tiles - 1) * step, off + fov
+    grid = plan_grid(x0, y0, x1, y1, fov, fov, overlap=0.0)
+    assert len(grid) == n_tiles
+
+
 def test_is_visited_false_when_nothing_visited():
     assert _is_visited(0.0, 0.0, visited=[], threshold=1.0) is False
 

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -114,6 +114,36 @@ def test_adding_a_region_produces_a_tile_grid():
     assert s.surveyStats() == (9, 0, 0.0)
 
 
+def test_the_tile_grid_is_serpentine_within_a_region():
+    # Alternating the direction of each row is what keeps a survey's stage
+    # travel down: at the end of a row the next tile is the one directly
+    # above, not all the way back at the far edge. Sorted (or any other
+    # row-major) order costs a full row's traverse per row and would still
+    # cover the region, so nothing else in the suite would notice the
+    # difference -- hence pinning the order itself here.
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    grid = s.tileGrid()
+    assert len(grid) == 9
+
+    rows = [grid[0:3], grid[3:6], grid[6:9]]
+    # Each row is one y, and the rows step through y in order.
+    ys = [row[0][1] for row in rows]
+    for row, y in zip(rows, ys):
+        assert [center[1] for center in row] == [pytest.approx(y)] * 3
+    assert ys == sorted(ys)
+
+    # And the x direction reverses row to row.
+    xs = [[center[0] for center in row] for row in rows]
+    assert xs[0] == sorted(xs[0])
+    assert xs[1] == sorted(xs[1], reverse=True)
+    assert xs[2] == sorted(xs[2])
+    # The step from the end of one row to the start of the next is one tile,
+    # which is the whole point; row-major order would make it two.
+    assert xs[0][-1] == pytest.approx(xs[1][0])
+    assert xs[1][-1] == pytest.approx(xs[2][0])
+
+
 def test_regions_is_a_copy_so_callers_cannot_mutate_slice_state():
     s = make_slice()
     s.addRegion(0, 0, 30e-6, 30e-6)
@@ -227,15 +257,6 @@ def test_fov_must_be_positive_in_both_axes():
         Slice(fov=(0.0, 10e-6))
     with pytest.raises(ValueError, match="fov must be positive"):
         Slice(fov=(10e-6, -1e-6))
-
-
-def test_directory_defaults_to_none_and_round_trips_through_the_constructor():
-    # `directory` is the acq4 slice directory handle this search state
-    # belongs to, kept so a caller can find where to write per-slice data
-    # alongside it; it must come back unchanged.
-    assert make_slice().directory is None
-    sentinel = object()
-    assert make_slice(directory=sentinel).directory is sentinel
 
 
 def test_threshold_is_half_the_step_between_tile_centers():

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -256,3 +256,13 @@ def test_overlap_produces_more_tiles_than_no_overlap_over_the_same_rectangle():
     overlapped = make_slice(overlap=5e-6)
     overlapped.addRegion(0, 0, 30e-6, 30e-6)
     assert len(overlapped.tileGrid()) > len(plain.tileGrid())
+
+
+def test_make_cell_producer_returns_a_view_the_slice_does_not_retain():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    producer = s.makeCellProducer(lambda center, constraints: [])
+    assert producer() == []
+    # The slice must not be reachable back to the producer, or the pair is a
+    # reference cycle. Nothing on the slice may hold it.
+    assert not any(v is producer for v in vars(s).values())

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -1,0 +1,52 @@
+"""Tests for SearchConstraints validation and the Slice object's regions,
+coverage, and survey statistics."""
+
+import pytest
+
+from acq4.experiment.slice import SearchConstraints
+
+
+def test_defaults_are_a_usable_search():
+    c = SearchConstraints()
+    assert c.depth_range == (-20e-6, -60e-6)
+    assert 0.0 <= c.min_health <= 1.0
+    assert c.max_cell_density > 0
+    assert c.rescans_allowed is False
+
+
+def test_depth_range_offsets_must_be_at_or_below_the_surface():
+    # Offsets are relative to the tissue surface and negative is deeper, so a
+    # positive offset would search in the bath above the tissue.
+    with pytest.raises(ValueError, match="at or below the surface"):
+        SearchConstraints(depth_range=(20e-6, -60e-6))
+
+
+def test_depth_range_must_span_a_nonzero_thickness():
+    with pytest.raises(ValueError, match="nonzero thickness"):
+        SearchConstraints(depth_range=(-40e-6, -40e-6))
+
+
+def test_depth_range_accepts_either_ordering():
+    # An operator may type the deeper bound first; both describe the same slab.
+    shallow_first = SearchConstraints(depth_range=(-20e-6, -60e-6))
+    deep_first = SearchConstraints(depth_range=(-60e-6, -20e-6))
+    assert shallow_first.z_span() == deep_first.z_span()
+    assert shallow_first.z_span() == pytest.approx(40e-6)
+
+
+def test_min_health_must_be_a_probability():
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        SearchConstraints(min_health=1.5)
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        SearchConstraints(min_health=-0.1)
+
+
+def test_max_cell_density_must_be_positive():
+    with pytest.raises(ValueError, match="positive"):
+        SearchConstraints(max_cell_density=0.0)
+
+
+def test_constraints_are_frozen():
+    c = SearchConstraints()
+    with pytest.raises(Exception):
+        c.min_health = 0.9

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -124,12 +124,9 @@ def test_a_second_region_extends_the_grid_without_disturbing_the_first():
     s = make_slice()
     s.addRegion(0, 0, 30e-6, 30e-6)
     first = s.tileGrid()
-    # 500e-6 keeps the region well clear of the first and, unlike 1e-3, does not
-    # land the tile count on a floating-point rounding boundary: subtracting
-    # two offsets of very different magnitude from each other can perturb an
-    # exact multiple of the FOV by less than an ULP, which is enough to push
-    # ceil() up to an extra tile.
-    s.addRegion(500e-6, 500e-6, 500e-6 + 30e-6, 500e-6 + 30e-6)
+    # 1e-3 keeps the region well clear of the first and sits at a realistic
+    # stage coordinate.
+    s.addRegion(1e-3, 1e-3, 1e-3 + 30e-6, 1e-3 + 30e-6)
     both = s.tileGrid()
     assert both[: len(first)] == first
     assert len(both) == 18

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -76,3 +76,157 @@ def test_constraints_are_frozen():
     c = SearchConstraints()
     with pytest.raises(Exception):
         c.min_health = 0.9
+
+
+from acq4.experiment.slice import Slice
+
+# A 10x10 um FOV with no overlap, so a 30x30 um region is exactly a 3x3 grid of
+# tiles and tile centers land on predictable coordinates.
+FOV = (10e-6, 10e-6)
+
+
+def make_slice(**kwargs):
+    kwargs.setdefault("fov", FOV)
+    return Slice(**kwargs)
+
+
+class FakeCell:
+    """Stand-in for acq4_automation's Cell: a global position and a health score."""
+
+    def __init__(self, position, score=1.0):
+        self.position = position
+        self.score = score
+
+
+def test_a_new_slice_has_no_regions_and_nothing_to_survey():
+    s = make_slice()
+    assert s.regions == []
+    assert s.tileGrid() == []
+    assert s.nextTile() is None
+    assert s.surveyStats() == (0, 0, 0.0)
+
+
+def test_adding_a_region_produces_a_tile_grid():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    assert len(s.tileGrid()) == 9
+    assert s.surveyStats() == (9, 0, 0.0)
+
+
+def test_regions_is_a_copy_so_callers_cannot_mutate_slice_state():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    s.regions.append((1, 1, 2, 2))
+    assert len(s.regions) == 1
+
+
+def test_a_second_region_extends_the_grid_without_disturbing_the_first():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    first = s.tileGrid()
+    # 500e-6 keeps the region well clear of the first and, unlike 1e-3, does not
+    # land the tile count on a floating-point rounding boundary: subtracting
+    # two offsets of very different magnitude from each other can perturb an
+    # exact multiple of the FOV by less than an ULP, which is enough to push
+    # ceil() up to an extra tile.
+    s.addRegion(500e-6, 500e-6, 500e-6 + 30e-6, 500e-6 + 30e-6)
+    both = s.tileGrid()
+    assert both[: len(first)] == first
+    assert len(both) == 18
+
+
+def test_marking_a_tile_covered_advances_next_tile():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    first = s.nextTile()
+    assert s.nextTile() == first, "nextTile must not mark; it only reports"
+    s.markCovered(first)
+    assert s.nextTile() != first
+    assert s.surveyStats() == (9, 1, pytest.approx(100 / 9))
+
+
+def test_next_tile_is_none_once_every_tile_is_covered():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    for _ in range(9):
+        s.markCovered(s.nextTile())
+    assert s.nextTile() is None
+    assert s.surveyStats() == (9, 9, 100.0)
+
+
+def test_coverage_survives_a_new_region_being_added():
+    # Shared coverage is the whole point: a second region's survey must not
+    # re-image the first region's tiles.
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    covered = s.nextTile()
+    s.markCovered(covered)
+    s.addRegion(1e-3, 1e-3, 1e-3 + 30e-6, 1e-3 + 30e-6)
+    assert covered in s.coveredTiles
+    assert s.surveyStats()[1] == 1
+
+
+def test_reset_coverage_forgets_imaged_tiles_but_keeps_regions():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    s.markCovered(s.nextTile())
+    s.resetCoverage()
+    assert s.coveredTiles == []
+    assert len(s.regions) == 1
+    assert s.surveyStats() == (9, 0, 0.0)
+
+
+def test_tile_volume_is_fov_area_times_the_depth_span():
+    s = make_slice(constraints=SearchConstraints(depth_range=(-20e-6, -60e-6)))
+    assert s.tileVolume() == pytest.approx(10e-6 * 10e-6 * 40e-6)
+
+
+def test_registered_cells_are_found_near_their_own_tile_only():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    tile = s.nextTile()
+    here = FakeCell((tile[0], tile[1], 0.0))
+    far = FakeCell((tile[0] + 1e-3, tile[1], 0.0))
+    s.registerCells([here, far])
+    near = s.cellsNearTile(tile)
+    assert here in near
+    assert far not in near
+
+
+def test_setting_constraints_replaces_them_wholesale():
+    s = make_slice()
+    replacement = SearchConstraints(min_health=0.9)
+    s.setConstraints(replacement)
+    assert s.constraints is replacement
+
+
+def test_fov_must_be_positive_in_both_axes():
+    # A non-positive FOV would make tile stepping and coverage matching
+    # meaningless, so both axes are checked independently.
+    with pytest.raises(ValueError, match="fov must be positive"):
+        Slice(fov=(0.0, 10e-6))
+    with pytest.raises(ValueError, match="fov must be positive"):
+        Slice(fov=(10e-6, -1e-6))
+
+
+def test_threshold_is_half_the_step_between_tile_centers():
+    # No overlap: the step is the smaller FOV axis, so threshold is half that.
+    s = make_slice(fov=(10e-6, 20e-6))
+    assert s.threshold == pytest.approx(5e-6)
+
+
+def test_threshold_falls_back_to_half_the_smaller_fov_when_overlap_swallows_the_step():
+    # An overlap >= the smaller FOV axis would make the step zero or negative,
+    # so threshold falls back to half the smaller FOV instead.
+    s = make_slice(fov=(10e-6, 20e-6), overlap=15e-6)
+    assert s.threshold == pytest.approx(5e-6)
+
+
+def test_overlap_produces_more_tiles_than_no_overlap_over_the_same_rectangle():
+    # Overlapping tiles step less far apart, so more of them are needed to
+    # cover the same extent.
+    plain = make_slice(overlap=0.0)
+    plain.addRegion(0, 0, 30e-6, 30e-6)
+    overlapped = make_slice(overlap=5e-6)
+    overlapped.addRegion(0, 0, 30e-6, 30e-6)
+    assert len(overlapped.tileGrid()) > len(plain.tileGrid())

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -3,7 +3,7 @@ coverage, and survey statistics."""
 
 import pytest
 
-from acq4.experiment.slice import SearchConstraints
+from acq4.experiment.slice import SearchConstraints, Slice
 
 
 def test_defaults_are_a_usable_search():
@@ -78,8 +78,6 @@ def test_constraints_are_frozen():
         c.min_health = 0.9
 
 
-from acq4.experiment.slice import Slice
-
 # A 10x10 um FOV with no overlap, so a 30x30 um region is exactly a 3x3 grid of
 # tiles and tile centers land on predictable coordinates.
 FOV = (10e-6, 10e-6)
@@ -151,6 +149,20 @@ def test_next_tile_is_none_once_every_tile_is_covered():
     assert s.surveyStats() == (9, 9, 100.0)
 
 
+def test_next_tile_follows_tile_grid_order():
+    # The grid is serpentine-ordered to minimize stage travel between tiles,
+    # so nextTile must hand out tileGrid()'s tiles in that same order, not
+    # merely some order that avoids repeats.
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    grid = s.tileGrid()
+    for expected in grid:
+        tile = s.nextTile()
+        assert tile == expected
+        s.markCovered(tile)
+    assert s.nextTile() is None
+
+
 def test_coverage_survives_a_new_region_being_added():
     # Shared coverage is the whole point: a second region's survey must not
     # re-image the first region's tiles.
@@ -161,6 +173,14 @@ def test_coverage_survives_a_new_region_being_added():
     s.addRegion(1e-3, 1e-3, 1e-3 + 30e-6, 1e-3 + 30e-6)
     assert covered in s.coveredTiles
     assert s.surveyStats()[1] == 1
+
+
+def test_covered_tiles_is_a_copy_so_callers_cannot_mutate_slice_state():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    s.markCovered(s.nextTile())
+    s.coveredTiles.append((1, 1))
+    assert len(s.coveredTiles) == 1
 
 
 def test_reset_coverage_forgets_imaged_tiles_but_keeps_regions():
@@ -204,6 +224,15 @@ def test_fov_must_be_positive_in_both_axes():
         Slice(fov=(0.0, 10e-6))
     with pytest.raises(ValueError, match="fov must be positive"):
         Slice(fov=(10e-6, -1e-6))
+
+
+def test_directory_defaults_to_none_and_round_trips_through_the_constructor():
+    # `directory` is the acq4 slice directory handle this search state
+    # belongs to, kept so a caller can find where to write per-slice data
+    # alongside it; it must come back unchanged.
+    assert make_slice().directory is None
+    sentinel = object()
+    assert make_slice(directory=sentinel).directory is sentinel
 
 
 def test_threshold_is_half_the_step_between_tile_centers():

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -1,6 +1,9 @@
 """Tests for SearchConstraints validation and the Slice object's regions,
 coverage, and survey statistics."""
 
+import gc
+import weakref
+
 import pytest
 
 from acq4.experiment.slice import SearchConstraints, Slice
@@ -263,6 +266,15 @@ def test_make_cell_producer_returns_a_view_the_slice_does_not_retain():
     s.addRegion(0, 0, 30e-6, 30e-6)
     producer = s.makeCellProducer(lambda center, constraints: [])
     assert producer() == []
-    # The slice must not be reachable back to the producer, or the pair is a
-    # reference cycle. Nothing on the slice may hold it.
-    assert not any(v is producer for v in vars(s).values())
+
+    # A reference cycle through the slice would keep the producer alive past
+    # its last strong reference; disabling the cyclic collector first means
+    # only reference counting is at work, so a dead weakref is proof the
+    # slice holds no path back to what it handed out, however deeply nested.
+    weak = weakref.ref(producer)
+    gc.disable()
+    try:
+        del producer
+        assert weak() is None
+    finally:
+        gc.enable()

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -19,6 +19,10 @@ def test_depth_range_offsets_must_be_at_or_below_the_surface():
     # positive offset would search in the bath above the tissue.
     with pytest.raises(ValueError, match="at or below the surface"):
         SearchConstraints(depth_range=(20e-6, -60e-6))
+    # The positive offset can land in either position of the pair, so both
+    # must be checked.
+    with pytest.raises(ValueError, match="at or below the surface"):
+        SearchConstraints(depth_range=(-60e-6, 20e-6))
 
 
 def test_depth_range_must_span_a_nonzero_thickness():
@@ -32,6 +36,28 @@ def test_depth_range_accepts_either_ordering():
     deep_first = SearchConstraints(depth_range=(-60e-6, -20e-6))
     assert shallow_first.z_span() == deep_first.z_span()
     assert shallow_first.z_span() == pytest.approx(40e-6)
+
+
+def test_z_bounds_adds_offsets_to_the_surface_and_orders_shallow_before_deep():
+    # z_bounds must return (shallower, deeper), which for negative offsets
+    # means (max, min); a swapped min/max or subtracted offset would only
+    # show up when the surface is nonzero, since surface=0 makes signed
+    # offsets look the same as their negation.
+    c = SearchConstraints(depth_range=(-20e-6, -60e-6))
+    assert c.z_bounds(-500e-6) == pytest.approx((-520e-6, -560e-6))
+
+
+def test_z_bounds_is_unaffected_by_depth_range_ordering():
+    c = SearchConstraints(depth_range=(-60e-6, -20e-6))
+    assert c.z_bounds(-500e-6) == pytest.approx((-520e-6, -560e-6))
+
+
+def test_z_bounds_at_a_zero_surface():
+    # surface=0.0 is the degenerate case where offsets equal their own
+    # negation's magnitude, so it alone can't catch a sign error; kept as a
+    # sanity check alongside the nonzero-surface cases above.
+    c = SearchConstraints(depth_range=(-20e-6, -60e-6))
+    assert c.z_bounds(0.0) == pytest.approx((-20e-6, -60e-6))
 
 
 def test_min_health_must_be_a_probability():

--- a/acq4/experiment/tests/test_tile_detector.py
+++ b/acq4/experiment/tests/test_tile_detector.py
@@ -1,0 +1,253 @@
+"""Tests for the tile detector's orchestration: the depth arithmetic it derives
+from each tile's surface, focus restoration, stop handling, and cell construction."""
+
+import pytest
+
+from acq4.experiment import tile_detector
+from acq4.experiment.slice import SearchConstraints
+from acq4.util.task import Stopped
+
+
+class FakeScope:
+    def __init__(self, surface=0.0):
+        self.surface = surface
+        self.moves = []
+
+    def setGlobalPosition(self, pos, speed="fast", name=None):
+        self.moves.append(tuple(pos))
+        return FakeFuture()
+
+    def findSurfaceDepth(self, imager):
+        return self.surface
+
+
+class FakeFuture:
+    def wait(self, **kwargs):
+        return None
+
+
+class FakeCamera:
+    def __init__(self, focus=-1e-3):
+        self._focus = focus
+        self.focusSets = []
+
+    def name(self):
+        return "FakeCamera"
+
+    def getFocusDepth(self):
+        return self._focus
+
+    def setFocusDepth(self, z, speed="fast", name=None):
+        self.focusSets.append(z)
+        return FakeFuture()
+
+    def getPixelSize(self):
+        return (0.32e-6, 0.32e-6)
+
+
+class FakeCell:
+    """Stand-in for acq4_automation's Cell; `trackerFails` makes tracker init raise."""
+
+    trackerFails = False
+
+    def __init__(self, position):
+        self.position = position
+        self.score = None
+        self.trackerInits = 0
+
+    def initializeTrackerFromStack(self, camera, stack, use_cellpose=False):
+        self.trackerInits += 1
+        if self.trackerFails:
+            raise ValueError("cell too close to the stack edge")
+
+
+@pytest.fixture
+def rig(monkeypatch):
+    """A detector wired to fake devices, with the device-touching helpers replaced.
+
+    Returns a namespace carrying the camera, the scope, the recorded _acquire
+    arguments, and the detector callable itself.
+    """
+    camera = FakeCamera()
+    scope = FakeScope(surface=-500e-6)
+    acquireCalls = []
+    detectCalls = []
+
+    def fakeAcquire(cam, start_z, stop_z, step_z):
+        acquireCalls.append((start_z, stop_z, step_z))
+        return ["frame"]
+
+    def fakeDetect(stack, xy_scale, z_scale, models, min_volume_m3, max_candidates):
+        detectCalls.append(
+            (stack, xy_scale, z_scale, models, min_volume_m3, max_candidates)
+        )
+        return [((1e-6, 2e-6, -530e-6), 0.8)]
+
+    monkeypatch.setattr(tile_detector, "_acquire", fakeAcquire)
+    monkeypatch.setattr(tile_detector, "_detect", fakeDetect)
+    monkeypatch.setattr(tile_detector, "_newCell", FakeCell)
+
+    detect = tile_detector.make_tile_detector(camera=camera, scope=scope, manager=None)
+
+    class Rig:
+        pass
+
+    rig = Rig()
+    rig.camera = camera
+    rig.scope = scope
+    rig.acquireCalls = acquireCalls
+    rig.detectCalls = detectCalls
+    rig.detect = detect
+    return rig
+
+
+def test_the_stack_spans_the_constrained_range_below_this_tiles_surface(rig):
+    # The whole reason depth is expressed as offsets from the surface: the slab
+    # follows the tissue, so a tile whose surface is at -500 um must be searched
+    # 20-60 um below THAT, not below zero.
+    rig.detect((0.0, 0.0), SearchConstraints(depth_range=(-20e-6, -60e-6)))
+
+    start_z, stop_z, step_z = rig.acquireCalls[0]
+    assert start_z == pytest.approx(-520e-6)
+    assert stop_z == pytest.approx(-560e-6)
+    assert step_z == pytest.approx(1e-6)
+
+
+def test_the_depth_range_is_read_from_the_constraints_it_is_given(rig):
+    # Not from a value captured when the detector was built: the operator may
+    # edit the range between runs, and the slice hands its current constraints
+    # to every call.
+    rig.detect((0.0, 0.0), SearchConstraints(depth_range=(-5e-6, -15e-6)))
+
+    start_z, stop_z, _ = rig.acquireCalls[0]
+    assert start_z == pytest.approx(-505e-6)
+    assert stop_z == pytest.approx(-515e-6)
+
+
+def test_the_stage_moves_to_the_tile_before_the_surface_is_found(rig):
+    # Surface is per tile, so searching for it before arriving would measure the
+    # previous tile's tissue.
+    rig.detect((3e-6, 4e-6), SearchConstraints())
+    assert rig.scope.moves == [(3e-6, 4e-6)]
+
+
+def test_focus_is_restored_after_a_successful_survey(rig):
+    before = rig.camera.getFocusDepth()
+    rig.detect((0.0, 0.0), SearchConstraints())
+    assert rig.camera.focusSets[-1] == pytest.approx(before)
+
+
+def test_focus_is_restored_when_acquisition_raises(rig, monkeypatch):
+    # A survey that dies mid-stack must not leave the objective parked deep in
+    # the tissue for whatever runs next.
+    before = rig.camera.getFocusDepth()
+
+    def boom(cam, start_z, stop_z, step_z):
+        raise RuntimeError("camera died")
+
+    monkeypatch.setattr(tile_detector, "_acquire", boom)
+
+    with pytest.raises(RuntimeError, match="camera died"):
+        rig.detect((0.0, 0.0), SearchConstraints())
+
+    assert rig.camera.focusSets[-1] == pytest.approx(before)
+
+
+def test_a_stop_prevents_the_survey_from_imaging(rig, monkeypatch):
+    # Imaging a tile is slow, so a stop must be honoured before the stack starts,
+    # not only after it finishes.
+    def stopNow():
+        raise Stopped("stopped by operator")
+
+    monkeypatch.setattr(tile_detector, "check_stop", stopNow)
+
+    with pytest.raises(Stopped):
+        rig.detect((0.0, 0.0), SearchConstraints())
+
+    assert rig.acquireCalls == []
+    assert rig.scope.moves == []
+
+
+def test_detected_cells_carry_their_health_score(rig):
+    cells = rig.detect((0.0, 0.0), SearchConstraints())
+    assert len(cells) == 1
+    assert cells[0].score == pytest.approx(0.8)
+    assert cells[0].position == (1e-6, 2e-6, -530e-6)
+
+
+def test_tracking_is_seeded_from_the_stack_the_cell_was_found_in(rig):
+    cells = rig.detect((0.0, 0.0), SearchConstraints())
+    assert cells[0].trackerInits == 1
+
+
+def test_a_cell_whose_tracker_cannot_be_seeded_is_still_returned(rig, monkeypatch):
+    # A cell too close to the stack edge cannot be extracted, but it is a real
+    # detection: discarding it would silently drop cells at every tile boundary.
+    monkeypatch.setattr(FakeCell, "trackerFails", True)
+
+    cells = rig.detect((0.0, 0.0), SearchConstraints())
+
+    assert len(cells) == 1
+    assert cells[0].score == pytest.approx(0.8)
+
+
+def test_the_pixel_size_and_step_reach_detection(rig):
+    rig.detect((0.0, 0.0), SearchConstraints())
+    stack, xy_scale, z_scale, _models, _min_volume, _n = rig.detectCalls[0]
+    assert stack == ["frame"]
+    assert xy_scale == pytest.approx(0.32e-6)
+    assert z_scale == pytest.approx(1e-6)
+
+
+def test_min_volume_and_max_candidates_reach_detection(monkeypatch):
+    # make_tile_detector's own min_volume_m3/max_candidates parameters must
+    # reach _detect unchanged, not get dropped or swapped with each other.
+    # Non-default values on both sides so a hard-coded default is caught.
+    camera = FakeCamera()
+    scope = FakeScope(surface=-500e-6)
+    detectCalls = []
+
+    def fakeAcquire(cam, start_z, stop_z, step_z):
+        return ["frame"]
+
+    def fakeDetect(stack, xy_scale, z_scale, models, min_volume_m3, max_candidates):
+        detectCalls.append((min_volume_m3, max_candidates))
+        return []
+
+    monkeypatch.setattr(tile_detector, "_acquire", fakeAcquire)
+    monkeypatch.setattr(tile_detector, "_detect", fakeDetect)
+    monkeypatch.setattr(tile_detector, "_newCell", FakeCell)
+
+    detect = tile_detector.make_tile_detector(
+        camera=camera,
+        scope=scope,
+        manager=None,
+        min_volume_m3=123e-18,
+        max_candidates=7,
+    )
+    detect((0.0, 0.0), SearchConstraints())
+
+    min_volume_m3, max_candidates = detectCalls[0]
+    assert min_volume_m3 == pytest.approx(123e-18)
+    assert max_candidates == 7
+
+
+class FakeManager:
+    def __init__(self, misc):
+        self.config = {"misc": misc}
+
+
+def test_health_models_come_from_the_misc_config():
+    models = tile_detector._health_models(
+        FakeManager({"segmenterPath": "/seg.pt", "classifierPath": "/cls.pt"})
+    )
+    assert models["segmenter"] == "/seg.pt"
+    assert models["classifier"] == "/cls.pt"
+    assert models["autoencoder"] is None
+    assert models["resnet_classifier"] is None
+
+
+def test_health_models_without_a_manager_are_all_unset():
+    # A headless or partially-configured rig must not raise here; detect_neurons
+    # accepts None for every model.
+    assert set(tile_detector._health_models(None).values()) == {None}

--- a/acq4/experiment/tests/test_tile_detector.py
+++ b/acq4/experiment/tests/test_tile_detector.py
@@ -9,20 +9,42 @@ from acq4.util.task import Stopped
 
 
 class FakeScope:
-    def __init__(self, surface=0.0):
+    """`camera` is wired in so `findSurfaceDepth` can move the camera's focus to
+    the surface it reports, the way `Microscope.findSurfaceDepth` ends with
+    `setFocusDepth(depth, ...).wait()` on the real device. Without that, a
+    focus-depth capture taken after the surface search would look identical to
+    one taken before it, and the two are not interchangeable."""
+
+    def __init__(self, camera, surface=0.0):
+        self.camera = camera
         self.surface = surface
         self.moves = []
+        # Ordered log of "move"/"move_waited"/"surface_search" events, so tests
+        # can pin the sequence the survey performs them in, not just that each
+        # one happened.
+        self.events = []
 
     def setGlobalPosition(self, pos, speed="fast", name=None):
         self.moves.append(tuple(pos))
-        return FakeFuture()
+        self.events.append("move")
+        return FakeFuture(self.events, "move_waited")
 
     def findSurfaceDepth(self, imager):
+        self.events.append("surface_search")
+        self.camera.setFocusDepth(self.surface, name="fake surface focus")
         return self.surface
 
 
 class FakeFuture:
+    def __init__(self, log=None, label=None):
+        self.waited = False
+        self._log = log
+        self._label = label
+
     def wait(self, **kwargs):
+        self.waited = True
+        if self._log is not None:
+            self._log.append(self._label)
         return None
 
 
@@ -39,10 +61,13 @@ class FakeCamera:
 
     def setFocusDepth(self, z, speed="fast", name=None):
         self.focusSets.append(z)
+        self._focus = z
         return FakeFuture()
 
     def getPixelSize(self):
-        return (0.32e-6, 0.32e-6)
+        # Asymmetric so a test reading the wrong axis (index 1 instead of 0)
+        # cannot pass by accident.
+        return (0.32e-6, 0.5e-6)
 
 
 class FakeCell:
@@ -54,9 +79,13 @@ class FakeCell:
         self.position = position
         self.score = None
         self.trackerInits = 0
+        self.trackerStack = None
+        self.trackerUseCellpose = None
 
     def initializeTrackerFromStack(self, camera, stack, use_cellpose=False):
         self.trackerInits += 1
+        self.trackerStack = stack
+        self.trackerUseCellpose = use_cellpose
         if self.trackerFails:
             raise ValueError("cell too close to the stack edge")
 
@@ -69,7 +98,7 @@ def rig(monkeypatch):
     arguments, and the detector callable itself.
     """
     camera = FakeCamera()
-    scope = FakeScope(surface=-500e-6)
+    scope = FakeScope(camera, surface=-500e-6)
     acquireCalls = []
     detectCalls = []
 
@@ -116,10 +145,13 @@ def test_the_stack_spans_the_constrained_range_below_this_tiles_surface(rig):
 def test_the_depth_range_is_read_from_the_constraints_it_is_given(rig):
     # Not from a value captured when the detector was built: the operator may
     # edit the range between runs, and the slice hands its current constraints
-    # to every call.
+    # to every call. Two calls on the SAME detector, so a detector that cached
+    # the first call's constraints would give the second call the first call's
+    # range instead of its own.
+    rig.detect((0.0, 0.0), SearchConstraints(depth_range=(-20e-6, -60e-6)))
     rig.detect((0.0, 0.0), SearchConstraints(depth_range=(-5e-6, -15e-6)))
 
-    start_z, stop_z, _ = rig.acquireCalls[0]
+    start_z, stop_z, _ = rig.acquireCalls[1]
     assert start_z == pytest.approx(-505e-6)
     assert stop_z == pytest.approx(-515e-6)
 
@@ -129,6 +161,16 @@ def test_the_stage_moves_to_the_tile_before_the_surface_is_found(rig):
     # previous tile's tissue.
     rig.detect((3e-6, 4e-6), SearchConstraints())
     assert rig.scope.moves == [(3e-6, 4e-6)]
+    assert rig.scope.events.index("move") < rig.scope.events.index("surface_search")
+
+
+def test_the_stage_move_is_waited_on_before_the_surface_is_found(rig):
+    # A future returned but never waited on means detection could run before
+    # the stage has physically arrived at the tile.
+    rig.detect((3e-6, 4e-6), SearchConstraints())
+    assert rig.scope.events.index("move_waited") < rig.scope.events.index(
+        "surface_search"
+    )
 
 
 def test_focus_is_restored_after_a_successful_survey(rig):
@@ -153,19 +195,29 @@ def test_focus_is_restored_when_acquisition_raises(rig, monkeypatch):
     assert rig.camera.focusSets[-1] == pytest.approx(before)
 
 
-def test_a_stop_prevents_the_survey_from_imaging(rig, monkeypatch):
-    # Imaging a tile is slow, so a stop must be honoured before the stack starts,
-    # not only after it finishes.
-    def stopNow():
-        raise Stopped("stopped by operator")
+@pytest.mark.parametrize("stop_at", [1, 2, 3, 4])
+def test_a_stop_prevents_the_survey_from_imaging(rig, monkeypatch, stop_at):
+    # Each of the four check_stop() calls guards one slow step -- the move,
+    # the surface search, the stack acquisition, and detection -- in that
+    # order. Raising on only the Nth call proves that specific guard is doing
+    # its job: every step from there on must not have run, regardless of
+    # whether the guards before it fired.
+    calls = []
 
-    monkeypatch.setattr(tile_detector, "check_stop", stopNow)
+    def stopAtNth():
+        calls.append(1)
+        if len(calls) == stop_at:
+            raise Stopped("stopped by operator")
+
+    monkeypatch.setattr(tile_detector, "check_stop", stopAtNth)
 
     with pytest.raises(Stopped):
         rig.detect((0.0, 0.0), SearchConstraints())
 
-    assert rig.acquireCalls == []
-    assert rig.scope.moves == []
+    assert bool(rig.scope.moves) == (stop_at > 1)
+    assert ("surface_search" in rig.scope.events) == (stop_at > 2)
+    assert bool(rig.acquireCalls) == (stop_at > 3)
+    assert rig.detectCalls == []
 
 
 def test_detected_cells_carry_their_health_score(rig):
@@ -178,6 +230,8 @@ def test_detected_cells_carry_their_health_score(rig):
 def test_tracking_is_seeded_from_the_stack_the_cell_was_found_in(rig):
     cells = rig.detect((0.0, 0.0), SearchConstraints())
     assert cells[0].trackerInits == 1
+    assert cells[0].trackerStack == ["frame"]
+    assert cells[0].trackerUseCellpose is True
 
 
 def test_a_cell_whose_tracker_cannot_be_seeded_is_still_returned(rig, monkeypatch):
@@ -193,10 +247,16 @@ def test_a_cell_whose_tracker_cannot_be_seeded_is_still_returned(rig, monkeypatc
 
 def test_the_pixel_size_and_step_reach_detection(rig):
     rig.detect((0.0, 0.0), SearchConstraints())
-    stack, xy_scale, z_scale, _models, _min_volume, _n = rig.detectCalls[0]
+    stack, xy_scale, z_scale, models, _min_volume, _n = rig.detectCalls[0]
     assert stack == ["frame"]
     assert xy_scale == pytest.approx(0.32e-6)
     assert z_scale == pytest.approx(1e-6)
+    assert models == {
+        "segmenter": None,
+        "autoencoder": None,
+        "classifier": None,
+        "resnet_classifier": None,
+    }
 
 
 def test_min_volume_and_max_candidates_reach_detection(monkeypatch):
@@ -204,7 +264,7 @@ def test_min_volume_and_max_candidates_reach_detection(monkeypatch):
     # reach _detect unchanged, not get dropped or swapped with each other.
     # Non-default values on both sides so a hard-coded default is caught.
     camera = FakeCamera()
-    scope = FakeScope(surface=-500e-6)
+    scope = FakeScope(camera, surface=-500e-6)
     detectCalls = []
 
     def fakeAcquire(cam, start_z, stop_z, step_z):
@@ -230,6 +290,36 @@ def test_min_volume_and_max_candidates_reach_detection(monkeypatch):
     min_volume_m3, max_candidates = detectCalls[0]
     assert min_volume_m3 == pytest.approx(123e-18)
     assert max_candidates == 7
+
+
+def test_step_z_reaches_acquisition_and_detection(monkeypatch):
+    # step_z must reach both _acquire and _detect unchanged. The default is
+    # 1e-6, so a non-default value is required to catch a hard-coded 1e-6 in
+    # either call site.
+    camera = FakeCamera()
+    scope = FakeScope(camera, surface=-500e-6)
+    acquireCalls = []
+    detectCalls = []
+
+    def fakeAcquire(cam, start_z, stop_z, step_z):
+        acquireCalls.append(step_z)
+        return ["frame"]
+
+    def fakeDetect(stack, xy_scale, z_scale, models, min_volume_m3, max_candidates):
+        detectCalls.append(z_scale)
+        return []
+
+    monkeypatch.setattr(tile_detector, "_acquire", fakeAcquire)
+    monkeypatch.setattr(tile_detector, "_detect", fakeDetect)
+    monkeypatch.setattr(tile_detector, "_newCell", FakeCell)
+
+    detect = tile_detector.make_tile_detector(
+        camera=camera, scope=scope, manager=None, step_z=3e-6
+    )
+    detect((0.0, 0.0), SearchConstraints())
+
+    assert acquireCalls[0] == pytest.approx(3e-6)
+    assert detectCalls[0] == pytest.approx(3e-6)
 
 
 class FakeManager:

--- a/acq4/experiment/tile_detector.py
+++ b/acq4/experiment/tile_detector.py
@@ -35,12 +35,16 @@ def make_tile_detector(
         logger.info("Surveying tile at %r", center)
         scope.setGlobalPosition(center, name="autopatch survey move").wait()
 
+        # Captured before the surface search: camera focus tracks scope focus,
+        # so a capture taken after `findSurfaceDepth` would be the tile's
+        # surface, not the depth the survey started from.
+        restore_depth = camera.getFocusDepth()
+
         check_stop()
         surface = synch(scope.findSurfaceDepth)(camera)
         start_z, stop_z = constraints.z_bounds(surface)
 
         check_stop()
-        restore_depth = camera.getFocusDepth()
         try:
             stack = _acquire(camera, start_z, stop_z, step_z)
         finally:
@@ -90,16 +94,15 @@ def _build_cells(camera, stack, results) -> list:
 
 
 def _newCell(position):
-    """A Cell at a global position.
+    """A Cell at `position`, which `_detect` already returns as a global coorx Point.
 
     Imported here, not at module scope: acq4_automation lives in an internal
     repository, and a top-level import would stop every test under
     acq4/experiment from collecting where it is absent.
     """
     from acq4_automation.feature_tracking.cell import Cell
-    from coorx import Point
 
-    return Cell(Point(position, "global"))
+    return Cell(position)
 
 
 def _acquire(camera, start_z: float, stop_z: float, step_z: float) -> list:

--- a/acq4/experiment/tile_detector.py
+++ b/acq4/experiment/tile_detector.py
@@ -1,0 +1,146 @@
+"""The imaging half of a cell producer: move to a tile, find its surface, acquire
+a stack over the constrained depth range, and return scored cell candidates."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from acq4.logging_config import get_logger
+from acq4.util.task import check_stop, synch
+
+logger = get_logger(__name__)
+
+
+def make_tile_detector(
+    camera,
+    scope,
+    manager,
+    step_z: float = 1e-6,
+    min_volume_m3: float = 0.0,
+    max_candidates: int = 5,
+) -> Callable:
+    """Build the detector seam `Slice.makeCellProducer()` needs.
+
+    `camera` and `scope` must be resolved on the GUI thread and passed in; the
+    returned callable runs on the orchestrator's worker thread, where reading a
+    device selector widget is not safe.
+
+    Surface is found per tile rather than once per slice, so the searched slab
+    follows uneven tissue -- that is the whole reason the depth range is
+    expressed as offsets from the surface instead of absolute stage z.
+    """
+
+    def detect(center, constraints) -> list:
+        check_stop()
+        logger.info("Surveying tile at %r", center)
+        scope.setGlobalPosition(center, name="autopatch survey move").wait()
+
+        check_stop()
+        surface = synch(scope.findSurfaceDepth)(camera)
+        start_z, stop_z = constraints.z_bounds(surface)
+
+        check_stop()
+        restore_depth = camera.getFocusDepth()
+        try:
+            stack = _acquire(camera, start_z, stop_z, step_z)
+        finally:
+            # Restored on the failure path too: a survey that dies mid-stack
+            # must not leave the objective parked deep in the tissue for
+            # whatever runs next.
+            camera.setFocusDepth(
+                restore_depth, name=f"{camera.name()} restore focus after survey stack"
+            )
+
+        check_stop()
+        results = _detect(
+            stack,
+            xy_scale=camera.getPixelSize()[0],
+            z_scale=step_z,
+            models=_health_models(manager),
+            min_volume_m3=min_volume_m3,
+            max_candidates=max_candidates,
+        )
+        logger.info("Tile at %r yielded %d candidates", center, len(results))
+        return _build_cells(camera, stack, results)
+
+    return detect
+
+
+def _build_cells(camera, stack, results) -> list:
+    """Cells for each (position, score) detection, tracking seeded from `stack`."""
+    cells = []
+    for position, score in results:
+        cell = _newCell(position)
+        cell.score = score
+        try:
+            # Seeded from the stack the cell was found in, so tracking is ready
+            # without re-acquiring a stack per cell.
+            cell.initializeTrackerFromStack(camera, stack, use_cellpose=True)
+        except Exception:
+            # A cell too close to the stack edge cannot be extracted, but it is
+            # still a real detection: queue it rather than silently dropping
+            # every cell near a tile boundary.
+            logger.warning(
+                "Could not initialize tracking for the cell detected at %r",
+                position,
+                exc_info=True,
+            )
+        cells.append(cell)
+    return cells
+
+
+def _newCell(position):
+    """A Cell at a global position.
+
+    Imported here, not at module scope: acq4_automation lives in an internal
+    repository, and a top-level import would stop every test under
+    acq4/experiment from collecting where it is absent.
+    """
+    from acq4_automation.feature_tracking.cell import Cell
+    from coorx import Point
+
+    return Cell(Point(position, "global"))
+
+
+def _acquire(camera, start_z: float, stop_z: float, step_z: float) -> list:
+    """The tile's z-stack."""
+    from acq4.util.imaging.sequencer import acquire_z_stack
+
+    return acquire_z_stack(
+        camera,
+        start_z,
+        stop_z,
+        step_z,
+        slow_fallback=False,
+        name="autopatch survey stack",
+    )
+
+
+def _detect(stack, xy_scale, z_scale, models, min_volume_m3, max_candidates) -> list:
+    """Scored (position, score) candidates in `stack`. See _newCell on the import."""
+    from acq4_automation.object_detection import detect_neurons
+
+    return detect_neurons(
+        stack,
+        xy_scale=xy_scale,
+        z_scale=z_scale,
+        trim_edges=True,
+        min_volume_m3=min_volume_m3,
+        n=max_candidates,
+        **models,
+    )
+
+
+def _health_models(manager) -> dict:
+    """The configured detection/classification model paths from global `misc` config.
+
+    The same keys AutomationDebug reads, so a rig configured for the debug
+    bench needs no extra configuration to run a survey.
+    """
+    misc = manager.config.get("misc", {}) if manager is not None else {}
+    return {
+        "segmenter": misc.get("segmenterPath", None),
+        "autoencoder": misc.get("autoencoderPath", None),
+        "classifier": misc.get("classifierPath", None),
+        "resnet_classifier": misc.get("resnetClassifierPath", None),
+    }

--- a/acq4/modules/AutomationDebug/survey.py
+++ b/acq4/modules/AutomationDebug/survey.py
@@ -4,95 +4,14 @@ a grid over a user-defined rectangle and track which tiles have been imaged.
 
 from __future__ import annotations
 
-import math
 from typing import TYPE_CHECKING
 
 import pyqtgraph as pg
 
+from acq4.experiment.search_grid import count_covered, plan_grid, select_next
+
 if TYPE_CHECKING:
     from .AutomationDebug import AutomationDebugWindow
-
-
-def _axis_centers(lo: float, hi: float, fov: float, overlap: float) -> list[float]:
-    """Tile centers along one axis whose union covers [lo, hi].
-
-    Step between tiles is ``fov - overlap``; the tile count is the smallest that
-    spans the extent, and the tiles are centered over it so the union fully
-    covers [lo, hi] (the outermost tiles may extend past the edges).
-    """
-    extent = hi - lo
-    step = fov - overlap
-    if step <= 0:
-        # Degrade gracefully if the overlap swallows the whole FOV.
-        step = fov
-    if extent <= fov:
-        return [(lo + hi) / 2.0]
-    n = math.ceil((extent - fov) / step) + 1
-    covered = fov + (n - 1) * step
-    extra = covered - extent
-    start = lo + fov / 2.0 - extra / 2.0
-    return [start + i * step for i in range(n)]
-
-
-def plan_grid(
-    x0: float,
-    y0: float,
-    x1: float,
-    y1: float,
-    fov_w: float,
-    fov_h: float,
-    overlap: float,
-) -> list[tuple[float, float]]:
-    """Serpentine-ordered tile centers whose union fully covers the rectangle.
-
-    The step between adjacent tiles is ``fov - overlap`` (an absolute distance).
-    The grid is centered over the rectangle so no part of it is left uncovered;
-    the outermost tiles may extend past the edges. A single tile at the rect
-    center is returned when the rect is smaller than one FOV. Rows alternate
-    direction (boustrophedon) to minimize stage travel.
-    """
-    xs = _axis_centers(min(x0, x1), max(x0, x1), fov_w, overlap)
-    ys = _axis_centers(min(y0, y1), max(y0, y1), fov_h, overlap)
-    grid: list[tuple[float, float]] = []
-    for j, cy in enumerate(ys):
-        row = xs if j % 2 == 0 else list(reversed(xs))
-        for cx in row:
-            grid.append((cx, cy))
-    return grid
-
-
-def _is_visited(
-    cx: float,
-    cy: float,
-    visited: list[tuple[float, float]],
-    threshold: float,
-) -> bool:
-    """Whether ``(cx, cy)`` lies within ``threshold`` of any visited center."""
-    return any(math.hypot(cx - vx, cy - vy) < threshold for vx, vy in visited)
-
-
-def select_next(
-    grid: list[tuple[float, float]],
-    visited: list[tuple[float, float]],
-    threshold: float,
-) -> tuple[float, float] | None:
-    """First center in ``grid`` not within ``threshold`` of any visited center.
-
-    Returns None when every planned tile has already been imaged.
-    """
-    for cx, cy in grid:
-        if not _is_visited(cx, cy, visited, threshold):
-            return (cx, cy)
-    return None
-
-
-def count_covered(
-    grid: list[tuple[float, float]],
-    visited: list[tuple[float, float]],
-    threshold: float,
-) -> int:
-    """Number of centers in ``grid`` within ``threshold`` of some visited center."""
-    return sum(1 for cx, cy in grid if _is_visited(cx, cy, visited, threshold))
 
 
 class SurveyRegion:

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -162,6 +162,33 @@ class AutopatchWindow(Qt.QWidget):
         if self.protocolPanel.protocolFile is not None:
             self._onProtocolLoaded(self.protocolPanel.protocolFile)
 
+    def _startSlice(self) -> bool:
+        """Install a fresh Slice for the tissue under the objective.
+
+        Returns whether one was created: a slice needs the camera's field of
+        view and a valid set of search constraints, and either being missing
+        leaves self.slice exactly as it was rather than installing a half-built
+        one. The camera-less case reports itself through SearchPanel; invalid
+        constraints have already reported themselves there.
+
+        Shared by newSlice() and addRegionHere(), so the construction lives in
+        one place -- but only the construction. Discarding the previous slice's
+        queued cells belongs to newSlice() alone: addRegionHere() creating the
+        slice that will hold its region must not throw away cells the operator
+        seeded by hand, which is all its button offers to do.
+        """
+        camera = self.cameraSelector.getSelectedObj()
+        if camera is None:
+            self.searchPanel.setError("Select a camera before starting a slice.")
+            return False
+        constraints = self.searchPanel.constraints()
+        if constraints is None:
+            return False
+        self.slice = Slice(fov=self._cameraFov(camera), constraints=constraints)
+        # There is a camera now, so retract the message above if it is up.
+        self.searchPanel.setError("")
+        return True
+
     def newSlice(self) -> None:
         """Start a fresh slice, discarding the current one and everything on it.
 
@@ -170,17 +197,15 @@ class AutopatchWindow(Qt.QWidget):
         has been swapped makes every one of those coordinates a place not to
         drive a pipette. The per-cell data already written under the old slice
         directory is the durable record; Area 5's list is a working queue.
+
+        What this deliberately does not do is stop the cell already in flight.
+        The queue behind it and Area 5's list are discarded, but that cell runs
+        to completion on the tissue it was found in -- it is being worked right
+        now, and yanking a pipette out mid-protocol is its own hazard. The
+        operator who has physically swapped the tissue presses Stop for that.
         """
-        camera = self.cameraSelector.getSelectedObj()
-        if camera is None:
-            self.searchPanel.errorLabel.setText(
-                "Select a camera before starting a slice."
-            )
+        if not self._startSlice():
             return
-        constraints = self.searchPanel.constraints()
-        if constraints is None:
-            return
-        self.slice = Slice(fov=self._cameraFov(camera), constraints=constraints)
         self.cellPanel.clearCells()
         if self.orchestrator is not None:
             # Detached before the queue is cleared, not after: a refill still
@@ -197,11 +222,15 @@ class AutopatchWindow(Qt.QWidget):
         self._refreshSurveyStats()
 
     def addRegionHere(self) -> None:
-        """Add a search region of roughly 3x3 fields of view around the camera center."""
-        if self.slice is None:
-            self.newSlice()
-            if self.slice is None:
-                return
+        """Add a search region of roughly 3x3 fields of view around the camera center.
+
+        A region is a reasonable first action, so a slice comes into existence
+        to hold it. Built directly rather than by way of newSlice(): that is the
+        discard-everything path, and an operator who seeded cells by hand and
+        then asked only for a region must not lose them.
+        """
+        if self.slice is None and not self._startSlice():
+            return
         camera = self.cameraSelector.getSelectedObj()
         if camera is None:
             return

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 
 from acq4.experiment.orchestrator import Orchestrator
+from acq4.experiment.slice import Slice
+from acq4.experiment.tile_detector import make_tile_detector
 from acq4.modules.Module import Module
 from acq4.util import Qt
 from acq4.util.InterfaceCombo import InterfaceCombo
@@ -13,14 +15,16 @@ from .cell_panel import CellPanel
 from .context_factory import make_context_factory
 from .example_protocols import install_example_protocols
 from .protocol_panel import ProtocolPanel
+from .search_panel import SearchPanel
 from .status_panel import StatusPanel
 
 
 class AutopatchWindow(Qt.QWidget):
     """The Autopatch run window: five labeled areas per the design doc.
 
-    Areas 1/2 stay empty placeholders in P1; Areas 3/4/5 hold the real
-    status/protocol/cell-queue content wired to a live Orchestrator.
+    Area 1 starts a slice, Area 2 configures the cell search over it, and
+    Areas 3/4/5 hold the status/protocol/cell-queue content wired to a live
+    Orchestrator.
     """
 
     def __init__(
@@ -86,6 +90,18 @@ class AutopatchWindow(Qt.QWidget):
         self.statusPanel = StatusPanel()
         self.area3Box.layout().addWidget(self.statusPanel)
 
+        # Area 1 holds only New slice: region graphics and the progress heatmap
+        # are Area 1's remaining content and are not built here.
+        self.newSliceBtn = Qt.QPushButton("New slice")
+        self.newSliceBtn.setToolTip(
+            "Discard the current slice -- its regions, coverage, and queued "
+            "cells -- and start a fresh one for newly mounted tissue."
+        )
+        self.area1Box.layout().addWidget(self.newSliceBtn)
+
+        self.searchPanel = SearchPanel()
+        self.area2Box.layout().addWidget(self.searchPanel)
+
         self.cellPanel = CellPanel(
             pipetteGetter=self.pipetteSelector.getSelectedObj,
             cameraGetter=self.cameraSelector.getSelectedObj,
@@ -96,8 +112,18 @@ class AutopatchWindow(Qt.QWidget):
         # The pipette resolved from self.pipetteSelector at the moment Start was
         # last pressed (GUI thread). The orchestrator's contextFactory reads this
         # cached value rather than the selector widget, since the factory is
-        # called from the orchestrator's worker thread -- see _resolvePipette().
+        # called from the orchestrator's worker thread -- see _onStartRun().
         self._cachedPipette = None
+        # The tissue currently under the objective, or None before the operator
+        # has started one. A Slice outlives individual runs: it holds the
+        # regions, the coverage every producer made from it shares, and the
+        # search constraints. Replaced only by newSlice().
+        self.slice = None
+        # Camera and scope resolved from cameraSelector at the moment Start was
+        # last pressed, for the same reason as _cachedPipette: the detector runs
+        # on the orchestrator's worker thread and must not read a selector.
+        self._cachedCamera = None
+        self._cachedScope = None
         self._tornDown = False
         self.protocolPanel.sigProtocolLoaded.connect(self._onProtocolLoaded)
         # Area 4 (the protocol picker/Reload) must not be usable while a
@@ -109,6 +135,21 @@ class AutopatchWindow(Qt.QWidget):
         # reference cycle -- exactly what bindOrchestrator/unbindOrchestrator
         # elsewhere are careful to avoid.
         self.statusPanel.sigInteractionLocked.connect(self.protocolPanel.setInteractionLocked)
+        self.newSliceBtn.clicked.connect(self.newSlice)
+        self.searchPanel.sigAddRegionRequested.connect(self.addRegionHere)
+        self.searchPanel.sigConstraintsChanged.connect(self._onConstraintsChanged)
+        self.statusPanel.sigInteractionLocked.connect(
+            self.searchPanel.setInteractionLocked
+        )
+        # Coverage advances on the worker thread as the producer images tiles, so
+        # the readout is refreshed off a status change rather than polled. Routed
+        # through StatusPanel, not connected to the orchestrator directly: the
+        # orchestrator is a parentless QObject and a connection from it to this
+        # window would give it a reference back, rebuilding the cycle
+        # bindOrchestrator/unbindOrchestrator exist to avoid. StatusPanel is in
+        # this window's widget tree, so this wiring is made once and never needs
+        # re-wiring per protocol load.
+        self.statusPanel.sigStatusChanged.connect(self._onRunStatus)
         # ProtocolPanel selects (and thus loads) a protocol as soon as its own
         # constructor's initial scan populates the combo -- before the
         # `sigProtocolLoaded` connection above exists, since that scan runs
@@ -121,13 +162,118 @@ class AutopatchWindow(Qt.QWidget):
         if self.protocolPanel.protocolFile is not None:
             self._onProtocolLoaded(self.protocolPanel.protocolFile)
 
-    def _resolvePipette(self) -> None:
-        """Snapshot the currently-selected pipette on the GUI thread. Called at
-        Start (before the orchestrator's worker thread starts running), so the
-        in-flight run never reads InterfaceCombo's currentIndex()/interfaceMap
-        off-thread. Re-resolved on every Start, so the selection may still
-        change between runs."""
+    def newSlice(self) -> None:
+        """Start a fresh slice, discarding the current one and everything on it.
+
+        Regions, coverage, and search constraints go with the old slice, and so
+        do the queued cells: a Cell is a coordinate in tissue, and tissue that
+        has been swapped makes every one of those coordinates a place not to
+        drive a pipette. The per-cell data already written under the old slice
+        directory is the durable record; Area 5's list is a working queue.
+        """
+        camera = self.cameraSelector.getSelectedObj()
+        if camera is None:
+            self.searchPanel.errorLabel.setText(
+                "Select a camera before starting a slice."
+            )
+            return
+        constraints = self.searchPanel.constraints()
+        if constraints is None:
+            return
+        self.slice = Slice(fov=self._cameraFov(camera), constraints=constraints)
+        self.cellPanel.clearCells()
+        if self.orchestrator is not None:
+            # clearCells() only drops the panel's own bookkeeping; the
+            # orchestrator's deque is a separate strong reference to the same
+            # cells and would keep handing them to the protocol.
+            self.orchestrator.clearQueue()
+            self.orchestrator.setCellProducer(None)
+        self._refreshSurveyStats()
+
+    def addRegionHere(self) -> None:
+        """Add a search region of roughly 3x3 fields of view around the camera center."""
+        if self.slice is None:
+            self.newSlice()
+            if self.slice is None:
+                return
+        camera = self.cameraSelector.getSelectedObj()
+        if camera is None:
+            return
+        fov_w, fov_h = self._cameraFov(camera)
+        # "roi" mode throughout: the field the camera actually images is what a
+        # tile covers, and globalCenterPosition defaults to "sensor", which is
+        # off-center for a cropped camera ROI.
+        cx, cy = camera.globalCenterPosition("roi")[:2]
+        w, h = fov_w * 3, fov_h * 3
+        self.slice.addRegion(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2)
+        self._refreshSurveyStats()
+
+    @staticmethod
+    def _cameraFov(camera) -> tuple[float, float]:
+        """The camera's imaged field width and height, in global metres."""
+        _, _, w, h = camera.getBoundary(globalCoords=True, mode="roi")
+        return abs(w), abs(h)
+
+    def _onConstraintsChanged(self, constraints) -> None:
+        # None means the spinboxes do not currently describe a valid search
+        # (SearchPanel already shows why); leave the live slice on its last
+        # good constraints rather than tearing them down mid-edit.
+        if constraints is not None and self.slice is not None:
+            self.slice.setConstraints(constraints)
+
+    def _refreshSurveyStats(self) -> None:
+        if self.slice is None:
+            self.searchPanel.setSurveyStats(0, 0, 0.0)
+        else:
+            self.searchPanel.setSurveyStats(*self.slice.surveyStats())
+
+    def _onRunStatus(self, status: str) -> None:
+        """Refresh Area 2's survey readout when the run's status moves.
+
+        Coverage advances on the orchestrator's worker thread, but this arrives
+        via StatusPanel on the GUI thread, so re-reading the slice here is safe.
+        """
+        if status in ("surveying", "waiting"):
+            self._refreshSurveyStats()
+
+    def _onStartRun(self) -> None:
+        """Snapshot GUI-thread-only state and install the cell producer at Start.
+
+        Runs on the GUI thread before the orchestrator's worker thread starts,
+        so the in-flight run never reads InterfaceCombo's
+        currentIndex()/interfaceMap off-thread. Re-resolved on every Start, so
+        the selection and the slice may both change between runs.
+        """
         self._cachedPipette = self.pipetteSelector.getSelectedObj()
+        self._cachedCamera = self.cameraSelector.getSelectedObj()
+        self._cachedScope = None
+        if self._cachedCamera is not None:
+            self._cachedScope = self._cachedCamera.scopeDev
+        self._installCellProducer()
+
+    def _installCellProducer(self) -> None:
+        """Give the orchestrator a producer for the current slice, or none.
+
+        Cleared rather than left stale whenever a survey is not possible: no
+        slice, no region, or no camera means the run is a plain drain of the
+        cells the operator seeded by hand, and a producer left over from a
+        previous Start would otherwise keep surveying tissue that is gone.
+        """
+        if self.orchestrator is None:
+            return
+        canSurvey = (
+            self.slice is not None
+            and self.slice.regions
+            and self._cachedCamera is not None
+            and self._cachedScope is not None
+        )
+        if not canSurvey:
+            self.orchestrator.setCellProducer(None)
+            return
+        detector = make_tile_detector(
+            camera=self._cachedCamera, scope=self._cachedScope, manager=self.manager
+        )
+        self.orchestrator.setCellProducer(self.slice.makeCellProducer(detector))
 
     def _onProtocolLoaded(self, protocolFile) -> None:
         # Loading a second protocol must not abandon a still-live Orchestrator:
@@ -155,7 +301,7 @@ class AutopatchWindow(Qt.QWidget):
         # leaning solely on teardown() having already dropped every reference.
         self.orchestrator.setParent(self)
         self.statusPanel.bindOrchestrator(
-            self.orchestrator, self.cellPanel, onStart=self._resolvePipette
+            self.orchestrator, self.cellPanel, onStart=self._onStartRun
         )
         self.cellPanel.bindOrchestrator(self.orchestrator)
 
@@ -181,6 +327,11 @@ class AutopatchWindow(Qt.QWidget):
             orchestrator.wait(timeout=5.0, updates=True)
         except Exception:
             pass
+        # The producer closes over the camera and scope devices and over a
+        # Slice this window may be about to replace. Leaving it installed on an
+        # orchestrator the window has stopped managing keeps all of that
+        # reachable from an object nothing is looking after any more.
+        orchestrator.setCellProducer(None)
         # The orchestrator's context factory closes over this window (to read
         # the cached pipette) and over cellPanel (to log), so as long as the
         # orchestrator is alive it keeps both alive too -- fine on its own,

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -183,11 +183,17 @@ class AutopatchWindow(Qt.QWidget):
         self.slice = Slice(fov=self._cameraFov(camera), constraints=constraints)
         self.cellPanel.clearCells()
         if self.orchestrator is not None:
+            # Detached before the queue is cleared, not after: a refill still
+            # in flight on the worker thread reads the producer and enqueues
+            # its result as two separate steps (see Orchestrator._refillQueue),
+            # so clearing the queue first leaves a window where that in-flight
+            # refill can still land one more old-slice tile in it after the
+            # operator has already declared the tissue gone.
+            self.orchestrator.setCellProducer(None)
             # clearCells() only drops the panel's own bookkeeping; the
             # orchestrator's deque is a separate strong reference to the same
             # cells and would keep handing them to the protocol.
             self.orchestrator.clearQueue()
-            self.orchestrator.setCellProducer(None)
         self._refreshSurveyStats()
 
     def addRegionHere(self) -> None:

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -48,6 +48,18 @@ class CellPanel(Qt.QWidget):
         self._timelineItems: dict[int, Qt.QListWidgetItem] = {}
         self._logs: dict[int, list[str]] = {}
         self._cells: dict[int, object] = {}
+        # id(cell) for each cell seeded here while no orchestrator was bound,
+        # and therefore still waiting to be enqueued into whichever
+        # orchestrator is bound next. Populated only by _enqueueAndAdd(), and
+        # only in that no-orchestrator case; emptied by bindOrchestrator()'s
+        # flush. A cell this panel merely learned about from an orchestrator's
+        # announcements is already queued or already finished, so it never
+        # belongs here -- self._cells alone cannot tell the two apart, and
+        # treating every cell in it as pending is how a coordinate in discarded
+        # tissue, or an already-patched cell, gets run again. A list rather than
+        # a set so the flush enqueues them in the order the operator seeded
+        # them, which is the order they will be patched in.
+        self._awaitingEnqueue: list[int] = []
         # id(entry) of whichever entry's widget currently occupies
         # showContainer, or None if it's empty. No action nests log_action
         # blocks today, but if one did, this lets a "finished" phase tell
@@ -95,12 +107,19 @@ class CellPanel(Qt.QWidget):
         self._orchestrator = orchestrator
         orchestrator.sigCurrentCell.connect(self._onCurrentCell)
         orchestrator.sigCellFinished.connect(self._onCellFinished)
-        # Cells seeded before a protocol was loaded (self._orchestrator was None)
-        # were held here without being enqueued; flush them into the newly bound
-        # orchestrator now, exactly once each, so a freshly loaded protocol runs
-        # over any cells the operator already seeded.
-        for cell in self._cells.values():
-            orchestrator.enqueue(cell)
+        # Cells seeded before a protocol was loaded (self._orchestrator was
+        # None) were held here without being enqueued; flush exactly those into
+        # the newly bound orchestrator now, exactly once each, so a freshly
+        # loaded protocol runs over any cells the operator already seeded.
+        # Deliberately not every cell in self._cells: that dict also holds cells
+        # this panel only ever learned about from an orchestrator's
+        # announcements (a survey producer's finds, and cells that have already
+        # finished), and enqueuing those here would patch a finished cell a
+        # second time -- or, after a "New slice", drive a pipette to a
+        # coordinate in tissue the operator has declared gone.
+        pending, self._awaitingEnqueue = self._awaitingEnqueue, []
+        for cellId in pending:
+            orchestrator.enqueue(self._cells[cellId])
 
     def unbindOrchestrator(self) -> None:
         """Disconnect everything bindOrchestrator() connected to the currently
@@ -137,6 +156,11 @@ class CellPanel(Qt.QWidget):
         nothing here should still reference a Cell afterward.
         """
         self._cells.clear()
+        # Cleared alongside self._cells, which is what the flush resolves these
+        # ids against: an id left behind here would either raise a KeyError on
+        # the next bind or, if that memory address were reused by an unrelated
+        # cell, enqueue that cell instead.
+        self._awaitingEnqueue.clear()
         self._rows.clear()
         self._timelines.clear()
         self._entryTimelineLoc.clear()
@@ -169,15 +193,30 @@ class CellPanel(Qt.QWidget):
     def _enqueueAndAdd(self, cell) -> None:
         # self._cells (via addCell) is the authoritative source of truth for
         # seeded cells, so seeding must work even before a protocol has been
-        # loaded and bound an orchestrator. If one IS bound, also enqueue the
-        # new cell into it immediately; unbound cells are flushed into whatever
-        # orchestrator bindOrchestrator() later binds, so this never
-        # double-enqueues.
+        # loaded and bound an orchestrator. If one IS bound, enqueue the new
+        # cell into it immediately; if not, record it as awaiting an enqueue so
+        # bindOrchestrator() flushes it into whichever orchestrator it later
+        # binds. Exactly one of the two happens per seeded cell, so this never
+        # double-enqueues -- and this is the only place _awaitingEnqueue grows,
+        # which is what keeps that flush to cells the operator seeded rather
+        # than every cell this panel has a row for.
         if self._orchestrator is not None:
             self._orchestrator.enqueue(cell)
+        else:
+            self._awaitingEnqueue.append(id(cell))
         self.addCell(cell)
 
     def addCell(self, cell) -> None:
+        """Give `cell` a row and the panel-side bookkeeping that row needs.
+
+        Display and bookkeeping only: it neither enqueues the cell nor records
+        it as awaiting an enqueue. Both the seeding path (_enqueueAndAdd, which
+        does one or the other before calling here) and the announcement paths
+        (_onCurrentCell/_onCellFinished, for a cell that is already queued,
+        already running, or already finished) go through this, and the
+        announcement paths must add nothing a later bindOrchestrator() would
+        act on.
+        """
         # Cell is a QObject; parenting it to this panel (itself parented into
         # the window's widget tree) lets Qt's ownership cascade destroy it
         # deterministically when the window closes, rather than relying solely
@@ -241,7 +280,9 @@ class CellPanel(Qt.QWidget):
             # the orchestrator's worker thread, so addCell() leaves it
             # unparented and self._cells is what keeps it alive instead -- see
             # addCell()'s own comment); it must never also call
-            # orchestrator.enqueue(), which would run the same cell twice.
+            # orchestrator.enqueue(), which would run the same cell twice, nor
+            # record it in self._awaitingEnqueue, which would have a later
+            # bindOrchestrator() do the same thing one protocol load later.
             self.addCell(cell)
             item = self._rows[id(cell)]
         item.setText(f"cell {id(cell)} — running")
@@ -333,7 +374,9 @@ class CellPanel(Qt.QWidget):
         # Orchestrator._processCell) without sigCurrentCell ever having fired
         # for it, so this cannot assume _onCurrentCell already gave it a row --
         # same reasoning as _onCurrentCell above: add one via addCell() only,
-        # never re-enqueue.
+        # never re-enqueue and never mark it as awaiting one. A cell that has
+        # finished is the clearest case of all: enqueuing it again patches a
+        # cell that has already been worked.
         item = self._rows.get(id(cell))
         if item is None:
             self.addCell(cell)

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -48,17 +48,20 @@ class CellPanel(Qt.QWidget):
         self._timelineItems: dict[int, Qt.QListWidgetItem] = {}
         self._logs: dict[int, list[str]] = {}
         self._cells: dict[int, object] = {}
-        # id(cell) for each cell seeded here while no orchestrator was bound,
-        # and therefore still waiting to be enqueued into whichever
-        # orchestrator is bound next. Populated only by _enqueueAndAdd(), and
-        # only in that no-orchestrator case; emptied by bindOrchestrator()'s
-        # flush. A cell this panel merely learned about from an orchestrator's
-        # announcements is already queued or already finished, so it never
-        # belongs here -- self._cells alone cannot tell the two apart, and
-        # treating every cell in it as pending is how a coordinate in discarded
-        # tissue, or an already-patched cell, gets run again. A list rather than
-        # a set so the flush enqueues them in the order the operator seeded
-        # them, which is the order they will be patched in.
+        # id(cell) for each cell that is not yet running under any
+        # orchestrator this panel is bound to, and so is still owed an
+        # enqueue. Grows from two places: _enqueueAndAdd(), when a cell is
+        # seeded with no orchestrator bound, and unbindOrchestrator(), which
+        # salvages whatever bindOrchestrator() has not yet flushed out of the
+        # outgoing orchestrator's own queue before that queue goes away with
+        # it. Emptied by bindOrchestrator()'s flush into whichever
+        # orchestrator is bound next. A cell this panel merely learned about
+        # from an orchestrator's announcements is already queued or already
+        # finished, so it never belongs here -- self._cells alone cannot tell
+        # the two apart, and treating every cell in it as pending is how a
+        # coordinate in discarded tissue, or an already-patched cell, gets run
+        # again. A list rather than a set so the flush enqueues them in the
+        # order they were queued, which is the order they will be patched in.
         self._awaitingEnqueue: list[int] = []
         # id(entry) of whichever entry's widget currently occupies
         # showContainer, or None if it's empty. No action nests log_action
@@ -107,16 +110,20 @@ class CellPanel(Qt.QWidget):
         self._orchestrator = orchestrator
         orchestrator.sigCurrentCell.connect(self._onCurrentCell)
         orchestrator.sigCellFinished.connect(self._onCellFinished)
-        # Cells seeded before a protocol was loaded (self._orchestrator was
-        # None) were held here without being enqueued; flush exactly those into
-        # the newly bound orchestrator now, exactly once each, so a freshly
-        # loaded protocol runs over any cells the operator already seeded.
-        # Deliberately not every cell in self._cells: that dict also holds cells
-        # this panel only ever learned about from an orchestrator's
-        # announcements (a survey producer's finds, and cells that have already
-        # finished), and enqueuing those here would patch a finished cell a
-        # second time -- or, after a "New slice", drive a pipette to a
-        # coordinate in tissue the operator has declared gone.
+        # _awaitingEnqueue now holds every cell still owed an enqueue: one
+        # seeded before any orchestrator was bound, or one salvaged, just
+        # above (this method's own call to unbindOrchestrator(), when this is
+        # a rebind), from the outgoing orchestrator's queue before that queue
+        # went away with it. Flush exactly those into the newly bound
+        # orchestrator now, exactly once each, so a freshly loaded protocol
+        # runs over any cell the operator already seeded, whichever of the
+        # two ways it ended up unqueued. Deliberately not every cell in
+        # self._cells: that dict also holds cells this panel only ever
+        # learned about from an orchestrator's announcements (a survey
+        # producer's finds, and cells that have already finished), and
+        # enqueuing those here would patch a finished cell a second time --
+        # or, after a "New slice", drive a pipette to a coordinate in tissue
+        # the operator has declared gone.
         pending, self._awaitingEnqueue = self._awaitingEnqueue, []
         for cellId in pending:
             orchestrator.enqueue(self._cells[cellId])
@@ -130,6 +137,23 @@ class CellPanel(Qt.QWidget):
         panel<->orchestrator signal wiring the same way -- leaving no dangling
         Qt connection either way.
 
+        Also salvages whatever is still sitting in the outgoing orchestrator's
+        queue into _awaitingEnqueue before letting go of it. Autopatch.
+        _onProtocolLoaded replaces the whole Orchestrator -- deque included --
+        when the operator switches to a different protocol, so a cell that
+        was enqueued straight into it (by _enqueueAndAdd, while it was bound,
+        or by a survey producer refilling the queue) and never popped for a
+        run would otherwise simply vanish along with it, while its row stays
+        on screen in Area 5. A cell already popped off the queue -- running,
+        finished, or skipped -- is not in pendingCells() any more, so this
+        can never resurrect one of those; that is the same distinction
+        addCell()'s other callers already rely on to keep a finished or
+        discarded cell out of this list. A pending cell this panel has not
+        seen before (a survey producer's find, still waiting its turn behind
+        whatever is running) gets its row and bookkeeping from addCell()
+        here, the same way an announced one gets it, so the id recorded below
+        always resolves against self._cells later.
+
         Note this does NOT touch onLogAction/sigActionEntry: that path is wired
         through the context factory (ExecutionContext.on_log_action, cell-bound
         per make_context_factory), not through an Orchestrator signal
@@ -137,6 +161,10 @@ class CellPanel(Qt.QWidget):
         """
         if self._orchestrator is None:
             return
+        for cell in self._orchestrator.pendingCells():
+            if id(cell) not in self._cells:
+                self.addCell(cell)
+            self._awaitingEnqueue.append(id(cell))
         Qt.disconnect(self._orchestrator.sigCurrentCell, self._onCurrentCell)
         Qt.disconnect(self._orchestrator.sigCellFinished, self._onCellFinished)
         self._orchestrator = None
@@ -197,9 +225,11 @@ class CellPanel(Qt.QWidget):
         # cell into it immediately; if not, record it as awaiting an enqueue so
         # bindOrchestrator() flushes it into whichever orchestrator it later
         # binds. Exactly one of the two happens per seeded cell, so this never
-        # double-enqueues -- and this is the only place _awaitingEnqueue grows,
-        # which is what keeps that flush to cells the operator seeded rather
-        # than every cell this panel has a row for.
+        # double-enqueues. unbindOrchestrator() is the other place
+        # _awaitingEnqueue grows, but only with cells it reads back out of an
+        # outgoing orchestrator's own queue -- never with a cell this panel
+        # merely has a row for -- so that flush still lands on cells actually
+        # owed a run rather than every cell this panel knows about.
         if self._orchestrator is not None:
             self._orchestrator.enqueue(cell)
         else:

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -127,11 +127,14 @@ class CellPanel(Qt.QWidget):
 
         Cell is a QObject; self._cells is the only strong Python reference
         keeping a seeded-but-not-yet-garbage-collected Cell alive once its own
-        run finishes (see addCell()), and Cell instances are parented to this
-        panel (also set in addCell()) so Qt's ownership cascade destroys them
-        deterministically when the window closes. This clears the Python-side
-        bookkeeping (and any per-cell signal connections a future change might
-        add) to match -- nothing here should still reference a Cell afterward.
+        run finishes (see addCell()). Most Cell instances are also parented to
+        this panel (also set in addCell()) so Qt's ownership cascade destroys
+        them deterministically when the window closes -- except a cell built
+        on the orchestrator's worker thread, which addCell() cannot parent
+        (see its comment), and for which self._cells is the only thing keeping
+        it alive at all. This clears the Python-side bookkeeping (and any
+        per-cell signal connections a future change might add) to match --
+        nothing here should still reference a Cell afterward.
         """
         self._cells.clear()
         self._rows.clear()
@@ -178,10 +181,22 @@ class CellPanel(Qt.QWidget):
         # Cell is a QObject; parenting it to this panel (itself parented into
         # the window's widget tree) lets Qt's ownership cascade destroy it
         # deterministically when the window closes, rather than relying solely
-        # on Python holding the last reference (see self._cells below). Guarded
-        # with getattr since tests stand in a plain object() for a cell.
+        # on Python holding the last reference (see self._cells below) -- but
+        # only for a cell that already lives on this (the GUI) thread. Qt
+        # refuses setParent() across threads outright (a stderr warning, not
+        # an exception, and moveToThread() is not the fix: Qt only allows that
+        # call from the thread an object currently lives on, so calling it
+        # from here would warn just the same). A cell a survey producer builds
+        # on the orchestrator's worker thread (tile_detector.py's _newCell,
+        # called from Orchestrator._refillQueue) arrives here still on that
+        # thread, so it is never parented; the strong reference this panel
+        # keeps in self._cells below is what keeps it alive instead, for as
+        # long as this panel exists, and clearCells() is what drops that
+        # reference at window teardown. Guarded with getattr since tests stand
+        # in a plain object() for a cell.
         setParent = getattr(cell, "setParent", None)
-        if setParent is not None:
+        thread = getattr(cell, "thread", None)
+        if setParent is not None and (thread is None or thread() is self.thread()):
             setParent(self)
         item = Qt.QListWidgetItem(f"cell {id(cell)} — queued")
         item.setData(Qt.Qt.UserRole, cell)
@@ -221,8 +236,11 @@ class CellPanel(Qt.QWidget):
             # seeded it (e.g. found by a survey producer inside
             # Orchestrator._refillQueue) is already enqueued -- addCell() here
             # only creates the row and the panel-side bookkeeping addCell()
-            # always sets up (timeline/log stores, the parenting, and the
-            # strong self._cells reference); it must never also call
+            # always sets up (timeline/log stores and the strong self._cells
+            # reference; the parenting too, except such a cell was built on
+            # the orchestrator's worker thread, so addCell() leaves it
+            # unparented and self._cells is what keeps it alive instead -- see
+            # addCell()'s own comment); it must never also call
             # orchestrator.enqueue(), which would run the same cell twice.
             self.addCell(cell)
             item = self._rows[id(cell)]

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -216,8 +216,17 @@ class CellPanel(Qt.QWidget):
         if cell is None:
             return
         item = self._rows.get(id(cell))
-        if item is not None:
-            item.setText(f"cell {id(cell)} — running")
+        if item is None:
+            # A cell the orchestrator announces without this panel ever having
+            # seeded it (e.g. found by a survey producer inside
+            # Orchestrator._refillQueue) is already enqueued -- addCell() here
+            # only creates the row and the panel-side bookkeeping addCell()
+            # always sets up (timeline/log stores, the parenting, and the
+            # strong self._cells reference); it must never also call
+            # orchestrator.enqueue(), which would run the same cell twice.
+            self.addCell(cell)
+            item = self._rows[id(cell)]
+        item.setText(f"cell {id(cell)} — running")
 
     def onLogAction(self, cell, entry) -> None:
         """ExecutionContext.on_log_action, cell-bound by the context factory
@@ -302,9 +311,16 @@ class CellPanel(Qt.QWidget):
                 child.widget().setParent(None)
 
     def _onCellFinished(self, cell, status: str) -> None:
+        # A cell can finish (e.g. the "skipped" outcome in
+        # Orchestrator._processCell) without sigCurrentCell ever having fired
+        # for it, so this cannot assume _onCurrentCell already gave it a row --
+        # same reasoning as _onCurrentCell above: add one via addCell() only,
+        # never re-enqueue.
         item = self._rows.get(id(cell))
-        if item is not None:
-            item.setText(f"cell {id(cell)} — {status}")
+        if item is None:
+            self.addCell(cell)
+            item = self._rows[id(cell)]
+        item.setText(f"cell {id(cell)} — {status}")
 
     def _onCellSelectionChanged(self, current, _previous) -> None:
         self.timelineList.clear()

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -105,6 +105,16 @@ class CellPanel(Qt.QWidget):
         self.sigActionEntry.connect(self._onActionEntry)
 
     def bindOrchestrator(self, orchestrator) -> None:
+        if orchestrator is self._orchestrator:
+            # unbindOrchestrator() salvages the outgoing orchestrator's pending
+            # cells into _awaitingEnqueue but leaves its queue exactly as it
+            # was -- there is nothing to clear it for on the replace-the-whole-
+            # Orchestrator path this normally serves. Binding to the very
+            # orchestrator already held would flush those same still-queued
+            # cells into it a second time, so there is nothing to do: it is
+            # already bound to exactly this orchestrator, with its queue
+            # exactly as it was.
+            return
         if self._orchestrator is not None:
             self.unbindOrchestrator()
         self._orchestrator = orchestrator

--- a/acq4/modules/Autopatch/search_panel.py
+++ b/acq4/modules/Autopatch/search_panel.py
@@ -8,6 +8,14 @@ import pyqtgraph as pg
 from acq4.experiment.slice import SearchConstraints
 from acq4.util import Qt
 
+# max_cell_density is stored in SI (cells per cubic metre), but a field of
+# view is on the order of a few cubic micrometres to nanolitres, not cubic
+# metres, so a raw SI density reads as an unreasoned power of ten. 1 nL is
+# 1e-12 m^3, so multiplying a cells/nL value by this factor gives cells/m^3;
+# a typical 200x200x40 um z-stack is ~1.6 nL, so a handful of cells/nL is
+# already a crowded field of view.
+_CELLS_PER_NL_TO_M3 = 1e12
+
 
 class SearchPanel(Qt.QWidget):
     """The four Area 2 search constraints, a region-seeding button, and a readout.
@@ -65,11 +73,10 @@ class SearchPanel(Qt.QWidget):
             step=0.05,
         )
         self.maxDensitySpin = self._makeSpin(
-            defaults.max_cell_density,
-            bounds=(1.0, 1e18),
-            step=1e12,
-            suffix="/m³",
-            siPrefix=True,
+            defaults.max_cell_density / _CELLS_PER_NL_TO_M3,
+            bounds=(1.0 / _CELLS_PER_NL_TO_M3, 1e18 / _CELLS_PER_NL_TO_M3),
+            step=1e12 / _CELLS_PER_NL_TO_M3,
+            suffix="cells/nL",
         )
         self.rescansCheck = Qt.QCheckBox("Rescans allowed")
         self.rescansCheck.setChecked(defaults.rescans_allowed)
@@ -113,10 +120,12 @@ class SearchPanel(Qt.QWidget):
         quantities.
 
         `siPrefix` is what makes a depth read "-20 µm" instead of
-        "-0.0000200 m" and a density "5 T/m³" instead of "5000000000000 /m³";
-        `value()` still returns plain metres and plain cells per cubic metre, so
-        the constraints built from these controls are unaffected by how they
-        render.
+        "-0.0000200 m"; `value()` still returns plain metres, so the
+        constraints built from these controls are unaffected by how they
+        render. The density spin box instead takes a plain `suffix` with no
+        `siPrefix`: its value is already a human-scaled cells/nL number, and
+        reprefixing a number like 5 would only reintroduce the unreadable
+        SI-scale display this is meant to avoid.
         """
         return pg.SpinBox(
             value=value, bounds=bounds, step=step, suffix=suffix, siPrefix=siPrefix
@@ -133,7 +142,7 @@ class SearchPanel(Qt.QWidget):
             constraints = SearchConstraints(
                 depth_range=(self.nearDepthSpin.value(), self.farDepthSpin.value()),
                 min_health=self.minHealthSpin.value(),
-                max_cell_density=self.maxDensitySpin.value(),
+                max_cell_density=self.maxDensitySpin.value() * _CELLS_PER_NL_TO_M3,
                 rescans_allowed=self.rescansCheck.isChecked(),
             )
         except ValueError as exc:

--- a/acq4/modules/Autopatch/search_panel.py
+++ b/acq4/modules/Autopatch/search_panel.py
@@ -21,9 +21,8 @@ class SearchPanel(Qt.QWidget):
     sigConstraintsChanged = Qt.Signal(object)  # SearchConstraints, or None if invalid
     sigAddRegionRequested = Qt.Signal()
 
-    def __init__(self, cameraGetter=None):
+    def __init__(self):
         super().__init__()
-        self._cameraGetter = cameraGetter or (lambda: None)
         defaults = SearchConstraints()
 
         # Depths are offsets from the tissue surface, negative being deeper, so

--- a/acq4/modules/Autopatch/search_panel.py
+++ b/acq4/modules/Autopatch/search_panel.py
@@ -1,0 +1,155 @@
+"""SearchPanel: Area 2's cell-finding config -- the search constraints that
+parameterise a cell producer, plus region seeding and a survey progress readout."""
+
+from __future__ import annotations
+
+from acq4.experiment.slice import SearchConstraints
+from acq4.util import Qt
+
+
+class SearchPanel(Qt.QWidget):
+    """The four Area 2 search constraints, a region-seeding button, and a readout.
+
+    Emits `sigConstraintsChanged` with a fresh SearchConstraints on every edit,
+    or with None when the widget values do not describe a valid search (an
+    operator dragging a spinbox passes through invalid intermediate values, and
+    that must not raise on the GUI thread). Region *graphics* are not this
+    panel's job: it asks its owner to seed a region and shows how much of the
+    result has been surveyed.
+    """
+
+    sigConstraintsChanged = Qt.Signal(object)  # SearchConstraints, or None if invalid
+    sigAddRegionRequested = Qt.Signal()
+
+    def __init__(self, cameraGetter=None):
+        super().__init__()
+        self._cameraGetter = cameraGetter or (lambda: None)
+        defaults = SearchConstraints()
+
+        # Depths are offsets from the tissue surface, negative being deeper, so
+        # the spin boxes read the way the design doc writes them (-20 um to
+        # -60 um) rather than as unsigned depths that get subtracted somewhere
+        # else.
+        self.nearDepthSpin = self._makeSpin(
+            defaults.depth_range[0],
+            minimum=-1e-3,
+            maximum=0.0,
+            step=5e-6,
+            suffix="m",
+            decimals=7,
+        )
+        self.farDepthSpin = self._makeSpin(
+            defaults.depth_range[1],
+            minimum=-1e-3,
+            maximum=0.0,
+            step=5e-6,
+            suffix="m",
+            decimals=7,
+        )
+        self.minHealthSpin = self._makeSpin(
+            defaults.min_health,
+            minimum=0.0,
+            maximum=1.0,
+            step=0.05,
+            suffix="",
+            decimals=2,
+        )
+        self.maxDensitySpin = self._makeSpin(
+            defaults.max_cell_density,
+            minimum=1.0,
+            maximum=1e18,
+            step=1e12,
+            suffix="/m³",
+            decimals=0,
+        )
+        self.rescansCheck = Qt.QCheckBox("Rescans allowed")
+        self.rescansCheck.setChecked(defaults.rescans_allowed)
+
+        self.addRegionBtn = Qt.QPushButton("Add region here")
+        self.addRegionBtn.setToolTip(
+            "Add a search region covering roughly 3x3 fields of view around the "
+            "camera's current center."
+        )
+        self.surveyLabel = Qt.QLabel("no region")
+        self.errorLabel = Qt.QLabel("")
+        self.errorLabel.setStyleSheet("color: red;")
+
+        form = Qt.QFormLayout()
+        form.addRow("Depth from surface, near", self.nearDepthSpin)
+        form.addRow("Depth from surface, far", self.farDepthSpin)
+        form.addRow("Minimum health", self.minHealthSpin)
+        form.addRow("Maximum cell density", self.maxDensitySpin)
+
+        layout = Qt.QVBoxLayout()
+        layout.addLayout(form)
+        layout.addWidget(self.rescansCheck)
+        layout.addWidget(self.addRegionBtn)
+        layout.addWidget(self.surveyLabel)
+        layout.addWidget(self.errorLabel)
+        self.setLayout(layout)
+
+        for spin in (
+            self.nearDepthSpin,
+            self.farDepthSpin,
+            self.minHealthSpin,
+            self.maxDensitySpin,
+        ):
+            spin.valueChanged.connect(self._onEdited)
+        self.rescansCheck.toggled.connect(self._onEdited)
+        self.addRegionBtn.clicked.connect(self.sigAddRegionRequested)
+
+    @staticmethod
+    def _makeSpin(value, minimum, maximum, step, suffix, decimals):
+        spin = Qt.QDoubleSpinBox()
+        spin.setDecimals(decimals)
+        spin.setRange(minimum, maximum)
+        spin.setSingleStep(step)
+        if suffix:
+            spin.setSuffix(f" {suffix}")
+        spin.setValue(value)
+        return spin
+
+    def constraints(self) -> SearchConstraints | None:
+        """The current widget values as constraints, or None if they are invalid.
+
+        Returning None rather than raising is what lets an operator drag a
+        spinbox through an invalid intermediate value without a traceback on
+        the GUI thread; the reason lands in errorLabel instead.
+        """
+        try:
+            constraints = SearchConstraints(
+                depth_range=(self.nearDepthSpin.value(), self.farDepthSpin.value()),
+                min_health=self.minHealthSpin.value(),
+                max_cell_density=self.maxDensitySpin.value(),
+                rescans_allowed=self.rescansCheck.isChecked(),
+            )
+        except ValueError as exc:
+            self.errorLabel.setText(str(exc))
+            return None
+        self.errorLabel.setText("")
+        return constraints
+
+    def _onEdited(self, *_args) -> None:
+        self.sigConstraintsChanged.emit(self.constraints())
+
+    def setSurveyStats(self, total: int, covered: int, percent: float) -> None:
+        if total == 0:
+            self.surveyLabel.setText("no region")
+            return
+        self.surveyLabel.setText(f"{covered}/{total} tiles imaged ({percent:.0f}%)")
+
+    def setInteractionLocked(self, locked: bool) -> None:
+        """Disable editing while a run is in flight; the readout stays visible.
+
+        The constraints parameterise a producer that is already surveying, so
+        editing them mid-run would silently change the search under it.
+        """
+        for w in (
+            self.nearDepthSpin,
+            self.farDepthSpin,
+            self.minHealthSpin,
+            self.maxDensitySpin,
+            self.rescansCheck,
+            self.addRegionBtn,
+        ):
+            w.setEnabled(not locked)

--- a/acq4/modules/Autopatch/search_panel.py
+++ b/acq4/modules/Autopatch/search_panel.py
@@ -3,6 +3,8 @@ parameterise a cell producer, plus region seeding and a survey progress readout.
 
 from __future__ import annotations
 
+import pyqtgraph as pg
+
 from acq4.experiment.slice import SearchConstraints
 from acq4.util import Qt
 
@@ -24,42 +26,50 @@ class SearchPanel(Qt.QWidget):
     def __init__(self):
         super().__init__()
         defaults = SearchConstraints()
+        # The two independent things errorLabel can be showing, kept apart so
+        # neither silently erases the other. The constraint message describes
+        # the spin box values themselves and is rewritten (or cleared) by every
+        # call to constraints(); the external one is a condition only this
+        # panel's owner can see -- no camera selected, say -- and stays true
+        # regardless of what the operator types here, so an edit must not wipe
+        # it. See _showError for which wins.
+        self._constraintError = ""
+        self._externalError = ""
 
         # Depths are offsets from the tissue surface, negative being deeper, so
         # the spin boxes read the way the design doc writes them (-20 um to
         # -60 um) rather than as unsigned depths that get subtracted somewhere
-        # else.
+        # else. The bounds keep that sign on the widget itself: a positive
+        # offset would search the bath above the tissue, and SearchConstraints
+        # rejects it, but a control that cannot be dragged there at all is
+        # better than an error message after the fact.
         self.nearDepthSpin = self._makeSpin(
             defaults.depth_range[0],
-            minimum=-1e-3,
-            maximum=0.0,
+            bounds=(-1e-3, 0.0),
             step=5e-6,
             suffix="m",
-            decimals=7,
+            siPrefix=True,
         )
         self.farDepthSpin = self._makeSpin(
             defaults.depth_range[1],
-            minimum=-1e-3,
-            maximum=0.0,
+            bounds=(-1e-3, 0.0),
             step=5e-6,
             suffix="m",
-            decimals=7,
+            siPrefix=True,
         )
+        # A probability, not a physical quantity: no unit to prefix, so this one
+        # takes the same widget purely for consistent look and stepping.
         self.minHealthSpin = self._makeSpin(
             defaults.min_health,
-            minimum=0.0,
-            maximum=1.0,
+            bounds=(0.0, 1.0),
             step=0.05,
-            suffix="",
-            decimals=2,
         )
         self.maxDensitySpin = self._makeSpin(
             defaults.max_cell_density,
-            minimum=1.0,
-            maximum=1e18,
+            bounds=(1.0, 1e18),
             step=1e12,
             suffix="/m³",
-            decimals=0,
+            siPrefix=True,
         )
         self.rescansCheck = Qt.QCheckBox("Rescans allowed")
         self.rescansCheck.setChecked(defaults.rescans_allowed)
@@ -98,15 +108,19 @@ class SearchPanel(Qt.QWidget):
         self.addRegionBtn.clicked.connect(self.sigAddRegionRequested)
 
     @staticmethod
-    def _makeSpin(value, minimum, maximum, step, suffix, decimals):
-        spin = Qt.QDoubleSpinBox()
-        spin.setDecimals(decimals)
-        spin.setRange(minimum, maximum)
-        spin.setSingleStep(step)
-        if suffix:
-            spin.setSuffix(f" {suffix}")
-        spin.setValue(value)
-        return spin
+    def _makeSpin(value, bounds, step, suffix="", siPrefix=False):
+        """A pyqtgraph SpinBox, the spin box the rest of acq4 uses for these
+        quantities.
+
+        `siPrefix` is what makes a depth read "-20 µm" instead of
+        "-0.0000200 m" and a density "5 T/m³" instead of "5000000000000 /m³";
+        `value()` still returns plain metres and plain cells per cubic metre, so
+        the constraints built from these controls are unaffected by how they
+        render.
+        """
+        return pg.SpinBox(
+            value=value, bounds=bounds, step=step, suffix=suffix, siPrefix=siPrefix
+        )
 
     def constraints(self) -> SearchConstraints | None:
         """The current widget values as constraints, or None if they are invalid.
@@ -123,10 +137,34 @@ class SearchPanel(Qt.QWidget):
                 rescans_allowed=self.rescansCheck.isChecked(),
             )
         except ValueError as exc:
-            self.errorLabel.setText(str(exc))
+            self._constraintError = str(exc)
+            self._showError()
             return None
-        self.errorLabel.setText("")
+        self._constraintError = ""
+        self._showError()
         return constraints
+
+    def setError(self, message: str) -> None:
+        """Show a message from this panel's owner on the panel's error line.
+
+        For conditions the panel cannot see for itself -- no camera selected,
+        say -- so the operator reads them where they already read constraint
+        errors, instead of the owner writing into errorLabel behind the panel's
+        back and having the next constraint edit clear it. An empty message
+        retracts it.
+        """
+        self._externalError = message
+        self._showError()
+
+    def _showError(self) -> None:
+        """Render whichever error is current, the constraint one first.
+
+        A constraint error is about the control the operator is touching right
+        now, so it takes the line while it lasts; the owner's message is still
+        held and comes back once the values are valid again, because whatever it
+        reported (no camera, say) is not something editing a spin box fixes.
+        """
+        self.errorLabel.setText(self._constraintError or self._externalError)
 
     def _onEdited(self, *_args) -> None:
         self.sigConstraintsChanged.emit(self.constraints())

--- a/acq4/modules/Autopatch/status_panel.py
+++ b/acq4/modules/Autopatch/status_panel.py
@@ -88,7 +88,7 @@ class StatusPanel(Qt.QWidget):
         # the same as "waiting" so Start is enabled and Stop/Pause/Next are not.
         self._currentStatus = None
         self.startBtn.clicked.connect(self._onStartClicked)
-        self.stopBtn.clicked.connect(orchestrator.stop)
+        self.stopBtn.clicked.connect(self._onStopClicked)
         self.pauseBtn.clicked.connect(self._onPauseClicked)
         self.nextBtn.clicked.connect(orchestrator.requestNextCell)
         orchestrator.sigStatus.connect(self._onStatus)
@@ -108,7 +108,7 @@ class StatusPanel(Qt.QWidget):
         if self._orchestrator is None:
             return
         Qt.disconnect(self.startBtn.clicked, self._onStartClicked)
-        Qt.disconnect(self.stopBtn.clicked, self._orchestrator.stop)
+        Qt.disconnect(self.stopBtn.clicked, self._onStopClicked)
         Qt.disconnect(self.pauseBtn.clicked, self._onPauseClicked)
         Qt.disconnect(self.nextBtn.clicked, self._orchestrator.requestNextCell)
         Qt.disconnect(self._orchestrator.sigStatus, self._onStatus)
@@ -125,6 +125,13 @@ class StatusPanel(Qt.QWidget):
         if self._onStart is not None:
             self._onStart()
         self._orchestrator.start()
+
+    def _onStopClicked(self) -> None:
+        # Qt's clicked signal carries a `checked` bool; connecting it straight
+        # to orchestrator.stop would pass that bool through as `reason`, so the
+        # run log would show "stopped by operator" as `False` rather than an
+        # actual reason. This wrapper drops the bool and supplies a real one.
+        self._orchestrator.stop("stopped by operator")
 
     def _onPauseClicked(self) -> None:
         # Toggle: Pause while running, Resume while paused -- see _updateButtons()

--- a/acq4/modules/Autopatch/status_panel.py
+++ b/acq4/modules/Autopatch/status_panel.py
@@ -15,6 +15,13 @@ class StatusPanel(Qt.QWidget):
     # are already careful to avoid.
     sigInteractionLocked = Qt.Signal(bool)
 
+    # The bound orchestrator's status, re-emitted for panels that need it but
+    # must not connect to the orchestrator themselves. The orchestrator is a
+    # parentless QObject, so a connection from it to the window would give it a
+    # reference back and rebuild the cycle bindOrchestrator/unbindOrchestrator
+    # exist to avoid -- the same reason sigInteractionLocked is routed this way.
+    sigStatusChanged = Qt.Signal(str)
+
     def __init__(self):
         super().__init__()
         self._orchestrator = None
@@ -132,7 +139,8 @@ class StatusPanel(Qt.QWidget):
         self.instructionLabel.setVisible(status == "error")
         self._currentStatus = status
         self._updateButtons()
-        self.sigInteractionLocked.emit(status in ("running", "paused"))
+        self.sigInteractionLocked.emit(status in ("running", "surveying", "paused"))
+        self.sigStatusChanged.emit(status)
 
     def _onCurrentCell(self, cell) -> None:
         # sigCurrentCell(None) fires once the orchestrator's queue drains (see
@@ -156,8 +164,11 @@ class StatusPanel(Qt.QWidget):
 
         No protocol bound: everything disabled. Otherwise: "waiting" (or no
         status yet, i.e. freshly bound and not yet started) enables only
-        Start; "running" enables Stop/Pause/Next; "paused" enables Stop/Pause
-        (relabeled "Resume") but not Next; "error" enables only Stop.
+        Start; "running" enables Stop/Pause/Next; "surveying" enables
+        Stop/Pause but not Next, since a next-cell request during a refill is
+        discarded (nothing is running and nothing is queued to advance past);
+        "paused" enables Stop/Pause (relabeled "Resume") but not Next;
+        "error" enables only Stop.
         """
         hasProtocol = self._orchestrator is not None
         status = self._currentStatus
@@ -167,6 +178,8 @@ class StatusPanel(Qt.QWidget):
             start, stop, pause, next_ = True, False, False, False
         elif status == "running":
             start, stop, pause, next_ = False, True, True, True
+        elif status == "surveying":
+            start, stop, pause, next_ = False, True, True, False
         elif status == "paused":
             start, stop, pause, next_ = False, True, True, False
         elif status == "error":

--- a/acq4/modules/Autopatch/tests/test_cell_panel.py
+++ b/acq4/modules/Autopatch/tests/test_cell_panel.py
@@ -218,6 +218,120 @@ def test_rebinding_disconnects_previous_orchestrators_signals(qapp):
     assert panel.cellList.item(0).text() == f"cell {id(cell)} — queued"
 
 
+def test_current_cell_for_an_unseeded_cell_gets_exactly_one_running_row(qapp):
+    """A cell the orchestrator announces via sigCurrentCell without ever having
+    been seeded through addFromTargetBtn/scatterFakeCellsBtn (i.e. a cell a
+    survey producer found and enqueued directly inside the orchestrator) must
+    still get a row -- and that row must read "running", not "queued", since
+    sigCurrentCell only ever fires for a cell about to run."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch)
+    cell = object()
+
+    orch.sigCurrentCell.emit(cell)
+
+    assert panel.cellList.count() == 1
+    assert panel.cellList.item(0).text() == f"cell {id(cell)} — running"
+
+
+def test_cell_finished_for_an_unseeded_cell_gets_a_row_with_its_status(qapp):
+    """A cell can finish (e.g. Orchestrator's "skipped" outcome) without
+    sigCurrentCell ever having fired for it, so _onCellFinished must add a row
+    on its own rather than assuming _onCurrentCell already did."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch)
+    cell = object()
+
+    orch.sigCellFinished.emit(cell, "skipped")
+
+    assert panel.cellList.count() == 1
+    assert "skipped" in panel.cellList.item(0).text()
+
+
+def test_current_cell_announced_twice_produces_exactly_one_row(qapp):
+    """A retrying cell (or one simply re-announced as current) must not gain a
+    second row -- self._rows is how _onCurrentCell tells it already has one."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch)
+    cell = object()
+
+    orch.sigCurrentCell.emit(cell)
+    orch.sigCurrentCell.emit(cell)
+
+    assert panel.cellList.count() == 1
+    assert panel.cellList.item(0).text() == f"cell {id(cell)} — running"
+
+
+def test_seeded_cell_announced_as_current_does_not_duplicate_its_row(qapp):
+    """A cell already seeded by hand (and so already holding a row from
+    addCell()) must not get a second row when the orchestrator later announces
+    it as current -- only its existing row's text should change."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    pip = _FakePipette((0, 0, 0))
+    panel = CellPanel(pipetteGetter=lambda: pip)
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch)
+    panel.addFromTargetBtn.click()
+    cell = orch.enqueued[0]
+    assert panel.cellList.count() == 1
+
+    orch.sigCurrentCell.emit(cell)
+
+    assert panel.cellList.count() == 1
+    assert panel.cellList.item(0).text() == f"cell {id(cell)} — running"
+
+
+def test_announced_cell_is_not_enqueued_into_the_bound_orchestrator(qapp):
+    """A cell the panel only learns about via sigCurrentCell/sigCellFinished is
+    already queued or running inside the orchestrator -- adding a display row
+    for it must never also call orchestrator.enqueue(), which would patch the
+    same cell a second time."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch)
+    cell = object()
+
+    orch.sigCurrentCell.emit(cell)
+    orch.sigCellFinished.emit(cell, "done")
+
+    assert orch.enqueued == []
+
+
+def test_announced_cell_row_is_selectable_with_a_usable_timeline_and_log(qapp):
+    """The whole point of giving an announced cell a row is that the operator
+    can select it and see its timeline/log -- prove the row is genuinely
+    usable (not just present) by selecting it and exercising the
+    setdefault-based log/timeline paths against it."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch)
+    cell = object()
+
+    orch.sigCurrentCell.emit(cell)
+    panel.cellList.setCurrentRow(0)
+
+    assert panel.cellList.currentItem().data(Qt.Qt.UserRole) is cell
+    assert id(cell) in panel._timelines
+    assert id(cell) in panel._logs
+
+    panel.appendLog(cell, "hello from a surveyed cell")
+    assert "hello from a surveyed cell" in panel.logView.toPlainText()
+
+
 def test_clear_cells_resets_shown_entry_id_and_clears_show_container(qapp):
     """clearCells() is also CellPanel's rebind path (a freshly loaded protocol
     calls it before binding the new orchestrator, with the panel itself still

--- a/acq4/modules/Autopatch/tests/test_cell_panel.py
+++ b/acq4/modules/Autopatch/tests/test_cell_panel.py
@@ -1,5 +1,9 @@
 """Tests for CellPanel: a manually-seeded cell queue (via "Add from target" and
 "Scatter fake cells") kept in sync with the Orchestrator's per-cell signals."""
+import gc
+import threading
+import weakref
+
 import numpy as np
 import pytest
 
@@ -45,6 +49,25 @@ class _FakeCamera:
 
     def globalCenterPosition(self):
         return self._center
+
+
+class _FakeQObjectCell(Qt.QObject):
+    """Stands in for a real Cell (also a QObject): built on a worker thread the
+    way tile_detector.py's _newCell constructs one from
+    Orchestrator._refillQueue, so it does not live on the GUI thread
+    addCell() runs on."""
+
+
+def _buildOnAnotherThread(factory):
+    result = {}
+
+    def build():
+        result["obj"] = factory()
+
+    t = threading.Thread(target=build)
+    t.start()
+    t.join()
+    return result["obj"]
 
 
 def test_add_from_target_enqueues_and_lists(qapp):
@@ -356,3 +379,69 @@ def test_clear_cells_resets_shown_entry_id_and_clears_show_container(qapp):
 
     assert panel._shownEntryId is None
     assert panel.showContainer.layout().count() == 0
+
+
+def test_current_cell_built_on_another_thread_gets_a_row_without_a_qt_warning(qapp):
+    """A cell a survey producer finds runs through tile_detector.py's _newCell
+    on the orchestrator's worker thread, so by the time sigCurrentCell carries
+    it here (on the GUI thread), it is a QObject that does not live on this
+    thread. Qt refuses setParent() across threads -- a stderr warning, not an
+    exception -- so addCell() must recognize this case and skip the parenting
+    rather than let that warning through; self._cells is what keeps such a
+    cell alive instead, for as long as this panel exists."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch)
+    cell = _buildOnAnotherThread(_FakeQObjectCell)
+    assert cell.thread() is not panel.thread()
+
+    messages = []
+    Qt.qInstallMessageHandler(
+        lambda msgType, context, message: messages.append(message)
+    )
+    try:
+        orch.sigCurrentCell.emit(cell)
+    finally:
+        Qt.qInstallMessageHandler(None)
+
+    assert messages == [], f"unexpected Qt warning(s): {messages}"
+    assert panel.cellList.count() == 1
+    assert panel.cellList.item(0).text() == f"cell {id(cell)} — running"
+    assert cell.parent() is None
+
+
+def test_current_cell_built_on_another_thread_is_still_freed_by_refcounting(qapp):
+    """Since a cross-thread cell is never parented (see the test above),
+    self._cells -- not Qt's ownership cascade -- must be what keeps it alive;
+    prove that reference is also what lets it go, the same way
+    tests/test_teardown.py proves for the same-thread case."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch)
+    cell = _buildOnAnotherThread(_FakeQObjectCell)
+
+    gc.disable()
+    try:
+        orch.sigCurrentCell.emit(cell)
+        assert panel.cellList.count() == 1
+
+        panel_ref = weakref.ref(panel)
+        cell_ref = weakref.ref(cell)
+
+        panel.clearCells()
+        assert panel._cells == {}
+
+        del cell, orch
+        del panel
+        # No gc.collect() below -- pure refcounting only, since gc is disabled.
+
+        assert (
+            cell_ref() is None
+        ), "cross-thread cell should be freed by refcounting alone"
+        assert panel_ref() is None, "panel should be freed by refcounting alone"
+    finally:
+        gc.enable()

--- a/acq4/modules/Autopatch/tests/test_cell_panel.py
+++ b/acq4/modules/Autopatch/tests/test_cell_panel.py
@@ -206,6 +206,131 @@ def test_bind_orchestrator_flushes_previously_held_cells_exactly_once(qapp):
     assert orch.enqueued.count(newCell) == 1
 
 
+def test_a_cell_known_only_from_an_announcement_is_not_flushed_into_a_later_orchestrator(
+    qapp,
+):
+    """bindOrchestrator()'s flush exists for cells the operator seeded before a
+    protocol was loaded. A cell this panel only ever learned about from an
+    orchestrator's announcements was never waiting to be enqueued -- it was
+    already queued somewhere else -- so binding a second orchestrator must not
+    hand it over. Both must hold at once: the announced cell is not flushed and
+    the genuinely-pending one still is, or "flush nothing" would pass this too.
+    """
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    pip = _FakePipette((1e-3, 2e-3, 3e-3))
+    panel = CellPanel(pipetteGetter=lambda: pip)
+
+    # Seeded with no orchestrator bound: this one is genuinely pending.
+    panel.addFromTargetBtn.click()
+    seededCell = list(panel._cells.values())[0]
+
+    first = _FakeOrchestrator()
+    panel.bindOrchestrator(first)
+    assert first.enqueued == [seededCell]
+
+    # And a cell the first orchestrator merely announces -- a survey producer's
+    # find, enqueued inside the orchestrator itself.
+    announced = object()
+    first.sigCurrentCell.emit(announced)
+    assert panel.cellList.count() == 2
+
+    second = _FakeOrchestrator()
+    panel.bindOrchestrator(second)
+
+    assert second.enqueued == [], "an announced cell was flushed into a rebind"
+
+
+def test_a_finished_cell_is_not_flushed_into_a_later_orchestrator(qapp):
+    """The "New slice" hazard, at panel level. newSlice() clears Area 5 and the
+    orchestrator's queue but deliberately leaves the in-flight cell running; it
+    finishes on the old tissue and is announced here. Loading a second protocol
+    must not then enqueue that coordinate into the new orchestrator -- the
+    operator has declared the tissue it names gone, and a pipette driven there
+    is driven into whatever is now under the objective.
+    """
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    first = _FakeOrchestrator()
+    panel.bindOrchestrator(first)
+    inFlight = object()
+    first.sigCurrentCell.emit(inFlight)
+
+    # The operator presses New slice: Area 5 and the queue are discarded while
+    # that cell keeps running.
+    panel.clearCells()
+    first.sigCellFinished.emit(inFlight, "done")
+
+    second = _FakeOrchestrator()
+    panel.bindOrchestrator(second)
+
+    assert second.enqueued == [], "a cell from discarded tissue was re-queued"
+
+
+def test_a_whole_survey_of_finished_cells_is_not_flushed_into_a_later_orchestrator(qapp):
+    """After a completed survey every produced cell has a row here. Loading a
+    second protocol must enqueue none of them: they have already been patched,
+    and running them again would patch each one a second time."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    first = _FakeOrchestrator()
+    panel.bindOrchestrator(first)
+
+    surveyed = [object() for _ in range(4)]
+    for cell in surveyed:
+        first.sigCurrentCell.emit(cell)
+        first.sigCellFinished.emit(cell, "done")
+    assert panel.cellList.count() == len(surveyed)
+
+    second = _FakeOrchestrator()
+    panel.bindOrchestrator(second)
+
+    assert second.enqueued == []
+    # The rows are still there -- the survey's record is not what gets dropped.
+    assert panel.cellList.count() == len(surveyed)
+
+
+def test_a_cell_seeded_while_bound_is_not_flushed_again_on_a_rebind(qapp):
+    """A cell seeded with an orchestrator already bound was enqueued into that
+    orchestrator there and then, so it is not awaiting an enqueue either; a
+    rebind must not treat it as one."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    pip = _FakePipette((1e-3, 2e-3, 3e-3))
+    panel = CellPanel(pipetteGetter=lambda: pip)
+    first = _FakeOrchestrator()
+    panel.bindOrchestrator(first)
+
+    panel.addFromTargetBtn.click()
+    assert len(first.enqueued) == 1
+
+    second = _FakeOrchestrator()
+    panel.bindOrchestrator(second)
+
+    assert second.enqueued == []
+
+
+def test_clear_cells_drops_the_pending_enqueue_bookkeeping(qapp):
+    """clearCells() is the "these coordinates are gone" path, so a cell seeded
+    before any orchestrator existed must not be flushed into one bound after
+    the clear."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    pip = _FakePipette((1e-3, 2e-3, 3e-3))
+    panel = CellPanel(pipetteGetter=lambda: pip)
+    panel.addFromTargetBtn.click()
+
+    panel.clearCells()
+    assert panel._awaitingEnqueue == []
+
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch)
+
+    assert orch.enqueued == []
+
+
 def test_cell_finished_updates_row(qapp):
     from acq4.modules.Autopatch.cell_panel import CellPanel
 

--- a/acq4/modules/Autopatch/tests/test_cell_panel.py
+++ b/acq4/modules/Autopatch/tests/test_cell_panel.py
@@ -26,6 +26,12 @@ class _FakeOrchestrator(Qt.QObject):
     def enqueue(self, cell):
         self.enqueued.append(cell)
 
+    def pendingCells(self):
+        """Stands in for Orchestrator.pendingCells(): this fake has no run
+        loop to pop a cell off, so every cell .enqueue() has ever seen is
+        still pending as far as a test using it is concerned."""
+        return list(self.enqueued)
+
 
 class _FakePipette:
     """Stands in for a PatchPipette: exposes .pipetteDevice.targetPosition()
@@ -209,12 +215,14 @@ def test_bind_orchestrator_flushes_previously_held_cells_exactly_once(qapp):
 def test_a_cell_known_only_from_an_announcement_is_not_flushed_into_a_later_orchestrator(
     qapp,
 ):
-    """bindOrchestrator()'s flush exists for cells the operator seeded before a
-    protocol was loaded. A cell this panel only ever learned about from an
-    orchestrator's announcements was never waiting to be enqueued -- it was
-    already queued somewhere else -- so binding a second orchestrator must not
-    hand it over. Both must hold at once: the announced cell is not flushed and
-    the genuinely-pending one still is, or "flush nothing" would pass this too.
+    """A cell this panel only ever learned about from an orchestrator's
+    announcements is already queued or already finished somewhere else, so
+    binding a second orchestrator must not hand it over -- unlike a cell that
+    is genuinely still sitting unrun in the outgoing orchestrator's own queue,
+    which unbindOrchestrator() does carry over (see
+    test_a_cell_seeded_while_bound_is_flushed_into_a_replacement_orchestrator).
+    Both must hold at once, or "flush everything the first orchestrator ever
+    saw" would pass this too.
     """
     from acq4.modules.Autopatch.cell_panel import CellPanel
 
@@ -238,7 +246,9 @@ def test_a_cell_known_only_from_an_announcement_is_not_flushed_into_a_later_orch
     second = _FakeOrchestrator()
     panel.bindOrchestrator(second)
 
-    assert second.enqueued == [], "an announced cell was flushed into a rebind"
+    assert second.enqueued == [
+        seededCell
+    ], "an announced cell was flushed into a rebind"
 
 
 def test_a_finished_cell_is_not_flushed_into_a_later_orchestrator(qapp):
@@ -268,7 +278,7 @@ def test_a_finished_cell_is_not_flushed_into_a_later_orchestrator(qapp):
     assert second.enqueued == [], "a cell from discarded tissue was re-queued"
 
 
-def test_a_whole_survey_of_finished_cells_is_not_flushed_into_a_later_orchestrator(qapp):
+def test_a_finished_survey_is_not_flushed_into_a_later_orchestrator(qapp):
     """After a completed survey every produced cell has a row here. Loading a
     second protocol must enqueue none of them: they have already been patched,
     and running them again would patch each one a second time."""
@@ -292,10 +302,13 @@ def test_a_whole_survey_of_finished_cells_is_not_flushed_into_a_later_orchestrat
     assert panel.cellList.count() == len(surveyed)
 
 
-def test_a_cell_seeded_while_bound_is_not_flushed_again_on_a_rebind(qapp):
-    """A cell seeded with an orchestrator already bound was enqueued into that
-    orchestrator there and then, so it is not awaiting an enqueue either; a
-    rebind must not treat it as one."""
+def test_a_cell_seeded_while_bound_is_flushed_into_a_replacement_orchestrator(qapp):
+    """A cell seeded with an orchestrator already bound is enqueued straight
+    into that orchestrator's own queue, not into _awaitingEnqueue -- so if
+    that orchestrator is replaced (a different protocol loaded) before the
+    cell ever runs, unbindOrchestrator() must read it back out of the
+    outgoing queue itself, or the cell's row would survive in Area 5 while
+    the replacement orchestrator's queue holds nothing for it."""
     from acq4.modules.Autopatch.cell_panel import CellPanel
 
     pip = _FakePipette((1e-3, 2e-3, 3e-3))
@@ -305,11 +318,12 @@ def test_a_cell_seeded_while_bound_is_not_flushed_again_on_a_rebind(qapp):
 
     panel.addFromTargetBtn.click()
     assert len(first.enqueued) == 1
+    cell = first.enqueued[0]
 
     second = _FakeOrchestrator()
     panel.bindOrchestrator(second)
 
-    assert second.enqueued == []
+    assert second.enqueued == [cell]
 
 
 def test_clear_cells_drops_the_pending_enqueue_bookkeeping(qapp):

--- a/acq4/modules/Autopatch/tests/test_cell_panel.py
+++ b/acq4/modules/Autopatch/tests/test_cell_panel.py
@@ -380,6 +380,31 @@ def test_rebinding_disconnects_previous_orchestrators_signals(qapp):
     assert panel.cellList.item(0).text() == f"cell {id(cell)} — queued"
 
 
+def test_rebinding_the_orchestrator_already_held_does_not_double_enqueue(qapp):
+    """bindOrchestrator() called with the orchestrator it already holds is
+    unreachable today -- the window that owns this panel always constructs a
+    fresh Orchestrator when a protocol loads -- but unbindOrchestrator() now
+    salvages the outgoing orchestrator's pending cells without clearing its
+    queue, so a same-orchestrator rebind would otherwise flush those same
+    still-queued cells into it a second time."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    pip = _FakePipette((1e-3, 2e-3, 3e-3))
+    panel = CellPanel(pipetteGetter=lambda: pip)
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch)
+
+    panel.addFromTargetBtn.click()
+    assert len(orch.enqueued) == 1
+    cell = orch.enqueued[0]
+
+    panel.bindOrchestrator(orch)
+
+    assert orch.enqueued == [
+        cell
+    ], "re-binding the orchestrator already held re-queued its pending cell"
+
+
 def test_current_cell_for_an_unseeded_cell_gets_exactly_one_running_row(qapp):
     """A cell the orchestrator announces via sigCurrentCell without ever having
     been seeded through addFromTargetBtn/scatterFakeCellsBtn (i.e. a cell a

--- a/acq4/modules/Autopatch/tests/test_orchestrator_cell_panel_seam.py
+++ b/acq4/modules/Autopatch/tests/test_orchestrator_cell_panel_seam.py
@@ -1,0 +1,157 @@
+"""Integration test for the Orchestrator <-> CellPanel seam: cells a real
+producer finds inside a real refill get Area 5 rows reading their real finish
+status, and an orchestrator bound afterward inherits none of them."""
+
+import os
+
+import pytest
+from coorx import Point
+
+from acq4.util import Qt
+
+_NOOP_PROTOCOL = '''"""Seam test fixture: resolves immediately without touching ctx."""
+
+
+def run(ctx, **kwargs):
+    return None
+'''
+
+# 100x80 um tiles over a 300x80 um region: exactly three tiles, each yielding
+# one cell, which is comfortably under the default cell-density cap for a tile
+# of this volume.
+FOV = (100e-6, 80e-6)
+REGION = (0.0, 0.0, 300e-6, 80e-6)
+TILE_COUNT = 3
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+def _protocolFile(tmp_path, name="demo.py"):
+    from acq4.experiment.protocol_file import ProtocolFile
+
+    path = os.path.join(str(tmp_path), name)
+    with open(path, "w") as fh:
+        fh.write(_NOOP_PROTOCOL)
+    pf = ProtocolFile(path)
+    pf.load()
+    return pf
+
+
+def _detector(center, constraints):
+    """The imaging seam, stubbed to find exactly one real Cell in each tile.
+
+    A genuine acq4_automation Cell rather than a stand-in: it is a QObject, and
+    CellPanel's parenting and strong-reference bookkeeping are written around
+    precisely that.
+    """
+    from acq4_automation.feature_tracking.cell import Cell
+
+    near, far = constraints.depth_range
+    cell = Cell(Point((center[0], center[1], (near + far) / 2), "global"))
+    cell.score = 1.0
+    return [cell]
+
+
+def _orchestrator(tmp_path, name="demo.py"):
+    from acq4.experiment.orchestrator import Orchestrator
+
+    return Orchestrator(_protocolFile(tmp_path, name))
+
+
+def _survey(tmp_path, name="demo.py"):
+    """A real Orchestrator with a real CellPanel bound and a real producer installed."""
+    from acq4.experiment.slice import Slice
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    orch = _orchestrator(tmp_path, name)
+    panel = CellPanel()
+    panel.bindOrchestrator(orch)
+    sliceState = Slice(fov=FOV)
+    sliceState.addRegion(*REGION)
+    orch.setCellProducer(sliceState.makeCellProducer(_detector))
+    return orch, panel, sliceState
+
+
+def test_produced_cells_get_rows_reading_their_finish_status(qapp, tmp_path):
+    """Nothing is seeded by hand: every row in Area 5 got there because the
+    orchestrator's refill asked the producer, announced what came back, and the
+    panel picked those announcements up."""
+    orch, panel, sliceState = _survey(tmp_path)
+    assert panel.cellList.count() == 0
+
+    orch.run_sync()
+
+    assert panel.cellList.count() == TILE_COUNT
+    rows = [panel.cellList.item(i).text() for i in range(TILE_COUNT)]
+    for row in rows:
+        assert "done" in row, f"row does not read its finish status: {row!r}"
+    # Each row names a distinct cell, and each is the cell the panel is holding.
+    assert len(set(rows)) == TILE_COUNT
+    assert len(panel._cells) == TILE_COUNT
+    allRows = " ".join(rows)
+    for cellId, cell in panel._cells.items():
+        assert f"cell {cellId}" in allRows
+        assert cell in sliceState.cellsNearTile(cell.position[:2])
+
+    # The whole region was surveyed on the way.
+    assert sliceState.surveyStats() == (TILE_COUNT, TILE_COUNT, pytest.approx(100.0))
+
+
+def test_binding_a_later_orchestrator_enqueues_none_of_the_surveyed_cells(
+    qapp, tmp_path
+):
+    """The regression guard for the flush, at the level the hazard actually
+    lives at. Every cell a completed survey produced has a row in Area 5, and
+    binding the orchestrator a second protocol load builds must enqueue none of
+    them: they have already been patched, and after a "New slice" their
+    coordinates name tissue that is gone.
+    """
+    orch, panel, _sliceState = _survey(tmp_path)
+    orch.run_sync()
+    assert panel.cellList.count() == TILE_COUNT
+
+    # No producer on this one, so the flush is the only thing that could fill it.
+    second = _orchestrator(tmp_path, name="second.py")
+    panel.bindOrchestrator(second)
+
+    assert list(second._queue) == []
+    # Proved by running it, not just by reading the deque: a second pass over an
+    # already-patched cell is the thing that must not happen.
+    ran = []
+    second.protocolFile.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    second.run_sync()
+    assert ran == [], "a cell from the finished survey was patched again"
+
+
+def test_a_cell_seeded_before_any_orchestrator_still_reaches_a_later_one(
+    qapp, tmp_path
+):
+    """The other half of the same rule, so "flush nothing" cannot pass: a cell
+    the operator seeded into an unbound panel is still handed to the orchestrator
+    bound afterward, and is actually run by it."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    class _FakePipette:
+        pipetteDevice = None
+
+    pipette = _FakePipette()
+    pipette.pipetteDevice = type(
+        "_FakeManipulator", (), {"targetPosition": lambda self: (1e-3, 2e-3, 3e-3)}
+    )()
+    panel = CellPanel(pipetteGetter=lambda: pipette)
+
+    panel.addFromTargetBtn.click()
+    assert panel.cellList.count() == 1
+    seeded = list(panel._cells.values())[0]
+
+    orch = _orchestrator(tmp_path)
+    ran = []
+    orch.protocolFile.run = lambda ctx, **kwargs: ran.append(ctx.cell)
+    panel.bindOrchestrator(orch)
+
+    assert list(orch._queue) == [seeded]
+    orch.run_sync()
+    assert ran == [seeded]

--- a/acq4/modules/Autopatch/tests/test_search_panel.py
+++ b/acq4/modules/Autopatch/tests/test_search_panel.py
@@ -27,14 +27,20 @@ def test_defaults_match_the_engines_defaults(qapp):
 def test_the_physical_controls_read_in_si_units(qapp):
     # On the control that decides how deep an objective travels, "-20 µm" is the
     # readable form; "-0.0000200 m" is a value an operator has to count zeros
-    # in. Same for a density in the low terahertz-per-cubic-metre range. The
-    # µ here is U+00B5, the character pyqtgraph's SI_PREFIXES uses.
+    # in. The µ here is U+00B5, the character pyqtgraph's SI_PREFIXES uses.
     panel = makePanel()
     assert panel.nearDepthSpin.text() == "-20 µm"
     assert panel.farDepthSpin.text() == "-60 µm"
-    assert panel.maxDensitySpin.text() == "5 T/m³"
     # A probability has no unit to prefix, so it reads as itself.
     assert panel.minHealthSpin.text() == "0.5"
+
+
+def test_the_density_control_reads_in_cells_per_nanolitre(qapp):
+    # max_cell_density is stored in SI (cells/m^3), but "5 T/m³" is not a
+    # number an operator reasons about a field of view in; "5 cells/nL" is,
+    # since a typical z-stack field of view is a couple of nanolitres.
+    panel = makePanel()
+    assert panel.maxDensitySpin.text() == "5 cells/nL"
 
 
 def test_editing_the_depth_range_is_reflected_in_the_constraints(qapp):
@@ -67,8 +73,12 @@ def test_editing_the_health_cutoff_is_reflected_in_the_constraints(qapp):
 
 
 def test_editing_the_max_cell_density_is_reflected_in_the_constraints(qapp):
+    # The spin box is in cells/nL; SearchConstraints.max_cell_density is SI
+    # cells/m^3. Setting 2 cells/nL must reach the constraint as 2e12
+    # cells/m^3 (1 nL == 1e-12 m^3) -- a dropped or inverted scale factor
+    # would leave this as 2.0 or 2e-12 instead.
     panel = makePanel()
-    panel.maxDensitySpin.setValue(2e12)
+    panel.maxDensitySpin.setValue(2.0)
     assert panel.constraints().max_cell_density == pytest.approx(2e12)
 
 
@@ -97,7 +107,7 @@ def test_editing_rescans_is_reflected_in_the_constraints(qapp):
             pytest.approx(0.75),
         ),
         (
-            lambda panel: panel.maxDensitySpin.setValue(2e12),
+            lambda panel: panel.maxDensitySpin.setValue(2.0),
             "max_cell_density",
             pytest.approx(2e12),
         ),

--- a/acq4/modules/Autopatch/tests/test_search_panel.py
+++ b/acq4/modules/Autopatch/tests/test_search_panel.py
@@ -1,0 +1,127 @@
+"""Tests for Area 2's cell-finding config: the search constraints it builds, the
+region-seeding request it emits, and the survey readout it shows."""
+
+import pytest
+
+from acq4.experiment.slice import SearchConstraints
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+def makePanel():
+    from acq4.modules.Autopatch.search_panel import SearchPanel
+
+    return SearchPanel()
+
+
+def test_defaults_match_the_engines_defaults(qapp):
+    # An operator who touches nothing must get the same search the engine
+    # documents, not a second set of defaults that silently disagrees.
+    assert makePanel().constraints() == SearchConstraints()
+
+
+def test_editing_the_depth_range_is_reflected_in_the_constraints(qapp):
+    panel = makePanel()
+    panel.nearDepthSpin.setValue(-10e-6)
+    panel.farDepthSpin.setValue(-50e-6)
+    assert panel.constraints().depth_range == (
+        pytest.approx(-10e-6),
+        pytest.approx(-50e-6),
+    )
+
+
+def test_editing_the_health_cutoff_is_reflected_in_the_constraints(qapp):
+    panel = makePanel()
+    panel.minHealthSpin.setValue(0.8)
+    assert panel.constraints().min_health == pytest.approx(0.8)
+
+
+def test_editing_the_max_cell_density_is_reflected_in_the_constraints(qapp):
+    panel = makePanel()
+    panel.maxDensitySpin.setValue(2e12)
+    assert panel.constraints().max_cell_density == pytest.approx(2e12)
+
+
+def test_editing_rescans_is_reflected_in_the_constraints(qapp):
+    panel = makePanel()
+    panel.rescansCheck.setChecked(True)
+    assert panel.constraints().rescans_allowed is True
+
+
+def test_an_edit_emits_the_new_constraints(qapp):
+    panel = makePanel()
+    emitted = []
+    panel.sigConstraintsChanged.connect(emitted.append)
+
+    panel.minHealthSpin.setValue(0.75)
+
+    assert emitted, "editing a constraint must announce the new search"
+    assert emitted[-1].min_health == pytest.approx(0.75)
+
+
+def test_an_invalid_depth_range_does_not_raise_out_of_the_widget(qapp):
+    # Constraint validation raises, and an operator dragging a spinbox through
+    # an invalid intermediate value must not crash the GUI thread.
+    panel = makePanel()
+    panel.nearDepthSpin.setValue(-30e-6)
+    panel.farDepthSpin.setValue(-30e-6)
+    assert panel.constraints() is None
+    assert panel.errorLabel.text() != ""
+
+
+def test_an_invalid_edit_announces_none_rather_than_staying_silent(qapp):
+    # A listener holding the last-good constraints has to be told the widget no
+    # longer describes a valid search, or it cannot decide to keep them.
+    panel = makePanel()
+    emitted = []
+    panel.sigConstraintsChanged.connect(emitted.append)
+
+    panel.farDepthSpin.setValue(panel.nearDepthSpin.value())
+
+    assert emitted[-1] is None
+
+
+def test_recovering_from_an_invalid_range_clears_the_error(qapp):
+    panel = makePanel()
+    panel.farDepthSpin.setValue(panel.nearDepthSpin.value())
+    assert panel.constraints() is None
+    panel.farDepthSpin.setValue(-70e-6)
+    assert panel.constraints() is not None
+    assert panel.errorLabel.text() == ""
+
+
+def test_add_region_button_emits_a_request(qapp):
+    panel = makePanel()
+    requests = []
+    panel.sigAddRegionRequested.connect(lambda: requests.append(True))
+
+    panel.addRegionBtn.click()
+
+    assert requests == [True]
+
+
+def test_survey_stats_are_shown(qapp):
+    panel = makePanel()
+    panel.setSurveyStats(9, 3, 100 / 3)
+    text = panel.surveyLabel.text()
+    assert "3" in text and "9" in text and "33" in text
+
+
+def test_survey_stats_with_no_region_read_as_no_region(qapp):
+    panel = makePanel()
+    panel.setSurveyStats(0, 0, 0.0)
+    assert "no region" in panel.surveyLabel.text().lower()
+
+
+def test_locking_disables_editing_but_not_the_readout(qapp):
+    panel = makePanel()
+    panel.setInteractionLocked(True)
+    assert not panel.minHealthSpin.isEnabled()
+    assert not panel.addRegionBtn.isEnabled()
+    panel.setInteractionLocked(False)
+    assert panel.minHealthSpin.isEnabled()
+    assert panel.addRegionBtn.isEnabled()

--- a/acq4/modules/Autopatch/tests/test_search_panel.py
+++ b/acq4/modules/Autopatch/tests/test_search_panel.py
@@ -52,15 +52,47 @@ def test_editing_rescans_is_reflected_in_the_constraints(qapp):
     assert panel.constraints().rescans_allowed is True
 
 
-def test_an_edit_emits_the_new_constraints(qapp):
+@pytest.mark.parametrize(
+    "edit, attr, expected",
+    [
+        (
+            lambda panel: panel.nearDepthSpin.setValue(-15e-6),
+            "depth_range",
+            (pytest.approx(-15e-6), pytest.approx(-60e-6)),
+        ),
+        (
+            lambda panel: panel.farDepthSpin.setValue(-70e-6),
+            "depth_range",
+            (pytest.approx(-20e-6), pytest.approx(-70e-6)),
+        ),
+        (
+            lambda panel: panel.minHealthSpin.setValue(0.75),
+            "min_health",
+            pytest.approx(0.75),
+        ),
+        (
+            lambda panel: panel.maxDensitySpin.setValue(2e12),
+            "max_cell_density",
+            pytest.approx(2e12),
+        ),
+        (lambda panel: panel.rescansCheck.setChecked(True), "rescans_allowed", True),
+    ],
+    ids=["near_depth", "far_depth", "min_health", "max_density", "rescans"],
+)
+def test_an_edit_emits_the_new_constraints(qapp, edit, attr, expected):
+    # Each control is wired to _onEdited independently; the window listens on
+    # sigConstraintsChanged to push edits into the live search, so a control
+    # missing this wiring means the operator changes a setting and nothing
+    # happens. Exercising every control here, not just constraints() directly,
+    # is what would catch a dropped connection.
     panel = makePanel()
     emitted = []
     panel.sigConstraintsChanged.connect(emitted.append)
 
-    panel.minHealthSpin.setValue(0.75)
+    edit(panel)
 
     assert emitted, "editing a constraint must announce the new search"
-    assert emitted[-1].min_health == pytest.approx(0.75)
+    assert getattr(emitted[-1], attr) == expected
 
 
 def test_an_invalid_depth_range_does_not_raise_out_of_the_widget(qapp):
@@ -117,11 +149,28 @@ def test_survey_stats_with_no_region_read_as_no_region(qapp):
     assert "no region" in panel.surveyLabel.text().lower()
 
 
-def test_locking_disables_editing_but_not_the_readout(qapp):
+@pytest.mark.parametrize(
+    "widgetName",
+    [
+        "nearDepthSpin",
+        "farDepthSpin",
+        "minHealthSpin",
+        "maxDensitySpin",
+        "rescansCheck",
+        "addRegionBtn",
+    ],
+)
+def test_locking_disables_editing_but_not_the_readout(qapp, widgetName):
+    # A run in flight parameterises a producer that is already surveying, so
+    # editing any constraint control or the add-region button mid-run would
+    # silently change the search underneath it; the lock must reach every one
+    # of them, in both directions, while leaving the readout alone.
     panel = makePanel()
+    widget = getattr(panel, widgetName)
+
     panel.setInteractionLocked(True)
-    assert not panel.minHealthSpin.isEnabled()
-    assert not panel.addRegionBtn.isEnabled()
+    assert not widget.isEnabled()
+    assert panel.surveyLabel.isEnabled()
+
     panel.setInteractionLocked(False)
-    assert panel.minHealthSpin.isEnabled()
-    assert panel.addRegionBtn.isEnabled()
+    assert widget.isEnabled()

--- a/acq4/modules/Autopatch/tests/test_search_panel.py
+++ b/acq4/modules/Autopatch/tests/test_search_panel.py
@@ -24,6 +24,19 @@ def test_defaults_match_the_engines_defaults(qapp):
     assert makePanel().constraints() == SearchConstraints()
 
 
+def test_the_physical_controls_read_in_si_units(qapp):
+    # On the control that decides how deep an objective travels, "-20 µm" is the
+    # readable form; "-0.0000200 m" is a value an operator has to count zeros
+    # in. Same for a density in the low terahertz-per-cubic-metre range. The
+    # µ here is U+00B5, the character pyqtgraph's SI_PREFIXES uses.
+    panel = makePanel()
+    assert panel.nearDepthSpin.text() == "-20 µm"
+    assert panel.farDepthSpin.text() == "-60 µm"
+    assert panel.maxDensitySpin.text() == "5 T/m³"
+    # A probability has no unit to prefix, so it reads as itself.
+    assert panel.minHealthSpin.text() == "0.5"
+
+
 def test_editing_the_depth_range_is_reflected_in_the_constraints(qapp):
     panel = makePanel()
     panel.nearDepthSpin.setValue(-10e-6)
@@ -32,6 +45,19 @@ def test_editing_the_depth_range_is_reflected_in_the_constraints(qapp):
         pytest.approx(-10e-6),
         pytest.approx(-50e-6),
     )
+
+
+@pytest.mark.parametrize("widgetName", ["nearDepthSpin", "farDepthSpin"])
+def test_the_depth_controls_cannot_be_driven_above_the_surface(qapp, widgetName):
+    # Depths are signed offsets from the tissue surface, so a positive value
+    # would search the bath above it. SearchConstraints rejects that, but the
+    # widget's own bounds are what stop the operator getting there at all.
+    panel = makePanel()
+    spin = getattr(panel, widgetName)
+
+    spin.setValue(50e-6)
+
+    assert spin.value() == pytest.approx(0.0)
 
 
 def test_editing_the_health_cutoff_is_reflected_in_the_constraints(qapp):
@@ -123,6 +149,49 @@ def test_recovering_from_an_invalid_range_clears_the_error(qapp):
     assert panel.constraints() is None
     panel.farDepthSpin.setValue(-70e-6)
     assert panel.constraints() is not None
+    assert panel.errorLabel.text() == ""
+
+
+def test_an_externally_set_error_is_shown(qapp):
+    panel = makePanel()
+    panel.setError("Select a camera before starting a slice.")
+    assert panel.errorLabel.text() == "Select a camera before starting a slice."
+
+
+def test_an_externally_set_error_survives_a_valid_constraint_edit(qapp):
+    # The owner's message is about something editing a spin box does not fix (no
+    # camera is selected either way), and errorLabel is the operator's only
+    # feedback for it, so a constraint edit that validates cleanly must not
+    # erase it.
+    panel = makePanel()
+    panel.setError("Select a camera before starting a slice.")
+
+    panel.minHealthSpin.setValue(0.75)
+
+    assert panel.constraints() is not None
+    assert panel.errorLabel.text() == "Select a camera before starting a slice."
+
+
+def test_a_constraint_error_takes_the_line_and_gives_it_back(qapp):
+    # A constraint error describes the control being touched right now, so it
+    # wins while it lasts -- and the owner's message, still true, comes back
+    # once the values are valid again rather than being lost.
+    panel = makePanel()
+    panel.setError("Select a camera before starting a slice.")
+
+    panel.farDepthSpin.setValue(panel.nearDepthSpin.value())
+    assert panel.constraints() is None
+    assert "thickness" in panel.errorLabel.text()
+
+    panel.farDepthSpin.setValue(-70e-6)
+    assert panel.constraints() is not None
+    assert panel.errorLabel.text() == "Select a camera before starting a slice."
+
+
+def test_an_empty_message_retracts_an_externally_set_error(qapp):
+    panel = makePanel()
+    panel.setError("Select a camera before starting a slice.")
+    panel.setError("")
     assert panel.errorLabel.text() == ""
 
 

--- a/acq4/modules/Autopatch/tests/test_status_panel.py
+++ b/acq4/modules/Autopatch/tests/test_status_panel.py
@@ -19,12 +19,14 @@ class _FakeOrchestrator(Qt.QObject):
     def __init__(self):
         super().__init__()
         self.started = self.stopped = self.paused = self.resumed = self.nexted = 0
+        self.stopReason = None
 
     def start(self):
         self.started += 1
 
     def stop(self, reason=""):
         self.stopped += 1
+        self.stopReason = reason
 
     def pause(self):
         self.paused += 1
@@ -63,6 +65,24 @@ def test_buttons_drive_the_bound_orchestrator(qapp):
     assert orch.paused == 1
     assert orch.stopped == 1
     assert orch.nexted == 1
+
+
+def test_stop_button_passes_a_real_reason_not_the_click_signal_s_bool(qapp):
+    # Qt's clicked signal carries a `checked` bool; connecting it straight to
+    # orchestrator.stop would pass that bool through as `reason`, landing a
+    # bogus `False` in the run log instead of a human-readable reason.
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch, _FakeEntrySource())
+
+    orch.sigStatus.emit("running")
+    panel.stopBtn.click()
+
+    assert orch.stopped == 1
+    assert isinstance(orch.stopReason, str) and orch.stopReason != ""
+    assert orch.stopReason is not False
 
 
 def test_pause_button_toggles_to_resume_while_paused(qapp):

--- a/acq4/modules/Autopatch/tests/test_status_panel.py
+++ b/acq4/modules/Autopatch/tests/test_status_panel.py
@@ -312,3 +312,81 @@ def test_unbinding_returns_to_no_protocol_gating(qapp):
     assert not panel.stopBtn.isEnabled()
     assert not panel.pauseBtn.isEnabled()
     assert not panel.nextBtn.isEnabled()
+
+
+def _boundPanel():
+    """A StatusPanel bound to a fake orchestrator, as every test here builds it."""
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch, _FakeEntrySource())
+    return panel, orch
+
+
+def test_surveying_keeps_stop_and_pause_available(qapp):
+    # Imaging a tile is slow. An operator who wants out mid-survey must not
+    # have to wait for the producer to find a cell first.
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("surveying")
+
+    assert panel.stopBtn.isEnabled()
+    assert panel.pauseBtn.isEnabled()
+    assert not panel.startBtn.isEnabled()
+
+
+def test_surveying_disables_next_cell(qapp):
+    # A next-cell request during a refill is discarded by design (nothing is
+    # running and nothing is queued to advance past), so the button must not
+    # invite a press that does nothing.
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("surveying")
+
+    assert not panel.nextBtn.isEnabled()
+
+
+def test_surveying_shows_in_the_status_label(qapp):
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("surveying")
+    assert panel.statusLabel.text() == "surveying"
+
+
+def test_surveying_locks_area_4(qapp):
+    # A run is in flight, so the protocol picker must stay locked -- reloading
+    # a protocol mid-survey is the second-orchestrator hazard.
+    panel, orch = _boundPanel()
+    locked = []
+    panel.sigInteractionLocked.connect(locked.append)
+    orch.sigStatus.emit("surveying")
+    assert locked[-1] is True
+
+
+def test_surveying_keeps_pause_labeled_pause(qapp):
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("surveying")
+    assert panel.pauseBtn.text() == "Pause"
+
+
+def test_status_is_re_emitted_for_panels_that_must_not_touch_the_orchestrator(qapp):
+    # The window needs the status to refresh Area 2's survey readout, but the
+    # orchestrator is a parentless QObject and must not hold a reference back
+    # to the window. This passthrough is that indirection.
+    panel, orch = _boundPanel()
+    seen = []
+    panel.sigStatusChanged.connect(seen.append)
+
+    orch.sigStatus.emit("surveying")
+    orch.sigStatus.emit("waiting")
+
+    assert seen == ["surveying", "waiting"]
+
+
+def test_the_status_passthrough_stops_on_unbind(qapp):
+    panel, orch = _boundPanel()
+    seen = []
+    panel.sigStatusChanged.connect(seen.append)
+
+    panel.unbindOrchestrator()
+    orch.sigStatus.emit("surveying")
+
+    assert seen == []

--- a/acq4/modules/Autopatch/tests/test_teardown.py
+++ b/acq4/modules/Autopatch/tests/test_teardown.py
@@ -177,6 +177,92 @@ def test_teardown_breaks_the_orchestrator_cell_window_cycle(qapp, tmp_path):
         gc.enable()
 
 
+def test_teardown_frees_the_slice_producer_and_cells_by_refcounting(qapp, tmp_path):
+    """The proof above cannot reach the cell-search half of the object graph:
+    its camera selector returns None, so no Slice is ever built and no producer
+    ever installed. This builds that half -- a slice, a region, a producer
+    closing over the camera and scope devices, and a cell run through the
+    protocol -- and proves the same thing about all of it: with the cyclic
+    collector disabled, plain refcounting frees the window, the slice, the
+    producer and the cells.
+
+    The producer is where the risk is: it holds the slice, the orchestrator
+    holds the producer, and the orchestrator is parented to the window, so a
+    teardown that left the producer installed would keep the slice and both
+    devices reachable from an object nothing is looking after any more.
+
+    The camera stand-in comes from test_window_integration rather than being
+    copied in here: it is the same mode-sensitive getBoundary/
+    globalCenterPosition/scopeDev fake the producer install needs, and a second
+    copy would be one more thing to keep in step with acq4's real Camera.
+    """
+    from acq4.modules.Autopatch.Autopatch import AutopatchWindow
+
+    from .test_window_integration import _FakeCameraWithDevice
+
+    _write_protocol(tmp_path, "demo.py", _NOOP_PROTOCOL)
+
+    gc.disable()
+    try:
+        win = AutopatchWindow(
+            module=None,
+            protocolDir=str(tmp_path),
+            pipetteSelector=_FakePipetteSelector(target=(1e-3, 2e-3, 3e-3)),
+            cameraSelector=_FakeCameraWithDevice(),
+        )
+        win.protocolPanel.fileCombo.setCurrentText("demo")
+
+        win.newSlice()
+        win.addRegionHere()
+        assert win.slice is not None
+        assert len(win.slice.regions) == 1
+
+        win.cellPanel.addFromTargetBtn.click()
+        assert win.cellPanel.cellList.count() == 1
+        seededCell = list(win.cellPanel._cells.values())[0]
+        # Selected before running so the run below actually populates
+        # _timelineItems, the same reason as the proof above.
+        win.cellPanel.cellList.setCurrentRow(0)
+
+        # What Start does on the GUI thread: cache the devices and install a
+        # producer built from the current slice.
+        win._onStartRun()
+        producer = win.orchestrator._cellProducer
+        assert producer is not None
+        assert producer._slice is win.slice
+
+        # And a cell's worth of protocol, inline on this thread (no gentletask
+        # ThreadTask, for the reason the first test's docstring gives), so the
+        # ctx.log_action wiring runs with the search half of the graph in place.
+        win.orchestrator.run_sync_cell(seededCell)
+        win.cellPanel.cellList.setCurrentRow(0)
+        assert win.cellPanel.timelineList.count() == 1
+
+        sliceState = win.slice
+        refs = {
+            "orchestrator": weakref.ref(win.orchestrator),
+            "producer": weakref.ref(producer),
+            "slice": weakref.ref(sliceState),
+            "seeded cell": weakref.ref(seededCell),
+            "window": weakref.ref(win),
+        }
+
+        win.teardown()
+
+        assert win.orchestrator is None
+        assert win.cellPanel._cells == {}
+
+        del producer, sliceState, seededCell
+        win.close()  # exercises the closeEvent path too; teardown() is idempotent
+        del win
+        # No gc.collect() below -- pure refcounting only, since gc is disabled.
+
+        for name, ref in refs.items():
+            assert ref() is None, f"{name} should be freed by refcounting alone"
+    finally:
+        gc.enable()
+
+
 def test_teardown_stops_an_in_flight_orchestrator_run(qapp, qtbot, tmp_path):
     """teardown() must stop a currently-running orchestrator rather than
     abandon it, and leave no panel still bound to it afterward."""

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -52,6 +52,80 @@ class _FakeCameraSelector(Qt.QWidget):
         return None
 
 
+class _FakeScope:
+    """Stands in for a Microscope: records survey moves and reports a surface."""
+
+    def __init__(self):
+        self.moves = []
+
+    def setGlobalPosition(self, pos, speed="fast", name=None):
+        self.moves.append(tuple(pos))
+        return _DoneFuture()
+
+    def findSurfaceDepth(self, imager):
+        return 0.0
+
+
+class _DoneFuture:
+    def wait(self, **kwargs):
+        return None
+
+
+class _FakeCamera:
+    """Stands in for a Camera: the three calls a cell producer's install needs.
+
+    getBoundary in "roi" mode gives the field a tile covers, globalCenterPosition
+    in "roi" mode gives where to seed a region, and scopeDev is the stage the
+    detector drives.
+    """
+
+    def __init__(self, fov=(10e-6, 10e-6), center=(0.0, 0.0, 0.0)):
+        self._fov = fov
+        self._center = center
+        self.scopeDev = _FakeScope()
+
+    def name(self):
+        return "FakeCamera"
+
+    def getBoundary(self, globalCoords=True, mode="sensor"):
+        w, h = self._fov
+        return self._center[0] - w / 2, self._center[1] - h / 2, w, h
+
+    def globalCenterPosition(self, mode="sensor"):
+        return self._center
+
+    def getPixelSize(self):
+        return (0.32e-6, 0.32e-6)
+
+
+class _FakeCameraWithDevice(Qt.QWidget):
+    """A camera selector that actually returns a camera, unlike _FakeCameraSelector."""
+
+    def __init__(self, camera=None):
+        super().__init__()
+        self.camera = camera if camera is not None else _FakeCamera()
+
+    def getSelectedObj(self):
+        return self.camera
+
+
+def _makeWindow(tmp_path, cameraSelector=None):
+    """An AutopatchWindow with a loaded no-op protocol, as the tests above build it."""
+    from acq4.modules.Autopatch.Autopatch import AutopatchWindow
+
+    if cameraSelector is None:
+        cameraSelector = _FakeCameraWithDevice()
+    _write_protocol(tmp_path, "demo.py", _NOOP_PROTOCOL)
+    win = AutopatchWindow(
+        module=None,
+        protocolDir=str(tmp_path),
+        pipetteSelector=_FakePipetteSelector(),
+        cameraSelector=cameraSelector,
+    )
+    win.protocolPanel.fileCombo.setCurrentText("demo")
+    return win
+
+
 _NOOP_PROTOCOL = '''"""Integration test fixture: resolves immediately without touching ctx."""
 
 
@@ -328,3 +402,203 @@ def test_area4_controls_disabled_while_running_and_reenabled_when_stopped(
     win.orchestrator.stop()
     qtbot.waitUntil(lambda: win.protocolPanel.fileCombo.isEnabled(), timeout=2000)
     assert win.protocolPanel.reloadBtn.isEnabled()
+
+
+def test_a_fresh_window_has_no_slice(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    # A slice is a commitment to a piece of tissue under the objective; the
+    # window must not invent one before the operator says so.
+    assert win.slice is None
+
+
+def test_new_slice_creates_a_slice_using_the_cameras_field_of_view(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    assert win.slice is not None
+    assert win.slice.tileGrid() == [], "a new slice has no regions to survey yet"
+
+
+def test_new_slice_without_a_camera_reports_rather_than_raising(qapp, tmp_path):
+    # _FakeCameraSelector returns None, the camera-less case.
+    win = _makeWindow(tmp_path, cameraSelector=_FakeCameraSelector())
+    win.newSlice()
+    assert win.slice is None
+    assert win.searchPanel.errorLabel.text() != ""
+
+
+def test_new_slice_with_invalid_constraints_creates_nothing_and_keeps_the_old_slice(
+    qapp, tmp_path
+):
+    # Spin box values that do not describe a valid search must not install a
+    # half-built slice over a good one, nor discard what the good one holds.
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    win.cellPanel._onScatterFakeCellsClicked()
+    first = win.slice
+    seededCells = win.cellPanel.cellList.count()
+    assert seededCells > 0
+
+    # Equal near and far depths span no thickness, so SearchConstraints rejects
+    # them and SearchPanel.constraints() reports None.
+    win.searchPanel.farDepthSpin.setValue(win.searchPanel.nearDepthSpin.value())
+    win.newSlice()
+
+    assert win.slice is first
+    assert len(win.slice.regions) == 1
+    assert win.cellPanel.cellList.count() == seededCells
+    assert win.searchPanel.errorLabel.text() != ""
+
+
+def test_add_region_here_seeds_a_multi_tile_region(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    assert len(win.slice.regions) == 1
+    assert len(win.slice.tileGrid()) > 1
+
+
+def test_add_region_here_without_a_slice_starts_one(qapp, tmp_path):
+    # Seeding a region is a reasonable first action: a slice comes into
+    # existence to hold it rather than the region being dropped.
+    win = _makeWindow(tmp_path)
+    assert win.slice is None
+
+    win.addRegionHere()
+
+    assert win.slice is not None
+    assert len(win.slice.regions) == 1
+    assert len(win.slice.tileGrid()) > 1
+
+
+def test_new_slice_replaces_the_slice_and_its_coverage(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    first = win.slice
+    first.markCovered(first.nextTile())
+
+    win.newSlice()
+
+    assert win.slice is not first
+    assert win.slice.regions == []
+    assert win.slice.coveredTiles == []
+
+
+def test_new_slice_clears_the_cell_list_and_the_orchestrators_queue(qapp, tmp_path):
+    # A Cell is a coordinate in tissue. Swapped tissue makes every one of those
+    # coordinates a place not to drive a pipette, so both the panel's list and
+    # the orchestrator's separate deque have to let go.
+    win = _makeWindow(tmp_path)
+    win.cellPanel._onScatterFakeCellsClicked()
+    assert win.cellPanel.cellList.count() > 0
+
+    ran = []
+    win.orchestrator.protocolFile.run = lambda ctx, **kw: ran.append(ctx.cell)
+
+    win.newSlice()
+
+    assert win.cellPanel.cellList.count() == 0
+    win.orchestrator.run_sync()
+    assert ran == [], "a cell survived New slice and was patched anyway"
+
+
+def test_start_installs_a_producer_when_a_slice_has_a_region(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+
+    win._onStartRun()
+
+    assert win.orchestrator._cellProducer is not None
+
+
+def test_start_installs_no_producer_without_a_slice(qapp, tmp_path):
+    # No slice means no tissue to survey: the run must be a plain queue drain
+    # of whatever the operator seeded by hand, not an error.
+    win = _makeWindow(tmp_path)
+    win._onStartRun()
+    assert win.orchestrator._cellProducer is None
+
+
+def test_start_installs_no_producer_for_a_slice_with_no_region(qapp, tmp_path):
+    # A slice with nowhere to look would have its producer report exhaustion on
+    # the first call, so installing one only adds a pointless refill round trip.
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win._onStartRun()
+    assert win.orchestrator._cellProducer is None
+
+
+def test_start_clears_a_stale_producer_once_the_slice_is_gone(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    win._onStartRun()
+    assert win.orchestrator._cellProducer is not None
+
+    win.slice = None
+    win._onStartRun()
+
+    assert win.orchestrator._cellProducer is None
+
+
+def test_teardown_clears_the_producer(qapp, tmp_path):
+    # The producer closes over the camera and scope devices; leaving it
+    # installed on a released orchestrator keeps them reachable from an object
+    # the window has stopped managing.
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    win._onStartRun()
+    orch = win.orchestrator
+
+    win.teardown()
+
+    assert orch._cellProducer is None
+
+
+def test_loading_a_second_protocol_clears_the_outgoing_producer(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    win._onStartRun()
+    outgoing = win.orchestrator
+
+    _write_protocol(str(tmp_path), "second.py", _NOOP_PROTOCOL)
+    # refreshFileList is the discovery scan the picker's popup runs; it lists the
+    # newly written file without force-reloading the one already loaded.
+    win.protocolPanel.refreshFileList()
+    win.protocolPanel.fileCombo.setCurrentText("second")
+
+    assert outgoing._cellProducer is None
+    assert win.orchestrator is not outgoing
+
+
+def test_editing_the_constraints_reaches_the_live_slice(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.searchPanel.minHealthSpin.setValue(0.85)
+    assert win.slice.constraints.min_health == pytest.approx(0.85)
+
+
+def test_invalid_constraints_leave_the_slice_alone(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    before = win.slice.constraints
+    win.searchPanel.farDepthSpin.setValue(win.searchPanel.nearDepthSpin.value())
+    assert win.slice.constraints is before
+
+
+def test_the_survey_readout_follows_the_slices_coverage(qapp, tmp_path):
+    # Coverage advances on the worker thread as tiles are imaged, so the readout
+    # is refreshed off the status signal rather than polled.
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    total = len(win.slice.tileGrid())
+    win.slice.markCovered(win.slice.nextTile())
+
+    win.statusPanel.sigStatusChanged.emit("surveying")
+
+    assert f"1/{total}" in win.searchPanel.surveyLabel.text()

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -467,6 +467,35 @@ def test_new_slice_without_a_camera_reports_rather_than_raising(qapp, tmp_path):
     assert win.searchPanel.errorLabel.text() != ""
 
 
+def test_the_no_camera_message_survives_a_constraint_edit(qapp, tmp_path):
+    """The window reports "no camera" through SearchPanel.setError(), not by
+    writing into errorLabel behind the panel's back: a valid spin box edit calls
+    SearchPanel.constraints(), which rewrites that same label, and would
+    otherwise erase the operator's only feedback while no slice exists."""
+    win = _makeWindow(tmp_path, cameraSelector=_FakeCameraSelector())
+    win.newSlice()
+    message = win.searchPanel.errorLabel.text()
+    assert message != ""
+
+    win.searchPanel.minHealthSpin.setValue(0.75)
+
+    assert win.searchPanel.errorLabel.text() == message
+
+
+def test_a_started_slice_retracts_the_no_camera_message(qapp, tmp_path):
+    # There is a camera now, so the message must not linger.
+    selector = _FakeCameraWithDevice()
+    win = _makeWindow(tmp_path, cameraSelector=_FakeCameraSelector())
+    win.newSlice()
+    assert win.searchPanel.errorLabel.text() != ""
+
+    win.cameraSelector = selector
+    win.newSlice()
+
+    assert win.slice is not None
+    assert win.searchPanel.errorLabel.text() == ""
+
+
 def test_new_slice_with_invalid_constraints_creates_nothing_and_keeps_the_old_slice(
     qapp, tmp_path
 ):
@@ -525,6 +554,28 @@ def test_add_region_here_without_a_slice_starts_one(qapp, tmp_path):
     assert win.slice is not None
     assert len(win.slice.regions) == 1
     assert len(win.slice.tileGrid()) > 1
+
+
+def test_add_region_here_without_a_slice_keeps_hand_seeded_cells(qapp, tmp_path):
+    """Creating the slice that will hold the region must not go through
+    newSlice(), which is the discard-everything path: the add-region button
+    offers only to add a region, and an operator who seeded cells by hand first
+    must still have them -- both the rows and the orchestrator's queue.
+    """
+    win = _makeWindow(tmp_path)
+    assert win.slice is None
+    win.cellPanel._onScatterFakeCellsClicked()
+    seeded = win.cellPanel.cellList.count()
+    assert seeded > 0
+    queued = list(win.orchestrator._queue)
+    assert len(queued) == seeded
+
+    win.addRegionHere()
+
+    assert win.slice is not None
+    assert len(win.slice.regions) == 1
+    assert win.cellPanel.cellList.count() == seeded
+    assert list(win.orchestrator._queue) == queued
 
 
 def test_new_slice_replaces_the_slice_and_its_coverage(qapp, tmp_path):

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -77,22 +77,47 @@ class _FakeCamera:
     getBoundary in "roi" mode gives the field a tile covers, globalCenterPosition
     in "roi" mode gives where to seed a region, and scopeDev is the stage the
     detector drives.
+
+    Mode-sensitive like the real Camera.getBoundary/globalCenterPosition
+    (acq4/devices/Camera/Camera.py): a cropped camera ROI sits off-center on
+    the sensor, so "roi" and "sensor" must answer with different rectangles
+    and different centers here too, or a caller that reaches for the wrong
+    mode string would coincidentally get away with it against this fake. The
+    ROI's field is also non-square and, by default, centered away from the
+    origin, so a region built from the wrong axis or from (0, 0) instead of
+    the camera's actual center shows up as a wrong coordinate rather than
+    passing by symmetry.
     """
 
-    def __init__(self, fov=(10e-6, 10e-6), center=(0.0, 0.0, 0.0)):
-        self._fov = fov
-        self._center = center
+    def __init__(self, roi_fov=(12e-6, 8e-6), roi_center=(5e-6, -3e-6, 0.0)):
+        self._roi_fov = roi_fov
+        self._roi_center = roi_center
+        # Larger than the ROI and centered on the origin -- a different
+        # rectangle, not the ROI under another name.
+        self._sensor_fov = (roi_fov[0] * 4, roi_fov[1] * 4)
+        self._sensor_center = (0.0, 0.0, 0.0)
         self.scopeDev = _FakeScope()
 
     def name(self):
         return "FakeCamera"
 
     def getBoundary(self, globalCoords=True, mode="sensor"):
-        w, h = self._fov
-        return self._center[0] - w / 2, self._center[1] - h / 2, w, h
+        if mode == "roi":
+            w, h = self._roi_fov
+            cx, cy, _ = self._roi_center
+        elif mode == "sensor":
+            w, h = self._sensor_fov
+            cx, cy, _ = self._sensor_center
+        else:
+            raise ValueError(f"mode must be 'sensor' or 'roi', got {mode!r}")
+        return cx - w / 2, cy - h / 2, w, h
 
     def globalCenterPosition(self, mode="sensor"):
-        return self._center
+        if mode == "roi":
+            return self._roi_center
+        elif mode == "sensor":
+            return self._sensor_center
+        raise ValueError(f"mode must be 'sensor' or 'roi', got {mode!r}")
 
     def getPixelSize(self):
         return (0.32e-6, 0.32e-6)
@@ -110,7 +135,9 @@ class _FakeCameraWithDevice(Qt.QWidget):
 
 
 def _makeWindow(tmp_path, cameraSelector=None):
-    """An AutopatchWindow with a loaded no-op protocol, as the tests above build it."""
+    """An AutopatchWindow with a loaded no-op protocol and a camera-backed
+    selector, for tests that don't care about protocol content but do need a
+    working camera to seed a slice or region."""
     from acq4.modules.Autopatch.Autopatch import AutopatchWindow
 
     if cameraSelector is None:
@@ -457,6 +484,21 @@ def test_add_region_here_seeds_a_multi_tile_region(qapp, tmp_path):
     assert len(win.slice.regions) == 1
     assert len(win.slice.tileGrid()) > 1
 
+    # The region itself must be 3x3 fields of view, centered on the camera's
+    # "roi" center -- not the sensor's, not the origin, and not anchored at a
+    # corner of the camera's center instead of straddling it. Computed
+    # independently of _cameraFov()/addRegionHere() (straight off the fake's
+    # "roi" boundary/center) so a bug in either of those is caught rather than
+    # echoed back at itself.
+    camera = win.cameraSelector.getSelectedObj()
+    _, _, fov_w, fov_h = camera.getBoundary(globalCoords=True, mode="roi")
+    cx, cy, _ = camera.globalCenterPosition("roi")
+    x0, y0, x1, y1 = win.slice.regions[0]
+    assert x0 == pytest.approx(cx - 3 * fov_w / 2)
+    assert y0 == pytest.approx(cy - 3 * fov_h / 2)
+    assert x1 == pytest.approx(cx + 3 * fov_w / 2)
+    assert y1 == pytest.approx(cy + 3 * fov_h / 2)
+
 
 def test_add_region_here_without_a_slice_starts_one(qapp, tmp_path):
     # Seeding a region is a reasonable first action: a slice comes into
@@ -503,6 +545,54 @@ def test_new_slice_clears_the_cell_list_and_the_orchestrators_queue(qapp, tmp_pa
     assert ran == [], "a cell survived New slice and was patched anyway"
 
 
+def test_new_slice_clears_the_producer(qapp, tmp_path):
+    # The producer closes over the slice it was built from; leaving it
+    # installed after that slice is discarded would keep surveying tissue
+    # the operator has already declared gone.
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    win._onStartRun()
+    assert win.orchestrator._cellProducer is not None
+
+    win.newSlice()
+
+    assert win.orchestrator._cellProducer is None
+
+
+def test_new_slice_detaches_the_producer_before_clearing_the_queue(qapp, tmp_path):
+    """newSlice() must clear the producer before clearing the queue: a refill
+    still in flight on the worker thread reads the producer and enqueues its
+    result as two separate steps (Orchestrator._refillQueue), so clearing the
+    queue first leaves a window where that in-flight refill can still land
+    one more old-slice tile in it after the operator has already declared the
+    tissue gone.
+
+    Deterministic rather than timing-dependent: clearQueue() is wrapped to
+    record whether the producer had already been detached by the time it
+    runs, exposing whichever order newSlice() actually calls the two methods
+    in without needing a second thread."""
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    win._onStartRun()
+    orch = win.orchestrator
+    assert orch._cellProducer is not None
+
+    producerAlreadyClearedWhenQueueCleared = []
+    realClearQueue = orch.clearQueue
+
+    def spyingClearQueue():
+        producerAlreadyClearedWhenQueueCleared.append(orch._cellProducer is None)
+        realClearQueue()
+
+    orch.clearQueue = spyingClearQueue
+
+    win.newSlice()
+
+    assert producerAlreadyClearedWhenQueueCleared == [True]
+
+
 def test_start_installs_a_producer_when_a_slice_has_a_region(qapp, tmp_path):
     win = _makeWindow(tmp_path)
     win.newSlice()
@@ -541,6 +631,93 @@ def test_start_clears_a_stale_producer_once_the_slice_is_gone(qapp, tmp_path):
     win._onStartRun()
 
     assert win.orchestrator._cellProducer is None
+
+
+class _CountingCameraSelector(Qt.QWidget):
+    """Like _CountingPipetteSelector, but for the camera: counts
+    getSelectedObj() calls and allows swapping the "selection" mid-test, so a
+    test can prove _onStartRun re-resolves the camera (and its scope) rather
+    than reusing whatever was cached from an earlier Start."""
+
+    def __init__(self, camera):
+        super().__init__()
+        self._camera = camera
+        self.callCount = 0
+
+    def getSelectedObj(self):
+        self.callCount += 1
+        return self._camera
+
+    def setCamera(self, camera) -> None:
+        self._camera = camera
+
+
+def test_camera_and_scope_are_re_resolved_on_every_start_not_cached(qapp, tmp_path):
+    """_onStartRun's docstring promises the camera and scope are re-resolved
+    on every Start, so the selection may change between runs. An operator who
+    switches the selected camera between runs must have the next run driven
+    by the new one, not a stale reference cached from an earlier Start."""
+    first = _FakeCamera()
+    selector = _CountingCameraSelector(first)
+    win = _makeWindow(tmp_path, cameraSelector=selector)
+    win.newSlice()
+    win.addRegionHere()
+
+    win._onStartRun()
+    assert win._cachedCamera is first
+    assert win._cachedScope is first.scopeDev
+
+    second = _FakeCamera()
+    selector.setCamera(second)
+    win._onStartRun()
+
+    assert win._cachedCamera is second
+    assert win._cachedScope is second.scopeDev
+
+
+def test_start_installs_a_producer_for_the_current_slice_not_a_stale_one(
+    qapp, tmp_path
+):
+    """_installCellProducer must build its producer from self.slice at the
+    moment Start is pressed, not from whichever slice an earlier Start
+    captured. newSlice() replacing a slice that already had a region (so the
+    survey check can't short-circuit the way it does when self.slice is None)
+    must have the next Start's producer survey the new slice, not the one it
+    replaced."""
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    firstSlice = win.slice
+    win._onStartRun()
+    assert win.orchestrator._cellProducer is not None
+
+    win.newSlice()
+    win.addRegionHere()
+    secondSlice = win.slice
+    assert secondSlice is not firstSlice
+
+    win._onStartRun()
+
+    producer = win.orchestrator._cellProducer
+    assert producer is not None
+    assert producer._slice is secondSlice
+
+
+def test_clicking_start_installs_a_producer(qapp, tmp_path):
+    """Every other producer test drives _onStartRun() directly, which would
+    still pass even if the real Start button stopped calling it. This one
+    drives the actual UI path -- clicking Start -- to prove the install is
+    still wired to it. The orchestrator's own start() is stubbed out so this
+    test exercises only the onStart hook, not a real run (which would need a
+    working camera/detector stack this window's fakes don't provide)."""
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    win.orchestrator.start = lambda: None
+
+    win.statusPanel.startBtn.click()
+
+    assert win.orchestrator._cellProducer is not None
 
 
 def test_teardown_clears_the_producer(qapp, tmp_path):

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -405,6 +405,84 @@ def test_loading_a_second_protocol_stops_and_releases_the_previous_orchestrator(
     assert firstOrchestrator.parent() is None
 
 
+def test_switching_to_a_different_protocol_carries_over_still_pending_seeded_cells(
+    qapp, tmp_path
+):
+    """A cell seeded through Area 5 while an orchestrator is bound is
+    enqueued straight into that orchestrator's own queue by
+    CellPanel._enqueueAndAdd(), and recorded in _awaitingEnqueue nowhere.
+    _onProtocolLoaded releases the whole outgoing Orchestrator -- its queue
+    included -- when the operator switches to a different protocol, so
+    without CellPanel.unbindOrchestrator() salvaging that queue first, the
+    seeded cell's row would survive in Area 5 while the freshly bound
+    orchestrator's queue held nothing for it, and pressing Start would patch
+    nothing."""
+    from acq4.modules.Autopatch.Autopatch import AutopatchWindow
+
+    _write_protocol(tmp_path, "first.py", _NOOP_PROTOCOL)
+    _write_protocol(tmp_path, "second.py", _NOOP_PROTOCOL)
+
+    win = AutopatchWindow(
+        module=None,
+        protocolDir=str(tmp_path),
+        pipetteSelector=_FakePipetteSelector(),
+        cameraSelector=_FakeCameraWithDevice(),
+    )
+    win.protocolPanel.fileCombo.setCurrentText("first")
+    firstOrchestrator = win.orchestrator
+
+    win.cellPanel._onScatterFakeCellsClicked()
+    seededCells = list(win.cellPanel._cells.values())
+    assert seededCells
+    assert firstOrchestrator.pendingCells() == seededCells
+
+    win.protocolPanel.fileCombo.setCurrentText("second")
+
+    assert win.orchestrator is not None
+    assert win.orchestrator is not firstOrchestrator
+    assert win.orchestrator.pendingCells() == seededCells
+    assert win.cellPanel.cellList.count() == len(seededCells)
+
+
+def test_a_finished_cell_seeded_while_bound_is_not_reflushed_on_protocol_switch(
+    qapp, qtbot, tmp_path
+):
+    """Complements the test above from the other direction: a cell seeded
+    while an orchestrator is bound is also enqueued straight into that
+    orchestrator's queue, but once a run actually pops and finishes it,
+    Orchestrator.pendingCells() no longer reports it. Switching to a
+    different protocol afterward must not hand that finished cell to the
+    freshly bound orchestrator for a second run -- the same pipette-safety
+    invariant the panel-level tests pin against an announced-only cell,
+    checked here against one this panel seeded itself."""
+    from acq4.modules.Autopatch.Autopatch import AutopatchWindow
+
+    _write_noop_protocol(tmp_path, "first.py")
+    _write_protocol(tmp_path, "second.py", _NOOP_PROTOCOL)
+
+    win = AutopatchWindow(
+        module=None,
+        protocolDir=str(tmp_path),
+        pipetteSelector=_FakePipetteSelector(target=(1e-3, 2e-3, 3e-3)),
+        cameraSelector=_FakeCameraSelector(),
+    )
+    win.protocolPanel.fileCombo.setCurrentText("first")
+    firstOrchestrator = win.orchestrator
+
+    win.cellPanel.addFromTargetBtn.click()
+    win.statusPanel.startBtn.click()
+    qtbot.waitUntil(
+        lambda: "done" in win.cellPanel.cellList.item(0).text(), timeout=2000
+    )
+    assert firstOrchestrator.pendingCells() == []
+
+    win.protocolPanel.fileCombo.setCurrentText("second")
+
+    assert win.orchestrator is not None
+    assert win.orchestrator is not firstOrchestrator
+    assert win.orchestrator.pendingCells() == []
+
+
 def test_area4_controls_disabled_while_running_and_reenabled_when_stopped(
     qapp, qtbot, tmp_path
 ):

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -110,6 +110,12 @@ class _FakeCamera:
             cx, cy, _ = self._sensor_center
         else:
             raise ValueError(f"mode must be 'sensor' or 'roi', got {mode!r}")
+        if not globalCoords:
+            # Local coordinates are pixel-space, a completely different scale
+            # than the metre-scale global bounds below -- a caller that reads
+            # this without globalCoords=True gets an obviously wrong field of
+            # view rather than one that happens to still look like metres.
+            return 0.0, 0.0, w * 1e6, h * 1e6
         return cx - w / 2, cy - h / 2, w, h
 
     def globalCenterPosition(self, mode="sensor"):
@@ -443,6 +449,14 @@ def test_new_slice_creates_a_slice_using_the_cameras_field_of_view(qapp, tmp_pat
     win.newSlice()
     assert win.slice is not None
     assert win.slice.tileGrid() == [], "a new slice has no regions to survey yet"
+
+    # The slice's field of view must be the camera's "roi" boundary, in the
+    # camera's own axis order -- not swapped, which would give the tile grid
+    # the wrong stride in each direction (the fake's roi_fov is deliberately
+    # non-square so a swap cannot pass by coincidence).
+    camera = win.cameraSelector.getSelectedObj()
+    _, _, fov_w, fov_h = camera.getBoundary(globalCoords=True, mode="roi")
+    assert win.slice._fov == pytest.approx((abs(fov_w), abs(fov_h)))
 
 
 def test_new_slice_without_a_camera_reports_rather_than_raising(qapp, tmp_path):

--- a/docs/superpowers/plans/2026-07-30-autopatch-p2b-slice-and-producer.md
+++ b/docs/superpowers/plans/2026-07-30-autopatch-p2b-slice-and-producer.md
@@ -45,6 +45,7 @@
 | `acq4/experiment/tests/test_search_grid.py` | Grid geometry tests, moved from `AutomationDebug/tests/test_survey.py`. |
 | `acq4/experiment/tests/test_slice.py` | `SearchConstraints` validation, `Slice` regions/coverage/stats. |
 | `acq4/experiment/tests/test_cell_producer.py` | Tile walk, `[]` vs `None`, health cutoff, density cap, rescans, leak. |
+| `acq4/experiment/tests/test_tile_detector.py` | Per-tile depth arithmetic, focus restoration, stop handling, cell construction. |
 | `acq4/modules/Autopatch/search_panel.py` | Area 2 widget: the four constraints, "Add region here", survey readout. |
 | `acq4/modules/Autopatch/tests/test_search_panel.py` | Area 2 widget behaviour. |
 | `.superpowers/sdd/p2b-smoke-brief.md` | Human-run live smoke-test brief (Task 12). |
@@ -1810,18 +1811,254 @@ EOF
 
 The one function that touches devices: move the stage to a tile, find that tile's surface, acquire a stack across the constrained depth range, detect and score cells, and build `Cell` objects with their trackers seeded from that stack. Modelled on `AutomationDebug/detection.py:_detectNeuronsZStack` and `autopatch.py:_autopatchFindCell`, which are the working reference for every one of these calls.
 
-Nothing headless can test this — it needs a microscope, a camera, and `acq4_automation`'s models. It is therefore deliberately thin: all the logic worth testing was pushed into Tasks 3–5. Its verification is Task 12's live smoke test.
+The device calls themselves cannot be exercised headlessly, but the orchestration around them can, and it holds the mistakes worth catching: the sign of the depth arithmetic, restoring focus on the failure path, and honouring a stop between slow steps. So the file is deliberately split — `detect()` sequences, and `_acquire`/`_detect`/`_newCell`/`_health_models` are module-level functions a test replaces with fakes via `monkeypatch.setattr`. No production seam is added for testability beyond that split, and no test asserts a call sequence for its own sake.
 
 **Files:**
 - Create: `acq4/experiment/tile_detector.py`
+- Create: `acq4/experiment/tests/test_tile_detector.py`
 
 **Interfaces:**
 - Consumes: `SearchConstraints.z_bounds(surface)` (Task 2).
-- Produces: `make_tile_detector(camera, scope, manager, step_z=1e-6, min_volume_m3=0.0, max_candidates=5) -> Callable[[tuple[float, float], SearchConstraints], list]`. The returned callable is the `detector` seam `CellProducer` takes (Task 4), and runs on the orchestrator's worker thread.
+- Produces: `make_tile_detector(camera, scope, manager, step_z=1e-6, min_volume_m3=0.0, max_candidates=5) -> Callable[[tuple[float, float], SearchConstraints], list]`. The returned callable is the `detector` seam `CellProducer` takes (Task 4), and runs on the orchestrator's worker thread. Module-level helpers `_acquire(camera, start_z, stop_z, step_z) -> list`, `_detect(stack, xy_scale, z_scale, models, min_volume_m3, max_candidates) -> list[tuple]`, `_newCell(position) -> Cell`, `_health_models(manager) -> dict`.
 
-- [ ] **Step 1: Write the implementation**
+- [ ] **Step 1: Write the failing tests**
 
-There is no failing-test step here: this file is device glue with no headless-testable behaviour, and inventing a mock microscope to assert call order would test the mock, not the code. Create `acq4/experiment/tile_detector.py`:
+Create `acq4/experiment/tests/test_tile_detector.py`:
+
+```python
+"""Tests for the tile detector's orchestration: the depth arithmetic it derives
+from each tile's surface, focus restoration, stop handling, and cell construction."""
+
+import pytest
+
+from acq4.experiment import tile_detector
+from acq4.experiment.slice import SearchConstraints
+from acq4.util.task import Stopped
+
+
+class FakeScope:
+    def __init__(self, surface=0.0):
+        self.surface = surface
+        self.moves = []
+
+    def setGlobalPosition(self, pos, speed="fast", name=None):
+        self.moves.append(tuple(pos))
+        return FakeFuture()
+
+    def findSurfaceDepth(self, imager):
+        return self.surface
+
+
+class FakeFuture:
+    def wait(self, **kwargs):
+        return None
+
+
+class FakeCamera:
+    def __init__(self, focus=-1e-3):
+        self._focus = focus
+        self.focusSets = []
+
+    def name(self):
+        return "FakeCamera"
+
+    def getFocusDepth(self):
+        return self._focus
+
+    def setFocusDepth(self, z, speed="fast", name=None):
+        self.focusSets.append(z)
+        return FakeFuture()
+
+    def getPixelSize(self):
+        return (0.32e-6, 0.32e-6)
+
+
+class FakeCell:
+    """Stand-in for acq4_automation's Cell; `trackerFails` makes tracker init raise."""
+
+    trackerFails = False
+
+    def __init__(self, position):
+        self.position = position
+        self.score = None
+        self.trackerInits = 0
+
+    def initializeTrackerFromStack(self, camera, stack, use_cellpose=False):
+        self.trackerInits += 1
+        if self.trackerFails:
+            raise ValueError("cell too close to the stack edge")
+
+
+@pytest.fixture
+def rig(monkeypatch):
+    """A detector wired to fake devices, with the device-touching helpers replaced.
+
+    Returns a namespace carrying the camera, the scope, the recorded _acquire
+    arguments, and the detector callable itself.
+    """
+    camera = FakeCamera()
+    scope = FakeScope(surface=-500e-6)
+    acquireCalls = []
+    detectCalls = []
+
+    def fakeAcquire(cam, start_z, stop_z, step_z):
+        acquireCalls.append((start_z, stop_z, step_z))
+        return ["frame"]
+
+    def fakeDetect(stack, xy_scale, z_scale, models, min_volume_m3, max_candidates):
+        detectCalls.append(
+            (stack, xy_scale, z_scale, models, min_volume_m3, max_candidates)
+        )
+        return [((1e-6, 2e-6, -530e-6), 0.8)]
+
+    monkeypatch.setattr(tile_detector, "_acquire", fakeAcquire)
+    monkeypatch.setattr(tile_detector, "_detect", fakeDetect)
+    monkeypatch.setattr(tile_detector, "_newCell", FakeCell)
+
+    detect = tile_detector.make_tile_detector(camera=camera, scope=scope, manager=None)
+
+    class Rig:
+        pass
+
+    rig = Rig()
+    rig.camera = camera
+    rig.scope = scope
+    rig.acquireCalls = acquireCalls
+    rig.detectCalls = detectCalls
+    rig.detect = detect
+    return rig
+
+
+def test_the_stack_spans_the_constrained_range_below_this_tiles_surface(rig):
+    # The whole reason depth is expressed as offsets from the surface: the slab
+    # follows the tissue, so a tile whose surface is at -500 um must be searched
+    # 20-60 um below THAT, not below zero.
+    rig.detect((0.0, 0.0), SearchConstraints(depth_range=(-20e-6, -60e-6)))
+
+    start_z, stop_z, step_z = rig.acquireCalls[0]
+    assert start_z == pytest.approx(-520e-6)
+    assert stop_z == pytest.approx(-560e-6)
+    assert step_z == pytest.approx(1e-6)
+
+
+def test_the_depth_range_is_read_from_the_constraints_it_is_given(rig):
+    # Not from a value captured when the detector was built: the operator may
+    # edit the range between runs, and the slice hands its current constraints
+    # to every call.
+    rig.detect((0.0, 0.0), SearchConstraints(depth_range=(-5e-6, -15e-6)))
+
+    start_z, stop_z, _ = rig.acquireCalls[0]
+    assert start_z == pytest.approx(-505e-6)
+    assert stop_z == pytest.approx(-515e-6)
+
+
+def test_the_stage_moves_to_the_tile_before_the_surface_is_found(rig):
+    # Surface is per tile, so searching for it before arriving would measure the
+    # previous tile's tissue.
+    rig.detect((3e-6, 4e-6), SearchConstraints())
+    assert rig.scope.moves == [(3e-6, 4e-6)]
+
+
+def test_focus_is_restored_after_a_successful_survey(rig):
+    before = rig.camera.getFocusDepth()
+    rig.detect((0.0, 0.0), SearchConstraints())
+    assert rig.camera.focusSets[-1] == pytest.approx(before)
+
+
+def test_focus_is_restored_when_acquisition_raises(rig, monkeypatch):
+    # A survey that dies mid-stack must not leave the objective parked deep in
+    # the tissue for whatever runs next.
+    before = rig.camera.getFocusDepth()
+
+    def boom(cam, start_z, stop_z, step_z):
+        raise RuntimeError("camera died")
+
+    monkeypatch.setattr(tile_detector, "_acquire", boom)
+
+    with pytest.raises(RuntimeError, match="camera died"):
+        rig.detect((0.0, 0.0), SearchConstraints())
+
+    assert rig.camera.focusSets[-1] == pytest.approx(before)
+
+
+def test_a_stop_prevents_the_survey_from_imaging(rig, monkeypatch):
+    # Imaging a tile is slow, so a stop must be honoured before the stack starts,
+    # not only after it finishes.
+    def stopNow():
+        raise Stopped("stopped by operator")
+
+    monkeypatch.setattr(tile_detector, "check_stop", stopNow)
+
+    with pytest.raises(Stopped):
+        rig.detect((0.0, 0.0), SearchConstraints())
+
+    assert rig.acquireCalls == []
+    assert rig.scope.moves == []
+
+
+def test_detected_cells_carry_their_health_score(rig):
+    cells = rig.detect((0.0, 0.0), SearchConstraints())
+    assert len(cells) == 1
+    assert cells[0].score == pytest.approx(0.8)
+    assert cells[0].position == (1e-6, 2e-6, -530e-6)
+
+
+def test_tracking_is_seeded_from_the_stack_the_cell_was_found_in(rig):
+    cells = rig.detect((0.0, 0.0), SearchConstraints())
+    assert cells[0].trackerInits == 1
+
+
+def test_a_cell_whose_tracker_cannot_be_seeded_is_still_returned(rig, monkeypatch):
+    # A cell too close to the stack edge cannot be extracted, but it is a real
+    # detection: discarding it would silently drop cells at every tile boundary.
+    monkeypatch.setattr(FakeCell, "trackerFails", True)
+
+    cells = rig.detect((0.0, 0.0), SearchConstraints())
+
+    assert len(cells) == 1
+    assert cells[0].score == pytest.approx(0.8)
+
+
+def test_the_pixel_size_and_step_reach_detection(rig):
+    rig.detect((0.0, 0.0), SearchConstraints())
+    stack, xy_scale, z_scale, _models, _min_volume, _n = rig.detectCalls[0]
+    assert stack == ["frame"]
+    assert xy_scale == pytest.approx(0.32e-6)
+    assert z_scale == pytest.approx(1e-6)
+
+
+class FakeManager:
+    def __init__(self, misc):
+        self.config = {"misc": misc}
+
+
+def test_health_models_come_from_the_misc_config():
+    models = tile_detector._health_models(
+        FakeManager({"segmenterPath": "/seg.pt", "classifierPath": "/cls.pt"})
+    )
+    assert models["segmenter"] == "/seg.pt"
+    assert models["classifier"] == "/cls.pt"
+    assert models["autoencoder"] is None
+    assert models["resnet_classifier"] is None
+
+
+def test_health_models_without_a_manager_are_all_unset():
+    # A headless or partially-configured rig must not raise here; detect_neurons
+    # accepts None for every model.
+    assert set(tile_detector._health_models(None).values()) == {None}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_tile_detector.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'acq4.experiment.tile_detector'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `acq4/experiment/tile_detector.py`:
 
 ```python
 """The imaging half of a cell producer: move to a tile, find its surface, acquire
@@ -1857,13 +2094,6 @@ def make_tile_detector(
     """
 
     def detect(center, constraints) -> list:
-        # Imported here, not at module scope: acq4_automation lives in an
-        # internal repository, and a top-level import would stop every test
-        # under acq4/experiment from collecting where it is absent.
-        from acq4_automation.feature_tracking.cell import Cell
-        from acq4_automation.object_detection import detect_neurons
-        from coorx import Point
-
         check_stop()
         logger.info("Surveying tile at %r", center)
         scope.setGlobalPosition(center, name="autopatch survey move").wait()
@@ -1877,51 +2107,85 @@ def make_tile_detector(
         try:
             stack = _acquire(camera, start_z, stop_z, step_z)
         finally:
+            # Restored on the failure path too: a survey that dies mid-stack
+            # must not leave the objective parked deep in the tissue for
+            # whatever runs next.
             camera.setFocusDepth(
                 restore_depth, name=f"{camera.name()} restore focus after survey stack"
             )
 
         check_stop()
-        models = _health_models(manager)
-        results = detect_neurons(
+        results = _detect(
             stack,
             xy_scale=camera.getPixelSize()[0],
             z_scale=step_z,
-            trim_edges=True,
+            models=_health_models(manager),
             min_volume_m3=min_volume_m3,
-            n=max_candidates,
-            **models,
+            max_candidates=max_candidates,
         )
         logger.info("Tile at %r yielded %d candidates", center, len(results))
-
-        cells = []
-        for position, score in results:
-            cell = Cell(Point(position, "global"))
-            cell.score = score
-            try:
-                # Seeded from the stack the cell was found in, so tracking is
-                # ready without re-acquiring a stack per cell. A cell too close
-                # to the stack edge cannot be extracted; queue it anyway rather
-                # than discarding a real detection.
-                cell.initializeTrackerFromStack(camera, stack, use_cellpose=True)
-            except Exception:
-                logger.warning(
-                    "Could not initialize tracking for the cell detected at %r",
-                    position,
-                    exc_info=True,
-                )
-            cells.append(cell)
-        return cells
+        return _build_cells(camera, stack, results)
 
     return detect
 
 
+def _build_cells(camera, stack, results) -> list:
+    """Cells for each (position, score) detection, tracking seeded from `stack`."""
+    cells = []
+    for position, score in results:
+        cell = _newCell(position)
+        cell.score = score
+        try:
+            # Seeded from the stack the cell was found in, so tracking is ready
+            # without re-acquiring a stack per cell.
+            cell.initializeTrackerFromStack(camera, stack, use_cellpose=True)
+        except Exception:
+            # A cell too close to the stack edge cannot be extracted, but it is
+            # still a real detection: queue it rather than silently dropping
+            # every cell near a tile boundary.
+            logger.warning(
+                "Could not initialize tracking for the cell detected at %r",
+                position,
+                exc_info=True,
+            )
+        cells.append(cell)
+    return cells
+
+
+def _newCell(position):
+    """A Cell at a global position.
+
+    Imported here, not at module scope: acq4_automation lives in an internal
+    repository, and a top-level import would stop every test under
+    acq4/experiment from collecting where it is absent.
+    """
+    from acq4_automation.feature_tracking.cell import Cell
+    from coorx import Point
+
+    return Cell(Point(position, "global"))
+
+
 def _acquire(camera, start_z: float, stop_z: float, step_z: float) -> list:
-    """The tile's z-stack, shallowest frame first."""
+    """The tile's z-stack."""
     from acq4.util.imaging.sequencer import acquire_z_stack
 
     return acquire_z_stack(
         camera, start_z, stop_z, step_z, slow_fallback=False, name="autopatch survey stack"
+    )
+
+
+def _detect(stack, xy_scale, z_scale, models, min_volume_m3, max_candidates) -> list:
+    """Scored (position, score) candidates in `stack`. See _newCell on the import."""
+    from acq4_automation.object_detection import detect_neurons
+
+    return detect_neurons(
+        stack,
+        xy_scale=xy_scale,
+        z_scale=z_scale,
+        trim_edges=True,
+        min_volume_m3=min_volume_m3,
+        n=max_candidates,
+        **models,
     )
 
 
@@ -1940,9 +2204,50 @@ def _health_models(manager) -> dict:
     }
 ```
 
-- [ ] **Step 2: Verify the module imports where `acq4_automation` is absent**
+- [ ] **Step 4: Run to verify they pass**
 
-This is the property that keeps `acq4/experiment/tests` collecting on a public runner, and it is the one thing about this file that *can* be checked mechanically:
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_tile_detector.py -v
+```
+
+Expected: 12 passed.
+
+- [ ] **Step 5: Mutation-verify the three absence-shaped assertions**
+
+(a) The depth sign. `z_bounds` is the one place the sign convention is applied, and a flipped sign would drive the objective *above* the tissue. Subtract instead of add in `SearchConstraints.z_bounds`:
+
+```python
+    def z_bounds(self, surface):
+        near, far = self.depth_range
+        return surface - max(near, far), surface - min(near, far)   # DEFECT
+```
+
+Expected: `test_the_stack_spans_the_constrained_range_below_this_tiles_surface` FAILS with `-480e-6` where `-520e-6` was expected. Revert.
+
+(b) Focus restoration on the failure path. Move the restore out of the `finally`:
+
+```python
+        stack = _acquire(camera, start_z, stop_z, step_z)
+        camera.setFocusDepth(restore_depth, name=...)     # DEFECT: not restored on raise
+```
+
+Expected: `test_focus_is_restored_when_acquisition_raises` FAILS (`focusSets` is empty, raising `IndexError`, or holds no restore value). Revert.
+
+(c) A cell with a failed tracker must survive. Re-raise instead of logging:
+
+```python
+        try:
+            cell.initializeTrackerFromStack(camera, stack, use_cellpose=True)
+        except Exception:
+            logger.warning(...)
+            continue                                       # DEFECT: drops a real detection
+```
+
+Expected: `test_a_cell_whose_tracker_cannot_be_seeded_is_still_returned` FAILS on `assert len(cells) == 1`. Revert.
+
+- [ ] **Step 6: Verify the module imports where `acq4_automation` is absent**
+
+This is the property that keeps `acq4/experiment/tests` collecting on a public runner:
 
 ```bash
 /home/martin/.miniforge3/envs/acq4-gl/bin/python -c "
@@ -1955,7 +2260,7 @@ print('imports clean:', callable(td.make_tile_detector))
 
 Expected: `imports clean: True`.
 
-- [ ] **Step 3: Verify the whole engine suite still collects and passes**
+- [ ] **Step 7: Run the whole engine suite and commit**
 
 ```bash
 /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/ -q
@@ -1963,17 +2268,17 @@ Expected: `imports clean: True`.
 
 Expected: all pass, no collection errors.
 
-- [ ] **Step 4: Commit**
-
 ```bash
-git add acq4/experiment/tile_detector.py
+git add acq4/experiment/tile_detector.py acq4/experiment/tests/test_tile_detector.py
 git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
 feat: add the tile detector, a cell producer's imaging half
 
 Moves to a tile, finds that tile's surface, acquires a stack across the
 constrained depth range, and returns scored cells with trackers seeded from
-that stack. acq4_automation is imported lazily so the engine's tests still
-collect where it is absent.
+that stack. The device calls are module-level functions so the orchestration
+around them -- the depth arithmetic, focus restoration on the failure path,
+and stop handling -- is tested with fakes. acq4_automation is imported lazily
+so the engine's tests still collect where it is absent.
 
 🤖 Generated with [Claude Code](https://claude.ai/code)
 EOF

--- a/docs/superpowers/plans/2026-07-30-autopatch-p2b-slice-and-producer.md
+++ b/docs/superpowers/plans/2026-07-30-autopatch-p2b-slice-and-producer.md
@@ -1,0 +1,2915 @@
+# Autopatch P2b — `Slice`, Area 2 cell-finding config, and a real cell producer
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the `Slice` object that owns a piece of tissue's search state, make it hand out real cell producers that image and detect cells tile by tile, and give the operator an Area 2 panel to configure the search — so the P2a `cellProducer` hook finally has something real plugged into it.
+
+**Architecture:** Three layers, split so the testable part is actually tested. (1) **Pure geometry** — the serpentine tile grid, already TDD'd in `acq4/modules/AutomationDebug/survey.py`, moves into `acq4/experiment/search_grid.py` where CI can reach it. (2) **Pure search logic** — `Slice` (regions, coverage, constraints) and `CellProducer` (tile walk, health cutoff, density cap, rescans, and the `[]`-vs-`None` exhaustion contract) are plain objects with no device or `acq4_automation` imports, driven in tests by a fake detector. (3) **Device glue** — `tile_detector.py` holds the one function that moves the stage, finds the surface, acquires a z-stack, and calls `detect_neurons`; it is thin by design because nothing headless can test it.
+
+`Slice` lives in `acq4/experiment/` (owner decision, 2026-07-30, resolving design §6b's open question) so its tests run on a public runner rather than in the `acq4_automation`-gated `modules/Autopatch/tests` directory that `conftest.py` skips.
+
+**Tech Stack:** Python 3.12, PyQt (via `acq4.util.Qt`), pyqtgraph, `acq4.util.task` (gentletask bridge: `check_stop`, `Stopped`, `run_in_gui_thread`, `synch`), pytest + pytest-qt, `acq4_automation` (internal: `object_detection.detect_neurons`, `feature_tracking.cell.Cell`).
+
+## Global Constraints
+
+- Python interpreter is `/home/martin/.miniforge3/envs/acq4-gl/bin/python`. Never `acq4-torch`.
+- All new files start with a brief 2-line comment/docstring explaining what the file does.
+- Comments are evergreen: never refer to refactors, "recently", "now", phases, or change history.
+- Commit format per repo `CLAUDE.md`: `<type>: <description>`, plus `--author` containing `(claude)`, plus the `🤖 Generated with [Claude Code](https://claude.ai/code)` footer. Commit email `outofculture@gmail.com`.
+- Never `git commit --no-verify`.
+- TDD: failing test first, watch it fail, minimal implementation, watch it pass, commit.
+- **Mutation-verify any test whose assertion is about absence, or about a value that could be trivially already-correct.** Three P2a tests were vacuous — they asserted the right property but could not reach the state that distinguishes fixed from broken code. Where this plan says "mutation-verify", it means: apply the named defect to the implementation, observe the named test fail, revert the defect. This is not optional and is not satisfied by re-reading the test.
+- "Depth" in this plan is *always* a z-range relative to the tissue surface. It is never a queue length. The `targetQueueDepth` concept was built in P2a and deleted on owner review; do not reintroduce it.
+- The producer contract from design §3.2 is load-bearing and must not be "simplified": `producer() -> Sequence[cell] | None`, where `[]` means "made progress, found nothing here, ask me again" and `None` means "exhausted, never ask again". A producer that returns `[]` forever wedges the run loop.
+- No `acq4_automation` import at module top level in any file under `acq4/experiment/`. Import it inside the function that needs it, the way `acq4/modules/AutomationDebug/detection.py` does — otherwise `acq4/experiment/tests` stops collecting on a public runner.
+- `Slice` and `CellProducer` are plain Python objects, not `QObject`s. They hold no widgets and must stay refcount-freeable (see Task 6).
+
+**Reference documents:**
+- Design doc: `/home/martin/src/acq4/acq4/autopatch-orchestration-design.md` (untracked, in the main checkout, not in this worktree) — §3.2 (Start loop / producer contract), §6b (`Slice`), §7 Area 1/Area 2, §10 (phasing).
+- P2a plan: `docs/superpowers/plans/2026-07-29-autopatch-p2a-cell-producer.md`.
+
+**Explicitly out of scope for P2b** (P2c or later): Area 1's draggable ROI graphics and the mirror-to-Camera checkbox; the progress heatmap rendering; the pinned-frames imaging workflow; disk persistence of slice state via `DirHandle.setInfo()` (design §6b calls this "not required for a first cut"); the cross-repo `acq4_automation.Cell` expansion the heatmap's per-cell colouring would force.
+
+---
+
+## File Structure
+
+**Created:**
+
+| File | Responsibility |
+|---|---|
+| `acq4/experiment/search_grid.py` | Pure serpentine tile-grid geometry, moved verbatim from `AutomationDebug/survey.py`. |
+| `acq4/experiment/slice.py` | `SearchConstraints` (the four Area 2 constraints, validated) and `Slice` (regions, coverage, constraints, `makeCellProducer()`). |
+| `acq4/experiment/cell_producer.py` | `CellProducer` — the callable the orchestrator's refill hook takes. Tile walk, filtering, exhaustion. |
+| `acq4/experiment/tile_detector.py` | `make_tile_detector()` — the real device glue: move stage, find surface, z-stack, `detect_neurons`. Lazy `acq4_automation` import. |
+| `acq4/experiment/tests/test_search_grid.py` | Grid geometry tests, moved from `AutomationDebug/tests/test_survey.py`. |
+| `acq4/experiment/tests/test_slice.py` | `SearchConstraints` validation, `Slice` regions/coverage/stats. |
+| `acq4/experiment/tests/test_cell_producer.py` | Tile walk, `[]` vs `None`, health cutoff, density cap, rescans, leak. |
+| `acq4/modules/Autopatch/search_panel.py` | Area 2 widget: the four constraints, "Add region here", survey readout. |
+| `acq4/modules/Autopatch/tests/test_search_panel.py` | Area 2 widget behaviour. |
+| `.superpowers/sdd/p2b-smoke-brief.md` | Human-run live smoke-test brief (Task 12). |
+
+**Modified:**
+
+| File | Change |
+|---|---|
+| `acq4/modules/AutomationDebug/survey.py` | Re-export the grid functions from `acq4/experiment/search_grid.py` instead of defining them. |
+| `acq4/modules/AutomationDebug/tests/test_survey.py` | Deleted; its content moves to `acq4/experiment/tests/test_search_grid.py`. |
+| `acq4/experiment/orchestrator.py` | Add the `"surveying"` status, clear `sigCurrentCell` before a refill, add `clearQueue()`. |
+| `acq4/experiment/tests/test_orchestrator_producer.py` | Tests for the three orchestrator changes above. |
+| `acq4/modules/Autopatch/status_panel.py` | Handle `"surveying"` in `_onStatus`/`_updateButtons`. |
+| `acq4/modules/Autopatch/tests/test_status_panel.py` | Tests for the `"surveying"` gating. |
+| `acq4/modules/Autopatch/Autopatch.py` | Own the `Slice`, Area 1 "New slice" button, Area 2 panel, install/clear the producer. |
+| `acq4/modules/Autopatch/tests/test_window_integration.py` | Producer install at Start, `setCellProducer(None)` on teardown/reload. |
+
+**Two decisions this plan makes, flagged for owner confirmation:**
+
+1. **`rescans_allowed=True` grants exactly one extra pass, not unlimited rescanning.** An unbounded rescan loop would never return `None`, which violates the §3.2 contract and wedges the run loop — so "unlimited" is not an available reading. One extra pass per producer is the smallest thing that makes the switch mean something while keeping the contract. Recorded in `CellProducer`'s docstring.
+2. **Depth range is stored as signed offsets from the surface** (design §7's example, −20 µm to −60 µm, is `depth_range=(-20e-6, -60e-6)`), so `z = surface + offset`. `AutomationDebug`'s spinboxes instead hold *positive* depths and subtract (`start_z = surface - spin.value()`); the signed form is used here because it matches the design doc's notation and makes the sign explicit at the one place it matters.
+
+---
+
+### Task 1: Move the tile-grid geometry into the engine
+
+The serpentine grid math is already written and TDD'd, but it lives in a UI module that `conftest.py` excludes from public CI, and P2b's producer needs it from the engine. Move it; leave `AutomationDebug` working by re-exporting. This is a refactor — no behaviour changes.
+
+**Files:**
+- Create: `acq4/experiment/search_grid.py`
+- Create: `acq4/experiment/tests/test_search_grid.py`
+- Modify: `acq4/modules/AutomationDebug/survey.py:1-96`
+- Delete: `acq4/modules/AutomationDebug/tests/test_survey.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `plan_grid(x0, y0, x1, y1, fov_w, fov_h, overlap) -> list[tuple[float, float]]`; `select_next(grid, visited, threshold) -> tuple[float, float] | None`; `count_covered(grid, visited, threshold) -> int`; `_is_visited(cx, cy, visited, threshold) -> bool`. All coordinates are global metres.
+
+- [ ] **Step 1: Create the new module by moving the four functions verbatim**
+
+Create `acq4/experiment/search_grid.py`. Copy `_axis_centers`, `plan_grid`, `_is_visited`, `select_next`, and `count_covered` from `acq4/modules/AutomationDebug/survey.py` **unchanged, including their docstrings** — they are correct and reviewed. Only the module docstring and the imports are new:
+
+```python
+"""Serpentine field-of-view tiling over a rectangular search region, and
+tracking which of those tiles have already been imaged."""
+
+from __future__ import annotations
+
+import math
+```
+
+Do not copy `import pyqtgraph as pg`, the `TYPE_CHECKING` block, or `SurveyRegion` — those are Qt/camera glue and stay in `AutomationDebug`.
+
+- [ ] **Step 2: Move the test file**
+
+Create `acq4/experiment/tests/test_search_grid.py` with the full content of `acq4/modules/AutomationDebug/tests/test_survey.py`, changing only the import and the module docstring:
+
+```python
+"""Tests for the search-region grid packing: serpentine FOV tiling that fully
+covers a rectangle, and choosing the next un-imaged tile."""
+
+import math
+
+from acq4.experiment.search_grid import (
+    _is_visited,
+    count_covered,
+    plan_grid,
+    select_next,
+)
+```
+
+Then delete `acq4/modules/AutomationDebug/tests/test_survey.py`.
+
+- [ ] **Step 3: Run the moved tests**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_search_grid.py -v
+```
+
+Expected: 12 passed (the same count `test_survey.py` had).
+
+- [ ] **Step 4: Repoint `survey.py` at the engine module**
+
+In `acq4/modules/AutomationDebug/survey.py`, delete the bodies of `_axis_centers`, `plan_grid`, `_is_visited`, `select_next`, and `count_covered`, and delete `import math`. Replace the import block so `SurveyRegion` (which stays) and any other importer get the functions from their new home:
+
+```python
+"""Survey-region support for the autopatch demo: pack the camera field of view as
+a grid over a user-defined rectangle and track which tiles have been imaged.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pyqtgraph as pg
+
+from acq4.experiment.search_grid import count_covered, plan_grid, select_next
+
+if TYPE_CHECKING:
+    from .AutomationDebug import AutomationDebugWindow
+```
+
+`SurveyRegion` itself is untouched. Note `_is_visited` is not re-exported: nothing outside the deleted test file used it.
+
+- [ ] **Step 5: Verify no importer broke**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -c "from acq4.modules.AutomationDebug.survey import SurveyRegion, plan_grid, select_next, count_covered; print('ok')"
+```
+
+Expected: `ok`.
+
+Then confirm nothing else referenced the moved names:
+
+```bash
+grep -rn "AutomationDebug.survey\|from .survey" --include=*.py acq4/
+```
+
+Expected: only `acq4/modules/AutomationDebug/AutomationDebug.py:27` (`from .survey import SurveyRegion`).
+
+- [ ] **Step 6: Run the full engine suite**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/ -q
+```
+
+Expected: all pass, 12 more than the pre-task count.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add acq4/experiment/search_grid.py acq4/experiment/tests/test_search_grid.py acq4/modules/AutomationDebug/survey.py acq4/modules/AutomationDebug/tests/test_survey.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+refactor: move the search-region grid math into acq4/experiment
+
+The serpentine tile grid is engine logic, needed by the cell producer, and
+its tests only ran where acq4_automation is installed because they lived
+under AutomationDebug/tests. SurveyRegion re-exports from the new home.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 2: `SearchConstraints`
+
+The four Area 2 search constraints as one validated value object. Validation matters because these come from operator spinboxes and a bad value silently produces either zero cells or every cell.
+
+**Files:**
+- Create: `acq4/experiment/slice.py`
+- Create: `acq4/experiment/tests/test_slice.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `SearchConstraints(depth_range: tuple[float, float] = (-20e-6, -60e-6), min_health: float = 0.5, max_cell_density: float = 5e12, rescans_allowed: bool = False)`, a frozen dataclass raising `ValueError` from `__post_init__` on invalid input. `max_cell_density` is cells per cubic metre (5e12 /m³ ≈ 5 cells per 1000 µm³... see Step 1's note on units).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `acq4/experiment/tests/test_slice.py`:
+
+```python
+"""Tests for SearchConstraints validation and the Slice object's regions,
+coverage, and survey statistics."""
+
+import pytest
+
+from acq4.experiment.slice import SearchConstraints
+
+
+def test_defaults_are_a_usable_search():
+    c = SearchConstraints()
+    assert c.depth_range == (-20e-6, -60e-6)
+    assert 0.0 <= c.min_health <= 1.0
+    assert c.max_cell_density > 0
+    assert c.rescans_allowed is False
+
+
+def test_depth_range_offsets_must_be_at_or_below_the_surface():
+    # Offsets are relative to the tissue surface and negative is deeper, so a
+    # positive offset would search in the bath above the tissue.
+    with pytest.raises(ValueError, match="at or below the surface"):
+        SearchConstraints(depth_range=(20e-6, -60e-6))
+
+
+def test_depth_range_must_span_a_nonzero_thickness():
+    with pytest.raises(ValueError, match="nonzero thickness"):
+        SearchConstraints(depth_range=(-40e-6, -40e-6))
+
+
+def test_depth_range_accepts_either_ordering():
+    # An operator may type the deeper bound first; both describe the same slab.
+    shallow_first = SearchConstraints(depth_range=(-20e-6, -60e-6))
+    deep_first = SearchConstraints(depth_range=(-60e-6, -20e-6))
+    assert shallow_first.z_span() == deep_first.z_span()
+    assert shallow_first.z_span() == pytest.approx(40e-6)
+
+
+def test_min_health_must_be_a_probability():
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        SearchConstraints(min_health=1.5)
+    with pytest.raises(ValueError, match="between 0 and 1"):
+        SearchConstraints(min_health=-0.1)
+
+
+def test_max_cell_density_must_be_positive():
+    with pytest.raises(ValueError, match="positive"):
+        SearchConstraints(max_cell_density=0.0)
+
+
+def test_constraints_are_frozen():
+    c = SearchConstraints()
+    with pytest.raises(Exception):
+        c.min_health = 0.9
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -v
+```
+
+Expected: collection error, `ModuleNotFoundError: No module named 'acq4.experiment.slice'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `acq4/experiment/slice.py`:
+
+```python
+"""Slice: the search state for one piece of tissue -- the regions to survey, the
+tiles already imaged, the search constraints, and the cell producers it hands out."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SearchConstraints:
+    """The Area 2 search constraints that parameterise a cell producer.
+
+    `depth_range` is a pair of z offsets **relative to the tissue surface**, in
+    metres, negative being deeper: the design's "-20 um through -60 um" is
+    (-20e-6, -60e-6). Surface is found per tile, so the slab follows uneven
+    tissue rather than being absolute stage z. Either ordering is accepted.
+
+    `min_health` is the classification model's score cutoff in [0, 1]; cells
+    scoring below it are not queued. `max_cell_density` is cells per cubic
+    metre, above which a tile counts as already crowded and is skipped rather
+    than having more targets packed into it. `rescans_allowed` permits
+    re-imaging tiles that have already been covered.
+    """
+
+    depth_range: tuple[float, float] = (-20e-6, -60e-6)
+    min_health: float = 0.5
+    # 5e12 cells/m^3 is 5 cells per (100 um)^3 -- dense for cortex, so the
+    # default cap only rejects genuinely crowded tissue.
+    max_cell_density: float = 5e12
+    rescans_allowed: bool = False
+
+    def __post_init__(self):
+        near, far = self.depth_range
+        if near > 0 or far > 0:
+            raise ValueError(
+                f"depth_range offsets must be at or below the surface (<= 0), got {self.depth_range}"
+            )
+        if near == far:
+            raise ValueError(f"depth_range must span a nonzero thickness, got {self.depth_range}")
+        if not 0.0 <= self.min_health <= 1.0:
+            raise ValueError(f"min_health must be between 0 and 1, got {self.min_health}")
+        if self.max_cell_density <= 0:
+            raise ValueError(f"max_cell_density must be positive, got {self.max_cell_density}")
+
+    def z_span(self) -> float:
+        """Thickness of the searched slab, in metres."""
+        near, far = self.depth_range
+        return abs(near - far)
+
+    def z_bounds(self, surface: float) -> tuple[float, float]:
+        """Absolute (shallower, deeper) z for a tile whose surface is at `surface`."""
+        near, far = self.depth_range
+        return surface + max(near, far), surface + min(near, far)
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -v
+```
+
+Expected: 7 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/experiment/slice.py acq4/experiment/tests/test_slice.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat: add SearchConstraints, the validated Area 2 search parameters
+
+Depth range is a signed pair of offsets from the tissue surface, never a
+queue length. Validation rejects a range above the surface, a zero-thickness
+slab, an out-of-range health cutoff, and a nonpositive density cap.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 3: `Slice` — regions, coverage, and survey stats
+
+`Slice` is the tissue-scoped state that outlives any one run. This task builds everything except `makeCellProducer()`, which Task 4 adds once there is a producer to make.
+
+**Files:**
+- Modify: `acq4/experiment/slice.py` (append `Slice`)
+- Modify: `acq4/experiment/tests/test_slice.py` (append `Slice` tests)
+
+**Interfaces:**
+- Consumes: `SearchConstraints` from Task 2; `plan_grid`, `select_next`, `count_covered` from Task 1.
+- Produces:
+  - `Slice(fov: tuple[float, float], constraints: SearchConstraints | None = None, overlap: float = 0.0, directory=None)`
+  - `slice_.addRegion(x0, y0, x1, y1) -> None`
+  - `slice_.regions -> list[tuple[float, float, float, float]]` (read-only copy)
+  - `slice_.constraints -> SearchConstraints`; `slice_.setConstraints(c) -> None`
+  - `slice_.tileGrid() -> list[tuple[float, float]]` — every region's tiles concatenated, region order preserved
+  - `slice_.nextTile() -> tuple[float, float] | None` — next uncovered tile; does **not** mark it
+  - `slice_.markCovered(center) -> None`
+  - `slice_.resetCoverage() -> None`
+  - `slice_.coveredTiles -> list[tuple[float, float]]` (read-only copy)
+  - `slice_.surveyStats() -> tuple[int, int, float]` — `(total_tiles, covered_tiles, percent)`
+  - `slice_.tileVolume() -> float` — one tile's searched volume in m³
+  - `slice_.registerCells(cells) -> None`; `slice_.cellsNearTile(center) -> list` — the density cap's bookkeeping
+  - `slice_.threshold -> float` — the "same tile" match radius
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/experiment/tests/test_slice.py`:
+
+```python
+from acq4.experiment.slice import Slice
+
+# A 10x10 um FOV with no overlap, so a 30x30 um region is exactly a 3x3 grid of
+# tiles and tile centers land on predictable coordinates.
+FOV = (10e-6, 10e-6)
+
+
+def make_slice(**kwargs):
+    kwargs.setdefault("fov", FOV)
+    return Slice(**kwargs)
+
+
+class FakeCell:
+    """Stand-in for acq4_automation's Cell: a global position and a health score."""
+
+    def __init__(self, position, score=1.0):
+        self.position = position
+        self.score = score
+
+
+def test_a_new_slice_has_no_regions_and_nothing_to_survey():
+    s = make_slice()
+    assert s.regions == []
+    assert s.tileGrid() == []
+    assert s.nextTile() is None
+    assert s.surveyStats() == (0, 0, 0.0)
+
+
+def test_adding_a_region_produces_a_tile_grid():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    assert len(s.tileGrid()) == 9
+    assert s.surveyStats() == (9, 0, 0.0)
+
+
+def test_regions_is_a_copy_so_callers_cannot_mutate_slice_state():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    s.regions.append((1, 1, 2, 2))
+    assert len(s.regions) == 1
+
+
+def test_a_second_region_extends_the_grid_without_disturbing_the_first():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    first = s.tileGrid()
+    s.addRegion(1e-3, 1e-3, 1e-3 + 30e-6, 1e-3 + 30e-6)
+    both = s.tileGrid()
+    assert both[: len(first)] == first
+    assert len(both) == 18
+
+
+def test_marking_a_tile_covered_advances_next_tile():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    first = s.nextTile()
+    assert s.nextTile() == first, "nextTile must not mark; it only reports"
+    s.markCovered(first)
+    assert s.nextTile() != first
+    assert s.surveyStats() == (9, 1, pytest.approx(100 / 9))
+
+
+def test_next_tile_is_none_once_every_tile_is_covered():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    for _ in range(9):
+        s.markCovered(s.nextTile())
+    assert s.nextTile() is None
+    assert s.surveyStats() == (9, 9, 100.0)
+
+
+def test_coverage_survives_a_new_region_being_added():
+    # Shared coverage is the whole point: a second region's survey must not
+    # re-image the first region's tiles.
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    covered = s.nextTile()
+    s.markCovered(covered)
+    s.addRegion(1e-3, 1e-3, 1e-3 + 30e-6, 1e-3 + 30e-6)
+    assert covered in s.coveredTiles
+    assert s.surveyStats()[1] == 1
+
+
+def test_reset_coverage_forgets_imaged_tiles_but_keeps_regions():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    s.markCovered(s.nextTile())
+    s.resetCoverage()
+    assert s.coveredTiles == []
+    assert len(s.regions) == 1
+    assert s.surveyStats() == (9, 0, 0.0)
+
+
+def test_tile_volume_is_fov_area_times_the_depth_span():
+    s = make_slice(constraints=SearchConstraints(depth_range=(-20e-6, -60e-6)))
+    assert s.tileVolume() == pytest.approx(10e-6 * 10e-6 * 40e-6)
+
+
+def test_registered_cells_are_found_near_their_own_tile_only():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    tile = s.nextTile()
+    here = FakeCell((tile[0], tile[1], 0.0))
+    far = FakeCell((tile[0] + 1e-3, tile[1], 0.0))
+    s.registerCells([here, far])
+    near = s.cellsNearTile(tile)
+    assert here in near
+    assert far not in near
+
+
+def test_setting_constraints_replaces_them_wholesale():
+    s = make_slice()
+    replacement = SearchConstraints(min_health=0.9)
+    s.setConstraints(replacement)
+    assert s.constraints is replacement
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -v
+```
+
+Expected: `ImportError: cannot import name 'Slice'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Append to `acq4/experiment/slice.py` (and add `from .search_grid import count_covered, plan_grid, select_next` to its imports):
+
+```python
+class Slice:
+    """The search state for one piece of tissue, and the source of its cell producers.
+
+    Owns the regions to survey (global-coordinate rectangles), the coverage
+    record of which field-of-view tiles have been imaged, the search
+    constraints, and -- once a producer is made from it -- the tiles and cells
+    that producer accumulates. Coverage is shared by every producer this slice
+    makes: that is what stops a second region's survey from re-imaging the
+    first's, and what gives `rescans_allowed` something to decide.
+
+    A slice, its coverage, and its producers persist across orchestrator runs.
+    They are replaced only when the operator starts a new slice. This is
+    deliberately the opposite of Orchestrator._producerExhausted, which is a
+    per-run cache: a producer that reported exhaustion is asked again next run,
+    precisely so a slice that has gained a region can be surveyed further.
+
+    Not a QObject: it holds no widgets, and staying a plain object keeps it
+    refcount-freeable rather than depending on Qt teardown ordering.
+    """
+
+    def __init__(self, fov, constraints=None, overlap=0.0, directory=None):
+        fov_w, fov_h = fov
+        if fov_w <= 0 or fov_h <= 0:
+            raise ValueError(f"fov must be positive in both axes, got {fov}")
+        self._fov = (abs(fov_w), abs(fov_h))
+        self._overlap = overlap
+        self._constraints = constraints if constraints is not None else SearchConstraints()
+        self._regions: list[tuple[float, float, float, float]] = []
+        self._covered: list[tuple[float, float]] = []
+        self._cells: list = []
+        # The acq4 slice directory (a DirHandle) this state belongs to, kept so
+        # a caller can write per-slice data alongside it. Not required for the
+        # in-memory search itself.
+        self.directory = directory
+
+    # ---- constraints ----
+    @property
+    def constraints(self) -> SearchConstraints:
+        return self._constraints
+
+    def setConstraints(self, constraints: SearchConstraints) -> None:
+        self._constraints = constraints
+
+    # ---- regions ----
+    @property
+    def regions(self) -> list[tuple[float, float, float, float]]:
+        """The search rectangles, as a copy: mutating the result changes nothing."""
+        return list(self._regions)
+
+    def addRegion(self, x0: float, y0: float, x1: float, y1: float) -> None:
+        """Add a global-coordinate rectangle to survey. Coverage is untouched."""
+        self._regions.append((x0, y0, x1, y1))
+
+    # ---- tiles and coverage ----
+    @property
+    def threshold(self) -> float:
+        """Distance below which two tile centers are the same tile."""
+        fov_w, fov_h = self._fov
+        step = min(fov_w - self._overlap, fov_h - self._overlap)
+        if step <= 0:
+            step = min(fov_w, fov_h)
+        return step / 2
+
+    def tileGrid(self) -> list[tuple[float, float]]:
+        """Every region's tile centers, concatenated in the order regions were added."""
+        grid: list[tuple[float, float]] = []
+        fov_w, fov_h = self._fov
+        for x0, y0, x1, y1 in self._regions:
+            grid.extend(plan_grid(x0, y0, x1, y1, fov_w, fov_h, self._overlap))
+        return grid
+
+    def nextTile(self) -> tuple[float, float] | None:
+        """The next tile center not yet covered, or None when all are.
+
+        Reports only: the caller marks a tile covered once it has actually
+        imaged it, so a tile abandoned by a stop is not silently skipped on the
+        next run.
+        """
+        return select_next(self.tileGrid(), self._covered, self.threshold)
+
+    def markCovered(self, center: tuple[float, float]) -> None:
+        self._covered.append(tuple(center))
+
+    def resetCoverage(self) -> None:
+        """Forget which tiles have been imaged, keeping regions and constraints."""
+        self._covered = []
+
+    @property
+    def coveredTiles(self) -> list[tuple[float, float]]:
+        return list(self._covered)
+
+    def surveyStats(self) -> tuple[int, int, float]:
+        """(total tiles, covered tiles, percent covered) across every region."""
+        grid = self.tileGrid()
+        total = len(grid)
+        covered = count_covered(grid, self._covered, self.threshold)
+        percent = 100.0 * covered / total if total else 0.0
+        return total, covered, percent
+
+    def tileVolume(self) -> float:
+        """The volume one tile searches: FOV area times the constrained depth span."""
+        fov_w, fov_h = self._fov
+        return fov_w * fov_h * self._constraints.z_span()
+
+    # ---- cells found in this tissue ----
+    def registerCells(self, cells) -> None:
+        """Record cells found in this slice, for the density cap's bookkeeping."""
+        self._cells.extend(cells)
+
+    def cellsNearTile(self, center: tuple[float, float]) -> list:
+        """Registered cells whose position falls within `center`'s tile."""
+        cx, cy = center
+        fov_w, fov_h = self._fov
+        found = []
+        for cell in self._cells:
+            pos = cell.position
+            if abs(pos[0] - cx) <= fov_w / 2 and abs(pos[1] - cy) <= fov_h / 2:
+                found.append(cell)
+        return found
+```
+
+Note `cell.position` is indexed, not attribute-accessed per axis: `acq4_automation.feature_tracking.cell.Cell` holds a `coorx.Point`, which supports indexing, and the tests' `FakeCell` uses a plain tuple.
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -v
+```
+
+Expected: 18 passed.
+
+- [ ] **Step 5: Mutation-verify the two absence-shaped assertions**
+
+`test_marking_a_tile_covered_advances_next_tile` asserts `nextTile()` does *not* mark, and `test_coverage_survives_a_new_region_being_added` asserts coverage is *not* lost. Both could pass against broken code.
+
+First, make `nextTile` mark the tile it returns:
+
+```python
+    def nextTile(self):
+        center = select_next(self.tileGrid(), self._covered, self.threshold)
+        if center is not None:
+            self.markCovered(center)      # DEFECT: nextTile must only report
+        return center
+```
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py::test_marking_a_tile_covered_advances_next_tile -v
+```
+
+Expected: FAIL on `assert s.nextTile() == first, "nextTile must not mark; it only reports"`. Revert the defect.
+
+Second, make `addRegion` clear coverage (the mistake `SurveyRegion.addRegion` actually makes — it calls `clearRegion()` first):
+
+```python
+    def addRegion(self, x0, y0, x1, y1):
+        self._covered = []                # DEFECT: coverage is shared, not per-region
+        self._regions.append((x0, y0, x1, y1))
+```
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py::test_coverage_survives_a_new_region_being_added -v
+```
+
+Expected: FAIL on `assert covered in s.coveredTiles`. Revert the defect.
+
+- [ ] **Step 6: Re-run and commit**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -q
+```
+
+Expected: 18 passed.
+
+```bash
+git add acq4/experiment/slice.py acq4/experiment/tests/test_slice.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat: add Slice, the per-tissue search state
+
+Owns the regions to survey, the shared coverage record, the search
+constraints, and the cells found in this tissue. Coverage is shared across
+regions and across producers, which is what stops a second region's survey
+from re-imaging the first's.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 4: `CellProducer` — the tile walk and the exhaustion contract
+
+The callable the orchestrator's refill hook takes. This task builds the walk and the `[]`-vs-`None` contract; Task 5 adds filtering.
+
+**Files:**
+- Create: `acq4/experiment/cell_producer.py`
+- Create: `acq4/experiment/tests/test_cell_producer.py`
+- Modify: `acq4/experiment/slice.py` (add `makeCellProducer`)
+- Modify: `acq4/experiment/tests/test_slice.py` (add the `makeCellProducer` test)
+
+**Interfaces:**
+- Consumes: `Slice` (`nextTile`, `markCovered`, `constraints`, `registerCells`, `cellsNearTile`, `tileVolume`, `resetCoverage`) from Task 3.
+- Produces:
+  - `CellProducer(slice_, detector)` with `__call__() -> list | None`.
+  - `detector(center: tuple[float, float], constraints: SearchConstraints) -> Sequence` — the injected seam. Returns candidate objects each exposing `.position` (indexable, global metres) and `.score` (health prediction in `[0, 1]`).
+  - `Slice.makeCellProducer(detector) -> CellProducer`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `acq4/experiment/tests/test_cell_producer.py`:
+
+```python
+"""Tests for CellProducer: walking a slice's tiles, the []-versus-None
+exhaustion contract, and the search constraints it filters candidates against."""
+
+import pytest
+
+from acq4.experiment.cell_producer import CellProducer
+from acq4.experiment.slice import SearchConstraints, Slice
+
+FOV = (10e-6, 10e-6)
+
+
+class FakeCandidate:
+    """Stand-in for a detected cell: a global position and a health score."""
+
+    def __init__(self, position, score=1.0):
+        self.position = position
+        self.score = score
+
+    def __repr__(self):
+        return f"FakeCandidate({self.position}, score={self.score})"
+
+
+class RecordingDetector:
+    """A detector seam that returns scripted results and records its calls.
+
+    `results` maps nothing -- it is consumed in order, one entry per call, each
+    entry being the list of candidates that call returns. Running past the end
+    returns an empty list (a barren tile), which is the common real case.
+    """
+
+    def __init__(self, results=()):
+        self._results = list(results)
+        self.calls = []
+
+    def __call__(self, center, constraints):
+        self.calls.append((tuple(center), constraints))
+        return self._results.pop(0) if self._results else []
+
+
+def make_slice(constraints=None, regions=((0, 0, 30e-6, 30e-6),)):
+    s = Slice(fov=FOV, constraints=constraints)
+    for r in regions:
+        s.addRegion(*r)
+    return s
+
+
+def test_a_call_images_one_tile_and_returns_its_cells():
+    s = make_slice()
+    tile = s.nextTile()
+    cell = FakeCandidate((tile[0], tile[1], -30e-6))
+    detector = RecordingDetector([[cell]])
+    producer = CellProducer(s, detector)
+
+    assert producer() == [cell]
+    assert detector.calls[0][0] == tile
+
+
+def test_the_imaged_tile_is_marked_covered_so_the_next_call_advances():
+    s = make_slice()
+    detector = RecordingDetector()
+    producer = CellProducer(s, detector)
+
+    producer()
+    producer()
+
+    assert detector.calls[0][0] != detector.calls[1][0]
+    assert len(s.coveredTiles) == 2
+
+
+def test_a_barren_tile_returns_empty_not_none():
+    # [] is "made progress, found nothing here, ask again"; None would end the
+    # whole run on the first empty field of view.
+    s = make_slice()
+    producer = CellProducer(s, RecordingDetector([[]]))
+    result = producer()
+    assert result == []
+    assert result is not None
+
+
+def test_none_only_once_every_tile_is_imaged():
+    s = make_slice(regions=((0, 0, 10e-6, 10e-6),))  # exactly one tile
+    producer = CellProducer(s, RecordingDetector())
+
+    assert producer() == []
+    assert producer() is None
+
+
+def test_a_slice_with_no_regions_is_exhausted_immediately():
+    s = Slice(fov=FOV)
+    detector = RecordingDetector()
+    producer = CellProducer(s, detector)
+
+    assert producer() is None
+    assert detector.calls == [], "nothing to image, so the detector must not run"
+
+
+def test_the_detector_receives_the_slices_current_constraints():
+    constraints = SearchConstraints(min_health=0.0, depth_range=(-5e-6, -25e-6))
+    s = make_slice(constraints=constraints)
+    detector = RecordingDetector()
+    CellProducer(s, detector)()
+    assert detector.calls[0][1] is constraints
+
+
+def test_found_cells_are_registered_with_the_slice():
+    s = make_slice()
+    tile = s.nextTile()
+    cell = FakeCandidate((tile[0], tile[1], -30e-6))
+    CellProducer(s, RecordingDetector([[cell]]))()
+    assert s.cellsNearTile(tile) == [cell]
+
+
+def test_a_detector_failure_marks_the_tile_covered_rather_than_retrying_it_forever():
+    # A tile that raises must not be handed out again on the next call: the
+    # orchestrator wraps a producer exception into AbortExperiment, but a
+    # producer used across runs would otherwise wedge on the same bad tile.
+    s = make_slice()
+    tile = s.nextTile()
+
+    def exploding(center, constraints):
+        raise RuntimeError("imaging failed")
+
+    producer = CellProducer(s, exploding)
+    with pytest.raises(RuntimeError, match="imaging failed"):
+        producer()
+    assert tile in s.coveredTiles
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_cell_producer.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'acq4.experiment.cell_producer'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `acq4/experiment/cell_producer.py`:
+
+```python
+"""CellProducer: the callable the orchestrator's refill hook takes, surveying one
+tile of a slice per call and returning the cells found there."""
+
+from __future__ import annotations
+
+from acq4.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class CellProducer:
+    """Images one tile of a slice per call and returns the cells found in it.
+
+    Satisfies the orchestrator's producer contract: a call returns either a
+    sequence of cells -- possibly empty, meaning "imaged a tile, found nothing
+    there, ask again" -- or None, meaning "every tile is imaged, never ask
+    again". The distinction is load-bearing: an empty field of view is the
+    common case, and reporting it as exhaustion would end a run on the first
+    barren tile.
+
+    A producer is a **view onto** its slice, not an owner of it. Coverage,
+    regions, and constraints all live on the slice and are shared with every
+    other producer made from it, so a producer built for a second run sees the
+    coverage the first run accumulated. The slice does not hold a reference
+    back (see Slice.makeCellProducer).
+
+    `detector(center, constraints)` is the injected imaging seam: it moves to
+    `center`, finds the surface, acquires a stack across the constrained depth
+    range, and returns candidate objects exposing `.position` (global metres)
+    and `.score` (the health prediction). Keeping it injected is what lets the
+    tile walk and the constraint filtering be tested without a microscope.
+    """
+
+    def __init__(self, slice_, detector):
+        self._slice = slice_
+        self._detector = detector
+
+    def __call__(self) -> list | None:
+        tile = self._slice.nextTile()
+        if tile is None:
+            return None
+        try:
+            candidates = self._detector(tile, self._slice.constraints)
+        finally:
+            # Marked whether or not imaging succeeded: a tile that raises must
+            # not be handed out again, or a producer reused across runs wedges
+            # on the same bad tile forever.
+            self._slice.markCovered(tile)
+        cells = list(candidates)
+        self._slice.registerCells(cells)
+        return cells
+```
+
+Then append `makeCellProducer` to `Slice` in `acq4/experiment/slice.py`:
+
+```python
+    def makeCellProducer(self, detector) -> "CellProducer":
+        """A producer that surveys this slice, one tile per call.
+
+        This slice keeps no reference to what it hands back. The producer holds
+        the slice, the orchestrator holds the producer, and that one-way chain
+        is refcount-freeable; storing producers here would close it into a cycle
+        only the cyclic GC could reclaim.
+        """
+        from .cell_producer import CellProducer
+
+        return CellProducer(self, detector)
+```
+
+The import is function-local to keep `slice.py` and `cell_producer.py` from importing each other at module scope.
+
+- [ ] **Step 4: Add the `makeCellProducer` test**
+
+Append to `acq4/experiment/tests/test_slice.py`:
+
+```python
+def test_make_cell_producer_returns_a_view_the_slice_does_not_retain():
+    s = make_slice()
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    producer = s.makeCellProducer(lambda center, constraints: [])
+    assert producer() == []
+    # The slice must not be reachable back to the producer, or the pair is a
+    # reference cycle. Nothing on the slice may hold it.
+    assert not any(v is producer for v in vars(s).values())
+```
+
+- [ ] **Step 5: Run to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_cell_producer.py acq4/experiment/tests/test_slice.py -v
+```
+
+Expected: 9 + 19 = 28 passed.
+
+- [ ] **Step 6: Mutation-verify the contract tests**
+
+`test_a_barren_tile_returns_empty_not_none` and `test_none_only_once_every_tile_is_imaged` are the two halves of the contract; a broken producer can pass one. Collapse the distinction:
+
+```python
+    def __call__(self):
+        tile = self._slice.nextTile()
+        if tile is None:
+            return None
+        try:
+            candidates = self._detector(tile, self._slice.constraints)
+        finally:
+            self._slice.markCovered(tile)
+        cells = list(candidates)
+        if not cells:
+            return None               # DEFECT: a barren tile is not exhaustion
+        self._slice.registerCells(cells)
+        return cells
+```
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_cell_producer.py -v
+```
+
+Expected: `test_a_barren_tile_returns_empty_not_none` FAILS on `assert result == []`. Revert.
+
+Then verify the tile-marking test is not vacuous by removing the `finally`:
+
+```python
+        candidates = self._detector(tile, self._slice.constraints)
+        self._slice.markCovered(tile)     # DEFECT: not marked when imaging raises
+```
+
+Expected: `test_a_detector_failure_marks_the_tile_covered_rather_than_retrying_it_forever` FAILS on `assert tile in s.coveredTiles`. Revert.
+
+- [ ] **Step 7: Commit**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/ -q
+```
+
+Expected: all pass.
+
+```bash
+git add acq4/experiment/cell_producer.py acq4/experiment/tests/test_cell_producer.py acq4/experiment/slice.py acq4/experiment/tests/test_slice.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat: add CellProducer, surveying one slice tile per call
+
+Satisfies the orchestrator's producer contract: [] for a barren tile that
+should be asked again, None only once every tile is imaged. The imaging step
+is an injected seam so the tile walk is testable without a microscope.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 5: `CellProducer` — health cutoff, density cap, and rescans
+
+The three remaining Area 2 constraints. `depth_range` is already passed through to the detector (it is the detector's job to acquire over it); these three are the producer's own filtering.
+
+**Files:**
+- Modify: `acq4/experiment/cell_producer.py`
+- Modify: `acq4/experiment/tests/test_cell_producer.py`
+
+**Interfaces:**
+- Consumes: everything from Task 4.
+- Produces: no new public names. `CellProducer.__call__` now filters by `constraints.min_health`, skips tiles already at `constraints.max_cell_density`, and honours `constraints.rescans_allowed`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/experiment/tests/test_cell_producer.py`:
+
+```python
+def test_candidates_below_the_health_cutoff_are_not_queued():
+    s = make_slice(constraints=SearchConstraints(min_health=0.6))
+    tile = s.nextTile()
+    good = FakeCandidate((tile[0], tile[1], -30e-6), score=0.9)
+    bad = FakeCandidate((tile[0] + 1e-6, tile[1], -30e-6), score=0.3)
+    producer = CellProducer(s, RecordingDetector([[good, bad]]))
+
+    assert producer() == [good]
+
+
+def test_a_candidate_exactly_at_the_cutoff_is_kept():
+    s = make_slice(constraints=SearchConstraints(min_health=0.6))
+    tile = s.nextTile()
+    borderline = FakeCandidate((tile[0], tile[1], -30e-6), score=0.6)
+    assert CellProducer(s, RecordingDetector([[borderline]]))() == [borderline]
+
+
+def test_a_tile_whose_every_candidate_is_rejected_returns_empty_not_none():
+    # Filtering everything out is still "made progress on a tile"; reporting it
+    # as exhaustion would end the run.
+    s = make_slice(constraints=SearchConstraints(min_health=0.9))
+    tile = s.nextTile()
+    weak = FakeCandidate((tile[0], tile[1], -30e-6), score=0.1)
+    producer = CellProducer(s, RecordingDetector([[weak]]))
+    result = producer()
+    assert result == []
+    assert result is not None
+
+
+def test_rejected_candidates_are_not_registered_with_the_slice():
+    s = make_slice(constraints=SearchConstraints(min_health=0.9))
+    tile = s.nextTile()
+    weak = FakeCandidate((tile[0], tile[1], -30e-6), score=0.1)
+    CellProducer(s, RecordingDetector([[weak]]))()
+    assert s.cellsNearTile(tile) == []
+
+
+def test_a_candidate_without_a_score_passes_the_cutoff():
+    # "Add from target" cells and any detector that does not score its output
+    # must not be silently discarded by a nonzero cutoff.
+    s = make_slice(constraints=SearchConstraints(min_health=0.9))
+    tile = s.nextTile()
+    unscored = FakeCandidate((tile[0], tile[1], -30e-6))
+    unscored.score = None
+    assert CellProducer(s, RecordingDetector([[unscored]]))() == [unscored]
+
+
+def _crowding_constraints(cells_per_tile):
+    """Constraints whose density cap is reached by `cells_per_tile` in one tile."""
+    volume = 10e-6 * 10e-6 * 40e-6
+    return SearchConstraints(
+        depth_range=(-20e-6, -60e-6),
+        min_health=0.0,
+        max_cell_density=cells_per_tile / volume,
+    )
+
+
+def test_a_tile_already_at_the_density_cap_is_skipped_without_imaging():
+    s = make_slice(constraints=_crowding_constraints(2))
+    tile = s.nextTile()
+    s.registerCells([
+        FakeCandidate((tile[0], tile[1], -30e-6)),
+        FakeCandidate((tile[0] + 1e-6, tile[1], -30e-6)),
+    ])
+    detector = RecordingDetector([[FakeCandidate((tile[0], tile[1], -30e-6))]])
+    producer = CellProducer(s, detector)
+
+    assert producer() == []
+    assert detector.calls == [], "a crowded tile must not be imaged at all"
+    assert tile in s.coveredTiles, "and it must not be handed out again"
+
+
+def test_a_tile_below_the_density_cap_is_imaged_normally():
+    s = make_slice(constraints=_crowding_constraints(2))
+    tile = s.nextTile()
+    s.registerCells([FakeCandidate((tile[0], tile[1], -30e-6))])
+    found = FakeCandidate((tile[0], tile[1], -35e-6))
+    detector = RecordingDetector([[found]])
+
+    assert CellProducer(s, detector)() == [found]
+    assert len(detector.calls) == 1
+
+
+def test_without_rescans_exhaustion_is_final():
+    s = make_slice(regions=((0, 0, 10e-6, 10e-6),),
+                   constraints=SearchConstraints(rescans_allowed=False))
+    producer = CellProducer(s, RecordingDetector())
+    producer()
+    assert producer() is None
+    assert producer() is None
+
+
+def test_rescans_allowed_grants_exactly_one_more_pass():
+    # Unlimited rescanning could never return None, which would wedge the run
+    # loop; one extra pass makes the switch mean something and keeps the
+    # contract. See CellProducer's docstring.
+    s = make_slice(regions=((0, 0, 10e-6, 10e-6),),
+                   constraints=SearchConstraints(rescans_allowed=True))
+    detector = RecordingDetector()
+    producer = CellProducer(s, detector)
+
+    assert producer() == []          # first pass images the only tile
+    assert producer() == []          # rescan re-images it
+    assert producer() is None        # and then it really is exhausted
+    assert len(detector.calls) == 2
+
+
+def test_a_second_producer_from_the_same_slice_gets_its_own_rescan_allowance():
+    # The allowance is per-producer, matching _producerExhausted's per-run
+    # lifetime, so a later run over the same slice may rescan again.
+    s = make_slice(regions=((0, 0, 10e-6, 10e-6),),
+                   constraints=SearchConstraints(rescans_allowed=True))
+    first = s.makeCellProducer(RecordingDetector())
+    first()
+    first()
+    assert first() is None
+
+    second = s.makeCellProducer(RecordingDetector())
+    assert second() == []
+    assert second() is None
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_cell_producer.py -v
+```
+
+Expected: `test_candidates_below_the_health_cutoff_are_not_queued` fails (both candidates returned), and the density/rescan tests fail similarly. Confirm each of the 11 new tests fails for the stated reason rather than erroring on a typo.
+
+- [ ] **Step 3: Write the implementation**
+
+Replace `CellProducer.__call__` in `acq4/experiment/cell_producer.py` and add the rescan state to `__init__`:
+
+```python
+    def __init__(self, slice_, detector):
+        self._slice = slice_
+        self._detector = detector
+        # Whether this producer has already spent its one rescan pass. Per
+        # producer, not per slice: the allowance mirrors the orchestrator's
+        # per-run _producerExhausted, so a later run over the same slice may
+        # rescan again.
+        self._rescanned = False
+
+    def __call__(self) -> list | None:
+        tile = self._nextTile()
+        if tile is None:
+            return None
+        constraints = self._slice.constraints
+        if self._isCrowded(tile, constraints):
+            # Nothing is imaged: the point of the density cap is to spend the
+            # imaging time elsewhere. Still marked covered, or this tile is
+            # handed out again on every call.
+            self._slice.markCovered(tile)
+            logger.info("Skipping tile %r: already at the cell-density cap", tile)
+            return []
+        try:
+            candidates = self._detector(tile, constraints)
+        finally:
+            self._slice.markCovered(tile)
+        cells = [c for c in candidates if self._isHealthy(c, constraints)]
+        self._slice.registerCells(cells)
+        return cells
+
+    def _nextTile(self):
+        """The next tile to image, spending the rescan allowance if needed."""
+        tile = self._slice.nextTile()
+        if tile is not None:
+            return tile
+        if not self._slice.constraints.rescans_allowed or self._rescanned:
+            return None
+        # One extra pass, and only one: an unbounded rescan loop could never
+        # return None, and the orchestrator's refill loop would never end.
+        self._rescanned = True
+        self._slice.resetCoverage()
+        logger.info("Rescanning: every tile was covered and rescans are allowed")
+        return self._slice.nextTile()
+
+    @staticmethod
+    def _isHealthy(candidate, constraints) -> bool:
+        """Whether `candidate` clears the health cutoff.
+
+        An unscored candidate passes: a detector that does not score its output,
+        or a cell seeded by hand, must not be silently discarded by a cutoff it
+        was never measured against.
+        """
+        score = getattr(candidate, "score", None)
+        return score is None or score >= constraints.min_health
+
+    def _isCrowded(self, tile, constraints) -> bool:
+        """Whether `tile` already holds cells at or above the density cap."""
+        volume = self._slice.tileVolume()
+        if volume <= 0:
+            return False
+        density = len(self._slice.cellsNearTile(tile)) / volume
+        return density >= constraints.max_cell_density
+```
+
+Extend the class docstring's final paragraph to record the rescan decision:
+
+```python
+    `rescans_allowed` grants exactly one extra pass over the slice's tiles, not
+    unlimited rescanning: a producer that could always find another tile would
+    never return None, and the orchestrator's refill loop would never end.
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_cell_producer.py -v
+```
+
+Expected: 20 passed.
+
+- [ ] **Step 5: Mutation-verify the three absence-shaped assertions**
+
+(a) The crowded tile must not be imaged. Change `_isCrowded`'s comparison to `>` so a tile *at* the cap is imaged:
+
+```python
+        return density > constraints.max_cell_density   # DEFECT: at the cap is crowded
+```
+
+Expected: `test_a_tile_already_at_the_density_cap_is_skipped_without_imaging` FAILS on `assert detector.calls == []`. Revert.
+
+(b) The rescan allowance must be spent. Remove the `self._rescanned` guard:
+
+```python
+        if not self._slice.constraints.rescans_allowed:
+            return None
+        self._slice.resetCoverage()        # DEFECT: unbounded rescanning
+```
+
+Expected: `test_rescans_allowed_grants_exactly_one_more_pass` FAILS on `assert producer() is None`. Revert.
+
+(c) A fully-filtered tile must not read as exhaustion. Return `None` for an empty filtered list:
+
+```python
+        cells = [c for c in candidates if self._isHealthy(c, constraints)]
+        if not cells:
+            return None                    # DEFECT: filtered-out is not exhausted
+```
+
+Expected: `test_a_tile_whose_every_candidate_is_rejected_returns_empty_not_none` FAILS. Revert.
+
+- [ ] **Step 6: Commit**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/ -q
+```
+
+Expected: all pass.
+
+```bash
+git add acq4/experiment/cell_producer.py acq4/experiment/tests/test_cell_producer.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat: filter produced cells by health, density, and rescan policy
+
+A tile at the density cap is skipped without being imaged; candidates below
+the health cutoff are dropped without being registered; both still report []
+rather than exhaustion. rescans_allowed grants one extra pass, since an
+unbounded one could never return None.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 6: Prove the slice/producer graph is refcount-freeable
+
+P1.5's exit segfault came from parentless `QObject`s cross-wired into a cycle only the cyclic GC could reclaim, and P2a added a leak test for the producer. `Slice` and `CellProducer` are new long-lived objects in that same graph, so they get the same proof.
+
+**Files:**
+- Modify: `acq4/experiment/tests/test_cell_producer.py`
+
+**Interfaces:**
+- Consumes: `Slice`, `CellProducer`.
+- Produces: nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `acq4/experiment/tests/test_cell_producer.py`:
+
+```python
+def test_slice_and_producer_are_freed_by_refcounting_alone():
+    """No cycle between a slice and the producers it makes.
+
+    Both outlive individual runs and neither is a QObject, so they must be
+    reclaimable without the cyclic collector -- the failure mode that produced
+    P1.5's exit segfault was a graph only gc could break, collected
+    non-deterministically and possibly off the GUI thread.
+    """
+    import gc
+    import weakref
+
+    s = Slice(fov=FOV)
+    s.addRegion(0, 0, 30e-6, 30e-6)
+    producer = s.makeCellProducer(RecordingDetector())
+    producer()
+
+    slice_ref = weakref.ref(s)
+    producer_ref = weakref.ref(producer)
+
+    gc.disable()
+    try:
+        del producer
+        assert producer_ref() is None, "producer survived; a cycle holds it"
+        del s
+        assert slice_ref() is None, "slice survived; a cycle holds it"
+    finally:
+        gc.enable()
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_cell_producer.py::test_slice_and_producer_are_freed_by_refcounting_alone -v
+```
+
+Expected: PASS — Tasks 3–5 already avoid the cycle deliberately (`makeCellProducer` stores nothing). A test that passes immediately is exactly the vacuous shape the global constraints warn about, so Step 3 is mandatory, not optional.
+
+- [ ] **Step 3: Mutation-verify by introducing the cycle**
+
+Make `Slice.makeCellProducer` retain what it hands out — the natural mistake:
+
+```python
+    def makeCellProducer(self, detector) -> "CellProducer":
+        from .cell_producer import CellProducer
+
+        producer = CellProducer(self, detector)
+        self._producers = getattr(self, "_producers", [])
+        self._producers.append(producer)      # DEFECT: closes the cycle
+        return producer
+```
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_cell_producer.py::test_slice_and_producer_are_freed_by_refcounting_alone -v
+```
+
+Expected: FAIL on `assert producer_ref() is None, "producer survived; a cycle holds it"`. Revert the defect.
+
+Also confirm the `makeCellProducer` test from Task 4 catches it:
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py::test_make_cell_producer_returns_a_view_the_slice_does_not_retain -v
+```
+
+Expected: with the defect applied, FAIL; after reverting, PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add acq4/experiment/tests/test_cell_producer.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+test: prove a slice and its producers are freed without the cyclic collector
+
+Both outlive individual runs, so a cycle between them would only be reclaimed
+non-deterministically -- the shape behind the P1.5 exit segfault. Verified by
+introducing the cycle and watching the test fail.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 7: Orchestrator — the `"surveying"` status, and `clearQueue()`
+
+Three engine changes. The first two close a P2a review deferral: nothing in `sigStatus` distinguishes surveying from patching, and `sigCurrentCell` still holds the finished cell while the producer images — which is what made P2a's Critical reachable in the first place. The third is needed by Task 11: "New slice" clears the cell list, and `CellPanel.clearCells()` only clears the panel's own bookkeeping, leaving the orchestrator's deque still holding cells in tissue that is no longer under the objective.
+
+**Files:**
+- Modify: `acq4/experiment/orchestrator.py:23-27` (signal docstring), `:158-217` (`_runLoopBody`), plus a new `clearQueue`
+- Modify: `acq4/experiment/tests/test_orchestrator_producer.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `sigStatus` may now emit `"surveying"`; `Orchestrator.clearQueue() -> None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/experiment/tests/test_orchestrator_producer.py`. Follow the existing file's fixtures — it already has `make_producer(batches)` and takes `make_pf` from `acq4/experiment/tests/conftest.py`; read the top of the file before writing so the helper use matches.
+
+```python
+def test_surveying_status_is_emitted_around_a_refill(make_pf):
+    orch = Orchestrator(make_pf())
+    statuses = []
+    orch.sigStatus.connect(statuses.append)
+    orch.setCellProducer(make_producer([[object()], None]))
+
+    orch.run_sync()
+
+    assert "surveying" in statuses
+    # And it must not be the last word: the run reports back to running for the
+    # cell it then works, and waiting once drained.
+    assert statuses.index("surveying") < statuses.index("waiting")
+
+
+def test_a_barren_survey_reports_surveying_without_ever_reporting_running(make_pf):
+    # The operator watching a slow, empty stretch of region must see
+    # "surveying", not a stale "running" that implies a cell is being patched.
+    orch = Orchestrator(make_pf())
+    statuses = []
+    orch.sigStatus.connect(statuses.append)
+    orch.setCellProducer(make_producer([[], [], None]))
+
+    orch.run_sync()
+
+    assert statuses.count("surveying") == 3
+
+
+def test_current_cell_is_cleared_before_the_producer_runs(make_pf):
+    # sigCurrentCell must not still name the just-finished cell while the
+    # producer images: Area 5 would attribute survey time to that cell, and it
+    # is the state that made P2a's next-cell Critical reachable.
+    pf = make_pf()
+    first = object()
+    orch = Orchestrator(pf)
+    orch.enqueue(first)
+
+    seen = []
+    orch.sigCurrentCell.connect(seen.append)
+
+    def producer():
+        # Whatever the orchestrator last announced must not be `first`.
+        assert seen[-1] is None, f"still following {seen[-1]!r} while surveying"
+        return None
+
+    orch.setCellProducer(producer)
+    orch.run_sync()
+
+    assert first in seen
+
+
+def test_clear_queue_drops_pending_cells(make_pf):
+    orch = Orchestrator(make_pf())
+    ran = []
+    orch.protocolFile.run = lambda ctx, **kw: ran.append(ctx.cell)
+    orch.enqueue(object())
+    orch.enqueue(object())
+
+    orch.clearQueue()
+    orch.run_sync()
+
+    assert ran == []
+
+
+def test_clear_queue_leaves_a_later_enqueue_working(make_pf):
+    orch = Orchestrator(make_pf())
+    ran = []
+    orch.protocolFile.run = lambda ctx, **kw: ran.append(ctx.cell)
+    orch.enqueue(object())
+    orch.clearQueue()
+    kept = object()
+    orch.enqueue(kept)
+
+    orch.run_sync()
+
+    assert ran == [kept]
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_orchestrator_producer.py -v -k "surveying or current_cell_is_cleared or clear_queue"
+```
+
+Expected: the two `surveying` tests fail on `assert "surveying" in statuses`; `test_current_cell_is_cleared_before_the_producer_runs` fails its in-producer assertion (or `IndexError` on `seen[-1]` when no cell ran before the producer — if so, seed the queue so a cell always precedes the refill, as written above); the two `clear_queue` tests fail with `AttributeError: 'Orchestrator' object has no attribute 'clearQueue'`.
+
+- [ ] **Step 3: Write the implementation**
+
+In `acq4/experiment/orchestrator.py`, update the signal declaration comment:
+
+```python
+    sigStatus = Qt.Signal(str)                 # "running"/"surveying"/"waiting"/"paused"/"error"
+```
+
+Add `clearQueue` next to `enqueue`:
+
+```python
+    def clearQueue(self) -> None:
+        """Drop every cell waiting in the queue, leaving any running cell alone.
+
+        The caller that seeded these cells is discarding them -- the operator
+        has swapped the tissue, so every queued position is a place not to
+        drive a pipette. Clearing the panel's own bookkeeping is not enough:
+        the deque is a separate strong reference and would otherwise keep
+        handing those positions to the protocol.
+        """
+        self._queue.clear()
+```
+
+In `_runLoopBody`, replace the refill branch:
+
+```python
+                if self._shouldRefill():
+                    # Surveying is not patching, and the operator watching a
+                    # slow, barren stretch of region must not read a stale
+                    # "running" as "a cell is being worked". Clearing the
+                    # current cell first is the same honesty: leaving the
+                    # just-finished cell named here made Area 5 attribute
+                    # survey time to it.
+                    self.sigCurrentCell.emit(None)
+                    self.sigStatus.emit("surveying")
+                    self._refillQueue()
+                    # Refill only ever runs against an empty queue, so a
+                    # request that arrived while the producer was working had
+                    # no cell to advance past: nothing was running and nothing
+                    # was queued. Consuming it against the first cell the
+                    # producer then returned would skip a cell the operator
+                    # never saw, without it ever being attempted.
+                    self._nextCellRequested = False
+                    # Back to the top rather than falling through to a cell:
+                    # re-checks pause and stop between refills, and lets a
+                    # producer returning [] be asked again next pass. Imaging
+                    # a tile is slow, so an operator pressing Stop mid-survey
+                    # must not have to wait out a refill that already started.
+                    continue
+```
+
+`_processCell` already emits `"running"` at the top of its retry loop, so a cell worked after a refill puts the status back without further change.
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_orchestrator_producer.py -v
+```
+
+Expected: all pass, including the 18 pre-existing tests.
+
+- [ ] **Step 5: Mutation-verify the current-cell clear**
+
+`test_current_cell_is_cleared_before_the_producer_runs` asserts an *absence* (that a stale cell is not still named). Remove the clear:
+
+```python
+                if self._shouldRefill():
+                    self.sigStatus.emit("surveying")     # DEFECT: no sigCurrentCell(None)
+                    self._refillQueue()
+```
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_orchestrator_producer.py::test_current_cell_is_cleared_before_the_producer_runs -v
+```
+
+Expected: FAIL on `assert seen[-1] is None, f"still following ..."`. Revert.
+
+- [ ] **Step 6: Run the whole engine suite and commit**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/ -q
+```
+
+Expected: all pass. Confirm no pre-existing test asserted an exact `sigStatus` sequence that a new `"surveying"` entry now breaks; if one did, update it to expect the new value rather than filtering it out.
+
+```bash
+git add acq4/experiment/orchestrator.py acq4/experiment/tests/test_orchestrator_producer.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat: report a distinct surveying status and add Orchestrator.clearQueue
+
+Surveying is not patching: the status now says so, and the current cell is
+cleared before the producer runs so a finished cell stops being credited with
+survey time. clearQueue lets a caller discarding its cells drop the deque's
+separate strong reference to them.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 8: StatusPanel — gate the buttons during a survey
+
+`_updateButtons`' final `else` disables *every* button for an unrecognised status. With Task 7 in place that means an operator watching a long survey cannot press Stop — the exact situation design §3.2 says Stop must work in ("imaging a tile is slow, so an operator pressing Stop during a barren stretch of region must not wait for the producer to find something first").
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/status_panel.py:130-181`
+- Modify: `acq4/modules/Autopatch/tests/test_status_panel.py`
+
+**Interfaces:**
+- Consumes: `"surveying"` from `Orchestrator.sigStatus` (Task 7).
+- Produces: `StatusPanel.sigStatusChanged = Qt.Signal(str)` — the bound orchestrator's status, re-emitted. Task 11's window listens to this to refresh the survey readout as tiles are imaged, rather than connecting itself to the orchestrator directly; the orchestrator is a parentless `QObject` and giving it a reference back to the window is the cycle shape that caused P1.5's exit segfault, which is why `sigInteractionLocked` already exists instead of a direct connection.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/modules/Autopatch/tests/test_status_panel.py`. The file has no `qtbot`/fixture-based panel setup: every test takes the module-scoped `qapp` fixture, constructs `StatusPanel()` inline, and binds it to the file's `_FakeOrchestrator()` and `_FakeEntrySource()`. Match that, and capture signals with a plain list rather than `qtbot.waitSignal`.
+
+```python
+def _boundPanel():
+    """A StatusPanel bound to a fake orchestrator, as every test here builds it."""
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch, _FakeEntrySource())
+    return panel, orch
+
+
+def test_surveying_keeps_stop_and_pause_available(qapp):
+    # Imaging a tile is slow. An operator who wants out mid-survey must not
+    # have to wait for the producer to find a cell first.
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("surveying")
+
+    assert panel.stopBtn.isEnabled()
+    assert panel.pauseBtn.isEnabled()
+    assert not panel.startBtn.isEnabled()
+
+
+def test_surveying_disables_next_cell(qapp):
+    # A next-cell request during a refill is discarded by design (nothing is
+    # running and nothing is queued to advance past), so the button must not
+    # invite a press that does nothing.
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("surveying")
+
+    assert not panel.nextBtn.isEnabled()
+
+
+def test_surveying_shows_in_the_status_label(qapp):
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("surveying")
+    assert panel.statusLabel.text() == "surveying"
+
+
+def test_surveying_locks_area_4(qapp):
+    # A run is in flight, so the protocol picker must stay locked -- reloading
+    # a protocol mid-survey is the second-orchestrator hazard.
+    panel, orch = _boundPanel()
+    locked = []
+    panel.sigInteractionLocked.connect(locked.append)
+    orch.sigStatus.emit("surveying")
+    assert locked[-1] is True
+
+
+def test_surveying_keeps_pause_labeled_pause(qapp):
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("surveying")
+    assert panel.pauseBtn.text() == "Pause"
+
+
+def test_status_is_re_emitted_for_panels_that_must_not_touch_the_orchestrator(qapp):
+    # The window needs the status to refresh Area 2's survey readout, but the
+    # orchestrator is a parentless QObject and must not hold a reference back
+    # to the window. This passthrough is that indirection.
+    panel, orch = _boundPanel()
+    seen = []
+    panel.sigStatusChanged.connect(seen.append)
+
+    orch.sigStatus.emit("surveying")
+    orch.sigStatus.emit("waiting")
+
+    assert seen == ["surveying", "waiting"]
+
+
+def test_the_status_passthrough_stops_on_unbind(qapp):
+    panel, orch = _boundPanel()
+    seen = []
+    panel.sigStatusChanged.connect(seen.append)
+
+    panel.unbindOrchestrator()
+    orch.sigStatus.emit("surveying")
+
+    assert seen == []
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_status_panel.py -v -k "surveying or passthrough"
+```
+
+Expected: `test_surveying_keeps_stop_and_pause_available` and `test_surveying_locks_area_4` FAIL (the `else` branch disables everything and `sigInteractionLocked` emits `False`); the two passthrough tests FAIL with `AttributeError: 'StatusPanel' object has no attribute 'sigStatusChanged'`. `test_surveying_disables_next_cell`, `test_surveying_shows_in_the_status_label`, and `test_surveying_keeps_pause_labeled_pause` pass already — for the wrong reason, which Step 4 pins down.
+
+- [ ] **Step 3: Write the implementation**
+
+In `acq4/modules/Autopatch/status_panel.py`, declare the passthrough signal next to `sigInteractionLocked`:
+
+```python
+    # The bound orchestrator's status, re-emitted for panels that need it but
+    # must not connect to the orchestrator themselves. The orchestrator is a
+    # parentless QObject, so a connection from it to the window would give it a
+    # reference back and rebuild the cycle bindOrchestrator/unbindOrchestrator
+    # exist to avoid -- the same reason sigInteractionLocked is routed this way.
+    sigStatusChanged = Qt.Signal(str)
+```
+
+Emit it from `_onStatus`, and extend the lock condition there:
+
+```python
+        self.sigInteractionLocked.emit(status in ("running", "surveying", "paused"))
+        self.sigStatusChanged.emit(status)
+```
+
+and add a `"surveying"` branch to `_updateButtons`, updating its docstring:
+
+```python
+    def _updateButtons(self) -> None:
+        """Gate Start/Stop/Pause/Next on whether a protocol is loaded (an
+        orchestrator is bound) and the orchestrator's last-reported status.
+
+        No protocol bound: everything disabled. Otherwise: "waiting" (or no
+        status yet, i.e. freshly bound and not yet started) enables only
+        Start; "running" enables Stop/Pause/Next; "surveying" enables
+        Stop/Pause but not Next, since a next-cell request during a refill is
+        discarded (nothing is running and nothing is queued to advance past);
+        "paused" enables Stop/Pause (relabeled "Resume") but not Next;
+        "error" enables only Stop.
+        """
+        hasProtocol = self._orchestrator is not None
+        status = self._currentStatus
+        if not hasProtocol:
+            start = stop = pause = next_ = False
+        elif status in (None, "waiting"):
+            start, stop, pause, next_ = True, False, False, False
+        elif status == "running":
+            start, stop, pause, next_ = False, True, True, True
+        elif status == "surveying":
+            start, stop, pause, next_ = False, True, True, False
+        elif status == "paused":
+            start, stop, pause, next_ = False, True, True, False
+        elif status == "error":
+            start, stop, pause, next_ = False, True, False, False
+        else:
+            start, stop, pause, next_ = False, False, False, False
+```
+
+- [ ] **Step 4: Run to verify they pass, then mutation-verify the two that passed early**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_status_panel.py -v
+```
+
+Expected: all pass.
+
+`test_surveying_disables_next_cell` passed before the fix because the catch-all `else` disabled everything, so it does not yet prove the `"surveying"` branch. Apply the plausible-but-wrong version that treats surveying exactly like running:
+
+```python
+        elif status in ("running", "surveying"):
+            start, stop, pause, next_ = False, True, True, True   # DEFECT
+```
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_status_panel.py -v -k surveying
+```
+
+Expected: `test_surveying_disables_next_cell` FAILS. Revert.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/modules/Autopatch/status_panel.py acq4/modules/Autopatch/tests/test_status_panel.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat: gate Area 3's buttons for the surveying status
+
+Stop and Pause stay available during a survey -- imaging a tile is slow and
+an operator must not have to wait for a cell to be found. Next cell is
+disabled, since a request during a refill is discarded by design.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 9: The real tile detector
+
+The one function that touches devices: move the stage to a tile, find that tile's surface, acquire a stack across the constrained depth range, detect and score cells, and build `Cell` objects with their trackers seeded from that stack. Modelled on `AutomationDebug/detection.py:_detectNeuronsZStack` and `autopatch.py:_autopatchFindCell`, which are the working reference for every one of these calls.
+
+Nothing headless can test this — it needs a microscope, a camera, and `acq4_automation`'s models. It is therefore deliberately thin: all the logic worth testing was pushed into Tasks 3–5. Its verification is Task 12's live smoke test.
+
+**Files:**
+- Create: `acq4/experiment/tile_detector.py`
+
+**Interfaces:**
+- Consumes: `SearchConstraints.z_bounds(surface)` (Task 2).
+- Produces: `make_tile_detector(camera, scope, manager, step_z=1e-6, min_volume_m3=0.0, max_candidates=5) -> Callable[[tuple[float, float], SearchConstraints], list]`. The returned callable is the `detector` seam `CellProducer` takes (Task 4), and runs on the orchestrator's worker thread.
+
+- [ ] **Step 1: Write the implementation**
+
+There is no failing-test step here: this file is device glue with no headless-testable behaviour, and inventing a mock microscope to assert call order would test the mock, not the code. Create `acq4/experiment/tile_detector.py`:
+
+```python
+"""The imaging half of a cell producer: move to a tile, find its surface, acquire
+a stack over the constrained depth range, and return scored cell candidates."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from acq4.logging_config import get_logger
+from acq4.util.task import check_stop, synch
+
+logger = get_logger(__name__)
+
+
+def make_tile_detector(
+    camera,
+    scope,
+    manager,
+    step_z: float = 1e-6,
+    min_volume_m3: float = 0.0,
+    max_candidates: int = 5,
+) -> Callable:
+    """Build the detector seam `Slice.makeCellProducer()` needs.
+
+    `camera` and `scope` must be resolved on the GUI thread and passed in; the
+    returned callable runs on the orchestrator's worker thread, where reading a
+    device selector widget is not safe.
+
+    Surface is found per tile rather than once per slice, so the searched slab
+    follows uneven tissue -- that is the whole reason the depth range is
+    expressed as offsets from the surface instead of absolute stage z.
+    """
+
+    def detect(center, constraints) -> list:
+        # Imported here, not at module scope: acq4_automation lives in an
+        # internal repository, and a top-level import would stop every test
+        # under acq4/experiment from collecting where it is absent.
+        from acq4_automation.feature_tracking.cell import Cell
+        from acq4_automation.object_detection import detect_neurons
+        from coorx import Point
+
+        check_stop()
+        logger.info("Surveying tile at %r", center)
+        scope.setGlobalPosition(center, name="autopatch survey move").wait()
+
+        check_stop()
+        surface = synch(scope.findSurfaceDepth)(camera)
+        start_z, stop_z = constraints.z_bounds(surface)
+
+        check_stop()
+        restore_depth = camera.getFocusDepth()
+        try:
+            stack = _acquire(camera, start_z, stop_z, step_z)
+        finally:
+            camera.setFocusDepth(
+                restore_depth, name=f"{camera.name()} restore focus after survey stack"
+            )
+
+        check_stop()
+        models = _health_models(manager)
+        results = detect_neurons(
+            stack,
+            xy_scale=camera.getPixelSize()[0],
+            z_scale=step_z,
+            trim_edges=True,
+            min_volume_m3=min_volume_m3,
+            n=max_candidates,
+            **models,
+        )
+        logger.info("Tile at %r yielded %d candidates", center, len(results))
+
+        cells = []
+        for position, score in results:
+            cell = Cell(Point(position, "global"))
+            cell.score = score
+            try:
+                # Seeded from the stack the cell was found in, so tracking is
+                # ready without re-acquiring a stack per cell. A cell too close
+                # to the stack edge cannot be extracted; queue it anyway rather
+                # than discarding a real detection.
+                cell.initializeTrackerFromStack(camera, stack, use_cellpose=True)
+            except Exception:
+                logger.warning(
+                    "Could not initialize tracking for the cell detected at %r",
+                    position,
+                    exc_info=True,
+                )
+            cells.append(cell)
+        return cells
+
+    return detect
+
+
+def _acquire(camera, start_z: float, stop_z: float, step_z: float) -> list:
+    """The tile's z-stack, shallowest frame first."""
+    from acq4.util.imaging.sequencer import acquire_z_stack
+
+    return acquire_z_stack(
+        camera, start_z, stop_z, step_z, slow_fallback=False, name="autopatch survey stack"
+    )
+
+
+def _health_models(manager) -> dict:
+    """The configured detection/classification model paths from global `misc` config.
+
+    The same keys AutomationDebug reads, so a rig configured for the debug
+    bench needs no extra configuration to run a survey.
+    """
+    misc = manager.config.get("misc", {}) if manager is not None else {}
+    return {
+        "segmenter": misc.get("segmenterPath", None),
+        "autoencoder": misc.get("autoencoderPath", None),
+        "classifier": misc.get("classifierPath", None),
+        "resnet_classifier": misc.get("resnetClassifierPath", None),
+    }
+```
+
+- [ ] **Step 2: Verify the module imports where `acq4_automation` is absent**
+
+This is the property that keeps `acq4/experiment/tests` collecting on a public runner, and it is the one thing about this file that *can* be checked mechanically:
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -c "
+import sys
+sys.modules['acq4_automation'] = None
+import acq4.experiment.tile_detector as td
+print('imports clean:', callable(td.make_tile_detector))
+"
+```
+
+Expected: `imports clean: True`.
+
+- [ ] **Step 3: Verify the whole engine suite still collects and passes**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/ -q
+```
+
+Expected: all pass, no collection errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add acq4/experiment/tile_detector.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat: add the tile detector, a cell producer's imaging half
+
+Moves to a tile, finds that tile's surface, acquires a stack across the
+constrained depth range, and returns scored cells with trackers seeded from
+that stack. acq4_automation is imported lazily so the engine's tests still
+collect where it is absent.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 10: Area 2 — the cell-finding config panel
+
+The operator-facing controls: the four search constraints, a button to seed a region around the current field of view, and a readout of survey progress. Region *graphics* (draggable ROIs, the mirror-to-Camera checkbox, the heatmap) are P2c; this panel's job is to make the producer configurable and startable.
+
+**Files:**
+- Create: `acq4/modules/Autopatch/search_panel.py`
+- Create: `acq4/modules/Autopatch/tests/test_search_panel.py`
+
+**Interfaces:**
+- Consumes: `SearchConstraints` (Task 2), `Slice` (Task 3).
+- Produces:
+  - `SearchPanel(cameraGetter=None)` — a `QWidget`.
+  - `panel.constraints() -> SearchConstraints | None` — built from the current widget values, or `None` when they do not describe a valid search.
+  - `panel.sigConstraintsChanged = Qt.Signal(object)` — emits a fresh `SearchConstraints` on any edit.
+  - `panel.sigAddRegionRequested = Qt.Signal()` — the "Add region here" button.
+  - `panel.setSurveyStats(total, covered, percent) -> None` — updates the readout.
+  - `panel.setInteractionLocked(locked: bool) -> None` — disables editing while a run is in flight.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `acq4/modules/Autopatch/tests/test_search_panel.py`. Match the sibling panel tests' style: a module-scoped `qapp` fixture, the widget constructed inline per test, and signals captured with a plain list — those files do not use `pytest-qt`'s `qtbot`.
+
+```python
+"""Tests for Area 2's cell-finding config: the search constraints it builds, the
+region-seeding request it emits, and the survey readout it shows."""
+
+import pytest
+
+from acq4.experiment.slice import SearchConstraints
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+def makePanel():
+    from acq4.modules.Autopatch.search_panel import SearchPanel
+
+    return SearchPanel()
+
+
+def test_defaults_match_the_engines_defaults(qapp):
+    # An operator who touches nothing must get the same search the engine
+    # documents, not a second set of defaults that silently disagrees.
+    assert makePanel().constraints() == SearchConstraints()
+
+
+def test_editing_the_depth_range_is_reflected_in_the_constraints(qapp):
+    panel = makePanel()
+    panel.nearDepthSpin.setValue(-10e-6)
+    panel.farDepthSpin.setValue(-50e-6)
+    assert panel.constraints().depth_range == (
+        pytest.approx(-10e-6),
+        pytest.approx(-50e-6),
+    )
+
+
+def test_editing_the_health_cutoff_is_reflected_in_the_constraints(qapp):
+    panel = makePanel()
+    panel.minHealthSpin.setValue(0.8)
+    assert panel.constraints().min_health == pytest.approx(0.8)
+
+
+def test_editing_rescans_is_reflected_in_the_constraints(qapp):
+    panel = makePanel()
+    panel.rescansCheck.setChecked(True)
+    assert panel.constraints().rescans_allowed is True
+
+
+def test_an_edit_emits_the_new_constraints(qapp):
+    panel = makePanel()
+    emitted = []
+    panel.sigConstraintsChanged.connect(emitted.append)
+
+    panel.minHealthSpin.setValue(0.75)
+
+    assert emitted, "editing a constraint must announce the new search"
+    assert emitted[-1].min_health == pytest.approx(0.75)
+
+
+def test_an_invalid_depth_range_does_not_raise_out_of_the_widget(qapp):
+    # Constraint validation raises, and an operator dragging a spinbox through
+    # an invalid intermediate value must not crash the GUI thread.
+    panel = makePanel()
+    panel.nearDepthSpin.setValue(-30e-6)
+    panel.farDepthSpin.setValue(-30e-6)
+    assert panel.constraints() is None
+    assert panel.errorLabel.text() != ""
+
+
+def test_an_invalid_edit_announces_none_rather_than_staying_silent(qapp):
+    # A listener holding the last-good constraints has to be told the widget no
+    # longer describes a valid search, or it cannot decide to keep them.
+    panel = makePanel()
+    emitted = []
+    panel.sigConstraintsChanged.connect(emitted.append)
+
+    panel.farDepthSpin.setValue(panel.nearDepthSpin.value())
+
+    assert emitted[-1] is None
+
+
+def test_recovering_from_an_invalid_range_clears_the_error(qapp):
+    panel = makePanel()
+    panel.farDepthSpin.setValue(panel.nearDepthSpin.value())
+    assert panel.constraints() is None
+    panel.farDepthSpin.setValue(-70e-6)
+    assert panel.constraints() is not None
+    assert panel.errorLabel.text() == ""
+
+
+def test_add_region_button_emits_a_request(qapp):
+    panel = makePanel()
+    requests = []
+    panel.sigAddRegionRequested.connect(lambda: requests.append(True))
+
+    panel.addRegionBtn.click()
+
+    assert requests == [True]
+
+
+def test_survey_stats_are_shown(qapp):
+    panel = makePanel()
+    panel.setSurveyStats(9, 3, 100 / 3)
+    text = panel.surveyLabel.text()
+    assert "3" in text and "9" in text and "33" in text
+
+
+def test_survey_stats_with_no_region_read_as_no_region(qapp):
+    panel = makePanel()
+    panel.setSurveyStats(0, 0, 0.0)
+    assert "no region" in panel.surveyLabel.text().lower()
+
+
+def test_locking_disables_editing_but_not_the_readout(qapp):
+    panel = makePanel()
+    panel.setInteractionLocked(True)
+    assert not panel.minHealthSpin.isEnabled()
+    assert not panel.addRegionBtn.isEnabled()
+    panel.setInteractionLocked(False)
+    assert panel.minHealthSpin.isEnabled()
+    assert panel.addRegionBtn.isEnabled()
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_search_panel.py -v
+```
+
+Expected: `ModuleNotFoundError: No module named 'acq4.modules.Autopatch.search_panel'`.
+
+- [ ] **Step 3: Write the implementation**
+
+Create `acq4/modules/Autopatch/search_panel.py`:
+
+```python
+"""SearchPanel: Area 2's cell-finding config -- the search constraints that
+parameterise a cell producer, plus region seeding and a survey progress readout."""
+from __future__ import annotations
+
+from acq4.experiment.slice import SearchConstraints
+from acq4.util import Qt
+
+
+class SearchPanel(Qt.QWidget):
+    """The four Area 2 search constraints, a region-seeding button, and a readout.
+
+    Emits `sigConstraintsChanged` with a fresh SearchConstraints on every edit,
+    or with None when the widget values do not describe a valid search (an
+    operator dragging a spinbox passes through invalid intermediate values, and
+    that must not raise on the GUI thread). Region *graphics* are not this
+    panel's job: it asks its owner to seed a region and shows how much of the
+    result has been surveyed.
+    """
+
+    sigConstraintsChanged = Qt.Signal(object)   # SearchConstraints, or None if invalid
+    sigAddRegionRequested = Qt.Signal()
+
+    def __init__(self, cameraGetter=None):
+        super().__init__()
+        self._cameraGetter = cameraGetter or (lambda: None)
+        defaults = SearchConstraints()
+
+        # Depths are offsets from the tissue surface, negative being deeper, so
+        # the spin boxes read the way the design doc writes them (-20 um to
+        # -60 um) rather than as unsigned depths that get subtracted somewhere
+        # else.
+        self.nearDepthSpin = self._makeSpin(
+            defaults.depth_range[0], minimum=-1e-3, maximum=0.0, step=5e-6, suffix="m", decimals=7
+        )
+        self.farDepthSpin = self._makeSpin(
+            defaults.depth_range[1], minimum=-1e-3, maximum=0.0, step=5e-6, suffix="m", decimals=7
+        )
+        self.minHealthSpin = self._makeSpin(
+            defaults.min_health, minimum=0.0, maximum=1.0, step=0.05, suffix="", decimals=2
+        )
+        self.maxDensitySpin = self._makeSpin(
+            defaults.max_cell_density, minimum=1.0, maximum=1e18, step=1e12,
+            suffix="/m³", decimals=0,
+        )
+        self.rescansCheck = Qt.QCheckBox("Rescans allowed")
+        self.rescansCheck.setChecked(defaults.rescans_allowed)
+
+        self.addRegionBtn = Qt.QPushButton("Add region here")
+        self.addRegionBtn.setToolTip(
+            "Add a search region covering roughly 3x3 fields of view around the "
+            "camera's current center."
+        )
+        self.surveyLabel = Qt.QLabel("no region")
+        self.errorLabel = Qt.QLabel("")
+        self.errorLabel.setStyleSheet("color: red;")
+
+        form = Qt.QFormLayout()
+        form.addRow("Depth from surface, near", self.nearDepthSpin)
+        form.addRow("Depth from surface, far", self.farDepthSpin)
+        form.addRow("Minimum health", self.minHealthSpin)
+        form.addRow("Maximum cell density", self.maxDensitySpin)
+
+        layout = Qt.QVBoxLayout()
+        layout.addLayout(form)
+        layout.addWidget(self.rescansCheck)
+        layout.addWidget(self.addRegionBtn)
+        layout.addWidget(self.surveyLabel)
+        layout.addWidget(self.errorLabel)
+        self.setLayout(layout)
+
+        for spin in (self.nearDepthSpin, self.farDepthSpin, self.minHealthSpin, self.maxDensitySpin):
+            spin.valueChanged.connect(self._onEdited)
+        self.rescansCheck.toggled.connect(self._onEdited)
+        self.addRegionBtn.clicked.connect(self.sigAddRegionRequested)
+
+    @staticmethod
+    def _makeSpin(value, minimum, maximum, step, suffix, decimals):
+        spin = Qt.QDoubleSpinBox()
+        spin.setDecimals(decimals)
+        spin.setRange(minimum, maximum)
+        spin.setSingleStep(step)
+        if suffix:
+            spin.setSuffix(f" {suffix}")
+        spin.setValue(value)
+        return spin
+
+    def constraints(self) -> SearchConstraints | None:
+        """The current widget values as constraints, or None if they are invalid.
+
+        Returning None rather than raising is what lets an operator drag a
+        spinbox through an invalid intermediate value without a traceback on
+        the GUI thread; the reason lands in errorLabel instead.
+        """
+        try:
+            constraints = SearchConstraints(
+                depth_range=(self.nearDepthSpin.value(), self.farDepthSpin.value()),
+                min_health=self.minHealthSpin.value(),
+                max_cell_density=self.maxDensitySpin.value(),
+                rescans_allowed=self.rescansCheck.isChecked(),
+            )
+        except ValueError as exc:
+            self.errorLabel.setText(str(exc))
+            return None
+        self.errorLabel.setText("")
+        return constraints
+
+    def _onEdited(self, *_args) -> None:
+        self.sigConstraintsChanged.emit(self.constraints())
+
+    def setSurveyStats(self, total: int, covered: int, percent: float) -> None:
+        if total == 0:
+            self.surveyLabel.setText("no region")
+            return
+        self.surveyLabel.setText(f"{covered}/{total} tiles imaged ({percent:.0f}%)")
+
+    def setInteractionLocked(self, locked: bool) -> None:
+        """Disable editing while a run is in flight; the readout stays visible.
+
+        The constraints parameterise a producer that is already surveying, so
+        editing them mid-run would silently change the search under it.
+        """
+        for w in (
+            self.nearDepthSpin,
+            self.farDepthSpin,
+            self.minHealthSpin,
+            self.maxDensitySpin,
+            self.rescansCheck,
+            self.addRegionBtn,
+        ):
+            w.setEnabled(not locked)
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_search_panel.py -v
+```
+
+Expected: 13 passed. If `test_defaults_match_the_engines_defaults` fails on floating-point representation (a `QDoubleSpinBox` rounds to its `decimals`), fix it by raising `decimals` on the offending spin box, not by loosening the assertion — an operator's default search silently differing from the documented one is the bug this test exists to catch. Note `max_cell_density`'s default is `5e12` with `decimals=0`, which a `QDoubleSpinBox` represents exactly; if the equality still fails there, widen the spin box's range rather than rounding the default.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/modules/Autopatch/search_panel.py acq4/modules/Autopatch/tests/test_search_panel.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat: add Area 2's cell-finding config panel
+
+The four search constraints, a region-seeding request, and a survey readout.
+Invalid spinbox values report None and an error line rather than raising on
+the GUI thread, and editing locks while a run is in flight.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 11: Wire the slice and producer into the window
+
+Everything above is inert until the window owns a `Slice`, installs a producer at Start, and releases it on teardown. This task also closes the remaining P2a deferral ("no teardown path calls `setCellProducer(None)`") and implements §6b's New-slice lifetime.
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/Autopatch.py:38-59` (area boxes), `:86-122` (panel construction), `:124-131` (`_resolvePipette`), `:132-161` (`_onProtocolLoaded`), `:194-219` (`teardown`)
+- Modify: `acq4/modules/Autopatch/tests/test_window_integration.py`
+
+**Interfaces:**
+- Consumes: `Slice`, `SearchConstraints`, `make_tile_detector`, `SearchPanel`, `Orchestrator.setCellProducer`/`clearQueue`, `StatusPanel.sigStatusChanged` (Task 8).
+- Produces: `AutopatchWindow.slice` (the current `Slice`, or `None`); `AutopatchWindow.newSlice()`; `AutopatchWindow.addRegionHere()`.
+
+- [ ] **Step 1: Add the camera stub and a window helper the new tests need**
+
+`test_window_integration.py` has no window fixture — each test constructs `AutopatchWindow(module=None, protocolDir=str(tmp_path), pipetteSelector=_FakePipetteSelector(), cameraSelector=_FakeCameraSelector())` inline after writing a protocol file — and its `_FakeCameraSelector.getSelectedObj()` returns `None`, so no existing test exercises a camera at all. Every test below needs one. Add these next to the existing stubs, leaving `_FakeCameraSelector` untouched so the tests that rely on a camera-less window keep working:
+
+```python
+class _FakeScope:
+    """Stands in for a Microscope: records survey moves and reports a surface."""
+
+    def __init__(self):
+        self.moves = []
+
+    def setGlobalPosition(self, pos, speed="fast", name=None):
+        self.moves.append(tuple(pos))
+        return _DoneFuture()
+
+    def findSurfaceDepth(self, imager):
+        return 0.0
+
+
+class _DoneFuture:
+    def wait(self, **kwargs):
+        return None
+
+
+class _FakeCamera:
+    """Stands in for a Camera: the three calls a cell producer's install needs.
+
+    getBoundary in "roi" mode gives the field a tile covers, globalCenterPosition
+    in "roi" mode gives where to seed a region, and scopeDev is the stage the
+    detector drives.
+    """
+
+    def __init__(self, fov=(10e-6, 10e-6), center=(0.0, 0.0, 0.0)):
+        self._fov = fov
+        self._center = center
+        self.scopeDev = _FakeScope()
+
+    def name(self):
+        return "FakeCamera"
+
+    def getBoundary(self, globalCoords=True, mode="sensor"):
+        w, h = self._fov
+        return self._center[0] - w / 2, self._center[1] - h / 2, w, h
+
+    def globalCenterPosition(self, mode="sensor"):
+        return self._center
+
+    def getPixelSize(self):
+        return (0.32e-6, 0.32e-6)
+
+
+class _FakeCameraWithDevice(Qt.QWidget):
+    """A camera selector that actually returns a camera, unlike _FakeCameraSelector."""
+
+    def __init__(self, camera=None):
+        super().__init__()
+        self.camera = camera if camera is not None else _FakeCamera()
+
+    def getSelectedObj(self):
+        return self.camera
+
+
+def _makeWindow(tmp_path, cameraSelector=None):
+    """An AutopatchWindow with a loaded no-op protocol, as the tests above build it."""
+    from acq4.modules.Autopatch.Autopatch import AutopatchWindow
+
+    _write_protocol(tmp_path, "demo.py", _NOOP_PROTOCOL)
+    win = AutopatchWindow(
+        module=None,
+        protocolDir=str(tmp_path),
+        pipetteSelector=_FakePipetteSelector(),
+        cameraSelector=cameraSelector if cameraSelector is not None else _FakeCameraWithDevice(),
+    )
+    win.protocolPanel.fileCombo.setCurrentText("demo")
+    return win
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Append them to the same file. Each takes `qapp` and `tmp_path`, matching the file's existing signatures.
+
+```python
+def test_a_fresh_window_has_no_slice(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    # A slice is a commitment to a piece of tissue under the objective; the
+    # window must not invent one before the operator says so.
+    assert win.slice is None
+
+
+def test_new_slice_creates_a_slice_using_the_cameras_field_of_view(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    assert win.slice is not None
+    assert win.slice.tileGrid() == [], "a new slice has no regions to survey yet"
+
+
+def test_new_slice_without_a_camera_reports_rather_than_raising(qapp, tmp_path):
+    # _FakeCameraSelector returns None, the camera-less case.
+    win = _makeWindow(tmp_path, cameraSelector=_FakeCameraSelector())
+    win.newSlice()
+    assert win.slice is None
+    assert win.searchPanel.errorLabel.text() != ""
+
+
+def test_add_region_here_seeds_a_multi_tile_region(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    assert len(win.slice.regions) == 1
+    assert len(win.slice.tileGrid()) > 1
+
+
+def test_new_slice_replaces_the_slice_and_its_coverage(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    first = win.slice
+    first.markCovered(first.nextTile())
+
+    win.newSlice()
+
+    assert win.slice is not first
+    assert win.slice.regions == []
+    assert win.slice.coveredTiles == []
+
+
+def test_new_slice_clears_the_cell_list_and_the_orchestrators_queue(qapp, tmp_path):
+    # A Cell is a coordinate in tissue. Swapped tissue makes every one of those
+    # coordinates a place not to drive a pipette, so both the panel's list and
+    # the orchestrator's separate deque have to let go.
+    win = _makeWindow(tmp_path)
+    win.cellPanel._onScatterFakeCellsClicked()
+    assert win.cellPanel.cellList.count() > 0
+
+    ran = []
+    win.orchestrator.protocolFile.run = lambda ctx, **kw: ran.append(ctx.cell)
+
+    win.newSlice()
+
+    assert win.cellPanel.cellList.count() == 0
+    win.orchestrator.run_sync()
+    assert ran == [], "a cell survived New slice and was patched anyway"
+
+
+def test_start_installs_a_producer_when_a_slice_has_a_region(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+
+    win._onStartRun()
+
+    assert win.orchestrator._cellProducer is not None
+
+
+def test_start_installs_no_producer_without_a_slice(qapp, tmp_path):
+    # No slice means no tissue to survey: the run must be a plain queue drain
+    # of whatever the operator seeded by hand, not an error.
+    win = _makeWindow(tmp_path)
+    win._onStartRun()
+    assert win.orchestrator._cellProducer is None
+
+
+def test_start_installs_no_producer_for_a_slice_with_no_region(qapp, tmp_path):
+    # A slice with nowhere to look would have its producer report exhaustion on
+    # the first call, so installing one only adds a pointless refill round trip.
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win._onStartRun()
+    assert win.orchestrator._cellProducer is None
+
+
+def test_start_clears_a_stale_producer_once_the_slice_is_gone(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    win._onStartRun()
+    assert win.orchestrator._cellProducer is not None
+
+    win.slice = None
+    win._onStartRun()
+
+    assert win.orchestrator._cellProducer is None
+
+
+def test_teardown_clears_the_producer(qapp, tmp_path):
+    # The producer closes over the camera and scope devices; leaving it
+    # installed on a released orchestrator keeps them reachable from an object
+    # the window has stopped managing.
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    win._onStartRun()
+    orch = win.orchestrator
+
+    win.teardown()
+
+    assert orch._cellProducer is None
+
+
+def test_loading_a_second_protocol_clears_the_outgoing_producer(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    win._onStartRun()
+    outgoing = win.orchestrator
+
+    _write_protocol(str(tmp_path), "second.py", _NOOP_PROTOCOL)
+    # refreshFileList is the discovery scan the picker's popup runs; it lists the
+    # newly written file without force-reloading the one already loaded.
+    win.protocolPanel.refreshFileList()
+    win.protocolPanel.fileCombo.setCurrentText("second")
+
+    assert outgoing._cellProducer is None
+    assert win.orchestrator is not outgoing
+
+
+def test_editing_the_constraints_reaches_the_live_slice(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.searchPanel.minHealthSpin.setValue(0.85)
+    assert win.slice.constraints.min_health == pytest.approx(0.85)
+
+
+def test_invalid_constraints_leave_the_slice_alone(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    before = win.slice.constraints
+    win.searchPanel.farDepthSpin.setValue(win.searchPanel.nearDepthSpin.value())
+    assert win.slice.constraints is before
+
+
+def test_the_survey_readout_follows_the_slices_coverage(qapp, tmp_path):
+    # Coverage advances on the worker thread as tiles are imaged, so the readout
+    # is refreshed off the status signal rather than polled.
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.addRegionHere()
+    total = len(win.slice.tileGrid())
+    win.slice.markCovered(win.slice.nextTile())
+
+    win.statusPanel.sigStatusChanged.emit("surveying")
+
+    assert f"1/{total}" in win.searchPanel.surveyLabel.text()
+```
+
+Add `import pytest` to the file if it is not already there. `test_loading_a_second_protocol_clears_the_outgoing_producer` drives the protocol picker (`refreshFileList()` then `fileCombo.setCurrentText(...)`) rather than calling `_onProtocolLoaded` directly, so it exercises the same path an operator does — the path that leaked a live orchestrator in P1.5.
+
+- [ ] **Step 3: Run to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py -v -k "slice or producer or constraints or readout"
+```
+
+Expected: `AttributeError` on `slice`, `newSlice`, `addRegionHere`, `_onStartRun`, and `searchPanel`.
+
+- [ ] **Step 4: Write the implementation**
+
+In `acq4/modules/Autopatch/Autopatch.py`:
+
+Add the imports:
+
+```python
+from acq4.experiment.slice import Slice
+from acq4.experiment.tile_detector import make_tile_detector
+
+from .search_panel import SearchPanel
+```
+
+Populate Areas 1 and 2, replacing the bare group boxes' emptiness. After `self.statusPanel` is constructed and before `self.cellPanel`:
+
+```python
+        # Area 1 holds only New slice for now: region graphics and the progress
+        # heatmap are Area 1's remaining content and are not built here.
+        self.newSliceBtn = Qt.QPushButton("New slice")
+        self.newSliceBtn.setToolTip(
+            "Discard the current slice -- its regions, coverage, and queued "
+            "cells -- and start a fresh one for newly mounted tissue."
+        )
+        self.area1Box.layout().addWidget(self.newSliceBtn)
+
+        self.searchPanel = SearchPanel(cameraGetter=self.cameraSelector.getSelectedObj)
+        self.area2Box.layout().addWidget(self.searchPanel)
+```
+
+Add the slice attribute next to `self._cachedPipette`:
+
+```python
+        # The tissue currently under the objective, or None before the operator
+        # has started one. A Slice outlives individual runs: it holds the
+        # regions, the coverage every producer made from it shares, and the
+        # search constraints. Replaced only by newSlice().
+        self.slice = None
+        # Camera and scope resolved from cameraSelector at the moment Start was
+        # last pressed, for the same reason as _cachedPipette: the detector runs
+        # on the orchestrator's worker thread and must not read a selector.
+        self._cachedCamera = None
+        self._cachedScope = None
+```
+
+Wire the new controls, alongside the existing `statusPanel.sigInteractionLocked` connection:
+
+```python
+        self.newSliceBtn.clicked.connect(self.newSlice)
+        self.searchPanel.sigAddRegionRequested.connect(self.addRegionHere)
+        self.searchPanel.sigConstraintsChanged.connect(self._onConstraintsChanged)
+        self.statusPanel.sigInteractionLocked.connect(self.searchPanel.setInteractionLocked)
+        # Coverage advances on the worker thread as the producer images tiles, so
+        # the readout is refreshed off a status change rather than polled. Routed
+        # through StatusPanel, not connected to the orchestrator directly: the
+        # orchestrator is a parentless QObject and a connection from it to this
+        # window would give it a reference back, rebuilding the cycle
+        # bindOrchestrator/unbindOrchestrator exist to avoid. StatusPanel is in
+        # this window's widget tree, so this wiring is made once and never needs
+        # re-wiring per protocol load.
+        self.statusPanel.sigStatusChanged.connect(self._onRunStatus)
+```
+
+Add the slice lifecycle methods:
+
+```python
+    def newSlice(self) -> None:
+        """Start a fresh slice, discarding the current one and everything on it.
+
+        Regions, coverage, and search constraints go with the old slice, and so
+        do the queued cells: a Cell is a coordinate in tissue, and tissue that
+        has been swapped makes every one of those coordinates a place not to
+        drive a pipette. The per-cell data already written under the old slice
+        directory is the durable record; Area 5's list is a working queue.
+        """
+        camera = self.cameraSelector.getSelectedObj()
+        if camera is None:
+            self.searchPanel.errorLabel.setText("Select a camera before starting a slice.")
+            return
+        constraints = self.searchPanel.constraints()
+        if constraints is None:
+            return
+        self.slice = Slice(fov=self._cameraFov(camera), constraints=constraints)
+        self.cellPanel.clearCells()
+        if self.orchestrator is not None:
+            # clearCells() only drops the panel's own bookkeeping; the
+            # orchestrator's deque is a separate strong reference to the same
+            # cells and would keep handing them to the protocol.
+            self.orchestrator.clearQueue()
+            self.orchestrator.setCellProducer(None)
+        self._refreshSurveyStats()
+
+    def addRegionHere(self) -> None:
+        """Add a search region of roughly 3x3 fields of view around the camera center."""
+        if self.slice is None:
+            self.newSlice()
+            if self.slice is None:
+                return
+        camera = self.cameraSelector.getSelectedObj()
+        if camera is None:
+            return
+        fov_w, fov_h = self._cameraFov(camera)
+        # "roi" mode throughout: the field the camera actually images is what a
+        # tile covers, and globalCenterPosition defaults to "sensor", which is
+        # off-center for a cropped camera ROI.
+        cx, cy = camera.globalCenterPosition("roi")[:2]
+        w, h = fov_w * 3, fov_h * 3
+        self.slice.addRegion(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2)
+        self._refreshSurveyStats()
+
+    @staticmethod
+    def _cameraFov(camera) -> tuple[float, float]:
+        """The camera's imaged field width and height, in global metres."""
+        _, _, w, h = camera.getBoundary(globalCoords=True, mode="roi")
+        return abs(w), abs(h)
+
+    def _onConstraintsChanged(self, constraints) -> None:
+        # None means the spinboxes do not currently describe a valid search
+        # (SearchPanel already shows why); leave the live slice on its last
+        # good constraints rather than tearing them down mid-edit.
+        if constraints is not None and self.slice is not None:
+            self.slice.setConstraints(constraints)
+
+    def _refreshSurveyStats(self) -> None:
+        if self.slice is None:
+            self.searchPanel.setSurveyStats(0, 0, 0.0)
+        else:
+            self.searchPanel.setSurveyStats(*self.slice.surveyStats())
+```
+
+Replace `_resolvePipette` with `_onStartRun`, which snapshots the devices *and* installs the producer — one GUI-thread seam, called through `StatusPanel`'s existing `onStart` hook:
+
+```python
+    def _onStartRun(self) -> None:
+        """Snapshot GUI-thread-only state and install the cell producer at Start.
+
+        Runs on the GUI thread before the orchestrator's worker thread starts,
+        so the in-flight run never reads InterfaceCombo's
+        currentIndex()/interfaceMap off-thread. Re-resolved on every Start, so
+        the selection and the slice may both change between runs.
+        """
+        self._cachedPipette = self.pipetteSelector.getSelectedObj()
+        self._cachedCamera = self.cameraSelector.getSelectedObj()
+        self._cachedScope = None
+        if self._cachedCamera is not None:
+            self._cachedScope = self._cachedCamera.scopeDev
+        self._installCellProducer()
+
+    def _installCellProducer(self) -> None:
+        """Give the orchestrator a producer for the current slice, or none.
+
+        Cleared rather than left stale whenever a survey is not possible: no
+        slice, no region, or no camera means the run is a plain drain of the
+        cells the operator seeded by hand, and a producer left over from a
+        previous Start would otherwise keep surveying tissue that is gone.
+        """
+        if self.orchestrator is None:
+            return
+        canSurvey = (
+            self.slice is not None
+            and self.slice.regions
+            and self._cachedCamera is not None
+            and self._cachedScope is not None
+        )
+        if not canSurvey:
+            self.orchestrator.setCellProducer(None)
+            return
+        detector = make_tile_detector(
+            camera=self._cachedCamera, scope=self._cachedScope, manager=self.manager
+        )
+        self.orchestrator.setCellProducer(self.slice.makeCellProducer(detector))
+```
+
+Point `bindOrchestrator` at the new hook, in `_onProtocolLoaded`:
+
+```python
+        self.statusPanel.bindOrchestrator(
+            self.orchestrator, self.cellPanel, onStart=self._onStartRun
+        )
+```
+
+Clear the producer wherever an orchestrator is released, in `_stopAndReleaseOrchestrator` — before `setParent(None)`:
+
+```python
+        # The producer closes over the camera and scope devices and over a
+        # Slice this window may be about to replace. Leaving it installed on an
+        # orchestrator the window has stopped managing keeps all of that
+        # reachable from an object nothing is looking after any more.
+        orchestrator.setCellProducer(None)
+```
+
+Finally, add the slot behind the `sigStatusChanged` connection made in the constructor:
+
+```python
+    def _onRunStatus(self, status: str) -> None:
+        """Refresh Area 2's survey readout when the run's status moves.
+
+        Coverage advances on the orchestrator's worker thread, but this arrives
+        via StatusPanel on the GUI thread, so re-reading the slice here is safe.
+        """
+        if status in ("surveying", "waiting"):
+            self._refreshSurveyStats()
+```
+
+Nothing needs disconnecting for this one: `sigStatusChanged` belongs to `self.statusPanel`, a child widget in this window's tree, and it is wired once in the constructor rather than per orchestrator — the same shape as the existing `sigInteractionLocked` → `protocolPanel.setInteractionLocked` connection.
+
+- [ ] **Step 5: Run to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py -v
+```
+
+Expected: all pass, including the pre-existing tests. If a call on `_FakeCamera` or `_FakeScope` turns out to be missing, extend the stub — do not weaken the test, since those calls are exactly what the producer install depends on.
+
+- [ ] **Step 6: Mutation-verify the two clearing behaviours**
+
+(a) The orchestrator's queue must actually be cleared. Remove the `clearQueue()` call from `newSlice`:
+
+```python
+        if self.orchestrator is not None:
+            self.orchestrator.setCellProducer(None)   # DEFECT: deque still holds the cells
+```
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py::test_new_slice_clears_the_cell_list_and_the_orchestrators_queue -v
+```
+
+Expected: FAIL on `assert ran == [], "a cell survived New slice and was patched anyway"`. Revert.
+
+(b) A stale producer must be cleared, not merely left unreplaced. Make `_installCellProducer` return early instead of clearing:
+
+```python
+        if not canSurvey:
+            return                                     # DEFECT: stale producer survives
+```
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py::test_start_clears_a_stale_producer_once_the_slice_is_gone -v
+```
+
+Expected: FAIL on `assert win.orchestrator._cellProducer is None`. Revert.
+
+- [ ] **Step 7: Run the whole Autopatch and engine suites**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/ acq4/modules/Autopatch/ acq4/modules/AutomationDebug/ -q
+```
+
+Expected: all pass. In particular `test_teardown.py`'s weakref/`gc.disable` regression tests must still pass — the new `Slice` and producer are reachable from the window, and a cycle through them would surface exactly there.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add acq4/modules/Autopatch/Autopatch.py acq4/modules/Autopatch/tests/test_window_integration.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat: own a Slice in the Autopatch window and install its cell producer
+
+New slice discards the tissue's regions, coverage, and queued cells -- both
+the panel's list and the orchestrator's separate deque. Start snapshots the
+camera and scope on the GUI thread and installs a producer for the current
+slice, clearing a stale one when a survey is no longer possible; every path
+that releases an orchestrator now clears its producer too.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 12: Live smoke-test brief
+
+The headless suite cannot reach the detector, the stage moves, the surface search, or `detect_neurons`. Task 9 is verified by an operator at a GUI, and P1.5's experience was that three of its four Criticals lived in exactly the panels CI skips. Write the brief; a human runs it.
+
+**Files:**
+- Create: `.superpowers/sdd/p2b-smoke-brief.md` (an untracked working file — `.superpowers/sdd/.gitignore` is `*`, so nothing in that directory can be committed, which is why this task has no commit step for it)
+
+**Interfaces:**
+- Consumes: everything.
+- Produces: nothing in code.
+
+- [ ] **Step 1: Write the brief**
+
+Create `.superpowers/sdd/p2b-smoke-brief.md`. It must contain, as numbered steps with an explicit expected observation each:
+
+1. **Launch.** `/home/martin/.miniforge3/envs/acq4-gl/bin/python bin/acq4 --config /home/martin/src/acq4/acq4/config/mock/default.cfg -m Autopatch` — `--config` also sets `manager.configDir`, so this runs worktree code against the main checkout's mock config (the config dir is gitignored and absent from every worktree). Expect a clean launch, Areas 1 and 2 populated, zero tracebacks. **Before testing anything param-related, refresh `<configDir>/autopatch_protocols/example_*.py` from this branch** — `install_example_protocols` never overwrites, so a stale on-disk copy silently shadows the bundled one.
+2. **New slice with no camera selected.** Expect the Area 2 error line to ask for a camera, and no slice to be created — not a traceback.
+3. **New slice with a camera selected.** Expect the readout to read "no region".
+4. **Add region here.** Expect the readout to show `0/N tiles imaged (0%)` with N > 1.
+5. **Edit each constraint.** Expect no traceback, and dragging the far-depth spinbox through the near-depth value to show a red error line that clears on recovery.
+6. **Start.** Expect Area 3 to read `surveying`, Stop and Pause enabled, Next cell disabled, Area 2 and Area 4 locked. Expect the stage to move and the survey readout to advance.
+7. **Stop mid-survey.** Expect the run to end promptly, without waiting for the current tile's detection to find something. This is design §3.2's explicit requirement and the reason Task 8 exists.
+8. **Pause mid-survey, then resume.** Expect no further tiles to be imaged while paused.
+9. **Run to exhaustion** with a small region and `rescans allowed` off. Expect the run to end at `waiting` with the readout at 100%, and the log to show one `Surveying tile at ...` line per tile.
+10. **Re-press Start on the exhausted slice.** Expect it to survey nothing new and end promptly — `_producerExhausted` is per-run, but the slice's coverage is not, so the producer reports exhaustion on its first call.
+11. **Enable `rescans allowed` and Start again.** Expect exactly one more pass over the tiles, then `waiting`.
+12. **Seed cells by hand, then press New slice.** Expect the cell list to empty, and a subsequent Start to patch nothing.
+13. **Load a second protocol while a survey is running.** Expect the outgoing run to stop, no second worker thread to touch the pipette, and no log lines from the old orchestrator arriving in the new session's Area 5.
+14. **Close the window.** Expect exit code 0 and no segfault — the teardown guard, and now with a `Slice` and producer in the graph.
+
+For each step record VERIFIED / NOT VERIFIED with what was actually observed. Note that screenshots are not available from an agent on this box: Qt renders Wayland-native, `import -window root` fails, and there is no `grim`.
+
+- [ ] **Step 2: Confirm the brief is not committable, and leave it uncommitted**
+
+```bash
+git check-ignore -v .superpowers/sdd/p2b-smoke-brief.md
+```
+
+Expected: `.superpowers/sdd/.gitignore:1:*	.superpowers/sdd/p2b-smoke-brief.md`. The brief is a working file for the human running it, exactly like `task-11-brief.md` from P1.5. Do not `git add -f` it.
+
+- [ ] **Step 3: Run the full test suite one last time**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/ -q 2>&1 | tail -20
+```
+
+Expected: all pass, no new failures against the pre-branch baseline. Record the count. Test output must be pristine: investigate any new warning rather than tolerating it.
+
+---
+
+## Coverage against the spec
+
+| Spec requirement | Task |
+|---|---|
+| §6b `Slice` owns the regions to search | 3 |
+| §6b `Slice` owns coverage, shared by every producer it makes | 3, 4 |
+| §6b `Slice` owns the search constraints | 2, 3 |
+| §6b `Slice.makeCellProducer()` returns the §3.2 callable | 4 |
+| §6b producers are views onto slice state, not owners | 4, 6 |
+| §6b New slice discards regions, coverage, constraints, and the cell list | 7, 11 |
+| §6b hard-coded binding to the acq4 slice directory | 3 (`Slice.directory`) |
+| §6b heatmap backing data | 3 (`surveyStats`, `coveredTiles`); rendering is P2c |
+| §6b persistence to `.index` | Deliberately out of scope ("not required for a first cut") |
+| §3.2 `producer() -> Sequence \| None`, `[]` vs `None` | 4, 5 |
+| §3.2 Stop and Pause honoured between refills | 8 (button gating); the loop behaviour landed in P2a |
+| §3.2 `_producerExhausted` is per-run, not a record of a spent slice | 5 (per-producer rescan allowance mirrors it) |
+| §7 Area 2 depth range, relative to surface, found per tile | 2, 9, 10 |
+| §7 Area 2 minimum health prediction | 5, 10 |
+| §7 Area 2 maximum cell density | 5, 10 |
+| §7 Area 2 rescans allowed | 5, 10 |
+| §7 Area 2 `auto-add`/`+add`/`recycle` button semantics | Parked by §12 as an implementation detail; not built |
+| §7 Area 1 New slice | 11 |
+| §7 Area 1 ROI graphics, mirror checkbox, heatmap, pinned frames | P2c |
+| P2a deferral: no status distinguishes surveying from patching | 7, 8 |
+| P2a deferral: `sigCurrentCell` holds the finished cell during a refill | 7 |
+| P2a deferral: no teardown path calls `setCellProducer(None)` | 11 |
+| P2a deferral: a lazy generator producer raising mid-iteration escapes unwrapped | Not addressed; `CellProducer` returns a concrete `list`, so no producer in this plan is lazy |
+| §10 cross-repo `acq4_automation.Cell` expansion | P2c, with the heatmap that forces it |


### PR DESCRIPTION
## What this is

**P2b** of the Autopatch module: the `Slice` object (design §6b), Area 2's cell-finding config (§7), and a real cell producer wired into the `cellProducer` hook P2a built. Cell-finding is now part of a running experiment — the orchestrator surveys tissue tile by tile as its queue drains, and patches what it finds.

Plan: `docs/superpowers/plans/2026-07-30-autopatch-p2b-slice-and-producer.md`. Base `_reviewed`, off the P2a merge `dbf5ac56a`. 29 commits, **477 tests** in the touched suites (827 repo-wide, 1 xfailed).

## Owner decisions taken before planning

- Regions come from a minimal **"Add region here"** button in Area 2; Area 1's ROI graphics, the mirror-to-Camera checkbox, and the progress heatmap stay **P2c**.
- The imaging/detection step is an **injected seam**, so the survey logic is tested headlessly with a fake detector.
- **`Slice` lives in `acq4/experiment/`** — resolves §6b's open question, and means its tests run where the internal `acq4_automation` is absent (`conftest.py` skips `modules/*/tests`, not `acq4/experiment/tests`).
- The `"surveying"` status and clearing `sigCurrentCell` before a refill land here, closing two P2a review deferrals.
- `tile_detector.py` is tested with **device fakes** rather than left untested.

## New

| File | What |
|---|---|
| `acq4/experiment/search_grid.py` | Serpentine FOV tiling, moved out of `AutomationDebug/survey.py` so it runs on public CI |
| `acq4/experiment/slice.py` | `SearchConstraints` + `Slice`: regions, shared coverage, constraints, `makeCellProducer()` |
| `acq4/experiment/cell_producer.py` | `CellProducer` — walks a slice's tiles, one per call |
| `acq4/experiment/tile_detector.py` | The hardware half: move, per-tile surface, z-stack, `detect_neurons`, seed tracking |
| `acq4/modules/Autopatch/search_panel.py` | Area 2: the four search constraints, region seeding, survey readout |

Plus `"surveying"` + `clearQueue()` + `pendingCells()` on `Orchestrator`, `sigStatusChanged` on `StatusPanel`, and the window owning a `Slice`.

## Two decisions flagged for confirmation

1. **`rescans_allowed=True` grants exactly ONE extra pass.** Unbounded rescanning could never return `None`, which violates §3.2's producer contract and wedges the run loop — so "unlimited" was not an available reading.
2. **Depth range is stored as signed offsets from the surface** — `(-20e-6, -60e-6)` — matching the design doc's notation rather than `AutomationDebug`'s positive-and-subtract spin boxes.

## Six real defects found and fixed

1. **Pre-existing, and it also fixes the AutomationDebug demo.** `_axis_centers` used an unguarded `math.ceil((extent - fov) / step)`. At millimetre stage offsets — i.e. wherever real tissue sits — `hi - lo` carries float error, the ratio lands just above an integer, and a whole extra row *and* column get planned. A 30 µm square with a 10 µm FOV planned **16 tiles where 9 cover it**: ~78% wasted imaging per survey, and a coverage percentage that never reached 100%.
2. **`clearQueue()` from the GUI thread raced the worker's `if not self._queue` / `popleft()`** — a clear landing between them raised `IndexError` that nothing catches, so pressing "New slice" mid-run crashed the experiment. Now one step, via `try/except IndexError`.
3. **Same shape again**: `_shouldRefill()` read the producer and `_refillQueue()` *called* it as separate steps, so a mid-run clear raised `TypeError: 'NoneType' object is not callable` → spurious red error + `AbortExperiment`. And a refill already in flight could deposit discarded-tissue coordinates *after* "New slice".
4. **A tile abandoned by Stop was marked covered** and never re-imaged, so `surveyStats()` reported 100% for a region containing an unimaged tile — contradicting `Slice.nextTile`'s own docstring.
5. **`restore_depth` was captured *after* `findSurfaceDepth`**, which itself moves focus to the surface — so it never restored the depth the survey started from. A dishonest fake hid it.
6. **`Cell` coordinates in swapped-out tissue walked back into the queue.** `CellPanel.bindOrchestrator` flushes `_cells` into a newly bound orchestrator, and surfacing produced cells made `_onCellFinished` re-insert discarded and already-finished cells. Proven: the pipette would be driven to a coordinate the operator declared gone, and every surveyed cell got patched twice.

Also: **cells found by a survey were invisible** — they reached the orchestrator via `enqueue()` and the panel only via signals, and both handlers silently did nothing without an existing row. They were patched with no row, and since the timeline and log are only reachable by selecting a row, the operator could not see what happened to them.

## Notes for the reviewer

- **The flush invariant regressed in *both* directions** across review rounds. Too wide re-runs discarded coordinates; too narrow loses the operator's queued work. A test for only one side passes happily while the other is broken — both are now pinned.
- **Surveyed cells are built on the worker thread**, so `addCell`'s `setParent(self)` cannot succeed for them (Qt warns, and the ownership cascade is never established). Parenting is now conditional, with the panel's strong reference as the documented guarantee. Only a cross-thread probe finds this.
- Reviews ran ~90 mutations across the branch. Several of the plan's own test blocks were **vacuous** — they asserted the right property but could not reach the state distinguishing fixed from broken code. Every fix here was verified by applying the defect and watching a named test fail.

## Not verifiable headlessly — needs a human at the rig

16-step brief at `.superpowers/sdd/p2b-smoke-brief.md` (gitignored). Real camera/scope/`detect_neurons` are untouched by any test. One open question worth checking there: `tile_detector` uses `scope.setGlobalPosition(tileCenter)`, but `Camera.moveCenterToGlobal` exists precisely for the scope-axis-vs-ROI-centre offset. This is character-for-character what the `AutomationDebug` reference does, so it is a question about both, not a regression — **confirm the imaged tiles land inside the region the operator drew.**

## Out of scope (P2c)

Area 1's ROI graphics, the mirror-to-Camera checkbox, the progress heatmap and the cross-repo `acq4_automation.Cell` expansion it forces, the pinned-frames imaging workflow, and disk persistence of slice state (§6b calls that "not required for a first cut").

🤖 Built with [Claude Code](https://claude.ai/code)
