### PR TITLE
fix: honour cancel and the survey region in the autopatch demo

### DIFF
--- a/acq4/modules/AutomationDebug/autopatch.py
+++ b/acq4/modules/AutomationDebug/autopatch.py
@@ -74,19 +74,8 @@ class Autopatcher:
                 cell_dir = run_in_gui_thread(data_manager.createNewFolder, "Cell")
                 cell_to_save = None
                 try:
-                    started_clean = ppip.isTipClean()
-                    if not started_clean:
-                        set_state("Autopatch: cleaning pipette")
-                        try:
-                            ppip.setState("clean", nextState="bath").wait(timeout=600)
-                        except Exception:
-                            set_state("Clean is unsafe to undo; quitting demo")
-                            logger.exception("Error during pipette clean - quitting autopatch demo")
-                            return
-                        if not ppip.isTipClean():
-                            set_state("Pipette still not clean after clean state; quitting demo")
-                            return
-                        win.scopeDevice.moveDip().wait()
+                    if not self._cleanPipetteIfNeeded():
+                        return
 
                     cell = self._autopatchFindCell()
                     if cell is None:
@@ -218,24 +207,74 @@ class Autopatcher:
             parent = parent.parent()
         return parent.mkdir('AutopatchDemo', autoIncrement=True)
 
+    def _cleanPipetteIfNeeded(self) -> bool:
+        """Clean the pipette if its tip is fouled, and dip the objective afterwards.
+
+        Returns whether the demo may go on to work a cell: False means the clean
+        did not leave a usable tip, so the caller quits rather than driving a
+        fouled pipette at tissue.
+        """
+        win = self._window
+        ppip = win.patchPipetteDevice
+        if ppip.isTipClean():
+            return True
+        set_state("Autopatch: cleaning pipette")
+        try:
+            ppip.setState("clean", nextState="bath").wait(timeout=600)
+        except Stopped:
+            # An operator cancel is not a clean failure. Stopped is an Exception,
+            # so without this it would be caught below and turned into a normal
+            # return -- the demo would report success for a run the operator
+            # stopped, and the traceback would be logged as an error.
+            raise
+        except Exception:
+            set_state("Clean is unsafe to undo; quitting demo")
+            logger.exception("Error during pipette clean - quitting autopatch demo")
+            return False
+        if not ppip.isTipClean():
+            set_state("Pipette still not clean after clean state; quitting demo")
+            return False
+        win.scopeDevice.moveDip().wait()
+        return True
+
+    def _cancelPatchState(self):
+        """Mirror the MultiPatch "Cancel" button (pipetteControl._cancelClicked):
+        stop the FSM state job the demo put the pipette into, which switches the
+        pipette to that state's declared fallback state.
+
+        A PatchPipetteState job is a *detached* task -- it belongs to the state
+        manager, not to whoever asked for the state -- so stopping the demo does
+        not cascade into it. Without this the demo's own poll loop unwinds while
+        the pipette carries on through approach -> cell detect -> seal on its own,
+        which is not what the operator asked for when they cancelled.
+        """
+        job = self._window.patchPipetteDevice.getState()
+        if job is not None:
+            job.stop("autopatch demo cancelled", wait=True)
+
     def _autopatchCellPatch(self, cell):
         win = self._window
         ppip = win.patchPipetteDevice
         ppip.setState("approach", startANewCell=False)
         # detect_finished = False
-        while True:
-            state = ppip.getState().stateName
-            # remove? seal state already has this (and this is colliding with seal's move)
-            # if state not in ("approach", "cell detect", "contact cell", "seal", "cell attached", "break in"):
-            #     if not detect_finished:
-            #         win.cameraDevice.moveCenterToGlobal(
-            #             cell.position, "fast", name="center on cell during patching"
-            #         ).wait()
-            #         detect_finished = True
-            if state in ("whole cell", "bath", "broken", "fouled"):
-                set_state(f"Exiting patch loop - ended in state {state}")
-                break
-            sleep(0.1)
+        try:
+            while True:
+                state = ppip.getState().stateName
+                # remove? seal state already has this (and this is colliding with seal's move)
+                # if state not in ("approach", "cell detect", "contact cell", "seal", "cell attached", "break in"):
+                #     if not detect_finished:
+                #         win.cameraDevice.moveCenterToGlobal(
+                #             cell.position, "fast", name="center on cell during patching"
+                #         ).wait()
+                #         detect_finished = True
+                if state in ("whole cell", "bath", "broken", "fouled"):
+                    set_state(f"Exiting patch loop - ended in state {state}")
+                    break
+                check_stop()
+                sleep(0.1)
+        except Stopped:
+            self._cancelPatchState()
+            raise
         return state
 
     def _outOfCells(self) -> bool:

--- a/acq4/modules/AutomationDebug/detection.py
+++ b/acq4/modules/AutomationDebug/detection.py
@@ -24,6 +24,9 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+# How many detected cells one z-stack contributes to the queue, best first.
+MAX_DETECTION_CANDIDATES = 5
+
 
 def _health_model_config(manager) -> dict:
     """Health-model paths and score cutoffs from the global ``misc`` config.
@@ -49,6 +52,26 @@ class CellDetector:
 
     def _ui(self):
         return self._window.ui
+
+    def _selectCandidates(self, detections, limit=MAX_DETECTION_CANDIDATES):
+        """The best `limit` detections that lie inside the survey region.
+
+        `detections` arrives health-ordered (best first) and untruncated. The
+        camera is free to image past the survey region -- a field of view that
+        straddles the edge is what gives the segmenter the context to find cells
+        sitting right at it -- but the region is the maximum area the demo may
+        patch in, so a cell found outside it is not a candidate.
+
+        Filtering before truncating is the point of asking for every detection
+        rather than the top few: on a tile that straddles the edge, truncating
+        first would let out-of-region cells use up the whole quota while usable
+        ones sit just below the cut. With no region set (manual detection, no
+        survey) there is nothing to be outside of, so every detection stands.
+        """
+        region = self._window._surveyRegion
+        if region.hasRegion():
+            detections = [d for d in detections if region.contains(d[0])]
+        return list(detections)[:limit]
 
     def _selectRankDir(self):
         path = Qt.QFileDialog.getExistingDirectory(
@@ -188,10 +211,17 @@ class CellDetector:
             multichannel=multichannel,  # Actual flag for detect_neurons
             trim_edges=True,
             min_volume_m3=win.ui.minVolumeSpin.value(),
-            n=5,  # Number of top candidates to return
+            # Every detection, not just the top few: _selectCandidates below drops
+            # the ones outside the survey region before taking the best of what is
+            # left, which it can only do if it is given the whole ranked list.
+            n=None,
             save_prefix=save_prefix,
         )
         logger.info(f"Neuron detection finished. Found {len(detection_results)} potential neurons.")
+        detection_results = self._selectCandidates(detection_results)
+        logger.info(
+            f"Keeping {len(detection_results)} of them: the best inside the survey region."
+        )
 
         win._current_detection_stack = detection_stack
         win._current_classification_stack = classification_stack

--- a/acq4/modules/AutomationDebug/survey.py
+++ b/acq4/modules/AutomationDebug/survey.py
@@ -98,6 +98,22 @@ class SurveyRegion:
         x0, y0 = float(pos.x()), float(pos.y())
         return x0, y0, x0 + float(size.x()), y0 + float(size.y())
 
+    def contains(self, pos) -> bool:
+        """Whether a global position lies within the survey rectangle (x/y only).
+
+        False when no region is set: with nothing bounding the search there is no
+        rectangle to be inside of, so callers gate on hasRegion() first.
+        """
+        if self._roi is None:
+            return False
+        x0, y0, x1, y1 = self._bounds()
+        # An ROI dragged past its own origin reports a negative size, so the
+        # corners _bounds() returns are not necessarily min/max.
+        return (
+            min(x0, x1) <= float(pos[0]) <= max(x0, x1)
+            and min(y0, y1) <= float(pos[1]) <= max(y0, y1)
+        )
+
     def _grid_and_threshold(self):
         """Return (grid, threshold) for the current ROI, camera FOV, and overlap."""
         fov_w, fov_h = self._fov()

--- a/acq4/modules/AutomationDebug/tests/test_autopatch_cancel.py
+++ b/acq4/modules/AutomationDebug/tests/test_autopatch_cancel.py
@@ -1,0 +1,98 @@
+# Tests for Autopatcher._autopatchCellPatch — cancelling the demo must also cancel
+# the PatchPipette FSM state job the demo put the pipette into.
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from acq4.modules.AutomationDebug.autopatch import Autopatcher
+from acq4.util.task import Stopped, asynch
+
+
+def _window_with_stuck_fsm():
+    """A window whose pipette reports a non-terminal FSM state forever, so the
+    patch poll loop only ever ends by being stopped."""
+    win = MagicMock()
+    job = MagicMock()
+    job.stateName = "approach"
+    win.patchPipetteDevice.setState.return_value = job
+    win.patchPipetteDevice.getState.return_value = job
+    return win, job
+
+
+def _run_until_entered(autopatcher, ppip):
+    """Start _autopatchCellPatch in a task and return it once it has entered the
+    FSM (so a stop lands mid-poll rather than before the body runs)."""
+    task = asynch(autopatcher._autopatchCellPatch, name="autopatch demo")(MagicMock())
+    deadline = time.time() + 5
+    while not ppip.setState.called and time.time() < deadline:
+        time.sleep(0.01)
+    assert ppip.setState.called, "patch loop never entered the approach state"
+    return task
+
+
+def test_stopping_the_demo_cancels_the_patch_state_job():
+    """A PatchPipetteState job is a detached task owned by the state manager, so a
+    cooperative stop of the demo does not cascade into it. Without an explicit
+    cancel the pipette keeps driving approach -> cell detect -> seal after the
+    operator has pressed the demo button to stop."""
+    win, job = _window_with_stuck_fsm()
+    autopatcher = Autopatcher(win)
+
+    task = _run_until_entered(autopatcher, win.patchPipetteDevice)
+    task.stop("user requested cancel")
+    with pytest.raises(Stopped):
+        task.wait(timeout=5)
+
+    job.stop.assert_called_once()
+    assert job.stop.call_args.kwargs.get("wait") is True
+
+
+class TestCleanPipetteIfNeeded:
+    @staticmethod
+    def _window(clean_before, clean_after=None):
+        win = MagicMock()
+        ppip = win.patchPipetteDevice
+        ppip.isTipClean.side_effect = [clean_before, clean_after]
+        return win
+
+    def test_skips_the_clean_when_the_tip_is_already_clean(self):
+        win = self._window(clean_before=True)
+        assert Autopatcher(win)._cleanPipetteIfNeeded() is True
+        win.patchPipetteDevice.setState.assert_not_called()
+
+    def test_cleans_and_dips_when_the_tip_is_fouled(self):
+        win = self._window(clean_before=False, clean_after=True)
+        assert Autopatcher(win)._cleanPipetteIfNeeded() is True
+        win.patchPipetteDevice.setState.assert_called_once_with("clean", nextState="bath")
+        win.scopeDevice.moveDip.assert_called_once()
+
+    def test_quits_when_the_clean_fails(self):
+        win = self._window(clean_before=False)
+        win.patchPipetteDevice.setState.return_value.wait.side_effect = RuntimeError("boom")
+        assert Autopatcher(win)._cleanPipetteIfNeeded() is False
+
+    def test_quits_when_the_tip_is_still_fouled_afterwards(self):
+        win = self._window(clean_before=False, clean_after=False)
+        assert Autopatcher(win)._cleanPipetteIfNeeded() is False
+        win.scopeDevice.moveDip.assert_not_called()
+
+    def test_propagates_an_operator_cancel(self):
+        """Stopped is an Exception, so a cancel during the clean would otherwise be
+        caught as a clean failure -- ending the demo normally, which the button
+        reports as a successful run."""
+        win = self._window(clean_before=False)
+        win.patchPipetteDevice.setState.return_value.wait.side_effect = Stopped("cancelled")
+        with pytest.raises(Stopped):
+            Autopatcher(win)._cleanPipetteIfNeeded()
+
+
+def test_reaching_a_terminal_state_does_not_cancel_the_state_job():
+    """The cancel is for an interrupted run only: a patch that ends normally must
+    leave the pipette resting in the terminal state it reached."""
+    win, job = _window_with_stuck_fsm()
+    job.stateName = "whole cell"
+    autopatcher = Autopatcher(win)
+
+    assert autopatcher._autopatchCellPatch(MagicMock()) == "whole cell"
+    job.stop.assert_not_called()

--- a/acq4/modules/AutomationDebug/tests/test_detection_search_region.py
+++ b/acq4/modules/AutomationDebug/tests/test_detection_search_region.py
@@ -1,0 +1,92 @@
+# Tests for restricting detected cells to the survey region: the camera may image
+# past the region, but only cells found inside it are candidates to patch.
+from unittest.mock import MagicMock
+
+import pytest
+
+from acq4.modules.AutomationDebug.detection import MAX_DETECTION_CANDIDATES, CellDetector
+from acq4.modules.AutomationDebug.survey import SurveyRegion
+
+
+class _Vec:
+    """Stand-in for the point objects pg.RectROI's pos()/size() return."""
+
+    def __init__(self, x, y):
+        self._x, self._y = x, y
+
+    def x(self):
+        return self._x
+
+    def y(self):
+        return self._y
+
+
+def _region(pos=(0.0, 0.0), size=(10.0, 10.0)):
+    region = SurveyRegion(MagicMock())
+    roi = MagicMock()
+    roi.pos.return_value = _Vec(*pos)
+    roi.size.return_value = _Vec(*size)
+    region._roi = roi
+    return region
+
+
+class TestContains:
+    def test_inside(self):
+        assert _region().contains((5.0, 5.0, -1.0))
+
+    @pytest.mark.parametrize("pos", [(-1.0, 5.0), (11.0, 5.0), (5.0, -1.0), (5.0, 11.0)])
+    def test_outside(self, pos):
+        assert not _region().contains(pos)
+
+    def test_on_the_boundary_counts_as_inside(self):
+        region = _region()
+        assert region.contains((0.0, 0.0))
+        assert region.contains((10.0, 10.0))
+
+    def test_handles_a_roi_dragged_to_negative_size(self):
+        """A RectROI resized past its own origin reports a negative size; the
+        rectangle it describes is the same one either way."""
+        region = _region(pos=(10.0, 10.0), size=(-10.0, -10.0))
+        assert region.contains((5.0, 5.0))
+        assert not region.contains((11.0, 5.0))
+
+    def test_no_region_contains_nothing(self):
+        assert not SurveyRegion(MagicMock()).contains((0.0, 0.0))
+
+
+class TestSelectCandidates:
+    @staticmethod
+    def _detector(region):
+        win = MagicMock()
+        win._surveyRegion = region
+        return CellDetector(win)
+
+    @staticmethod
+    def _detection(x, y, score=1.0):
+        return ((x, y, -50e-6), score)
+
+    def test_drops_detections_outside_the_region(self):
+        detector = self._detector(_region())
+        inside = self._detection(5.0, 5.0)
+        outside = self._detection(50.0, 5.0)
+        assert detector._selectCandidates([inside, outside]) == [inside]
+
+    def test_filters_before_truncating(self):
+        """An edge tile must not spend its whole quota on out-of-region cells while
+        usable ones sit just below the cut."""
+        detector = self._detector(_region())
+        outside = [self._detection(50.0, 5.0) for _ in range(MAX_DETECTION_CANDIDATES)]
+        inside = [self._detection(1.0 + i, 5.0) for i in range(3)]
+        assert detector._selectCandidates(outside + inside) == inside
+
+    def test_keeps_the_best_detections_when_more_are_in_region_than_wanted(self):
+        detector = self._detector(_region())
+        detections = [self._detection(1.0, 1.0 + i) for i in range(MAX_DETECTION_CANDIDATES + 4)]
+        selected = detector._selectCandidates(detections)
+        assert selected == detections[:MAX_DETECTION_CANDIDATES]
+
+    def test_keeps_everything_when_no_region_is_set(self):
+        """Manual detection with no survey region has nothing to be outside of."""
+        detector = self._detector(SurveyRegion(MagicMock()))
+        detections = [self._detection(500.0, 500.0), self._detection(5.0, 5.0)]
+        assert detector._selectCandidates(detections) == detections


### PR DESCRIPTION
Two fixes to the Automation Debug autopatch demo.

## 1. Cancelling the demo did not cancel the patch FSM

Pressing the **Autopatch Demo** button to stop a run left the pipette working the cell — it carried on through approach → cell detect → seal on its own while the demo's poll loop unwound around it.

**Root cause:** `PatchPipetteState` is constructed with `detach=True` (`states/_base.py`), deliberately, so that a state transition does not make the incoming state a gentletask child of the outgoing one — otherwise the new state would be cascade-stopped the instant the old one stops. The consequence is that a cooperative stop of the *demo* task never cascades into the state job either. `_autopatchCellPatch` sets the pipette into `"approach"` and then only polls `getState().stateName`, so once its `sleep()` raised `Stopped` there was nothing left to stop the FSM.

The fix stops the job explicitly when `Stopped` propagates out of the poll loop, mirroring the MultiPatch **Cancel** button (`pipetteControl._cancelClicked`) so the pipette lands in the state's *declared fallback* state rather than a hard-coded holding state. This is what `acq4/experiment/actions/fsm.py::_safe_abort` already does for the replacement Autopatch module; the older demo had no equivalent.

**Second cancel bug found while auditing the other steps:** `Stopped` is an `Exception`, so a cancel during the pipette clean was caught by the bare `except Exception` there and turned into a normal return — `FutureButton` then reported **"Success"** for a run the operator had stopped, with the traceback logged as an error. Extracted `_cleanPipetteIfNeeded()` so that branch gets the `except Stopped: raise` guard the same function already uses twice elsewhere, and so it is testable.

Every other blocking step in `_autopatchDemo` (goHome, goAboveTarget, goApproach, survey moves, z-stacks, task-runner sequence, sonication sleeps) was traced and does cascade correctly. The move path was confirmed end-to-end against a real `MockStage`: a parent-task stop halts the simulated stage mid-move.

## 2. The survey region now bounds the *cells*, not the camera

The survey region is meant to be the maximum area the demo may patch in, but nothing enforced it: detection ran per tile and queued whatever it found, including cells in the part of the field of view hanging off the edge of the region.

The camera is deliberately still allowed to image past the region — a field of view straddling the edge is what gives the segmenter the pixels around a cell sitting right at it, and cropping to the region first would clip those cells and lose them. So the bound is applied to the detected cells instead:

- `SurveyRegion.contains()` (handles an ROI dragged to negative size).
- `CellDetector._selectCandidates()`: filter to the region, *then* take the best 5.
- `detect_neurons(..., n=None)` instead of `n=5`.

Filtering before truncating is the point of that last change: on a tile that straddles the edge, truncating first lets out-of-region cells use up the whole quota while usable ones sit just below the cut. `n` only slices the health-ordered list at the very end, after all segmentation and scoring, so asking for the full list costs no extra compute — only a longer returned list.

With no region set (manual detection, no survey) there is nothing to be outside of and every detection stands.

## Review notes

- `plan_grid()` / the tiling strategy is **untouched** — this deliberately does not change what the camera images, only which cells are eligible.
- `detect_neurons` logs `cell centers ijk: {cells[:n]}`; with `n=None` that info line now lists every detection rather than five. Verbose on a dense tile, but it lives in acq4-automation and is harmless.
- New tests: `tests/test_autopatch_cancel.py`, `tests/test_detection_search_region.py`. Full suite: 930 passed, 1 xfailed.

🤖 Generated with [Claude Code](https://claude.ai/code)