### PR TITLE
Autopatch P2c-2: tissue-motion feedback loop and the New-slice data directory

### DIFF
--- a/acq4/experiment/actions/device.py
+++ b/acq4/experiment/actions/device.py
@@ -10,8 +10,6 @@ ctx.pipette is a PatchPipette; the underlying manipulator is ctx.pipette.pipette
 """
 from __future__ import annotations
 
-from acq4_automation.feature_tracking import CellTrackingLost
-
 from acq4.util.imaging.sequencer import run_image_sequence
 from acq4.util.task import run_in_gui_thread
 
@@ -140,6 +138,11 @@ def cellfie(ctx, height: float = 30e-6, step: float = 1e-6) -> None:
             storage_dir=storage,
             name="cellfie",
         ).wait()
+        # Imported here, not at module scope: acq4_automation lives in an internal
+        # repository, and a top-level import would stop every test under
+        # acq4/experiment from collecting where it is absent.
+        from acq4_automation.feature_tracking import CellTrackingLost
+
         # Initialize the tracker reference used to follow the cell during patching.
         try:
             ctx.cell.initializeTracker(imager, use_cellpose=True)

--- a/acq4/experiment/actions/device.py
+++ b/acq4/experiment/actions/device.py
@@ -10,6 +10,8 @@ ctx.pipette is a PatchPipette; the underlying manipulator is ctx.pipette.pipette
 """
 from __future__ import annotations
 
+from acq4_automation.feature_tracking import CellTrackingLost
+
 from acq4.util.imaging.sequencer import run_image_sequence
 from acq4.util.task import run_in_gui_thread
 
@@ -139,7 +141,14 @@ def cellfie(ctx, height: float = 30e-6, step: float = 1e-6) -> None:
             name="cellfie",
         ).wait()
         # Initialize the tracker reference used to follow the cell during patching.
-        ctx.cell.initializeTracker(imager, use_cellpose=True)
+        try:
+            ctx.cell.initializeTracker(imager, use_cellpose=True)
+        except CellTrackingLost as exc:
+            # The tracker could not re-find this cell against its own reference
+            # stacks, so the stacks are useless: the cell has drifted out of
+            # reach or died. That is a question about the tissue, not about this
+            # action, and the window is what can answer it. Never returns.
+            ctx.tissue_moved(exc.reason or str(exc))
 
 
 def load_preset(ctx, preset: str | None = None) -> None:

--- a/acq4/experiment/actions/storage.py
+++ b/acq4/experiment/actions/storage.py
@@ -1,45 +1,59 @@
-"""Storage protocol function: create managed data directories for an experiment run."""
+"""Storage protocol function: create managed data directories for an experiment
+run, and the manager-only helper a UI button can call without a run."""
 from __future__ import annotations
 
 import time
 
 
-def new_data_dir(ctx, level: str = "Cell", set_current: bool = True):
+def create_data_dir(manager, level: str = "Cell", set_current: bool = True):
     """Create a new managed data directory of a given type ("level") under the
     current storage directory and (by default) make it current. Returns the
     created directory.
 
     Mirrors the non-GUI logic of DataManagerModule.createNewFolder: for a typed
-    level the parent is chosen by walking up the tree so a directory is not nested
-    inside another of the same type. The special level "Folder" makes an untyped
-    "NewFolder" under the current directory.
+    level the parent is chosen by walking up the tree so a directory is not
+    nested inside another of the same type. The special level "Folder" makes an
+    untyped "NewFolder" under the current directory.
+
+    Takes a manager rather than an ExecutionContext so that both a protocol
+    action and an operator's button can call it. Autopatch's New slice is a
+    click with no run in progress, and a UI button must not have to fabricate a
+    context to reach engine logic.
+    """
+    cdir = manager.getCurrentDir()
+    if not cdir.isManaged():
+        cdir.createIndex()
+    if level == "Folder":
+        new_dir = cdir.mkdir("NewFolder", autoIncrement=True)
+        new_dir.setInfo({})
+    else:
+        spec = manager.folderTypesConfig()[level]
+        name = time.strftime(spec["name"])
+        # Walk up to avoid nesting a directory inside one of the same type.
+        parent = cdir
+        check_dir = cdir
+        for _ in range(5):
+            if not check_dir.isManaged():
+                break
+            if check_dir.info().get("dirType") == level:
+                parent = check_dir.parent()
+                break
+            check_dir = check_dir.parent()
+        new_dir = parent.mkdir(name, autoIncrement=True)
+        info = {"dirType": level}
+        if spec.get("experimentalUnit", False):
+            info["expUnit"] = True
+        new_dir.setInfo(info)
+    if set_current:
+        manager.setCurrentDir(new_dir)
+    return new_dir
+
+
+def new_data_dir(ctx, level: str = "Cell", set_current: bool = True):
+    """Create a new managed data directory for this run and report it to the UI.
+
+    The protocol-facing wrapper around create_data_dir: same behaviour, plus the
+    log_action entry that puts it in Area 5's timeline.
     """
     with ctx.log_action("New Data Directory"):
-        man = ctx.manager
-        cdir = man.getCurrentDir()
-        if not cdir.isManaged():
-            cdir.createIndex()
-        if level == "Folder":
-            new_dir = cdir.mkdir("NewFolder", autoIncrement=True)
-            new_dir.setInfo({})
-        else:
-            spec = man.folderTypesConfig()[level]
-            name = time.strftime(spec["name"])
-            # Walk up to avoid nesting a directory inside one of the same type.
-            parent = cdir
-            check_dir = cdir
-            for _ in range(5):
-                if not check_dir.isManaged():
-                    break
-                if check_dir.info().get("dirType") == level:
-                    parent = check_dir.parent()
-                    break
-                check_dir = check_dir.parent()
-            new_dir = parent.mkdir(name, autoIncrement=True)
-            info = {"dirType": level}
-            if spec.get("experimentalUnit", False):
-                info["expUnit"] = True
-            new_dir.setInfo(info)
-        if set_current:
-            man.setCurrentDir(new_dir)
-        return new_dir
+        return create_data_dir(ctx.manager, level=level, set_current=set_current)

--- a/acq4/experiment/context.py
+++ b/acq4/experiment/context.py
@@ -6,7 +6,13 @@ import contextlib
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
-from .exceptions import AbortExperiment, AdvanceToNextCell, FlowSignal, RetryCurrentCell
+from .exceptions import (
+    AbortExperiment,
+    AdvanceToNextCell,
+    FlowSignal,
+    RetryCurrentCell,
+    TrackingLost,
+)
 from .log_entry import ActionLogEntry
 
 
@@ -34,6 +40,15 @@ class ExecutionContext:
     # ExecutionContext (as built directly by tests, or a contextFactory that
     # doesn't set it) simply never requests one.
     next_cell_requested: Callable[[], bool] = field(default=_no_next_cell_requested)
+    # Supplied by the Autopatch window's context factory: the capability to
+    # react to a cell the tracker could not re-find. Called as hook(ctx, reason)
+    # -- the context is passed at call time rather than bound into the hook,
+    # because a stored closure over this object would make it reference itself,
+    # and a cycle here is only reclaimable by the cyclic GC. The engine holds no
+    # slice knowledge; this is how the window lends it some.
+    tissue_moved_hook: Callable[[Any, str], None] | None = field(
+        default=None, repr=False
+    )
     # Set by next_cell/retry_cell/abort to the FlowSignal each is about to
     # raise, before raising it -- so the orchestrator can tell, on the
     # success path of a protocol run(), whether a flow signal was raised and
@@ -53,6 +68,22 @@ class ExecutionContext:
     def abort(self) -> None:
         """Stop the whole experiment run."""
         self._raise_flow_signal(AbortExperiment("abort experiment"))
+
+    def tissue_moved(self, reason: str) -> None:
+        """Report that the tracker could not re-find this cell. Never returns.
+
+        With a hook bound, the window prompts the operator and ends the cell,
+        which leaves this call by way of a FlowSignal. With no hook -- headless,
+        or a context built directly by a test -- a re-find failure is the plain
+        TrackingLost error it is, and the orchestrator's catch-all halts the run.
+
+        The fall-through raise is not dead code: a hook that returns instead of
+        ending the cell would otherwise let the protocol carry on against a
+        coordinate we have just established is stale.
+        """
+        if self.tissue_moved_hook is not None:
+            self.tissue_moved_hook(self, reason)
+        raise TrackingLost(reason)
 
     def _raise_flow_signal(self, exc: FlowSignal) -> None:
         """Record `exc` on pending_flow_signal, then raise it.

--- a/acq4/experiment/context.py
+++ b/acq4/experiment/context.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import contextlib
 from dataclasses import dataclass, field
-from typing import Any, Callable
+from typing import Any, Callable, NoReturn
 
 from .exceptions import (
     AbortExperiment,
@@ -69,7 +69,7 @@ class ExecutionContext:
         """Stop the whole experiment run."""
         self._raise_flow_signal(AbortExperiment("abort experiment"))
 
-    def tissue_moved(self, reason: str) -> None:
+    def tissue_moved(self, reason: str) -> NoReturn:
         """Report that the tracker could not re-find this cell. Never returns.
 
         With a hook bound, the window prompts the operator and ends the cell,

--- a/acq4/experiment/exceptions.py
+++ b/acq4/experiment/exceptions.py
@@ -29,6 +29,18 @@ class NoSolution(OrchestrationError):
     typeName = "NoSolution"
 
 
+class TrackingLost(OrchestrationError):
+    """The cell tracker could not re-find a cell against its reference stacks.
+
+    Deliberately not in ABNORMAL_STATE_EXCEPTIONS: this is not a pipette FSM
+    state, it is what a re-verify reports. Reaching the orchestrator uncaught
+    halts the run, which is the right default wherever no tissue-motion hook is
+    bound to handle it (see ExecutionContext.tissue_moved).
+    """
+
+    typeName = "TrackingLost"
+
+
 class FlowSignal(Exception):
     """Base for control-flow signals raised by flow actions."""
 

--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -90,6 +90,16 @@ class Orchestrator(Qt.QObject):
         and would otherwise be ignored for the rest of the run.
         """
         self._cellProducer = producer
+        self.clearProducerExhausted()
+
+    def clearProducerExhausted(self) -> None:
+        """Ask the producer again, even though it already reported exhaustion.
+
+        The flag is a per-run cache of "there is nothing left to find". Anything
+        that puts uncovered tiles back on the slice -- installing a producer, or
+        a forced rescan after the tissue moved -- invalidates it, and leaving it
+        set ends the run on a queue that could have been refilled.
+        """
         self._producerExhausted = False
 
     def _defaultContext(self, cell) -> ExecutionContext:

--- a/acq4/experiment/slice.py
+++ b/acq4/experiment/slice.py
@@ -82,7 +82,7 @@ class Slice:
     refcount-freeable rather than depending on Qt teardown ordering.
     """
 
-    def __init__(self, fov, constraints=None, overlap=0.0):
+    def __init__(self, fov, constraints=None, overlap=0.0, dirHandle=None):
         fov_w, fov_h = fov
         if fov_w <= 0 or fov_h <= 0:
             raise ValueError(f"fov must be positive in both axes, got {fov}")
@@ -94,6 +94,11 @@ class Slice:
         self._regions: list[SearchRegion] = []
         self._covered: list[tuple[float, float]] = []
         self._cells: list = []
+        # The Data Manager directory this slice's data is written under, or None
+        # for a slice that came into existence to hold a region rather than by
+        # way of New slice. The handle is also what a later change would call
+        # setInfo()/info() on to persist regions and coverage.
+        self.dirHandle = dirHandle
 
     # ---- constraints ----
     @property

--- a/acq4/experiment/slice.py
+++ b/acq4/experiment/slice.py
@@ -204,8 +204,17 @@ class Slice:
 
         A position inside no region frees nothing: a hand-seeded cell was never
         part of the survey, so there is no coverage of it to invalidate.
+
+        `position` is an indexable global coordinate; only `[0]` and `[1]` are
+        read, so a `coorx.Point` and a plain tuple both work, and a 3-D
+        position (as a detected cell's is) works too.
         """
-        here = [r for r in self._regions if r.overlapsTile(position, self._fov)]
+        # A region is a shape in the xy plane, so only the first two
+        # coordinates of position matter here; a cell's depth is not part of
+        # the overlap question. Narrowing to a plain (x, y) tuple also lets
+        # this accept a coorx.Point, a Cell.position, or a bare tuple alike.
+        xy = (position[0], position[1])
+        here = [r for r in self._regions if r.overlapsTile(xy, self._fov)]
         if not here:
             return 0
         stale = [
@@ -221,8 +230,8 @@ class Slice:
                 if not isAttempted(cell):
                     drop.add(id(cell))
         self._cells = [c for c in self._cells if id(c) not in drop]
-        staleIds = {id(t) for t in stale}
-        self._covered = [t for t in self._covered if id(t) not in staleIds]
+        stale_ids = {id(t) for t in stale}
+        self._covered = [t for t in self._covered if id(t) not in stale_ids]
         return len(stale)
 
     @property

--- a/acq4/experiment/slice.py
+++ b/acq4/experiment/slice.py
@@ -173,6 +173,58 @@ class Slice:
         """Forget which tiles have been imaged, keeping regions and constraints."""
         self._covered = []
 
+    def forceRescan(self, position, isAttempted) -> int:
+        """Re-open the region(s) around `position` for imaging. Returns tiles freed.
+
+        The response to the tracker losing a cell: the coordinates around it are
+        no longer trustworthy, so the coverage record claiming that ground was
+        already searched has to go, and the cells found there have to be
+        rediscovered where they actually are now.
+
+        Scoped to the region(s) the position falls in, not the whole slice. An
+        operator working through their third region should not pay to re-image
+        the two they finished, and re-imaging a finished region is also a chance
+        to re-detect and re-patch cells already dealt with.
+
+        The cost of that scoping, deliberately accepted: tissue motion is global,
+        while this treats it as local. If the slice genuinely shifted, finished
+        regions are stale too and are not re-imaged here. That is the right
+        trade for settling, drift, and swelling -- motion small relative to a
+        region -- and the wrong one for a slice that was physically bumped, where
+        the tool is New slice rather than a rescan. Nothing here can tell those
+        two cases apart.
+
+        `isAttempted` decides which cells survive. Attempted cells stay
+        registered at their old positions -- near enough, since the motion is
+        small -- so they keep counting toward the density cap and the rescan is
+        less likely to resurface a cell already worked. Never-attempted cells are
+        dropped so their tiles can come back uncrowded and be found again where
+        they now are. The predicate is a parameter because attempted-ness is
+        orchestration state held by the UI, not something a slice can know.
+
+        A position inside no region frees nothing: a hand-seeded cell was never
+        part of the survey, so there is no coverage of it to invalidate.
+        """
+        here = [r for r in self._regions if r.overlapsTile(position, self._fov)]
+        if not here:
+            return 0
+        stale = [
+            t
+            for t in self._covered
+            if any(r.overlapsTile(t, self._fov) for r in here)
+        ]
+        if not stale:
+            return 0
+        drop = set()
+        for tile in stale:
+            for cell in self.cellsNearTile(tile):
+                if not isAttempted(cell):
+                    drop.add(id(cell))
+        self._cells = [c for c in self._cells if id(c) not in drop]
+        staleIds = {id(t) for t in stale}
+        self._covered = [t for t in self._covered if id(t) not in staleIds]
+        return len(stale)
+
     @property
     def coveredTiles(self) -> list[tuple[float, float]]:
         return list(self._covered)

--- a/acq4/experiment/tests/test_actions_device.py
+++ b/acq4/experiment/tests/test_actions_device.py
@@ -3,7 +3,7 @@ find_surface, cellfie, run_task): fakes prove the right device calls happen in o
 import pytest
 
 from acq4.experiment.context import ExecutionContext
-from acq4.experiment.exceptions import OrchestrationError
+from acq4.experiment.exceptions import AdvanceToNextCell, OrchestrationError, TrackingLost
 from acq4.experiment.actions.device import (
     go_home,
     go_search,
@@ -167,9 +167,12 @@ class FakeTaskRunnerModule:
 class FakeCell:
     def __init__(self):
         self.tracker_calls = []
+        self.tracker_error = None
 
     def initializeTracker(self, imager, use_cellpose=False):
         self.tracker_calls.append((imager, use_cellpose))
+        if self.tracker_error is not None:
+            raise self.tracker_error
 
 
 @pytest.fixture
@@ -312,6 +315,22 @@ def test_find_surface_wraps_value_error(ctx, pip):
 # -- cellfie --------------------------------------------------------------
 
 
+def _cellfie_context(monkeypatch, tmp_path, tissue_moved_hook=None):
+    """An ExecutionContext wired for cellfie with the z-stack save stubbed out.
+
+    cellfie's imaging is real-hardware work; only its tracker-initialization
+    tail is under test here. FakePipette, FakeManager, and FakeCell already
+    cover everything cellfie touches, so this only wires them together.
+    """
+    monkeypatch.setattr(device_mod, "run_image_sequence", lambda *a, **k: _Waitable())
+    return ExecutionContext(
+        cell=FakeCell(),
+        pipette=FakePipette(),
+        manager=FakeManager(),
+        tissue_moved_hook=tissue_moved_hook,
+    )
+
+
 def test_cellfie_focuses_saves_zstack_and_initializes_tracker(ctx, pip, monkeypatch):
     names = _entry_names(ctx)
     pip.pipetteDevice.target_position = (0.0, 0.0, 100e-6)
@@ -357,6 +376,48 @@ def test_cellfie_default_height_and_step(ctx, pip, monkeypatch):
     start, end, step = calls[0]
     assert step == 1e-6
     assert end - start == pytest.approx(30e-6)
+
+
+def test_cellfie_routes_a_lost_cell_to_the_tissue_moved_hook(monkeypatch, tmp_path):
+    from acq4_automation.feature_tracking import CellTrackingLost
+
+    seen = []
+
+    def hook(ctx, reason):
+        seen.append(reason)
+        ctx.next_cell()
+
+    ctx = _cellfie_context(monkeypatch, tmp_path, tissue_moved_hook=hook)
+    ctx.cell.tracker_error = CellTrackingLost("lost", reason="no features matched")
+
+    with pytest.raises(AdvanceToNextCell):
+        cellfie(ctx)
+    assert seen == ["no features matched"]
+
+
+def test_cellfie_lets_an_unrelated_valueerror_propagate(monkeypatch, tmp_path):
+    # Only the named class is tissue motion. A bare ValueError out of the
+    # tracker stack is a bug, and classifying it as motion would trigger a
+    # destructive rescan whose prompt defaults to "Rescan".
+    called = []
+    ctx = _cellfie_context(
+        monkeypatch, tmp_path, tissue_moved_hook=lambda c, r: called.append(r)
+    )
+    ctx.cell.tracker_error = ValueError("something else entirely")
+
+    with pytest.raises(ValueError, match="something else entirely"):
+        cellfie(ctx)
+    assert called == []
+
+
+def test_cellfie_with_no_hook_raises_trackinglost(monkeypatch, tmp_path):
+    from acq4_automation.feature_tracking import CellTrackingLost
+
+    ctx = _cellfie_context(monkeypatch, tmp_path)
+    ctx.cell.tracker_error = CellTrackingLost("lost", reason="no features")
+
+    with pytest.raises(TrackingLost):
+        cellfie(ctx)
 
 
 # -- run_task -------------------------------------------------------------

--- a/acq4/experiment/tests/test_actions_device.py
+++ b/acq4/experiment/tests/test_actions_device.py
@@ -21,6 +21,12 @@ from acq4.experiment.actions.device import (
 )
 from acq4.experiment.actions import device as device_mod
 
+# cellfie reaches acq4_automation twice at call time: for CellTrackingLost, and for
+# DEFORMATION_TOLERANCE by way of AutomationDebug.feature_tracking. That package is
+# internal and is not a declared dependency, so the tests that actually call cellfie
+# only run where it is installed. Everything else in this module runs everywhere.
+_CELLFIE_SKIP_REASON = "cellfie needs acq4_automation, an internal package"
+
 
 class _Waitable:
     """Stand-in for the Future-like object real device calls return: .wait()
@@ -338,6 +344,7 @@ def _cellfie_context(monkeypatch, tmp_path, tissue_moved_hook=None):
 
 
 def test_cellfie_focuses_saves_zstack_and_initializes_tracker(ctx, pip, monkeypatch):
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
     names = _entry_names(ctx)
     pip.pipetteDevice.target_position = (0.0, 0.0, 100e-6)
     calls = []
@@ -376,6 +383,7 @@ def test_cellfie_focuses_saves_zstack_and_initializes_tracker(ctx, pip, monkeypa
 
 
 def test_cellfie_default_height_and_step(ctx, pip, monkeypatch):
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
     pip.pipetteDevice.target_position = (0.0, 0.0, 100e-6)
     calls = []
     monkeypatch.setattr(
@@ -394,6 +402,7 @@ def test_cellfie_default_height_and_step(ctx, pip, monkeypatch):
 
 
 def test_cellfie_routes_a_lost_cell_to_the_tissue_moved_hook(monkeypatch, tmp_path):
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
     from acq4_automation.feature_tracking import CellTrackingLost
 
     seen = []
@@ -411,6 +420,7 @@ def test_cellfie_routes_a_lost_cell_to_the_tissue_moved_hook(monkeypatch, tmp_pa
 
 
 def test_cellfie_lets_an_unrelated_valueerror_propagate(monkeypatch, tmp_path):
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
     # Only the named class is tissue motion. A bare ValueError out of the
     # tracker stack is a bug, and classifying it as motion would trigger a
     # destructive rescan whose prompt defaults to "Rescan".
@@ -426,6 +436,7 @@ def test_cellfie_lets_an_unrelated_valueerror_propagate(monkeypatch, tmp_path):
 
 
 def test_cellfie_with_no_hook_raises_trackinglost(monkeypatch, tmp_path):
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
     from acq4_automation.feature_tracking import CellTrackingLost
 
     ctx = _cellfie_context(monkeypatch, tmp_path)

--- a/acq4/experiment/tests/test_actions_prompt_storage.py
+++ b/acq4/experiment/tests/test_actions_prompt_storage.py
@@ -263,3 +263,38 @@ def test_new_data_dir_folder_level_makes_untyped_new_folder(root_dir):
 
     assert new_dir.shortName().startswith("NewFolder")
     assert "dirType" not in new_dir.info()
+
+
+def test_create_data_dir_needs_no_context(root_dir):
+    # A UI button has no run and no ExecutionContext, and must not fabricate one
+    # to reach engine logic.
+    from acq4.experiment.actions.storage import create_data_dir
+
+    man = FakeManager(root_dir)
+    created = create_data_dir(man, level="Slice")
+
+    assert created.info()["dirType"] == "Slice"
+    assert man.getCurrentDir() is created
+
+
+def test_create_data_dir_can_leave_the_current_dir_alone(root_dir):
+    from acq4.experiment.actions.storage import create_data_dir
+
+    man = FakeManager(root_dir)
+    before = man.getCurrentDir()
+    created = create_data_dir(man, level="Slice", set_current=False)
+
+    assert created is not before
+    assert man.getCurrentDir() is before
+
+
+def test_new_data_dir_still_behaves_identically_through_the_wrapper(root_dir):
+    # The action keeps its log_action wrapper and its behaviour; only the body
+    # moved.
+    entries = []
+    man = FakeManager(root_dir)
+    ctx = ExecutionContext(manager=man, on_log_action=entries.append)
+    created = new_data_dir(ctx, level="Slice")
+
+    assert created.info()["dirType"] == "Slice"
+    assert [e.name for e in entries] == ["New Data Directory"]

--- a/acq4/experiment/tests/test_context.py
+++ b/acq4/experiment/tests/test_context.py
@@ -69,3 +69,57 @@ def test_abort_records_the_signal_on_ctx_before_raising():
         ctx.abort()
     except AbortExperiment as exc:
         assert ctx.pending_flow_signal is exc
+
+
+# -- tissue_moved hook -------------------------------------------------------
+
+
+def test_tissue_moved_raises_trackinglost_when_no_hook_is_bound():
+    # Headless and in tests there is no window to prompt, so a re-find failure
+    # is the plain error it is and the catch-all halts the run. Safe default.
+    from acq4.experiment.context import ExecutionContext
+    from acq4.experiment.exceptions import TrackingLost
+
+    ctx = ExecutionContext()
+    with pytest.raises(TrackingLost, match="no features"):
+        ctx.tissue_moved("no features")
+
+
+def test_tissue_moved_passes_the_context_and_reason_to_the_hook():
+    from acq4.experiment.context import ExecutionContext
+    from acq4.experiment.exceptions import AdvanceToNextCell
+
+    seen = []
+
+    def hook(ctx, reason):
+        seen.append((ctx, reason))
+        ctx.next_cell()
+
+    ctx = ExecutionContext(tissue_moved_hook=hook)
+    with pytest.raises(AdvanceToNextCell):
+        ctx.tissue_moved("tissue drifted")
+    assert seen == [(ctx, "tissue drifted")]
+
+
+def test_tissue_moved_never_returns_normally_even_if_the_hook_does():
+    # The contract is that this call does not come back. A hook that forgets to
+    # end the cell must not leave the protocol running against a stale
+    # coordinate; falling through to the safe default is what stops that.
+    from acq4.experiment.context import ExecutionContext
+    from acq4.experiment.exceptions import TrackingLost
+
+    ctx = ExecutionContext(tissue_moved_hook=lambda ctx, reason: None)
+    with pytest.raises(TrackingLost):
+        ctx.tissue_moved("hook returned")
+
+
+def test_tissue_moved_hook_is_not_stored_as_a_bound_partial():
+    # A hook closing over the context would make the context reference itself.
+    # Assert the field holds exactly what was passed in.
+    from acq4.experiment.context import ExecutionContext
+
+    def hook(ctx, reason):
+        ctx.next_cell()
+
+    ctx = ExecutionContext(tissue_moved_hook=hook)
+    assert ctx.tissue_moved_hook is hook

--- a/acq4/experiment/tests/test_exceptions.py
+++ b/acq4/experiment/tests/test_exceptions.py
@@ -55,3 +55,12 @@ def test_raise_if_abnormal_returns_for_unmapped_internal_hop():
 def test_raise_if_abnormal_message_includes_context():
     with pytest.raises(exc.BrokenPipette, match="reseal"):
         exc.raise_if_abnormal("broken", expected=(), context="reseal")
+
+
+def test_tracking_lost_is_an_orchestration_error():
+    from acq4.experiment.exceptions import OrchestrationError, TrackingLost
+
+    # Routed by the taxonomy, not surfaced as an unexpected bug: a cell the
+    # tracker cannot re-find is a domain condition with a defined response.
+    assert issubclass(TrackingLost, OrchestrationError)
+    assert TrackingLost.typeName == "TrackingLost"

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -500,30 +500,6 @@ def test_every_barren_refill_pass_reports_surveying(make_pf):
     assert statuses.count("surveying") == 3
 
 
-def test_clear_producer_exhausted_lets_an_exhausted_producer_be_asked_again():
-    # A producer that reported exhaustion is never asked again for the rest of
-    # the run. After a forced rescan there are uncovered tiles once more, so the
-    # flag has to be cleared or the loop ends on a queue the producer could
-    # have refilled.
-    orch = Orchestrator(make_pf())
-    orch.setCellProducer(lambda: None)
-    orch._producerExhausted = True
-
-    orch.clearProducerExhausted()
-
-    assert orch._producerExhausted is False
-    assert orch._shouldRefill() is True
-
-
-def test_set_cell_producer_still_clears_exhaustion():
-    # The extraction must not move behaviour off setCellProducer, which existing
-    # callers rely on.
-    orch = Orchestrator(make_pf())
-    orch._producerExhausted = True
-    orch.setCellProducer(lambda: [])
-    assert orch._producerExhausted is False
-
-
 def test_current_cell_is_cleared_before_the_producer_runs(make_pf):
     # sigCurrentCell must not still name the just-finished cell while the
     # producer images: Area 5 would attribute survey time to that cell, and a
@@ -699,12 +675,6 @@ def test_no_producer_never_reports_surveying(make_pf):
     statuses = []
     orch = Orchestrator(pf)
     orch.sigStatus.connect(statuses.append)
-    orch.enqueue("c1")
-    orch.enqueue("c2")
-
-    orch.run_sync()
-
-    assert "surveying" not in statuses
     orch.enqueue("c1")
     orch.enqueue("c2")
 

--- a/acq4/experiment/tests/test_orchestrator_producer.py
+++ b/acq4/experiment/tests/test_orchestrator_producer.py
@@ -500,6 +500,30 @@ def test_every_barren_refill_pass_reports_surveying(make_pf):
     assert statuses.count("surveying") == 3
 
 
+def test_clear_producer_exhausted_lets_an_exhausted_producer_be_asked_again():
+    # A producer that reported exhaustion is never asked again for the rest of
+    # the run. After a forced rescan there are uncovered tiles once more, so the
+    # flag has to be cleared or the loop ends on a queue the producer could
+    # have refilled.
+    orch = Orchestrator(make_pf())
+    orch.setCellProducer(lambda: None)
+    orch._producerExhausted = True
+
+    orch.clearProducerExhausted()
+
+    assert orch._producerExhausted is False
+    assert orch._shouldRefill() is True
+
+
+def test_set_cell_producer_still_clears_exhaustion():
+    # The extraction must not move behaviour off setCellProducer, which existing
+    # callers rely on.
+    orch = Orchestrator(make_pf())
+    orch._producerExhausted = True
+    orch.setCellProducer(lambda: [])
+    assert orch._producerExhausted is False
+
+
 def test_current_cell_is_cleared_before_the_producer_runs(make_pf):
     # sigCurrentCell must not still name the just-finished cell while the
     # producer images: Area 5 would attribute survey time to that cell, and a
@@ -681,3 +705,33 @@ def test_no_producer_never_reports_surveying(make_pf):
     orch.run_sync()
 
     assert "surveying" not in statuses
+    orch.enqueue("c1")
+    orch.enqueue("c2")
+
+    orch.run_sync()
+
+    assert "surveying" not in statuses
+
+
+def test_clear_producer_exhausted_lets_an_exhausted_producer_be_asked_again(make_pf):
+    # A producer that reported exhaustion is never asked again for the rest of
+    # the run. After a forced rescan there are uncovered tiles once more, so the
+    # flag has to be cleared or the loop ends on a queue the producer could
+    # have refilled.
+    orch = Orchestrator(make_pf())
+    orch.setCellProducer(lambda: None)
+    orch._producerExhausted = True
+
+    orch.clearProducerExhausted()
+
+    assert orch._producerExhausted is False
+    assert orch._shouldRefill() is True
+
+
+def test_set_cell_producer_still_clears_exhaustion(make_pf):
+    # The extraction must not move behaviour off setCellProducer, which existing
+    # callers rely on.
+    orch = Orchestrator(make_pf())
+    orch._producerExhausted = True
+    orch.setCellProducer(lambda: [])
+    assert orch._producerExhausted is False

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -396,3 +396,107 @@ def test_a_polygon_narrower_than_one_tile_still_gets_a_grid():
     assert len(grid) > 0
     assert len(grid) < len(plan_grid(0.0, 6e-6, 22e-6, 30e-6, FOV[0], FOV[1], 0.0))
     assert s.nextTile() == grid[0]
+
+
+class _PositionedCell:
+    """A stand-in for acq4_automation's Cell: a position is all Slice reads."""
+
+    def __init__(self, position):
+        self.position = position
+
+
+def _two_region_slice():
+    """A slice with two well-separated regions at realistic stage coordinates.
+
+    Deliberately not at the origin, and deliberately not square: a symmetric
+    fixture cannot test an asymmetric mapping, and origin-centred geometry
+    cannot see coordinate-magnitude float error.
+    """
+    s = Slice(fov=(20e-6, 10e-6))
+    s.addRegion(RectRegion(1e-3, 2e-3, 1e-3 + 60e-6, 2e-3 + 30e-6))
+    s.addRegion(RectRegion(5e-3, 7e-3, 5e-3 + 60e-6, 7e-3 + 30e-6))
+    return s
+
+
+def test_force_rescan_uncovers_only_the_region_holding_the_position():
+    s = _two_region_slice()
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+    covered_before = len(s.coveredTiles)
+
+    uncovered = s.forceRescan((1e-3 + 30e-6, 2e-3 + 15e-6), lambda cell: False)
+
+    assert uncovered > 0
+    remaining = s.coveredTiles
+    assert len(remaining) == covered_before - uncovered
+    # Every surviving covered tile belongs to the far region.
+    far = s.regions[1]
+    assert all(far.overlapsTile(t, (20e-6, 10e-6)) for t in remaining)
+
+
+def test_force_rescan_outside_every_region_is_a_no_op():
+    # A hand-seeded cell outside every drawn region has no coverage to
+    # invalidate; hand-added cells are outside the scanner's responsibility.
+    s = _two_region_slice()
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+    before = list(s.coveredTiles)
+
+    assert s.forceRescan((9e-3, 9e-3), lambda cell: False) == 0
+    assert s.coveredTiles == before
+
+
+def test_force_rescan_deregisters_only_never_attempted_cells():
+    s = _two_region_slice()
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+    tile = s.tileGrid()[0]
+    attempted = _PositionedCell((tile[0], tile[1], -30e-6))
+    fresh = _PositionedCell((tile[0], tile[1], -35e-6))
+    s.registerCells([attempted, fresh])
+
+    s.forceRescan(tile, lambda cell: cell is attempted)
+
+    near = s.cellsNearTile(tile)
+    assert attempted in near
+    assert fresh not in near
+
+
+def test_force_rescan_leaves_cells_in_untouched_regions_registered():
+    s = _two_region_slice()
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+    far_tile = [t for t in s.tileGrid() if t[0] > 4e-3][0]
+    far_cell = _PositionedCell((far_tile[0], far_tile[1], -30e-6))
+    s.registerCells([far_cell])
+
+    s.forceRescan((1e-3 + 30e-6, 2e-3 + 15e-6), lambda cell: False)
+
+    assert far_cell in s.cellsNearTile(far_tile)
+
+
+def test_force_rescan_does_not_touch_regions_or_constraints():
+    s = _two_region_slice()
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+    regions_before = s.regions
+    constraints_before = s.constraints
+
+    s.forceRescan((1e-3 + 30e-6, 2e-3 + 15e-6), lambda cell: False)
+
+    assert s.regions == regions_before
+    assert s.constraints is constraints_before
+
+
+def test_force_rescan_uncovers_every_overlapping_region():
+    # Overlapping regions both hold the position, so both must be re-imaged.
+    s = Slice(fov=(20e-6, 10e-6))
+    s.addRegion(RectRegion(1e-3, 2e-3, 1e-3 + 60e-6, 2e-3 + 30e-6))
+    s.addRegion(RectRegion(1e-3 + 20e-6, 2e-3, 1e-3 + 80e-6, 2e-3 + 30e-6))
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+
+    s.forceRescan((1e-3 + 30e-6, 2e-3 + 15e-6), lambda cell: False)
+
+    assert s.coveredTiles == []
+

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -526,6 +526,17 @@ def test_force_rescan_accepts_a_3d_coorx_point_position():
     assert all(far.overlapsTile(t, (20e-6, 10e-6)) for t in remaining)
 
 
+def test_slice_holds_its_data_directory():
+    handle = object()
+    assert Slice(fov=(20e-6, 10e-6), dirHandle=handle).dirHandle is handle
+
+
+def test_slice_without_a_data_directory_is_valid():
+    # A slice created implicitly by "Add region here" was never formally started
+    # and honestly has no directory.
+    assert Slice(fov=(20e-6, 10e-6)).dirHandle is None
+
+
 def test_force_rescan_uncovers_every_overlapping_region():
     # Overlapping regions both hold the position, so both must be re-imaged.
     s = Slice(fov=(20e-6, 10e-6))

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -4,6 +4,7 @@ coverage, and survey statistics."""
 import gc
 import weakref
 
+import coorx
 import pytest
 
 from acq4.experiment.search_grid import plan_grid
@@ -486,6 +487,43 @@ def test_force_rescan_does_not_touch_regions_or_constraints():
 
     assert s.regions == regions_before
     assert s.constraints is constraints_before
+
+
+def test_force_rescan_accepts_a_3d_tuple_position():
+    # A detected cell's position carries depth as a third element (a real
+    # example: acq4_automation.feature_tracking.cell.Cell.position, built from
+    # a stack scanned in z). forceRescan must use only the xy of that position
+    # rather than fail trying to unpack three values as two.
+    s = _two_region_slice()
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+    covered_before = len(s.coveredTiles)
+
+    uncovered = s.forceRescan((1e-3 + 30e-6, 2e-3 + 15e-6, -30e-6), lambda cell: False)
+
+    assert uncovered > 0
+    remaining = s.coveredTiles
+    assert len(remaining) == covered_before - uncovered
+    far = s.regions[1]
+    assert all(far.overlapsTile(t, (20e-6, 10e-6)) for t in remaining)
+
+
+def test_force_rescan_accepts_a_3d_coorx_point_position():
+    # The tile detector hands cells a global coorx.Point, not a tuple, so that
+    # shape needs the same xy narrowing a plain 3-tuple gets.
+    s = _two_region_slice()
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+    covered_before = len(s.coveredTiles)
+
+    position = coorx.Point([1e-3 + 30e-6, 2e-3 + 15e-6, -30e-6])
+    uncovered = s.forceRescan(position, lambda cell: False)
+
+    assert uncovered > 0
+    remaining = s.coveredTiles
+    assert len(remaining) == covered_before - uncovered
+    far = s.regions[1]
+    assert all(far.overlapsTile(t, (20e-6, 10e-6)) for t in remaining)
 
 
 def test_force_rescan_uncovers_every_overlapping_region():

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -12,6 +12,7 @@ from acq4.experiment.slice import Slice
 from acq4.experiment.tile_detector import make_tile_detector
 from acq4.modules.Module import Module
 from acq4.util import Qt
+from acq4.util.HelpfulException import HelpfulException
 from acq4.util.InterfaceCombo import InterfaceCombo
 
 from .cell_panel import CellPanel
@@ -165,6 +166,24 @@ class AutopatchWindow(Qt.QWidget):
         if self.protocolPanel.protocolFile is not None:
             self._onProtocolLoaded(self.protocolPanel.protocolFile)
 
+    def _canStartSlice(self) -> bool:
+        """Whether the camera and search constraints currently support
+        starting a slice, reporting the reason through SearchPanel exactly as
+        _startSlice() itself does.
+
+        Split out so newSlice() can run this check before create_data_dir()
+        commits to a new storage directory -- constructing the Slice remains
+        _startSlice()'s job alone, called only once directory creation has
+        already succeeded.
+        """
+        camera = self.cameraSelector.getSelectedObj()
+        if camera is None:
+            self.searchPanel.setError("Select a camera before starting a slice.")
+            return False
+        if self.searchPanel.constraints() is None:
+            return False
+        return True
+
     def _startSlice(self, dirHandle=None) -> bool:
         """Install a fresh Slice for the tissue under the objective.
 
@@ -183,13 +202,10 @@ class AutopatchWindow(Qt.QWidget):
         directory by the time it calls here, while addRegionHere() calls here
         with none, which is what leaves its implicit slice's dirHandle at None.
         """
+        if not self._canStartSlice():
+            return False
         camera = self.cameraSelector.getSelectedObj()
-        if camera is None:
-            self.searchPanel.setError("Select a camera before starting a slice.")
-            return False
         constraints = self.searchPanel.constraints()
-        if constraints is None:
-            return False
         self.slice = Slice(
             fov=self._cameraFov(camera), constraints=constraints, dirHandle=dirHandle
         )
@@ -217,13 +233,23 @@ class AutopatchWindow(Qt.QWidget):
         is the step that can fail -- an operator who has not chosen a storage
         directory is the likeliest first use of this button -- and a failure that
         has already thrown away their cells is worse than the failure itself.
+
+        The camera/constraints check runs before that directory is even
+        created, though: those are the likelier first-use failure, and an
+        operator missing a camera should not have storage repointed into a
+        fresh, empty Slice directory before finding that out.
         """
+        if not self._canStartSlice():
+            return
         try:
             dirHandle = create_data_dir(self.manager, level="Slice")
-        except Exception as exc:
+        except HelpfulException as exc:
             # Area 3's instruction band does not exist yet, so this goes where
             # the operator already reads "Select a camera before starting a
-            # slice".
+            # slice". Narrowed to HelpfulException -- the "Storage directory
+            # has not been set." case -- so a genuine programming error (a
+            # missing manager, say) propagates instead of being reported as
+            # storage guidance.
             self.searchPanel.setError(str(exc))
             return
         if not self._startSlice(dirHandle=dirHandle):

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -193,6 +193,7 @@ class AutopatchWindow(Qt.QWidget):
         self.slice = Slice(
             fov=self._cameraFov(camera), constraints=constraints, dirHandle=dirHandle
         )
+        self.searchPanel.setSliceReady(True)
         # There is a camera now, so retract the message above if it is up.
         self.searchPanel.setError("")
         return True

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 
 from acq4.experiment.actions.prompt import prompt
+from acq4.experiment.actions.storage import create_data_dir
 from acq4.experiment.orchestrator import Orchestrator
 from acq4.experiment.search_region import EllipseRegion, RectRegion
 from acq4.experiment.slice import Slice
@@ -164,7 +165,7 @@ class AutopatchWindow(Qt.QWidget):
         if self.protocolPanel.protocolFile is not None:
             self._onProtocolLoaded(self.protocolPanel.protocolFile)
 
-    def _startSlice(self) -> bool:
+    def _startSlice(self, dirHandle=None) -> bool:
         """Install a fresh Slice for the tissue under the objective.
 
         Returns whether one was created: a slice needs the camera's field of
@@ -177,7 +178,10 @@ class AutopatchWindow(Qt.QWidget):
         one place -- but only the construction. Discarding the previous slice's
         queued cells belongs to newSlice() alone: addRegionHere() creating the
         slice that will hold its region must not throw away cells the operator
-        seeded by hand, which is all its button offers to do.
+        seeded by hand, which is all its button offers to do. `dirHandle` is
+        the pass-through for that same reason: newSlice() has already created a
+        directory by the time it calls here, while addRegionHere() calls here
+        with none, which is what leaves its implicit slice's dirHandle at None.
         """
         camera = self.cameraSelector.getSelectedObj()
         if camera is None:
@@ -186,7 +190,9 @@ class AutopatchWindow(Qt.QWidget):
         constraints = self.searchPanel.constraints()
         if constraints is None:
             return False
-        self.slice = Slice(fov=self._cameraFov(camera), constraints=constraints)
+        self.slice = Slice(
+            fov=self._cameraFov(camera), constraints=constraints, dirHandle=dirHandle
+        )
         # There is a camera now, so retract the message above if it is up.
         self.searchPanel.setError("")
         return True
@@ -205,8 +211,21 @@ class AutopatchWindow(Qt.QWidget):
         to completion on the tissue it was found in -- it is being worked right
         now, and yanking a pipette out mid-protocol is its own hazard. The
         operator who has physically swapped the tissue presses Stop for that.
+
+        The slice directory is created before anything is discarded. Creating it
+        is the step that can fail -- an operator who has not chosen a storage
+        directory is the likeliest first use of this button -- and a failure that
+        has already thrown away their cells is worse than the failure itself.
         """
-        if not self._startSlice():
+        try:
+            dirHandle = create_data_dir(self.manager, level="Slice")
+        except Exception as exc:
+            # Area 3's instruction band does not exist yet, so this goes where
+            # the operator already reads "Select a camera before starting a
+            # slice".
+            self.searchPanel.setError(str(exc))
+            return
+        if not self._startSlice(dirHandle=dirHandle):
             return
         self.cellPanel.clearCells()
         if self.orchestrator is not None:

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 
+from acq4.experiment.actions.prompt import prompt
 from acq4.experiment.orchestrator import Orchestrator
 from acq4.experiment.search_region import EllipseRegion, RectRegion
 from acq4.experiment.slice import Slice
@@ -283,6 +284,45 @@ class AutopatchWindow(Qt.QWidget):
         if status in ("surveying", "waiting"):
             self._refreshSurveyStats()
 
+    def _onTissueMoved(self, cell, ctx, reason: str) -> None:
+        """ExecutionContext.tissue_moved, cell-bound by the context factory.
+
+        Runs on the orchestrator's worker thread, mid-cell. Never returns: both
+        answers end the cell.
+
+        The operator decides, because a rescan is destructive in its own way --
+        it re-images ground already searched and can re-detect cells already
+        worked. "Rescan the slice" is offered first and is therefore what a
+        headless run picks: driving a pipette to a coordinate known to be stale
+        is a hardware risk, while patching a cell twice is a data-hygiene cost,
+        so the cheaper mistake goes first.
+        """
+        pending = len(self.orchestrator.pendingCells()) if self.orchestrator else 0
+        answer = prompt(
+            ctx,
+            message=(
+                f"Cell tracking could not re-find this cell ({reason}).\n"
+                "The tissue may have moved. Rescanning discards the "
+                f"{pending} cell(s) still queued and re-images this region; "
+                "cells already patched may be found again."
+            ),
+            title="Tissue may have moved",
+            choices=("Rescan the slice", "Skip this cell only"),
+        )
+        if answer == "Rescan the slice":
+            if self.slice is not None:
+                self.slice.forceRescan(cell.position, self.cellPanel.isAttempted)
+            if self.orchestrator is not None:
+                # After the answer, not before: a cell the operator seeds by
+                # hand while the prompt is open is a coordinate in the same
+                # moved tissue and goes with the rest.
+                self.orchestrator.clearQueue()
+                self.orchestrator.clearProducerExhausted()
+        # Area 2's survey readout is deliberately not refreshed here: this is the
+        # worker thread, and _refreshSurveyStats touches widgets. The next status
+        # change routes through _onRunStatus on the GUI thread and picks it up.
+        ctx.next_cell()
+
     def _onStartRun(self) -> None:
         """Snapshot GUI-thread-only state and install the cell producer at Start.
 
@@ -337,6 +377,7 @@ class AutopatchWindow(Qt.QWidget):
             manager=self.manager,
             log=self.cellPanel.appendLog,
             onLogAction=self.cellPanel.onLogAction,
+            tissueMoved=self._onTissueMoved,
         )
         self.orchestrator = Orchestrator(
             protocolFile, manager=self.manager, contextFactory=contextFactory

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -359,11 +359,19 @@ class AutopatchWindow(Qt.QWidget):
             if self.slice is not None:
                 self.slice.forceRescan(cell.position, self.cellPanel.isAttempted)
             if self.orchestrator is not None:
+                # Captured before clearQueue(), which is the one call that
+                # makes pendingCells() report nothing at all.
+                discarded = self.orchestrator.pendingCells()
                 # After the answer, not before: a cell the operator seeds by
                 # hand while the prompt is open is a coordinate in the same
                 # moved tissue and goes with the rest.
                 self.orchestrator.clearQueue()
                 self.orchestrator.clearProducerExhausted()
+                # Area 5's rows must match what the operator just agreed to
+                # discard; an attempted cell keeps its row regardless -- it is
+                # the session record, not a stale queued entry -- which is
+                # discardCells()'s own job to enforce.
+                self.cellPanel.discardCells(discarded)
         # Area 2's survey readout is deliberately not refreshed here: this is the
         # worker thread, and _refreshSurveyStats touches widgets. The next status
         # change routes through _onRunStatus on the GUI thread and picks it up.

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -27,6 +27,11 @@ class CellPanel(Qt.QWidget):
     # after ctx.log_action() creates the entry), "status" (entry.set_status()),
     # "widget" (entry.set_details_widget()), or "finished" (entry._finish()).
     sigActionEntry = Qt.Signal(object, object, str)
+    # Emitted by discardCells() so a rescan's row removal, arriving from the
+    # orchestrator's worker thread the same way appendLog()/onLogAction() do,
+    # is marshaled onto the GUI thread by Qt's automatic queued connection
+    # rather than touching cellList directly.
+    sigCellsDiscarded = Qt.Signal(object)
 
     def __init__(self, pipetteGetter=None, cameraGetter=None):
         super().__init__()
@@ -113,6 +118,7 @@ class CellPanel(Qt.QWidget):
         self.cellList.currentItemChanged.connect(self._onCellSelectionChanged)
         self.sigLogMessage.connect(self._onLogMessage)
         self.sigActionEntry.connect(self._onActionEntry)
+        self.sigCellsDiscarded.connect(self._onCellsDiscarded)
 
     def bindOrchestrator(self, orchestrator) -> None:
         if orchestrator is self._orchestrator:
@@ -218,6 +224,42 @@ class CellPanel(Qt.QWidget):
         self.cellList.clear()
         self._clearShowContainer()
         self._shownEntryId = None
+
+    def discardCells(self, cells) -> None:
+        """Drop the panel-side bookkeeping for `cells` -- rows, timelines,
+        logs, and the strong references that keep them alive -- the same
+        stores clearCells() drops for every cell, but scoped to this subset.
+
+        A cell isAttempted() already reports as started is never touched: its
+        row is the session record, not a stale queued entry, so it survives
+        even if it is passed in here.
+
+        Used by AutopatchWindow._onTissueMoved's rescan branch, which runs on
+        the orchestrator's worker thread, so this only ever emits
+        sigCellsDiscarded rather than touching cellList directly -- Qt's
+        automatic queued connection marshals the update onto the GUI thread,
+        the same way appendLog()/onLogAction() do above.
+        """
+        self.sigCellsDiscarded.emit(list(cells))
+
+    def _onCellsDiscarded(self, cells) -> None:
+        for cell in cells:
+            if self.isAttempted(cell):
+                continue
+            cellId = id(cell)
+            self._cells.pop(cellId, None)
+            # Cleared alongside _cells for the same reason clearCells() clears
+            # it: a stale id left behind here could be flushed into a later
+            # orchestrator by bindOrchestrator(), driving a pipette to a
+            # coordinate in tissue the operator has just declared gone.
+            if cellId in self._awaitingEnqueue:
+                self._awaitingEnqueue.remove(cellId)
+            self._attempted.discard(cellId)
+            item = self._rows.pop(cellId, None)
+            if item is not None:
+                self.cellList.takeItem(self.cellList.row(item))
+            self._timelines.pop(cellId, None)
+            self._logs.pop(cellId, None)
 
     def _onAddFromTargetClicked(self) -> None:
         pipette = self._pipetteGetter()

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -79,8 +79,10 @@ class CellPanel(Qt.QWidget):
         # in sync with it on teardown.
         self._attempted = set()
         # id(entry) of whichever entry's widget currently occupies
-        # showContainer, or None if it's empty. No action nests log_action
-        # blocks today, but if one did, this lets a "finished" phase tell
+        # showContainer, or None if it's empty. An action can nest a
+        # log_action block inside another still-open one -- prompt() opens an
+        # "Operator Prompt" entry inside cellfie's still-open entry when
+        # tracking loses the cell -- so this lets a "finished" phase tell
         # whether it actually owns what's mounted before clearing it -- an
         # inner entry finishing must not tear down an outer entry's still-live
         # widget.

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -63,6 +63,16 @@ class CellPanel(Qt.QWidget):
         # again. A list rather than a set so the flush enqueues them in the
         # order they were queued, which is the order they will be patched in.
         self._awaitingEnqueue: list[int] = []
+        # Cells the orchestrator has started work on, by id. Recorded from both
+        # sigCurrentCell and sigCellFinished: a cell interrupted mid-run may
+        # never emit a terminal status, and "retry" is emitted mid-flight
+        # without being terminal, so "has work started" is the reliable question
+        # and does not depend on the terminal-status vocabulary.
+        #
+        # Holds ids, never cells: this panel must not be the thing keeping a
+        # Cell alive beyond self._cells, and must not add a second store to keep
+        # in sync with it on teardown.
+        self._attempted = set()
         # id(entry) of whichever entry's widget currently occupies
         # showContainer, or None if it's empty. No action nests log_action
         # blocks today, but if one did, this lets a "finished" phase tell
@@ -199,6 +209,7 @@ class CellPanel(Qt.QWidget):
         # the next bind or, if that memory address were reused by an unrelated
         # cell, enqueue that cell instead.
         self._awaitingEnqueue.clear()
+        self._attempted.clear()
         self._rows.clear()
         self._timelines.clear()
         self._entryTimelineLoc.clear()
@@ -290,6 +301,15 @@ class CellPanel(Qt.QWidget):
         # reference here for the panel's lifetime keeps the original object alive.
         self._cells[id(cell)] = cell
 
+    def isAttempted(self, cell) -> bool:
+        """Whether the orchestrator has ever started work on `cell`.
+
+        Slice.forceRescan takes this as its predicate: attempted cells stay
+        registered in the density record through a rescan, never-attempted ones
+        are dropped so they can be found again where they now are.
+        """
+        return id(cell) in self._attempted
+
     def appendLog(self, cell, message: str) -> None:
         # May be called from the orchestrator's worker thread (ExecutionContext.log,
         # bound per-cell by the context factory); emitting rather than touching
@@ -309,6 +329,7 @@ class CellPanel(Qt.QWidget):
         # and the details container directly.
         if cell is None:
             return
+        self._attempted.add(id(cell))
         item = self._rows.get(id(cell))
         if item is None:
             # A cell the orchestrator announces without this panel ever having
@@ -417,6 +438,7 @@ class CellPanel(Qt.QWidget):
         # never re-enqueue and never mark it as awaiting one. A cell that has
         # finished is the clearest case of all: enqueuing it again patches a
         # cell that has already been worked.
+        self._attempted.add(id(cell))
         item = self._rows.get(id(cell))
         if item is None:
             self.addCell(cell)

--- a/acq4/modules/Autopatch/context_factory.py
+++ b/acq4/modules/Autopatch/context_factory.py
@@ -14,6 +14,7 @@ def make_context_factory(
     manager,
     log: Callable[[object, str], None] | None = None,
     onLogAction: Callable[[object, object], None] | None = None,
+    tissueMoved: Callable[[object, object, str], None] | None = None,
 ) -> Callable[[object], ExecutionContext]:
     def _factory(cell) -> ExecutionContext:
         kwargs = dict(cell=cell, pipette=pipetteGetter(), manager=manager)
@@ -26,6 +27,12 @@ def make_context_factory(
             # bind this cell the same way, so the UI-side sink (onLogAction)
             # knows which cell an ActionLogEntry belongs to.
             kwargs["on_log_action"] = partial(onLogAction, cell)
+        if tissueMoved is not None:
+            # Only the cell is bound in. ExecutionContext.tissue_moved passes
+            # itself at call time, so the context is never captured in a closure
+            # it also owns -- that would be a self-reference the cyclic GC alone
+            # could break.
+            kwargs["tissue_moved_hook"] = partial(tissueMoved, cell)
         return ExecutionContext(**kwargs)
 
     return _factory

--- a/acq4/modules/Autopatch/search_panel.py
+++ b/acq4/modules/Autopatch/search_panel.py
@@ -44,6 +44,15 @@ class SearchPanel(Qt.QWidget):
         self._constraintError = ""
         self._externalError = ""
 
+        # The two independent reasons this panel can be locked, kept apart for
+        # the same reason the two error strings are: neither writer can see the
+        # other's condition, so collapsing them into one boolean would let a run
+        # ending unlock a panel that still has no slice behind it. A panel with
+        # no slice starts locked -- New slice is what makes Area 2 usable, and
+        # the greyed-out controls are how the operator is told so.
+        self._runLocked = False
+        self._sliceReady = False
+
         # Depths are offsets from the tissue surface, negative being deeper, so
         # the spin boxes read the way the design doc writes them (-20 um to
         # -60 um) rather than as unsigned depths that get subtracted somewhere
@@ -126,6 +135,8 @@ class SearchPanel(Qt.QWidget):
         self.rescansCheck.toggled.connect(self._onEdited)
         self.addRegionBtn.clicked.connect(self.sigAddRegionRequested)
 
+        self._applyLock()
+
     @staticmethod
     def _makeSpin(value, bounds, step, suffix="", siPrefix=False):
         """A pyqtgraph SpinBox, the spin box the rest of acq4 uses for these
@@ -206,6 +217,21 @@ class SearchPanel(Qt.QWidget):
         The constraints parameterise a producer that is already surveying, so
         editing them mid-run would silently change the search under it.
         """
+        self._runLocked = locked
+        self._applyLock()
+
+    def setSliceReady(self, ready: bool) -> None:
+        """Whether a slice exists for these controls to configure.
+
+        Area 2 parameterises a search over a slice, so with no slice there is
+        nothing for these values to mean; New slice is the button that makes
+        them live.
+        """
+        self._sliceReady = ready
+        self._applyLock()
+
+    def _applyLock(self) -> None:
+        locked = self._runLocked or not self._sliceReady
         for w in (
             self.nearDepthSpin,
             self.farDepthSpin,

--- a/acq4/modules/Autopatch/tests/test_cell_panel.py
+++ b/acq4/modules/Autopatch/tests/test_cell_panel.py
@@ -609,3 +609,78 @@ def test_current_cell_built_on_another_thread_is_still_freed_by_refcounting(qapp
         assert panel_ref() is None, "panel should be freed by refcounting alone"
     finally:
         gc.enable()
+
+
+def test_a_queued_cell_is_not_attempted(qapp):
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    cell = object()
+    panel.addCell(cell)
+
+    assert panel.isAttempted(cell) is False
+
+
+def test_a_running_cell_is_attempted(qapp):
+    """A cell interrupted mid-run may never emit a terminal status, so
+    starting work on it -- not finishing -- is what marks it."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    cell = object()
+    panel.addCell(cell)
+
+    panel._onCurrentCell(cell)
+
+    assert panel.isAttempted(cell) is True
+
+
+def test_a_finished_cell_is_attempted(qapp):
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    cell = object()
+    panel.addCell(cell)
+
+    panel._onCellFinished(cell, "done")
+
+    assert panel.isAttempted(cell) is True
+
+
+def test_a_cell_finished_without_ever_being_current_is_attempted(qapp):
+    """Orchestrator._processCell can emit "skipped" without sigCurrentCell
+    ever firing for that cell."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    cell = object()
+
+    panel._onCellFinished(cell, "skipped")
+
+    assert panel.isAttempted(cell) is True
+
+
+def test_a_none_current_cell_does_not_crash_or_mark_anything(qapp):
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+
+    panel._onCurrentCell(None)
+
+    assert panel.isAttempted(None) is False
+
+
+def test_clear_cells_forgets_the_attempted_set(qapp):
+    """Left behind, a stale id would report a brand-new cell at a reused
+    memory address as already attempted -- the same hazard _awaitingEnqueue
+    is cleared for."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    cell = object()
+    panel.addCell(cell)
+    panel._onCellFinished(cell, "done")
+
+    panel.clearCells()
+
+    assert panel.isAttempted(cell) is False

--- a/acq4/modules/Autopatch/tests/test_cell_panel.py
+++ b/acq4/modules/Autopatch/tests/test_cell_panel.py
@@ -670,6 +670,62 @@ def test_a_none_current_cell_does_not_crash_or_mark_anything(qapp):
     assert panel.isAttempted(None) is False
 
 
+def test_discard_cells_removes_rows_for_cells_never_attempted(qapp):
+    """A rescan discards whatever is still queued when the tissue moved; their
+    rows in Area 5 must go with them, or an operator told "your N queued
+    cells are discarded" still sees them listed as queued."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    discarded = object()
+    panel.addCell(discarded)
+    kept = object()
+    panel.addCell(kept)
+
+    panel.discardCells([discarded])
+
+    assert panel.cellList.count() == 1
+    assert panel.cellList.item(0).data(Qt.Qt.UserRole) is kept
+    assert id(discarded) not in panel._cells
+    assert id(discarded) not in panel._rows
+    assert id(discarded) not in panel._timelines
+    assert id(discarded) not in panel._logs
+
+
+def test_discard_cells_never_removes_an_attempted_cells_row(qapp):
+    """An attempted cell's row is the session record. discardCells() must
+    never drop it, even when it is passed in directly -- e.g. a retried cell
+    still sitting in the queue when the tissue moved."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    attempted = object()
+    panel.addCell(attempted)
+    panel._onCurrentCell(attempted)
+
+    panel.discardCells([attempted])
+
+    assert panel.cellList.count() == 1
+    assert id(attempted) in panel._cells
+    assert panel.isAttempted(attempted) is True
+
+
+def test_discard_cells_drops_the_awaiting_enqueue_bookkeeping(qapp):
+    """A discarded cell seeded before any orchestrator was bound must not be
+    flushed into one bound afterward -- the same hazard clearCells() exists
+    to avoid."""
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    cell = object()
+    panel.addCell(cell)
+    panel._awaitingEnqueue.append(id(cell))
+
+    panel.discardCells([cell])
+
+    assert panel._awaitingEnqueue == []
+
+
 def test_clear_cells_forgets_the_attempted_set(qapp):
     """Left behind, a stale id would report a brand-new cell at a reused
     memory address as already attempted -- the same hazard _awaitingEnqueue

--- a/acq4/modules/Autopatch/tests/test_cell_panel.py
+++ b/acq4/modules/Autopatch/tests/test_cell_panel.py
@@ -661,13 +661,21 @@ def test_a_cell_finished_without_ever_being_current_is_attempted(qapp):
 
 
 def test_a_none_current_cell_does_not_crash_or_mark_anything(qapp):
+    """_onCurrentCell(None) must be a genuine no-op: no crash, no row added
+    for it, and no disturbance to a real cell already marked attempted --
+    not just a check against isAttempted(None), which is False by default for
+    any argument and so can never fail."""
     from acq4.modules.Autopatch.cell_panel import CellPanel
 
     panel = CellPanel()
+    cell = object()
+    panel.addCell(cell)
+    panel._onCurrentCell(cell)
 
     panel._onCurrentCell(None)
 
-    assert panel.isAttempted(None) is False
+    assert panel.isAttempted(cell) is True
+    assert panel.cellList.count() == 1
 
 
 def test_discard_cells_removes_rows_for_cells_never_attempted(qapp):

--- a/acq4/modules/Autopatch/tests/test_context_factory.py
+++ b/acq4/modules/Autopatch/tests/test_context_factory.py
@@ -90,3 +90,25 @@ def test_factory_binds_on_log_action_per_cell_so_entries_can_be_scoped():
     ctxB.on_log_action(entryB)
 
     assert calls == [(cellA, entryA), (cellB, entryB)]
+
+
+def test_tissue_moved_hook_is_bound_per_cell():
+    from acq4.modules.Autopatch.context_factory import make_context_factory
+
+    seen = []
+    factory = make_context_factory(
+        pipetteGetter=lambda: None,
+        manager=None,
+        tissueMoved=lambda cell, ctx, reason: seen.append((cell, reason)),
+    )
+    cell = object()
+    ctx = factory(cell)
+    ctx.tissue_moved_hook(ctx, "drifted")
+    assert seen == [(cell, "drifted")]
+
+
+def test_no_tissue_moved_hook_leaves_the_context_on_its_safe_default():
+    from acq4.modules.Autopatch.context_factory import make_context_factory
+
+    factory = make_context_factory(pipetteGetter=lambda: None, manager=None)
+    assert factory(object()).tissue_moved_hook is None

--- a/acq4/modules/Autopatch/tests/test_search_panel.py
+++ b/acq4/modules/Autopatch/tests/test_search_panel.py
@@ -207,6 +207,9 @@ def test_an_empty_message_retracts_an_externally_set_error(qapp):
 
 def test_add_region_button_emits_a_request(qapp):
     panel = makePanel()
+    # A disabled button does not deliver clicks; this test is about the
+    # button's wiring, not the no-slice lock, so give it a slice.
+    panel.setSliceReady(True)
     requests = []
     panel.sigAddRegionRequested.connect(lambda: requests.append(True))
 
@@ -247,6 +250,9 @@ def test_locking_disables_editing_but_not_the_readout(qapp, widgetName):
     # of them, in both directions, while leaving the readout alone.
     panel = makePanel()
     widget = getattr(panel, widgetName)
+    # A slice already exists here: this test is about the run-lock reaching
+    # every control, not about the separate no-slice lock covered elsewhere.
+    panel.setSliceReady(True)
 
     panel.setInteractionLocked(True)
     assert not widget.isEnabled()
@@ -269,3 +275,58 @@ def test_the_region_shape_reports_a_key_not_the_combo_label(qapp):
     panel = makePanel()
     panel.shapeCombo.setCurrentIndex(panel.shapeCombo.findData("ellipse"))
     assert panel.regionShape() == "ellipse"
+
+
+def _controls(panel):
+    return (
+        panel.nearDepthSpin,
+        panel.farDepthSpin,
+        panel.minHealthSpin,
+        panel.maxDensitySpin,
+        panel.rescansCheck,
+        panel.addRegionBtn,
+        panel.shapeCombo,
+    )
+
+
+def test_locked_when_no_slice_and_not_running(qapp):
+    panel = makePanel()
+    panel.setSliceReady(False)
+    panel.setInteractionLocked(False)
+    assert all(not w.isEnabled() for w in _controls(panel))
+
+
+def test_locked_when_no_slice_and_running(qapp):
+    panel = makePanel()
+    panel.setSliceReady(False)
+    panel.setInteractionLocked(True)
+    assert all(not w.isEnabled() for w in _controls(panel))
+
+
+def test_locked_when_slice_ready_but_running(qapp):
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setInteractionLocked(True)
+    assert all(not w.isEnabled() for w in _controls(panel))
+
+
+def test_unlocked_only_when_slice_ready_and_not_running(qapp):
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setInteractionLocked(False)
+    assert all(w.isEnabled() for w in _controls(panel))
+
+
+def test_a_run_ending_does_not_unlock_a_panel_with_no_slice(qapp):
+    # The two-writers bug this design exists to prevent: sigInteractionLocked
+    # firing False at the end of a run must not override slice-readiness.
+    panel = makePanel()
+    panel.setSliceReady(False)
+    panel.setInteractionLocked(True)
+    panel.setInteractionLocked(False)
+    assert all(not w.isEnabled() for w in _controls(panel))
+
+
+def test_a_panel_starts_locked_before_any_slice_exists(qapp):
+    panel = makePanel()
+    assert all(not w.isEnabled() for w in _controls(panel))

--- a/acq4/modules/Autopatch/tests/test_teardown.py
+++ b/acq4/modules/Autopatch/tests/test_teardown.py
@@ -194,18 +194,25 @@ def test_teardown_frees_the_slice_producer_and_cells_by_refcounting(qapp, tmp_pa
     The camera stand-in comes from test_window_integration rather than being
     copied in here: it is the same mode-sensitive getBoundary/
     globalCenterPosition/scopeDev fake the producer install needs, and a second
-    copy would be one more thing to keep in step with acq4's real Camera.
+    copy would be one more thing to keep in step with acq4's real Camera. The
+    manager stand-in is the same: newSlice() needs somewhere real to create a
+    Slice directory, and test_window_integration's _FakeManager (backed by an
+    actual DirHandle) is that fixture already.
     """
+    from types import SimpleNamespace
+
+    import acq4.util.DataManager as dm
     from acq4.modules.Autopatch.Autopatch import AutopatchWindow
 
-    from .test_window_integration import _FakeCameraWithDevice
+    from .test_window_integration import _FakeCameraWithDevice, _FakeManager
 
     _write_protocol(tmp_path, "demo.py", _NOOP_PROTOCOL)
+    storageRoot = dm.getDirHandle(str(tmp_path / "storage"), create=True)
 
     gc.disable()
     try:
         win = AutopatchWindow(
-            module=None,
+            module=SimpleNamespace(manager=_FakeManager(storageRoot)),
             protocolDir=str(tmp_path),
             pipetteSelector=_FakePipetteSelector(target=(1e-3, 2e-3, 3e-3)),
             cameraSelector=_FakeCameraWithDevice(),

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -1155,3 +1155,9 @@ def test_add_region_here_does_not_create_a_directory(win):
     # subsequent write lands.
     win.addRegionHere()
     assert win.slice.dirHandle is None
+
+
+def test_area_2_is_locked_until_a_slice_exists(win):
+    assert not win.searchPanel.addRegionBtn.isEnabled()
+    win.newSlice()
+    assert win.searchPanel.addRegionBtn.isEnabled()

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -1164,6 +1164,11 @@ def test_new_slice_discards_nothing_when_the_directory_cannot_be_made(win):
 
     cell = _makeCell()
     win.cellPanel.addCell(cell)
+    # Primed attempted before the failing call, so the assertion below
+    # actually discriminates: isAttempted(cell) is False by default for any
+    # cell newSlice() never touches, which would pass whether or not the
+    # failed call left this bookkeeping alone.
+    win.cellPanel._onCurrentCell(cell)
     win.orchestrator.enqueue(cell)
     assert win.cellPanel.cellList.count() == 1
 
@@ -1175,7 +1180,7 @@ def test_new_slice_discards_nothing_when_the_directory_cannot_be_made(win):
 
     assert win.slice is oldSlice
     assert win.cellPanel.cellList.count() == 1
-    assert win.cellPanel.isAttempted(cell) is False
+    assert win.cellPanel.isAttempted(cell) is True
     assert win.orchestrator.pendingCells() == [cell]
 
 

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -1098,6 +1098,47 @@ def test_tissue_moved_keeps_attempted_cells_in_the_density_record(win, monkeypat
     assert cell in slice_.cellsNearTile(tile)
 
 
+def test_tissue_moved_rescan_discards_the_queued_cells_rows(win, monkeypatch):
+    """The prompt tells the operator the queued cells are discarded; their
+    rows in Area 5 must actually go, or the operator sees the opposite of
+    what they just agreed to -- cells still listed as queued."""
+    monkeypatch.setattr(
+        _autopatchModule, "prompt", lambda ctx, **kw: "Rescan the slice"
+    )
+    slice_, cell, ctx = _sliceWithCoveredTiles(win)
+    queued = _makeCell()
+    win.cellPanel.addCell(queued)
+    win.orchestrator.enqueue(queued)
+    assert win.cellPanel.cellList.count() == 1
+
+    with pytest.raises(AdvanceToNextCell):
+        win._onTissueMoved(cell, ctx, "no features")
+
+    assert win.cellPanel.cellList.count() == 0
+
+
+def test_tissue_moved_rescan_keeps_an_attempted_cells_row(win, monkeypatch):
+    """A cell isAttempted() reports as already started keeps its row through
+    a rescan even if it is still sitting in the queue (e.g. a retry) -- it is
+    the session record, not a stale queued entry, so clearCells()'s
+    discard-everything behaviour must not apply to it."""
+    monkeypatch.setattr(
+        _autopatchModule, "prompt", lambda ctx, **kw: "Rescan the slice"
+    )
+    slice_, cell, ctx = _sliceWithCoveredTiles(win)
+    attempted = _makeCell()
+    win.cellPanel.addCell(attempted)
+    win.cellPanel._onCurrentCell(attempted)
+    win.orchestrator.enqueue(attempted)
+    assert win.cellPanel.cellList.count() == 1
+
+    with pytest.raises(AdvanceToNextCell):
+        win._onTissueMoved(cell, ctx, "no features")
+
+    assert win.cellPanel.cellList.count() == 1
+    assert win.cellPanel.isAttempted(attempted) is True
+
+
 def test_new_slice_creates_a_slice_directory_and_makes_it_current(win):
     win.newSlice()
     assert win.slice.dirHandle is not None

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -1010,6 +1010,9 @@ def test_tissue_moved_rescans_and_clears_the_queue_on_the_first_answer(win, monk
         _autopatchModule, "prompt", lambda ctx, **kw: "Rescan the slice"
     )
     slice_, cell, ctx = _sliceWithCoveredTiles(win)
+    # Primed True so the post-call assertion below actually distinguishes
+    # "cleared by the rescan handler" from "left at its untouched default".
+    win.orchestrator._producerExhausted = True
 
     with pytest.raises(AdvanceToNextCell):
         win._onTissueMoved(cell, ctx, "no features")

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -1138,6 +1138,42 @@ def test_new_slice_discards_nothing_when_the_directory_cannot_be_made(win):
     assert win.orchestrator.pendingCells() == [cell]
 
 
+def test_new_slice_without_a_camera_does_not_repoint_storage(qapp, tmp_path):
+    """_startSlice()'s validation must run before create_data_dir(): a failed
+    New slice (no camera selected here) must leave the current storage
+    directory exactly where it was, not have already created and switched to
+    a fresh, empty Slice directory before discovering the camera is missing.
+    """
+    win = _makeWindow(tmp_path, cameraSelector=_FakeCameraSelector())
+    before = win.manager.getCurrentDir()
+
+    win.newSlice()
+
+    assert win.slice is None
+    assert win.manager.getCurrentDir() is before
+
+
+def test_new_slice_lets_a_programming_error_propagate(qapp, tmp_path):
+    """create_data_dir raising something other than HelpfulException is a
+    programming error (here, because module=None leaves self.manager as None,
+    the constructor's documented headless/test mode) -- not storage guidance
+    for the operator -- so it must propagate rather than being swallowed into
+    Area 2's error line."""
+    from acq4.modules.Autopatch.Autopatch import AutopatchWindow
+
+    _write_protocol(tmp_path, "demo.py", _NOOP_PROTOCOL)
+    win = AutopatchWindow(
+        module=None,
+        protocolDir=str(tmp_path),
+        pipetteSelector=_FakePipetteSelector(),
+        cameraSelector=_FakeCameraWithDevice(),
+    )
+    win.protocolPanel.fileCombo.setCurrentText("demo")
+
+    with pytest.raises(AttributeError):
+        win.newSlice()
+
+
 def test_new_slice_reports_a_missing_storage_directory_in_area_2(win):
     from acq4.util.HelpfulException import HelpfulException
 

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -1,11 +1,17 @@
 """Integration test: loading a protocol builds and binds a fresh Orchestrator
 to the window's StatusPanel/CellPanel, and a seeded cell runs end-to-end."""
+import importlib
 import os
 
 import pytest
+from coorx import Point
 
+from acq4.experiment.context import ExecutionContext
+from acq4.experiment.exceptions import AdvanceToNextCell
 from acq4.experiment.search_region import EllipseRegion, RectRegion
+from acq4.experiment.slice import Slice
 from acq4.util import Qt
+from acq4_automation.feature_tracking.cell import Cell
 
 
 @pytest.fixture(scope="module")
@@ -171,6 +177,11 @@ def run(ctx, **kwargs):
 def _write_protocol(path, name, body):
     with open(os.path.join(path, name), "w") as fh:
         fh.write(body)
+
+
+@pytest.fixture
+def win(qapp, tmp_path):
+    return _makeWindow(tmp_path)
 
 
 def test_loading_a_protocol_builds_and_binds_an_orchestrator(qapp, tmp_path):
@@ -957,3 +968,90 @@ def test_the_survey_readout_follows_the_slices_coverage(qapp, tmp_path):
     win.statusPanel.sigStatusChanged.emit("surveying")
 
     assert f"1/{total}" in win.searchPanel.surveyLabel.text()
+
+
+# acq4.modules.Autopatch's __init__.py does `from .Autopatch import Autopatch`,
+# which re-exports the Module subclass under the same name as the submodule and
+# shadows it on the package: a dotted-string monkeypatch target
+# ("acq4.modules.Autopatch.Autopatch.prompt") resolves attribute-by-attribute and
+# lands on that class rather than the submodule, so `prompt` isn't found there.
+# importlib.import_module goes through sys.modules instead and reaches the
+# actual submodule, where AutopatchWindow._onTissueMoved's module-level `prompt`
+# name lives.
+_autopatchModule = importlib.import_module("acq4.modules.Autopatch.Autopatch")
+
+
+def _sliceWithCoveredTiles(win):
+    """Install a Slice on `win` with one fully-covered region at a realistic,
+    non-square stage coordinate, seed a cell inside its first tile, enqueue a
+    second cell on the orchestrator, and return (slice, cell, ctx).
+
+    Built directly rather than through win.newSlice()/addRegionHere(): those
+    size the region off the fake camera's micrometre-scale field of view,
+    which cannot expose the millimetre-magnitude float error a real stage
+    position can. Not origin-centered and not square, for the same reason.
+    """
+    slice_ = Slice(fov=(20e-6, 10e-6))
+    slice_.addRegion(RectRegion(1e-3, 2e-3, 1e-3 + 60e-6, 2e-3 + 30e-6))
+    for tile in slice_.tileGrid():
+        slice_.markCovered(tile)
+    win.slice = slice_
+
+    tile = slice_.tileGrid()[0]
+    cell = Cell(Point([tile[0], tile[1], -30e-6], "global"))
+    secondCell = Cell(Point([tile[0] + 5e-6, tile[1], -30e-6], "global"))
+    win.orchestrator.enqueue(secondCell)
+
+    return slice_, cell, ExecutionContext(cell=cell)
+
+
+def test_tissue_moved_rescans_and_clears_the_queue_on_the_first_answer(win, monkeypatch):
+    monkeypatch.setattr(
+        _autopatchModule, "prompt", lambda ctx, **kw: "Rescan the slice"
+    )
+    slice_, cell, ctx = _sliceWithCoveredTiles(win)
+
+    with pytest.raises(AdvanceToNextCell):
+        win._onTissueMoved(cell, ctx, "no features")
+
+    assert slice_.coveredTiles == []
+    assert win.orchestrator.pendingCells() == []
+    assert win.orchestrator._producerExhausted is False
+
+
+def test_tissue_moved_leaves_everything_alone_on_the_second_answer(win, monkeypatch):
+    monkeypatch.setattr(
+        _autopatchModule, "prompt", lambda ctx, **kw: "Skip this cell only"
+    )
+    slice_, cell, ctx = _sliceWithCoveredTiles(win)
+    coveredBefore = list(slice_.coveredTiles)
+    pendingBefore = win.orchestrator.pendingCells()
+
+    with pytest.raises(AdvanceToNextCell):
+        win._onTissueMoved(cell, ctx, "no features")
+
+    assert slice_.coveredTiles == coveredBefore
+    assert win.orchestrator.pendingCells() == pendingBefore
+
+
+def test_tissue_moved_ends_the_cell_on_both_answers(win, monkeypatch):
+    for answer in ("Rescan the slice", "Skip this cell only"):
+        monkeypatch.setattr(_autopatchModule, "prompt", lambda ctx, **kw: answer)
+        _slice, cell, ctx = _sliceWithCoveredTiles(win)
+        with pytest.raises(AdvanceToNextCell):
+            win._onTissueMoved(cell, ctx, "no features")
+
+
+def test_tissue_moved_keeps_attempted_cells_in_the_density_record(win, monkeypatch):
+    monkeypatch.setattr(
+        _autopatchModule, "prompt", lambda ctx, **kw: "Rescan the slice"
+    )
+    slice_, cell, ctx = _sliceWithCoveredTiles(win)
+    tile = slice_.tileGrid()[0]
+    win.cellPanel._onCellFinished(cell, "done")
+    slice_.registerCells([cell])
+
+    with pytest.raises(AdvanceToNextCell):
+        win._onTissueMoved(cell, ctx, "no features")
+
+    assert cell in slice_.cellsNearTile(tile)

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -2,10 +2,12 @@
 to the window's StatusPanel/CellPanel, and a seeded cell runs end-to-end."""
 import importlib
 import os
+from types import SimpleNamespace
 
 import pytest
 from coorx import Point
 
+import acq4.util.DataManager as dm
 from acq4.experiment.context import ExecutionContext
 from acq4.experiment.exceptions import AdvanceToNextCell
 from acq4.experiment.search_region import EllipseRegion, RectRegion
@@ -147,23 +149,59 @@ class _FakeCameraWithDevice(Qt.QWidget):
         return self.camera
 
 
+# The one folder type newSlice() asks create_data_dir for. A real Manager's
+# config carries many more, but this window only ever creates a "Slice".
+_FOLDER_TYPES = {"Slice": {"name": "Slice_%Y%m%d_%H%M%S", "experimentalUnit": False}}
+
+
+class _FakeManager:
+    """Stands in for Manager: backed by a real DirHandle (on tmp_path) so
+    create_data_dir's mkdir/setInfo calls land on an actual directory, the way
+    they would through the real Manager AutopatchWindow otherwise gets from
+    its module."""
+
+    def __init__(self, root_dir):
+        self._current_dir = root_dir
+
+    def getCurrentDir(self):
+        return self._current_dir
+
+    def setCurrentDir(self, d):
+        self._current_dir = d
+
+    def folderTypesConfig(self):
+        return _FOLDER_TYPES
+
+
 def _makeWindow(tmp_path, cameraSelector=None):
     """An AutopatchWindow with a loaded no-op protocol and a camera-backed
     selector, for tests that don't care about protocol content but do need a
-    working camera to seed a slice or region."""
+    working camera to seed a slice or region.
+
+    Also wires up a manager backed by a real (temporary) managed directory, so
+    newSlice()'s create_data_dir call has somewhere real to write -- kept in a
+    subdirectory of tmp_path separate from the protocol files written directly
+    into tmp_path above."""
     from acq4.modules.Autopatch.Autopatch import AutopatchWindow
 
     if cameraSelector is None:
         cameraSelector = _FakeCameraWithDevice()
     _write_protocol(tmp_path, "demo.py", _NOOP_PROTOCOL)
+    storageRoot = dm.getDirHandle(str(tmp_path / "storage"), create=True)
     win = AutopatchWindow(
-        module=None,
+        module=SimpleNamespace(manager=_FakeManager(storageRoot)),
         protocolDir=str(tmp_path),
         pipetteSelector=_FakePipetteSelector(),
         cameraSelector=cameraSelector,
     )
     win.protocolPanel.fileCombo.setCurrentText("demo")
     return win
+
+
+def _makeCell():
+    """A Cell at an arbitrary global position, standing in for one a real
+    detector would have found -- only its identity matters to these tests."""
+    return Cell(Point([1e-3, 2e-3, -30e-6], "global"))
 
 
 _NOOP_PROTOCOL = '''"""Integration test fixture: resolves immediately without touching ctx."""
@@ -1058,3 +1096,62 @@ def test_tissue_moved_keeps_attempted_cells_in_the_density_record(win, monkeypat
         win._onTissueMoved(cell, ctx, "no features")
 
     assert cell in slice_.cellsNearTile(tile)
+
+
+def test_new_slice_creates_a_slice_directory_and_makes_it_current(win):
+    win.newSlice()
+    assert win.slice.dirHandle is not None
+    assert win.slice.dirHandle.info()["dirType"] == "Slice"
+    assert win.manager.getCurrentDir() is win.slice.dirHandle
+
+
+def test_new_slice_discards_nothing_when_the_directory_cannot_be_made(win):
+    """Directory creation happens before anything is thrown away, so a failed
+    attempt must leave the old slice, the seeded cell's row, and the
+    orchestrator's queue exactly as they were.
+
+    win.newSlice() is called once, successfully, before the failure is
+    injected: the state asserted unchanged below has to be genuinely populated
+    first, or "unchanged" would also describe a window that never started a
+    slice at all.
+    """
+    from acq4.util.HelpfulException import HelpfulException
+
+    win.newSlice()
+    oldSlice = win.slice
+    assert oldSlice is not None
+
+    cell = _makeCell()
+    win.cellPanel.addCell(cell)
+    win.orchestrator.enqueue(cell)
+    assert win.cellPanel.cellList.count() == 1
+
+    def boom(*a, **k):
+        raise HelpfulException("Storage directory has not been set.")
+
+    win.manager.getCurrentDir = boom
+    win.newSlice()
+
+    assert win.slice is oldSlice
+    assert win.cellPanel.cellList.count() == 1
+    assert win.cellPanel.isAttempted(cell) is False
+    assert win.orchestrator.pendingCells() == [cell]
+
+
+def test_new_slice_reports_a_missing_storage_directory_in_area_2(win):
+    from acq4.util.HelpfulException import HelpfulException
+
+    def boom(*a, **k):
+        raise HelpfulException("Storage directory has not been set.")
+
+    win.manager.getCurrentDir = boom
+    win.newSlice()
+
+    assert "Storage directory" in win.searchPanel.errorLabel.text()
+
+
+def test_add_region_here_does_not_create_a_directory(win):
+    # A button labelled "add region" must not silently repoint where every
+    # subsequent write lands.
+    win.addRegionHere()
+    assert win.slice.dirHandle is None

--- a/docs/superpowers/plans/2026-08-05-autopatch-p2c-2-tissue-motion-and-slice-dir.md
+++ b/docs/superpowers/plans/2026-08-05-autopatch-p2c-2-tissue-motion-and-slice-dir.md
@@ -1,0 +1,2088 @@
+# Autopatch P2c-2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire the tissue-motion feedback loop between the cell tracker, the slice, and the orchestrator; and make **New slice** create a real Data Manager slice directory with Area 2 gated behind it.
+
+**Architecture:** Two independent pieces sharing no code. Piece A spans two repos: `acq4-automation` gains a named `CellTrackingLost` exception and an opt-out for its movement guard; `acq4` gains a `TrackingLost` orchestration error, a `ctx.tissue_moved()` hook, a region-scoped `Slice.forceRescan()`, and the window glue that prompts the operator. Piece B factors `new_data_dir`'s body into a `manager`-only helper so a UI button can call it, reorders `newSlice()` so a failure discards nothing, and gives `SearchPanel` a second, independent lock reason.
+
+**Tech Stack:** Python 3, PyQt5 via `acq4.util.Qt`, pytest, pyqtgraph, coorx.
+
+**Spec:** `docs/superpowers/specs/2026-08-05-autopatch-p2c-2-tissue-motion-and-slice-dir-design.md`
+
+## Global Constraints
+
+- **Python interpreter:** `/home/martin/.miniforge3/envs/acq4-gl/bin/python`. Never `acq4-torch`.
+- **acq4 test command:** `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests acq4/modules/Autopatch/tests -q`
+- **Baseline:** 510 tests pass in those two suites at `4a3c82e0b`. Any task ending with fewer than 510 passing has broken something.
+- **acq4-automation repo:** `/home/martin/src/acq4/acq4-automation`, used by Tasks 1-3 only. **It is currently checked out on `feature/smooth-vector-field-z`, not `main`.** See Task 1 Step 0; do not resolve this by guessing.
+- **Commit author:** `--author="Martin Chase (claude) <outofculture@gmail.com>"` on every commit in both repos.
+- **Commit format:** conventional commits (`feat:`, `fix:`, `test:`, `refactor:`, `docs:`), imperative mood, present tense.
+- **Never** use `--no-verify`.
+- **Comments are evergreen.** Describe the code as it is; never reference "the old behaviour", "previously", or this migration.
+- **Do not widen `SearchRegion`.** Its contract is exactly `bounds()` + `overlapsTile()`. Adding `contains(point)` is explicitly rejected by the spec.
+- **Do not replace the closed-form geometry in `search_region.py` with `QPainterPath`.** It was measured wrong: 24 of 225 tiles misreported at SI-metre scale.
+
+---
+
+## File Structure
+
+**acq4-automation** (Tasks 1-3)
+
+| File | Responsibility | Change |
+|---|---|---|
+| `acq4_automation/feature_tracking/interfaces.py` | Shared vocabulary: results, decisions, enums | Add `CellTrackingLost` |
+| `acq4_automation/feature_tracking/__init__.py` | Package export surface | Export `CellTrackingLost` |
+| `acq4_automation/feature_tracking/cell_tracker.py` | Tracker base: acquisition + validation | `validate_movement` param on `track_next_frame` |
+| `acq4_automation/feature_tracking/cell.py` | `Cell` QObject: tracker lifecycle | `validate_movement` param on `updatePosition`; re-verify raises `CellTrackingLost` |
+| `acq4_automation/feature_tracking/test_cell_tracking_lost.py` | **New.** Tests for all three above | Create |
+
+**acq4 engine** (Tasks 4-8)
+
+| File | Responsibility | Change |
+|---|---|---|
+| `acq4/experiment/exceptions.py` | Orchestration taxonomy | Add `TrackingLost` |
+| `acq4/experiment/context.py` | Per-run bundle + flow control | Add `tissue_moved()` method + `tissue_moved_hook` field |
+| `acq4/experiment/actions/device.py` | Device-wrapping protocol functions | `cellfie()` translates `CellTrackingLost` |
+| `acq4/experiment/slice.py` | Search state for one piece of tissue | Add `forceRescan()`; `dirHandle` (Task 12) |
+| `acq4/experiment/orchestrator.py` | Run loop, queue, producer | Extract `clearProducerExhausted()` |
+
+**acq4 UI** (Tasks 9-13)
+
+| File | Responsibility | Change |
+|---|---|---|
+| `acq4/modules/Autopatch/cell_panel.py` | Area 5: cell rows, timelines, logs | Track the attempted set; expose `isAttempted()` |
+| `acq4/modules/Autopatch/context_factory.py` | Builds the per-cell `ExecutionContext` | Bind the `tissueMoved` hook |
+| `acq4/modules/Autopatch/Autopatch.py` | The window; owns Slice + Orchestrator | `_onTissueMoved()`; `newSlice()` reorder; slice-ready wiring |
+| `acq4/modules/Autopatch/search_panel.py` | Area 2 controls | Two independent lock reasons |
+| `acq4/experiment/actions/storage.py` | Managed data directories | Extract `create_data_dir()` |
+
+---
+
+## Piece A - Tissue-motion feedback loop
+
+### Task 1: `CellTrackingLost` exception (acq4-automation)
+
+**Files:**
+- Modify: `/home/martin/src/acq4/acq4-automation/acq4_automation/feature_tracking/interfaces.py`
+- Modify: `/home/martin/src/acq4/acq4-automation/acq4_automation/feature_tracking/__init__.py`
+- Test: `/home/martin/src/acq4/acq4-automation/acq4_automation/feature_tracking/test_cell_tracking_lost.py` (create)
+
+**Interfaces:**
+- Produces: `CellTrackingLost(ValueError)` with attribute `reason: str | None`. Importable as `from acq4_automation.feature_tracking import CellTrackingLost`. Tasks 2, 3, and 6 depend on this name and import path.
+
+- [ ] **Step 0: Resolve the branch question before touching anything**
+
+The repo is on `feature/smooth-vector-field-z` with a clean tracked tree (only untracked `best-segmenter` and `cellpose_grid_results.json`). The spec says the work belongs on `main`.
+
+Run:
+
+```bash
+cd /home/martin/src/acq4/acq4-automation && git status -sb && git log --oneline -1 main
+```
+
+**Stop and ask the operator** which they want: switch this checkout to `main`, or branch off `main` here. Do not switch branches in a repo with active feature work without being told to. Note that `acq4_automation` is installed editable from *this* checkout, so a separate worktree would not be visible to acq4's tests without a `PYTHONPATH` override.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `acq4_automation/feature_tracking/test_cell_tracking_lost.py`:
+
+```python
+"""CellTrackingLost: the named exception for a cell the tracker cannot re-find.
+
+Subclassing ValueError is load-bearing, not incidental -- existing callers catch
+ValueError from initializeTracker and must keep working.
+"""
+
+import pytest
+
+from acq4_automation.feature_tracking import CellTrackingLost
+
+
+def test_is_a_valueerror():
+    # AutomationDebug/autopatch.py catches ValueError from initializeTracker and
+    # skips the cell. Narrowing that to a non-ValueError would break it silently.
+    assert issubclass(CellTrackingLost, ValueError)
+
+
+def test_caught_by_a_bare_except_valueerror():
+    try:
+        raise CellTrackingLost("no features matched")
+    except ValueError as exc:
+        assert "no features matched" in str(exc)
+    else:
+        pytest.fail("CellTrackingLost was not caught as a ValueError")
+
+
+def test_carries_the_tracker_reason():
+    exc = CellTrackingLost("cell lost", reason="Too uncertain to track")
+    assert exc.reason == "Too uncertain to track"
+
+
+def test_reason_defaults_to_none():
+    assert CellTrackingLost("cell lost").reason is None
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /home/martin/src/acq4/acq4-automation && /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4_automation/feature_tracking/test_cell_tracking_lost.py -v
+```
+
+Expected: collection error, `ImportError: cannot import name 'CellTrackingLost'`.
+
+- [ ] **Step 3: Add the exception**
+
+In `interfaces.py`, after the imports and before `class TrackingAction`:
+
+```python
+class CellTrackingLost(ValueError):
+    """The tracker could not re-find a cell against its own reference stacks.
+
+    Raised only from Cell.initializeTracker's re-verify path, where a failure
+    means the reference stacks are useless: the cell has drifted out of reach or
+    died. Tracking failures during an ongoing patch -- a pipette occluding the
+    features, say -- are a different condition and never raise this.
+
+    Subclasses ValueError so callers that predate the named class keep catching
+    it. `reason` carries the tracker's own reason_for_failure, which is what an
+    operator being asked to authorise a rescan needs in order to answer.
+    """
+
+    def __init__(self, message: str, reason: str | None = None):
+        super().__init__(message)
+        self.reason = reason
+```
+
+In `__init__.py`, add:
+
+```python
+from acq4_automation.feature_tracking.interfaces import CellTrackingLost
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Same command as Step 2. Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/martin/src/acq4/acq4-automation && git add acq4_automation/feature_tracking/interfaces.py acq4_automation/feature_tracking/__init__.py acq4_automation/feature_tracking/test_cell_tracking_lost.py && git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "feat: add CellTrackingLost for a cell the tracker cannot re-find"
+```
+
+---
+
+### Task 2: `validate_movement` opt-out (acq4-automation)
+
+**Files:**
+- Modify: `acq4_automation/feature_tracking/cell_tracker.py` (`track_next_frame`)
+- Modify: `acq4_automation/feature_tracking/cell.py` (`updatePosition`)
+- Test: `acq4_automation/feature_tracking/test_cell_tracking_lost.py` (append)
+
+**Interfaces:**
+- Consumes: nothing from Task 1.
+- Produces: `CellTracker.track_next_frame(force_refresh=False, feature_radius=None, validate_movement=True)` and `Cell.updatePosition(feature_radius=None, force_refresh=False, validate_movement=True)`. Task 3 calls `updatePosition(..., validate_movement=False)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test_cell_tracking_lost.py`:
+
+```python
+import coorx
+
+from acq4_automation.feature_tracking.cell_tracker import CellTracker
+from acq4_automation.feature_tracking.interfaces import TrackingResult
+
+
+class _StubTracker(CellTracker):
+    """A CellTracker with acquisition and matching stubbed out.
+
+    Only the movement-validation branch of track_next_frame is under test, so
+    everything upstream of it returns a fixed successful result.
+    """
+
+    def __init__(self, result_position, last_position, movement_threshold):
+        super().__init__(movement_threshold=movement_threshold)
+        self._last_position = coorx.Point(last_position, "global")
+        self._forced_result = TrackingResult(
+            success=True,
+            position=coorx.Point(result_position, "global"),
+            offset=None,
+            uncertainty=0.1,
+            tracker_type="stub",
+        )
+
+    def _acquire_images(self, position, single):
+        raise AssertionError("the stub must not acquire")
+
+    def _track_single_frame(self):
+        return self._forced_result
+
+    def next_action(self):
+        from acq4_automation.feature_tracking.interfaces import (
+            TrackingAction,
+            TrackingDecision,
+        )
+
+        return TrackingDecision(
+            action=TrackingAction.SINGLE_FRAME, reason="stubbed"
+        )
+
+
+def _far_apart_tracker():
+    # 500 um apart with a 50 um threshold: unambiguously over, at a realistic
+    # stage coordinate rather than at the origin.
+    return _StubTracker(
+        result_position=(1e-3 + 500e-6, 2e-3, 0.0),
+        last_position=(1e-3, 2e-3, 0.0),
+        movement_threshold=50e-6,
+    )
+
+
+def test_movement_guard_rejects_a_far_jump_by_default():
+    with pytest.raises(ValueError, match="moved too much"):
+        _far_apart_tracker().track_next_frame()
+
+
+def test_movement_guard_can_be_bypassed():
+    # Re-verify re-establishes the baseline rather than continuing a track: if
+    # the features matched, we know where the cell is, at any distance.
+    result = _far_apart_tracker().track_next_frame(validate_movement=False)
+    assert result.success
+
+
+def test_bypassing_the_guard_still_updates_tracking_state():
+    # The adopted position has to become the new baseline, or the next frame is
+    # measured against a stale one and trips the guard that was just bypassed.
+    tracker = _far_apart_tracker()
+    tracker.track_next_frame(validate_movement=False)
+    assert tracker.position.coordinates[0] == pytest.approx(1e-3 + 500e-6)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /home/martin/src/acq4/acq4-automation && /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4_automation/feature_tracking/test_cell_tracking_lost.py -v -k movement
+```
+
+Expected: `test_movement_guard_rejects_a_far_jump_by_default` passes (existing behaviour), the other two FAIL with `TypeError: track_next_frame() got an unexpected keyword argument 'validate_movement'`.
+
+If `test_movement_guard_rejects_a_far_jump_by_default` does *not* pass, the stub is not reaching `_validate_movement` and the other two tests would be vacuous. Fix the stub before continuing.
+
+- [ ] **Step 3: Thread the parameter through**
+
+In `cell_tracker.py`, change the signature:
+
+```python
+    def track_next_frame(
+        self,
+        force_refresh: bool = False,
+        feature_radius: Optional[float] = None,
+        validate_movement: bool = True,
+    ) -> TrackingResult:
+```
+
+Add to its docstring's Parameters section:
+
+```
+        validate_movement : bool
+            Whether to enforce the jump limit against the last tracked position.
+            True for ongoing tracking, where frames are seconds apart and a large
+            jump is implausible -- and where sigPositionChanged drives pipette
+            targets, so a spuriously confident match is a hardware risk. False
+            when re-establishing a baseline after a gap, where legitimate
+            accumulated drift can exceed the same threshold.
+```
+
+Change the validation call:
+
+```python
+        # validate movement
+        self.tracking_results.append(result)
+        if validate_movement and result.success and result.position is not None:
+            self._validate_movement(result)
+```
+
+In `cell.py`, change `updatePosition`:
+
+```python
+    def updatePosition(self, feature_radius=None, force_refresh=False, validate_movement=True):
+```
+
+and its call through:
+
+```python
+            result = self._tracker.track_next_frame(
+                force_refresh=force_refresh,
+                feature_radius=feature_radius,
+                validate_movement=validate_movement,
+            )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd /home/martin/src/acq4/acq4-automation && /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4_automation/feature_tracking/ -q
+```
+
+Expected: all pass, including the pre-existing tracking tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/martin/src/acq4/acq4-automation && git add acq4_automation/feature_tracking/cell_tracker.py acq4_automation/feature_tracking/cell.py acq4_automation/feature_tracking/test_cell_tracking_lost.py && git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "feat: let a caller bypass the tracker's jump guard when re-baselining"
+```
+
+---
+
+### Task 3: `initializeTracker` raises `CellTrackingLost` (acq4-automation)
+
+**Files:**
+- Modify: `acq4_automation/feature_tracking/cell.py` (`initializeTracker`)
+- Test: `acq4_automation/feature_tracking/test_cell_tracking_lost.py` (append)
+
+**Interfaces:**
+- Consumes: `CellTrackingLost` (Task 1), `validate_movement` (Task 2).
+- Produces: `Cell.initializeTracker` raises `CellTrackingLost` with `reason` set from `tracker.last_result.reason_for_failure`. Signature is **unchanged**. Task 6 catches this.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `test_cell_tracking_lost.py`:
+
+```python
+from acq4_automation.feature_tracking.cell import Cell
+
+
+class _ReVerifyTracker:
+    """Stands in for an already-initialized tracker on a Cell.
+
+    Records how updatePosition's work was requested, so the re-verify path's
+    contract can be asserted without any acquisition.
+    """
+
+    def __init__(self, succeed, reason=None):
+        self._succeed = succeed
+        self.position = coorx.Point((1e-3, 2e-3, 0.0), "global")
+        self.last_result = TrackingResult(
+            success=succeed,
+            position=self.position if succeed else None,
+            offset=None,
+            uncertainty=0.1,
+            tracker_type="stub",
+            reason_for_failure=reason,
+        )
+        self.calls = []
+        self.allow_refresh_reference = True
+
+    def next_action(self):
+        from acq4_automation.feature_tracking.interfaces import (
+            TrackingAction,
+            TrackingDecision,
+        )
+
+        return TrackingDecision(
+            action=TrackingAction.SINGLE_FRAME, reason="stubbed"
+        )
+
+    def track_next_frame(self, force_refresh=False, feature_radius=None, validate_movement=True):
+        self.calls.append(
+            {"force_refresh": force_refresh, "validate_movement": validate_movement}
+        )
+        return self.last_result
+
+
+def _cell_with_tracker(tracker):
+    cell = Cell(coorx.Point((1e-3, 2e-3, 0.0), "global"))
+    cell._tracker = tracker
+    return cell
+
+
+def test_reverify_failure_raises_celltrackinglost_with_the_reason():
+    tracker = _ReVerifyTracker(succeed=False, reason="All object stacks failed to match")
+    cell = _cell_with_tracker(tracker)
+    with pytest.raises(CellTrackingLost) as caught:
+        cell.initializeTracker(imager=None)
+    assert caught.value.reason == "All object stacks failed to match"
+
+
+def test_reverify_bypasses_the_movement_guard():
+    # If the features matched, we adopt the new position at any distance.
+    tracker = _ReVerifyTracker(succeed=True)
+    _cell_with_tracker(tracker).initializeTracker(imager=None)
+    assert tracker.calls[0]["validate_movement"] is False
+
+
+def test_reverify_success_does_not_raise():
+    tracker = _ReVerifyTracker(succeed=True)
+    _cell_with_tracker(tracker).initializeTracker(imager=None)
+
+
+def test_reverify_failure_is_still_catchable_as_valueerror():
+    tracker = _ReVerifyTracker(succeed=False, reason="no features")
+    cell = _cell_with_tracker(tracker)
+    with pytest.raises(ValueError):
+        cell.initializeTracker(imager=None)
+
+
+def test_missing_reason_is_tolerated():
+    # A tracker that failed without recording a reason must still raise, not
+    # blow up reaching for the attribute.
+    tracker = _ReVerifyTracker(succeed=False, reason=None)
+    cell = _cell_with_tracker(tracker)
+    with pytest.raises(CellTrackingLost) as caught:
+        cell.initializeTracker(imager=None)
+    assert caught.value.reason is None
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+cd /home/martin/src/acq4/acq4-automation && /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4_automation/feature_tracking/test_cell_tracking_lost.py -v -k reverify
+```
+
+Expected: `test_reverify_failure_raises_celltrackinglost_with_the_reason` FAILS (plain `ValueError`, not `CellTrackingLost`), `test_reverify_bypasses_the_movement_guard` FAILS (`validate_movement` is `True`).
+
+- [ ] **Step 3: Change the re-verify path**
+
+In `cell.py`, add the import:
+
+```python
+from acq4_automation.feature_tracking.interfaces import CellTrackingLost
+```
+
+Replace the `elif` branch of `initializeTracker`:
+
+```python
+        elif not self.updatePosition(
+            feature_radius=feature_radius,
+            force_refresh=force_refresh,
+            # Re-verify re-establishes the baseline rather than continuing a
+            # track. _last_position may be hours stale here, so legitimate
+            # accumulated drift would trip a guard that exists to catch
+            # implausible frame-to-frame jumps. If the features matched at all,
+            # we know where the cell is and track from there.
+            validate_movement=False,
+        ):
+            last = getattr(self._tracker, "last_result", None)
+            reason = getattr(last, "reason_for_failure", None)
+            raise CellTrackingLost(
+                f"Cell moved too much to treat as tracked: {reason}", reason=reason
+            )
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd /home/martin/src/acq4/acq4-automation && /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4_automation/feature_tracking/ -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Mutation-test the bypass assertion**
+
+`test_reverify_bypasses_the_movement_guard` asserts a value that could be trivially already-correct. Prove it is not vacuous:
+
+1. Change `validate_movement=False` back to `validate_movement=True` in `initializeTracker`.
+2. Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4_automation/feature_tracking/test_cell_tracking_lost.py -k bypasses -v`
+3. **Expected: FAIL.** If it passes, the stub is not recording the call and the test proves nothing.
+4. Restore `validate_movement=False`. Re-run: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/martin/src/acq4/acq4-automation && git add acq4_automation/feature_tracking/cell.py acq4_automation/feature_tracking/test_cell_tracking_lost.py && git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "feat: raise CellTrackingLost with the tracker's reason on a failed re-verify"
+```
+
+---
+
+### Task 4: `TrackingLost` orchestration error (acq4)
+
+**Files:**
+- Modify: `acq4/experiment/exceptions.py`
+- Test: `acq4/experiment/tests/test_exceptions.py`
+
+**Interfaces:**
+- Produces: `acq4.experiment.exceptions.TrackingLost(OrchestrationError)`, `typeName = "TrackingLost"`. Tasks 5 and 6 import it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `acq4/experiment/tests/test_exceptions.py`:
+
+```python
+def test_tracking_lost_is_an_orchestration_error():
+    from acq4.experiment.exceptions import OrchestrationError, TrackingLost
+
+    # Routed by the taxonomy, not surfaced as an unexpected bug: a cell the
+    # tracker cannot re-find is a domain condition with a defined response.
+    assert issubclass(TrackingLost, OrchestrationError)
+    assert TrackingLost.typeName == "TrackingLost"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_exceptions.py -v -k tracking_lost
+```
+
+Expected: FAIL, `ImportError: cannot import name 'TrackingLost'`.
+
+- [ ] **Step 3: Add the exception**
+
+In `acq4/experiment/exceptions.py`, after `class NoSolution`:
+
+```python
+class TrackingLost(OrchestrationError):
+    """The cell tracker could not re-find a cell against its reference stacks.
+
+    Deliberately not in ABNORMAL_STATE_EXCEPTIONS: this is not a pipette FSM
+    state, it is what a re-verify reports. Reaching the orchestrator uncaught
+    halts the run, which is the right default wherever no tissue-motion hook is
+    bound to handle it (see ExecutionContext.tissue_moved).
+    """
+
+    typeName = "TrackingLost"
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Same command as Step 2. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/experiment/exceptions.py acq4/experiment/tests/test_exceptions.py && git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "feat: add TrackingLost to the orchestration exception taxonomy"
+```
+
+---
+
+### Task 5: `ctx.tissue_moved()` hook (acq4)
+
+**Files:**
+- Modify: `acq4/experiment/context.py`
+- Test: `acq4/experiment/tests/test_context.py`
+
+**Interfaces:**
+- Consumes: `TrackingLost` (Task 4).
+- Produces:
+  - `ExecutionContext.tissue_moved_hook: Callable[[ExecutionContext, str], None] | None = None` — a field.
+  - `ExecutionContext.tissue_moved(reason: str) -> NoReturn` — a **method**. Never returns normally.
+  - The hook is invoked as `hook(ctx, reason)`. Task 10 binds `partial(window._onTissueMoved, cell)`, so the window's handler signature is `(cell, ctx, reason)`.
+
+**Why a method plus a field, rather than a plain callable field like `log`:** the hook needs the context in order to prompt and to call `ctx.next_cell()`. Storing a `partial` that closes over the context would make the context reference itself — a cycle reclaimable only by the cyclic GC, which is exactly the failure mode Autopatch's deterministic teardown exists to avoid. Passing `self` at call time costs nothing and stores nothing.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `acq4/experiment/tests/test_context.py`:
+
+```python
+def test_tissue_moved_raises_trackinglost_when_no_hook_is_bound():
+    # Headless and in tests there is no window to prompt, so a re-find failure
+    # is the plain error it is and the catch-all halts the run. Safe default.
+    from acq4.experiment.context import ExecutionContext
+    from acq4.experiment.exceptions import TrackingLost
+
+    ctx = ExecutionContext()
+    with pytest.raises(TrackingLost, match="no features"):
+        ctx.tissue_moved("no features")
+
+
+def test_tissue_moved_passes_the_context_and_reason_to_the_hook():
+    from acq4.experiment.context import ExecutionContext
+    from acq4.experiment.exceptions import AdvanceToNextCell
+
+    seen = []
+
+    def hook(ctx, reason):
+        seen.append((ctx, reason))
+        ctx.next_cell()
+
+    ctx = ExecutionContext(tissue_moved_hook=hook)
+    with pytest.raises(AdvanceToNextCell):
+        ctx.tissue_moved("tissue drifted")
+    assert seen == [(ctx, "tissue drifted")]
+
+
+def test_tissue_moved_never_returns_normally_even_if_the_hook_does():
+    # The contract is that this call does not come back. A hook that forgets to
+    # end the cell must not leave the protocol running against a stale
+    # coordinate; falling through to the safe default is what stops that.
+    from acq4.experiment.context import ExecutionContext
+    from acq4.experiment.exceptions import TrackingLost
+
+    ctx = ExecutionContext(tissue_moved_hook=lambda ctx, reason: None)
+    with pytest.raises(TrackingLost):
+        ctx.tissue_moved("hook returned")
+
+
+def test_tissue_moved_hook_is_not_stored_as_a_bound_partial():
+    # A hook closing over the context would make the context reference itself.
+    # Assert the field holds exactly what was passed in.
+    from acq4.experiment.context import ExecutionContext
+
+    def hook(ctx, reason):
+        ctx.next_cell()
+
+    ctx = ExecutionContext(tissue_moved_hook=hook)
+    assert ctx.tissue_moved_hook is hook
+```
+
+Ensure `import pytest` is present at the top of the file.
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_context.py -v -k tissue_moved
+```
+
+Expected: all four FAIL with `TypeError: __init__() got an unexpected keyword argument 'tissue_moved_hook'` or `AttributeError: 'ExecutionContext' object has no attribute 'tissue_moved'`.
+
+- [ ] **Step 3: Add the field and the method**
+
+In `acq4/experiment/context.py`, extend the import:
+
+```python
+from .exceptions import (
+    AbortExperiment,
+    AdvanceToNextCell,
+    FlowSignal,
+    RetryCurrentCell,
+    TrackingLost,
+)
+```
+
+Add the field after `next_cell_requested`:
+
+```python
+    # Supplied by the Autopatch window's context factory: the capability to
+    # react to a cell the tracker could not re-find. Called as hook(ctx, reason)
+    # -- the context is passed at call time rather than bound into the hook,
+    # because a stored closure over this object would make it reference itself,
+    # and a cycle here is only reclaimable by the cyclic GC. The engine holds no
+    # slice knowledge; this is how the window lends it some.
+    tissue_moved_hook: Callable[[Any, str], None] | None = field(
+        default=None, repr=False
+    )
+```
+
+Add the method next to `next_cell`/`retry_cell`/`abort`:
+
+```python
+    def tissue_moved(self, reason: str) -> None:
+        """Report that the tracker could not re-find this cell. Never returns.
+
+        With a hook bound, the window prompts the operator and ends the cell,
+        which leaves this call by way of a FlowSignal. With no hook -- headless,
+        or a context built directly by a test -- a re-find failure is the plain
+        TrackingLost error it is, and the orchestrator's catch-all halts the run.
+
+        The fall-through raise is not dead code: a hook that returns instead of
+        ending the cell would otherwise let the protocol carry on against a
+        coordinate we have just established is stale.
+        """
+        if self.tissue_moved_hook is not None:
+            self.tissue_moved_hook(self, reason)
+        raise TrackingLost(reason)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_context.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/experiment/context.py acq4/experiment/tests/test_context.py && git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "feat: add the tissue_moved hook to ExecutionContext"
+```
+
+---
+
+### Task 6: `cellfie()` translates `CellTrackingLost` (acq4)
+
+**Files:**
+- Modify: `acq4/experiment/actions/device.py` (`cellfie`)
+- Test: `acq4/experiment/tests/test_actions_device.py`
+
+**Interfaces:**
+- Consumes: `CellTrackingLost` (Task 1), `ctx.tissue_moved` (Task 5).
+- Produces: no new names. `cellfie` gains one `try/except`.
+
+The precedent for translating a library exception at the action boundary is `find_surface`, in this same module.
+
+- [ ] **Step 1: Write the failing test**
+
+The existing `test_actions_device.py` has a fake cell with `initializeTracker` (around line 170). Append:
+
+```python
+def test_cellfie_routes_a_lost_cell_to_the_tissue_moved_hook(monkeypatch, tmp_path):
+    from acq4_automation.feature_tracking import CellTrackingLost
+
+    from acq4.experiment.actions.device import cellfie
+    from acq4.experiment.exceptions import AdvanceToNextCell
+
+    seen = []
+
+    def hook(ctx, reason):
+        seen.append(reason)
+        ctx.next_cell()
+
+    ctx = _cellfie_context(monkeypatch, tmp_path, tissue_moved_hook=hook)
+    ctx.cell.tracker_error = CellTrackingLost("lost", reason="no features matched")
+
+    with pytest.raises(AdvanceToNextCell):
+        cellfie(ctx)
+    assert seen == ["no features matched"]
+
+
+def test_cellfie_lets_an_unrelated_valueerror_propagate(monkeypatch, tmp_path):
+    # Only the named class is tissue motion. A bare ValueError out of the
+    # tracker stack is a bug, and classifying it as motion would trigger a
+    # destructive rescan whose prompt defaults to "Rescan".
+    from acq4.experiment.actions.device import cellfie
+
+    called = []
+    ctx = _cellfie_context(
+        monkeypatch, tmp_path, tissue_moved_hook=lambda c, r: called.append(r)
+    )
+    ctx.cell.tracker_error = ValueError("something else entirely")
+
+    with pytest.raises(ValueError, match="something else entirely"):
+        cellfie(ctx)
+    assert called == []
+
+
+def test_cellfie_with_no_hook_raises_trackinglost(monkeypatch, tmp_path):
+    from acq4_automation.feature_tracking import CellTrackingLost
+
+    from acq4.experiment.actions.device import cellfie
+    from acq4.experiment.exceptions import TrackingLost
+
+    ctx = _cellfie_context(monkeypatch, tmp_path)
+    ctx.cell.tracker_error = CellTrackingLost("lost", reason="no features")
+
+    with pytest.raises(TrackingLost):
+        cellfie(ctx)
+```
+
+Add a `_cellfie_context` helper alongside the existing device-test fakes. Follow the file's established fake style; the fake cell's `initializeTracker` must raise `self.tracker_error` when set:
+
+```python
+def _cellfie_context(monkeypatch, tmp_path, tissue_moved_hook=None):
+    """An ExecutionContext wired for cellfie with the z-stack save stubbed out.
+
+    cellfie's imaging is real-hardware work; only its tracker-initialization
+    tail is under test here.
+    """
+    monkeypatch.setattr(
+        "acq4.experiment.actions.device.run_image_sequence",
+        lambda *a, **k: _ImmediateFuture(),
+    )
+    return ExecutionContext(
+        cell=_TrackerFakeCell(),
+        pipette=_CellfieFakePipette(),
+        manager=_FakeManager(tmp_path),
+        tissue_moved_hook=tissue_moved_hook,
+    )
+```
+
+Build `_TrackerFakeCell`, `_CellfieFakePipette`, `_FakeManager`, and `_ImmediateFuture` from the fakes already in this file — reuse them where they exist rather than duplicating. `_TrackerFakeCell.initializeTracker` is:
+
+```python
+    def initializeTracker(self, imager, use_cellpose=False):
+        self.tracker_calls.append((imager, use_cellpose))
+        if self.tracker_error is not None:
+            raise self.tracker_error
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_actions_device.py -v -k cellfie
+```
+
+Expected: the two hook tests FAIL (`CellTrackingLost` propagates uncaught); `test_cellfie_lets_an_unrelated_valueerror_propagate` passes already.
+
+- [ ] **Step 3: Translate at the boundary**
+
+In `acq4/experiment/actions/device.py`, add the import:
+
+```python
+from acq4_automation.feature_tracking import CellTrackingLost
+```
+
+Replace the last line of `cellfie`:
+
+```python
+        # Initialize the tracker reference used to follow the cell during patching.
+        try:
+            ctx.cell.initializeTracker(imager, use_cellpose=True)
+        except CellTrackingLost as exc:
+            # The tracker could not re-find this cell against its own reference
+            # stacks, so the stacks are useless: the cell has drifted out of
+            # reach or died. That is a question about the tissue, not about this
+            # action, and the window is what can answer it. Never returns.
+            ctx.tissue_moved(exc.reason or str(exc))
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_actions_device.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/experiment/actions/device.py acq4/experiment/tests/test_actions_device.py && git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "feat: route a lost cell from cellfie to the tissue-moved hook"
+```
+
+---
+
+### Task 7: `Slice.forceRescan()` (acq4)
+
+**Files:**
+- Modify: `acq4/experiment/slice.py`
+- Test: `acq4/experiment/tests/test_slice.py`
+
+**Interfaces:**
+- Produces: `Slice.forceRescan(position, isAttempted) -> int`.
+  - `position`: an indexable global coordinate; only `[0]` and `[1]` are read, so a `coorx.Point` and a plain tuple both work.
+  - `isAttempted`: `Callable[[cell], bool]`. Task 9 supplies `CellPanel.isAttempted`.
+  - Returns the number of tiles un-covered. Tasks 10 and its tests use the count.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `acq4/experiment/tests/test_slice.py`:
+
+```python
+class _PositionedCell:
+    """A stand-in for acq4_automation's Cell: a position is all Slice reads."""
+
+    def __init__(self, position):
+        self.position = position
+
+
+def _two_region_slice():
+    """A slice with two well-separated regions at realistic stage coordinates.
+
+    Deliberately not at the origin, and deliberately not square: a symmetric
+    fixture cannot test an asymmetric mapping, and origin-centred geometry
+    cannot see coordinate-magnitude float error.
+    """
+    s = Slice(fov=(20e-6, 10e-6))
+    s.addRegion(RectRegion(1e-3, 2e-3, 1e-3 + 60e-6, 2e-3 + 30e-6))
+    s.addRegion(RectRegion(5e-3, 7e-3, 5e-3 + 60e-6, 7e-3 + 30e-6))
+    return s
+
+
+def test_force_rescan_uncovers_only_the_region_holding_the_position():
+    s = _two_region_slice()
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+    covered_before = len(s.coveredTiles)
+
+    uncovered = s.forceRescan((1e-3 + 30e-6, 2e-3 + 15e-6), lambda cell: False)
+
+    assert uncovered > 0
+    remaining = s.coveredTiles
+    assert len(remaining) == covered_before - uncovered
+    # Every surviving covered tile belongs to the far region.
+    far = s.regions[1]
+    assert all(far.overlapsTile(t, (20e-6, 10e-6)) for t in remaining)
+
+
+def test_force_rescan_outside_every_region_is_a_no_op():
+    # A hand-seeded cell outside every drawn region has no coverage to
+    # invalidate; hand-added cells are outside the scanner's responsibility.
+    s = _two_region_slice()
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+    before = list(s.coveredTiles)
+
+    assert s.forceRescan((9e-3, 9e-3), lambda cell: False) == 0
+    assert s.coveredTiles == before
+
+
+def test_force_rescan_deregisters_only_never_attempted_cells():
+    s = _two_region_slice()
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+    tile = s.tileGrid()[0]
+    attempted = _PositionedCell((tile[0], tile[1], -30e-6))
+    fresh = _PositionedCell((tile[0], tile[1], -35e-6))
+    s.registerCells([attempted, fresh])
+
+    s.forceRescan(tile, lambda cell: cell is attempted)
+
+    near = s.cellsNearTile(tile)
+    assert attempted in near
+    assert fresh not in near
+
+
+def test_force_rescan_leaves_cells_in_untouched_regions_registered():
+    s = _two_region_slice()
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+    far_tile = [t for t in s.tileGrid() if t[0] > 4e-3][0]
+    far_cell = _PositionedCell((far_tile[0], far_tile[1], -30e-6))
+    s.registerCells([far_cell])
+
+    s.forceRescan((1e-3 + 30e-6, 2e-3 + 15e-6), lambda cell: False)
+
+    assert far_cell in s.cellsNearTile(far_tile)
+
+
+def test_force_rescan_does_not_touch_regions_or_constraints():
+    s = _two_region_slice()
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+    regions_before = s.regions
+    constraints_before = s.constraints
+
+    s.forceRescan((1e-3 + 30e-6, 2e-3 + 15e-6), lambda cell: False)
+
+    assert s.regions == regions_before
+    assert s.constraints is constraints_before
+
+
+def test_force_rescan_uncovers_every_overlapping_region():
+    # Overlapping regions both hold the position, so both must be re-imaged.
+    s = Slice(fov=(20e-6, 10e-6))
+    s.addRegion(RectRegion(1e-3, 2e-3, 1e-3 + 60e-6, 2e-3 + 30e-6))
+    s.addRegion(RectRegion(1e-3 + 20e-6, 2e-3, 1e-3 + 80e-6, 2e-3 + 30e-6))
+    for tile in s.tileGrid():
+        s.markCovered(tile)
+
+    s.forceRescan((1e-3 + 30e-6, 2e-3 + 15e-6), lambda cell: False)
+
+    assert s.coveredTiles == []
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -v -k force_rescan
+```
+
+Expected: all FAIL with `AttributeError: 'Slice' object has no attribute 'forceRescan'`.
+
+- [ ] **Step 3: Implement**
+
+In `acq4/experiment/slice.py`, add after `resetCoverage`:
+
+```python
+    def forceRescan(self, position, isAttempted) -> int:
+        """Re-open the region(s) around `position` for imaging. Returns tiles freed.
+
+        The response to the tracker losing a cell: the coordinates around it are
+        no longer trustworthy, so the coverage record claiming that ground was
+        already searched has to go, and the cells found there have to be
+        rediscovered where they actually are now.
+
+        Scoped to the region(s) the position falls in, not the whole slice. An
+        operator working through their third region should not pay to re-image
+        the two they finished, and re-imaging a finished region is also a chance
+        to re-detect and re-patch cells already dealt with.
+
+        The cost of that scoping, deliberately accepted: tissue motion is global,
+        while this treats it as local. If the slice genuinely shifted, finished
+        regions are stale too and are not re-imaged here. That is the right
+        trade for settling, drift, and swelling -- motion small relative to a
+        region -- and the wrong one for a slice that was physically bumped, where
+        the tool is New slice rather than a rescan. Nothing here can tell those
+        two cases apart.
+
+        `isAttempted` decides which cells survive. Attempted cells stay
+        registered at their old positions -- near enough, since the motion is
+        small -- so they keep counting toward the density cap and the rescan is
+        less likely to resurface a cell already worked. Never-attempted cells are
+        dropped so their tiles can come back uncrowded and be found again where
+        they now are. The predicate is a parameter because attempted-ness is
+        orchestration state held by the UI, not something a slice can know.
+
+        A position inside no region frees nothing: a hand-seeded cell was never
+        part of the survey, so there is no coverage of it to invalidate.
+        """
+        here = [r for r in self._regions if r.overlapsTile(position, self._fov)]
+        if not here:
+            return 0
+        stale = [
+            t
+            for t in self._covered
+            if any(r.overlapsTile(t, self._fov) for r in here)
+        ]
+        if not stale:
+            return 0
+        drop = set()
+        for tile in stale:
+            for cell in self.cellsNearTile(tile):
+                if not isAttempted(cell):
+                    drop.add(id(cell))
+        self._cells = [c for c in self._cells if id(c) not in drop]
+        staleIds = {id(t) for t in stale}
+        self._covered = [t for t in self._covered if id(t) not in staleIds]
+        return len(stale)
+```
+
+**Note on the identity filter:** `stale` holds the very tuple objects that are in `self._covered`, so filtering by `id()` removes exactly those and cannot accidentally drop an equal-valued tile from another region. Do not rewrite this as a value comparison.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Mutation-test the two absence assertions**
+
+`test_force_rescan_deregisters_only_never_attempted_cells` and `test_force_rescan_leaves_cells_in_untouched_regions_registered` both assert something is *absent* or *unchanged*, and would pass against broken code if the fixture never reaches the distinguishing state.
+
+For each, apply the defect, confirm the test fails, then restore:
+
+1. Replace `if not isAttempted(cell)` with `if True` — run `-k deregisters`. **Expected FAIL** (the attempted cell is dropped too). Restore.
+2. Replace `here = [...]` with `here = list(self._regions)` — run `-k untouched_regions`. **Expected FAIL** (the far region's cell is dropped). Restore.
+3. Re-run the full file: all pass.
+
+If either mutant passes, the test is vacuous — fix the fixture before continuing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add acq4/experiment/slice.py acq4/experiment/tests/test_slice.py && git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "feat: add region-scoped Slice.forceRescan for a moved slice"
+```
+
+---
+
+### Task 8: `Orchestrator.clearProducerExhausted()` (acq4)
+
+**Files:**
+- Modify: `acq4/experiment/orchestrator.py`
+- Test: `acq4/experiment/tests/test_orchestrator_producer.py`
+
+**Interfaces:**
+- Produces: `Orchestrator.clearProducerExhausted() -> None`. `setCellProducer` calls it. Task 10 calls it directly.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `acq4/experiment/tests/test_orchestrator_producer.py`, following the file's existing fixture style:
+
+```python
+def test_clear_producer_exhausted_lets_an_exhausted_producer_be_asked_again():
+    # A producer that reported exhaustion is never asked again for the rest of
+    # the run. After a forced rescan there are uncovered tiles once more, so the
+    # flag has to be cleared or the loop ends on a queue the producer could
+    # have refilled.
+    orch = Orchestrator()
+    orch.setCellProducer(lambda: None)
+    orch._producerExhausted = True
+
+    orch.clearProducerExhausted()
+
+    assert orch._producerExhausted is False
+    assert orch._shouldRefill() is True
+
+
+def test_set_cell_producer_still_clears_exhaustion():
+    # The extraction must not move behaviour off setCellProducer, which existing
+    # callers rely on.
+    orch = Orchestrator()
+    orch._producerExhausted = True
+    orch.setCellProducer(lambda: [])
+    assert orch._producerExhausted is False
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_orchestrator_producer.py -v -k producer_exhausted
+```
+
+Expected: the first FAILS with `AttributeError: 'Orchestrator' object has no attribute 'clearProducerExhausted'`; the second passes.
+
+- [ ] **Step 3: Extract the method**
+
+In `acq4/experiment/orchestrator.py`, add next to `setCellProducer`:
+
+```python
+    def clearProducerExhausted(self) -> None:
+        """Ask the producer again, even though it already reported exhaustion.
+
+        The flag is a per-run cache of "there is nothing left to find". Anything
+        that puts uncovered tiles back on the slice -- installing a producer, or
+        a forced rescan after the tissue moved -- invalidates it, and leaving it
+        set ends the run on a queue that could have been refilled.
+        """
+        self._producerExhausted = False
+```
+
+and change `setCellProducer`'s body to use it:
+
+```python
+        self._cellProducer = producer
+        self.clearProducerExhausted()
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_orchestrator_producer.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/experiment/orchestrator.py acq4/experiment/tests/test_orchestrator_producer.py && git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "refactor: extract clearProducerExhausted from setCellProducer"
+```
+
+---
+
+### Task 9: `CellPanel` tracks which cells were attempted (acq4)
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/cell_panel.py`
+- Test: `acq4/modules/Autopatch/tests/test_cell_panel.py`
+
+**Interfaces:**
+- Produces: `CellPanel.isAttempted(cell) -> bool`. Task 7's `forceRescan` takes this as its predicate; Task 10 passes it.
+
+**Definition:** a cell is *attempted* once the orchestrator has started work on it — recorded from **both** `sigCurrentCell` and `sigCellFinished`. Both, not just the latter: a cell interrupted mid-run may never emit a terminal status, and `retry` is emitted mid-flight without being terminal. Asking "has work started" avoids re-deriving the terminal-status list, which the reuse-completed-cells spec still owes.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `acq4/modules/Autopatch/tests/test_cell_panel.py`, matching the file's existing panel/orchestrator fixture style:
+
+```python
+def test_a_queued_cell_is_not_attempted(qapp):
+    panel = CellPanel()
+    cell = _makeCell()
+    panel.addCell(cell)
+    assert panel.isAttempted(cell) is False
+
+
+def test_a_running_cell_is_attempted(qapp):
+    # A cell interrupted mid-run may never emit a terminal status, so starting
+    # work on it -- not finishing -- is what marks it.
+    panel = CellPanel()
+    cell = _makeCell()
+    panel.addCell(cell)
+    panel._onCurrentCell(cell)
+    assert panel.isAttempted(cell) is True
+
+
+def test_a_finished_cell_is_attempted(qapp):
+    panel = CellPanel()
+    cell = _makeCell()
+    panel.addCell(cell)
+    panel._onCellFinished(cell, "done")
+    assert panel.isAttempted(cell) is True
+
+
+def test_a_cell_finished_without_ever_being_current_is_attempted(qapp):
+    # Orchestrator._processCell can emit "skipped" without sigCurrentCell ever
+    # firing for that cell.
+    panel = CellPanel()
+    cell = _makeCell()
+    panel._onCellFinished(cell, "skipped")
+    assert panel.isAttempted(cell) is True
+
+
+def test_a_none_current_cell_does_not_crash_or_mark_anything(qapp):
+    panel = CellPanel()
+    panel._onCurrentCell(None)
+    assert panel.isAttempted(None) is False
+
+
+def test_clear_cells_forgets_the_attempted_set(qapp):
+    # Left behind, a stale id would report a brand-new cell at a reused memory
+    # address as already attempted -- the same hazard _awaitingEnqueue is
+    # cleared for.
+    panel = CellPanel()
+    cell = _makeCell()
+    panel.addCell(cell)
+    panel._onCellFinished(cell, "done")
+    panel.clearCells()
+    assert panel.isAttempted(cell) is False
+```
+
+Use the file's existing helper for building a `Cell` (`_makeCell` or equivalent) and its existing `qapp` fixture rather than introducing new ones.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_cell_panel.py -v -k attempted
+```
+
+Expected: FAIL with `AttributeError: 'CellPanel' object has no attribute 'isAttempted'`.
+
+- [ ] **Step 3: Implement**
+
+In `CellPanel.__init__`, alongside the other per-cell stores:
+
+```python
+        # Cells the orchestrator has started work on, by id. Recorded from both
+        # sigCurrentCell and sigCellFinished: a cell interrupted mid-run may
+        # never emit a terminal status, and "retry" is emitted mid-flight
+        # without being terminal, so "has work started" is the reliable question
+        # and does not depend on the terminal-status vocabulary.
+        #
+        # Holds ids, never cells: this panel must not be the thing keeping a
+        # Cell alive beyond self._cells, and must not add a second store to keep
+        # in sync with it on teardown.
+        self._attempted = set()
+```
+
+In `_onCurrentCell`, after the `if cell is None: return` guard:
+
+```python
+        self._attempted.add(id(cell))
+```
+
+At the top of `_onCellFinished`:
+
+```python
+        self._attempted.add(id(cell))
+```
+
+Add the accessor next to the other public panel methods:
+
+```python
+    def isAttempted(self, cell) -> bool:
+        """Whether the orchestrator has ever started work on `cell`.
+
+        Slice.forceRescan takes this as its predicate: attempted cells stay
+        registered in the density record through a rescan, never-attempted ones
+        are dropped so they can be found again where they now are.
+        """
+        return id(cell) in self._attempted
+```
+
+In `clearCells`, alongside the other `.clear()` calls:
+
+```python
+        self._attempted.clear()
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_cell_panel.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Mutation-test the negative assertions**
+
+`test_a_queued_cell_is_not_attempted` and `test_clear_cells_forgets_the_attempted_set` both assert `False`, which is also what a permanently-empty set returns.
+
+1. Make `isAttempted` `return True`. Run `-k attempted`. **Expected: both negative tests FAIL.** Restore.
+2. Remove `self._attempted.clear()` from `clearCells`. Run `-k clear_cells_forgets`. **Expected: FAIL.** Restore.
+3. Re-run: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add acq4/modules/Autopatch/cell_panel.py acq4/modules/Autopatch/tests/test_cell_panel.py && git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "feat: track which cells the orchestrator has attempted"
+```
+
+---
+
+### Task 10: Wire the window's tissue-moved handler (acq4)
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/context_factory.py`
+- Modify: `acq4/modules/Autopatch/Autopatch.py`
+- Test: `acq4/modules/Autopatch/tests/test_context_factory.py`
+- Test: `acq4/modules/Autopatch/tests/test_window_integration.py`
+
+**Interfaces:**
+- Consumes: `ctx.tissue_moved_hook` (Task 5), `Slice.forceRescan` (Task 7), `Orchestrator.clearProducerExhausted` (Task 8), `CellPanel.isAttempted` (Task 9).
+- Produces:
+  - `make_context_factory(pipetteGetter, manager, log=None, onLogAction=None, tissueMoved=None)` — binds `partial(tissueMoved, cell)`, so the hook is called as `tissueMoved(cell, ctx, reason)`.
+  - `AutopatchWindow._onTissueMoved(cell, ctx, reason) -> None`.
+
+- [ ] **Step 1: Write the failing context-factory test**
+
+Append to `acq4/modules/Autopatch/tests/test_context_factory.py`:
+
+```python
+def test_tissue_moved_hook_is_bound_per_cell():
+    seen = []
+    factory = make_context_factory(
+        pipetteGetter=lambda: None,
+        manager=None,
+        tissueMoved=lambda cell, ctx, reason: seen.append((cell, reason)),
+    )
+    cell = object()
+    ctx = factory(cell)
+    ctx.tissue_moved_hook(ctx, "drifted")
+    assert seen == [(cell, "drifted")]
+
+
+def test_no_tissue_moved_hook_leaves_the_context_on_its_safe_default():
+    factory = make_context_factory(pipetteGetter=lambda: None, manager=None)
+    assert factory(object()).tissue_moved_hook is None
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_context_factory.py -v -k tissue_moved
+```
+
+Expected: FAIL, `TypeError: make_context_factory() got an unexpected keyword argument 'tissueMoved'`.
+
+- [ ] **Step 3: Bind the hook in the factory**
+
+In `acq4/modules/Autopatch/context_factory.py`, add the parameter and the binding:
+
+```python
+def make_context_factory(
+    pipetteGetter: Callable[[], object],
+    manager,
+    log: Callable[[object, str], None] | None = None,
+    onLogAction: Callable[[object, object], None] | None = None,
+    tissueMoved: Callable[[object, object, str], None] | None = None,
+) -> Callable[[object], ExecutionContext]:
+```
+
+inside `_factory`, before the `return`:
+
+```python
+        if tissueMoved is not None:
+            # Only the cell is bound in. ExecutionContext.tissue_moved passes
+            # itself at call time, so the context is never captured in a closure
+            # it also owns -- that would be a self-reference the cyclic GC alone
+            # could break.
+            kwargs["tissue_moved_hook"] = partial(tissueMoved, cell)
+```
+
+- [ ] **Step 4: Run it to verify it passes**
+
+Same command as Step 2. Expected: PASS.
+
+- [ ] **Step 5: Write the failing window test**
+
+Append to `acq4/modules/Autopatch/tests/test_window_integration.py`, using that file's existing window fixture:
+
+```python
+def test_tissue_moved_rescans_and_clears_the_queue_on_the_first_answer(win, monkeypatch):
+    monkeypatch.setattr(
+        "acq4.modules.Autopatch.Autopatch.prompt",
+        lambda ctx, **kw: "Rescan the slice",
+    )
+    slice_, cell, ctx = _sliceWithCoveredTiles(win)
+
+    with pytest.raises(AdvanceToNextCell):
+        win._onTissueMoved(cell, ctx, "no features")
+
+    assert slice_.coveredTiles == []
+    assert win.orchestrator.pendingCells() == []
+    assert win.orchestrator._producerExhausted is False
+
+
+def test_tissue_moved_leaves_everything_alone_on_the_second_answer(win, monkeypatch):
+    monkeypatch.setattr(
+        "acq4.modules.Autopatch.Autopatch.prompt",
+        lambda ctx, **kw: "Skip this cell only",
+    )
+    slice_, cell, ctx = _sliceWithCoveredTiles(win)
+    coveredBefore = list(slice_.coveredTiles)
+    pendingBefore = win.orchestrator.pendingCells()
+
+    with pytest.raises(AdvanceToNextCell):
+        win._onTissueMoved(cell, ctx, "no features")
+
+    assert slice_.coveredTiles == coveredBefore
+    assert win.orchestrator.pendingCells() == pendingBefore
+
+
+def test_tissue_moved_ends_the_cell_on_both_answers(win, monkeypatch):
+    for answer in ("Rescan the slice", "Skip this cell only"):
+        monkeypatch.setattr(
+            "acq4.modules.Autopatch.Autopatch.prompt", lambda ctx, **kw: answer
+        )
+        _slice, cell, ctx = _sliceWithCoveredTiles(win)
+        with pytest.raises(AdvanceToNextCell):
+            win._onTissueMoved(cell, ctx, "no features")
+
+
+def test_tissue_moved_keeps_attempted_cells_in_the_density_record(win, monkeypatch):
+    monkeypatch.setattr(
+        "acq4.modules.Autopatch.Autopatch.prompt",
+        lambda ctx, **kw: "Rescan the slice",
+    )
+    slice_, cell, ctx = _sliceWithCoveredTiles(win)
+    tile = slice_.tileGrid()[0]
+    win.cellPanel._onCellFinished(cell, "done")
+    slice_.registerCells([cell])
+
+    with pytest.raises(AdvanceToNextCell):
+        win._onTissueMoved(cell, ctx, "no features")
+
+    assert cell in slice_.cellsNearTile(tile)
+```
+
+Write `_sliceWithCoveredTiles(win)` as a module-level helper in that file: install a `Slice` on `win` with one region at a realistic, non-square stage coordinate, mark every tile covered, seed one cell positioned inside the first tile, enqueue a second cell on the orchestrator, and return `(slice, cell, ExecutionContext(cell=cell))`. Reuse the file's existing slice/orchestrator setup helpers where they exist.
+
+- [ ] **Step 6: Run it to verify it fails**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py -v -k tissue_moved
+```
+
+Expected: FAIL with `AttributeError: 'AutopatchWindow' object has no attribute '_onTissueMoved'`.
+
+- [ ] **Step 7: Implement the handler**
+
+In `acq4/modules/Autopatch/Autopatch.py`, add the import:
+
+```python
+from acq4.experiment.actions.prompt import prompt
+```
+
+Add the handler next to the other slice methods:
+
+```python
+    def _onTissueMoved(self, cell, ctx, reason: str) -> None:
+        """ExecutionContext.tissue_moved, cell-bound by the context factory.
+
+        Runs on the orchestrator's worker thread, mid-cell. Never returns: both
+        answers end the cell.
+
+        The operator decides, because a rescan is destructive in its own way --
+        it re-images ground already searched and can re-detect cells already
+        worked. "Rescan the slice" is offered first and is therefore what a
+        headless run picks: driving a pipette to a coordinate known to be stale
+        is a hardware risk, while patching a cell twice is a data-hygiene cost,
+        so the cheaper mistake goes first.
+        """
+        pending = len(self.orchestrator.pendingCells()) if self.orchestrator else 0
+        answer = prompt(
+            ctx,
+            message=(
+                f"Cell tracking could not re-find this cell ({reason}).\n"
+                "The tissue may have moved. Rescanning discards the "
+                f"{pending} cell(s) still queued and re-images this region; "
+                "cells already patched may be found again."
+            ),
+            title="Tissue may have moved",
+            choices=("Rescan the slice", "Skip this cell only"),
+        )
+        if answer == "Rescan the slice":
+            if self.slice is not None:
+                self.slice.forceRescan(cell.position, self.cellPanel.isAttempted)
+            if self.orchestrator is not None:
+                # After the answer, not before: a cell the operator seeds by hand
+                # while the prompt is open is a coordinate in the same moved
+                # tissue and goes with the rest.
+                self.orchestrator.clearQueue()
+                self.orchestrator.clearProducerExhausted()
+        # Area 2's survey readout is deliberately not refreshed here: this is the
+        # worker thread, and _refreshSurveyStats touches widgets. The next status
+        # change routes through _onRunStatus on the GUI thread and picks it up.
+        ctx.next_cell()
+```
+
+Wire the factory in `_onProtocolLoaded` (or wherever `make_context_factory` is currently called) by adding:
+
+```python
+            tissueMoved=self._onTissueMoved,
+```
+
+- [ ] **Step 8: Run the tests to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 9: Confirm teardown still frees the graph**
+
+The new hook adds a window-to-context edge. `test_teardown.py` exists to catch exactly this.
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_teardown.py -q
+```
+
+Expected: all pass. If a weakref test now fails, the hook is being stored somewhere it closes over the context — revisit Step 3.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add acq4/modules/Autopatch/context_factory.py acq4/modules/Autopatch/Autopatch.py acq4/modules/Autopatch/tests/test_context_factory.py acq4/modules/Autopatch/tests/test_window_integration.py && git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "feat: prompt and rescan when the tracker loses a cell"
+```
+
+---
+
+## Piece B - New slice creates a Data Manager directory
+
+### Task 11: Extract `create_data_dir()` (acq4)
+
+**Files:**
+- Modify: `acq4/experiment/actions/storage.py`
+- Test: `acq4/experiment/tests/test_actions_prompt_storage.py`
+
+**Interfaces:**
+- Produces: `create_data_dir(manager, level="Cell", set_current=True)` returning the created `DirHandle`. `new_data_dir(ctx, ...)` becomes its `ctx.log_action()` wrapper. Task 12 calls `create_data_dir`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `acq4/experiment/tests/test_actions_prompt_storage.py`, reusing that file's existing fake manager:
+
+```python
+def test_create_data_dir_needs_no_context(tmp_path):
+    # A UI button has no run and no ExecutionContext, and must not fabricate one
+    # to reach engine logic.
+    from acq4.experiment.actions.storage import create_data_dir
+
+    man = _FakeManager(tmp_path)
+    created = create_data_dir(man, level="Slice")
+
+    assert created.info()["dirType"] == "Slice"
+    assert man.getCurrentDir() is created
+
+
+def test_create_data_dir_can_leave_the_current_dir_alone(tmp_path):
+    from acq4.experiment.actions.storage import create_data_dir
+
+    man = _FakeManager(tmp_path)
+    before = man.getCurrentDir()
+    created = create_data_dir(man, level="Slice", set_current=False)
+
+    assert created is not before
+    assert man.getCurrentDir() is before
+
+
+def test_new_data_dir_still_behaves_identically_through_the_wrapper(tmp_path):
+    # The action keeps its log_action wrapper and its behaviour; only the body
+    # moved.
+    from acq4.experiment.actions.storage import new_data_dir
+
+    entries = []
+    ctx = ExecutionContext(
+        manager=_FakeManager(tmp_path), on_log_action=entries.append
+    )
+    created = new_data_dir(ctx, level="Slice")
+
+    assert created.info()["dirType"] == "Slice"
+    assert [e.name for e in entries] == ["New Data Directory"]
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_actions_prompt_storage.py -v -k create_data_dir
+```
+
+Expected: FAIL, `ImportError: cannot import name 'create_data_dir'`.
+
+- [ ] **Step 3: Extract the body**
+
+Rewrite `acq4/experiment/actions/storage.py` so the whole existing body of `new_data_dir` — unchanged apart from `ctx.manager` becoming the `manager` parameter — lives in `create_data_dir`, and the action wraps it:
+
+```python
+"""Storage protocol function: create managed data directories for an experiment
+run, and the manager-only helper a UI button can call without a run."""
+from __future__ import annotations
+
+import time
+
+
+def create_data_dir(manager, level: str = "Cell", set_current: bool = True):
+    """Create a new managed data directory of a given type ("level") under the
+    current storage directory and (by default) make it current. Returns the
+    created directory.
+
+    Mirrors the non-GUI logic of DataManagerModule.createNewFolder: for a typed
+    level the parent is chosen by walking up the tree so a directory is not
+    nested inside another of the same type. The special level "Folder" makes an
+    untyped "NewFolder" under the current directory.
+
+    Takes a manager rather than an ExecutionContext so that both a protocol
+    action and an operator's button can call it. Autopatch's New slice is a
+    click with no run in progress, and a UI button must not have to fabricate a
+    context to reach engine logic.
+    """
+    cdir = manager.getCurrentDir()
+    if not cdir.isManaged():
+        cdir.createIndex()
+    if level == "Folder":
+        new_dir = cdir.mkdir("NewFolder", autoIncrement=True)
+        new_dir.setInfo({})
+    else:
+        spec = manager.folderTypesConfig()[level]
+        name = time.strftime(spec["name"])
+        # Walk up to avoid nesting a directory inside one of the same type.
+        parent = cdir
+        check_dir = cdir
+        for _ in range(5):
+            if not check_dir.isManaged():
+                break
+            if check_dir.info().get("dirType") == level:
+                parent = check_dir.parent()
+                break
+            check_dir = check_dir.parent()
+        new_dir = parent.mkdir(name, autoIncrement=True)
+        info = {"dirType": level}
+        if spec.get("experimentalUnit", False):
+            info["expUnit"] = True
+        new_dir.setInfo(info)
+    if set_current:
+        manager.setCurrentDir(new_dir)
+    return new_dir
+
+
+def new_data_dir(ctx, level: str = "Cell", set_current: bool = True):
+    """Create a new managed data directory for this run and report it to the UI.
+
+    The protocol-facing wrapper around create_data_dir: same behaviour, plus the
+    log_action entry that puts it in Area 5's timeline.
+    """
+    with ctx.log_action("New Data Directory"):
+        return create_data_dir(ctx.manager, level=level, set_current=set_current)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_actions_prompt_storage.py -q
+```
+
+Expected: all pass, including the pre-existing `new_data_dir` tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/experiment/actions/storage.py acq4/experiment/tests/test_actions_prompt_storage.py && git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "refactor: extract create_data_dir so a UI button needs no context"
+```
+
+---
+
+### Task 12: `newSlice()` creates the slice directory (acq4)
+
+**Files:**
+- Modify: `acq4/experiment/slice.py` (`__init__`)
+- Modify: `acq4/modules/Autopatch/Autopatch.py` (`newSlice`)
+- Test: `acq4/experiment/tests/test_slice.py`
+- Test: `acq4/modules/Autopatch/tests/test_window_integration.py`
+
+**Interfaces:**
+- Consumes: `create_data_dir` (Task 11).
+- Produces: `Slice(fov, constraints=None, overlap=0.0, dirHandle=None)` with a `dirHandle` attribute.
+
+- [ ] **Step 1: Write the failing Slice test**
+
+Append to `acq4/experiment/tests/test_slice.py`:
+
+```python
+def test_slice_holds_its_data_directory():
+    handle = object()
+    assert Slice(fov=(20e-6, 10e-6), dirHandle=handle).dirHandle is handle
+
+
+def test_slice_without_a_data_directory_is_valid():
+    # A slice created implicitly by "Add region here" was never formally started
+    # and honestly has no directory.
+    assert Slice(fov=(20e-6, 10e-6)).dirHandle is None
+```
+
+- [ ] **Step 2: Run to verify it fails, then implement**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -v -k data_directory
+```
+
+Expected: FAIL, `TypeError: __init__() got an unexpected keyword argument 'dirHandle'`.
+
+In `Slice.__init__`, add the parameter and attribute:
+
+```python
+    def __init__(self, fov, constraints=None, overlap=0.0, dirHandle=None):
+```
+
+```python
+        # The Data Manager directory this slice's data is written under, or None
+        # for a slice that came into existence to hold a region rather than by
+        # way of New slice. The handle is also what a later change would call
+        # setInfo()/info() on to persist regions and coverage.
+        self.dirHandle = dirHandle
+```
+
+Re-run: PASS.
+
+- [ ] **Step 3: Write the failing window tests**
+
+Append to `acq4/modules/Autopatch/tests/test_window_integration.py`:
+
+```python
+def test_new_slice_creates_a_slice_directory_and_makes_it_current(win):
+    win.newSlice()
+    assert win.slice.dirHandle is not None
+    assert win.slice.dirHandle.info()["dirType"] == "Slice"
+    assert win.manager.getCurrentDir() is win.slice.dirHandle
+
+
+def test_new_slice_discards_nothing_when_the_directory_cannot_be_made(win):
+    # Create the directory first, discard only on success: a failure that has
+    # already thrown away the operator's cells is worse than the failure.
+    from acq4.util.debug import HelpfulException
+
+    oldSlice = win.slice
+    cell = _makeCell()
+    win.cellPanel.addCell(cell)
+    win.orchestrator.enqueue(cell)
+
+    def boom(*a, **k):
+        raise HelpfulException("Storage directory has not been set.")
+
+    win.manager.getCurrentDir = boom
+    win.newSlice()
+
+    assert win.slice is oldSlice
+    assert win.cellPanel.isAttempted(cell) is False
+    assert win.orchestrator.pendingCells() == [cell]
+
+
+def test_new_slice_reports_a_missing_storage_directory_in_area_2(win):
+    from acq4.util.debug import HelpfulException
+
+    def boom(*a, **k):
+        raise HelpfulException("Storage directory has not been set.")
+
+    win.manager.getCurrentDir = boom
+    win.newSlice()
+
+    assert "Storage directory" in win.searchPanel.errorLabel.text()
+
+
+def test_add_region_here_does_not_create_a_directory(win):
+    # A button labelled "add region" must not silently repoint where every
+    # subsequent write lands.
+    win.addRegionHere()
+    assert win.slice.dirHandle is None
+```
+
+- [ ] **Step 4: Run to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py -v -k "new_slice or add_region_here"
+```
+
+Expected: the directory tests FAIL (`dirHandle` is `None`).
+
+- [ ] **Step 5: Implement**
+
+In `Autopatch.py`, add the import:
+
+```python
+from acq4.experiment.actions.storage import create_data_dir
+```
+
+Rewrite `newSlice`, keeping the existing docstring and adding the directory paragraph:
+
+```python
+    def newSlice(self) -> None:
+        """Start a fresh slice, discarding the current one and everything on it.
+
+        [keep the existing docstring body verbatim, then add:]
+
+        The slice directory is created before anything is discarded. Creating it
+        is the step that can fail -- an operator who has not chosen a storage
+        directory is the likeliest first use of this button -- and a failure that
+        has already thrown away their cells is worse than the failure itself.
+        """
+        try:
+            dirHandle = create_data_dir(self.manager, level="Slice")
+        except Exception as exc:
+            # Area 3's instruction band does not exist yet, so this goes where
+            # the operator already reads "Select a camera before starting a
+            # slice".
+            self.searchPanel.setError(str(exc))
+            return
+        if not self._startSlice(dirHandle=dirHandle):
+            return
+        self.cellPanel.clearCells()
+        if self.orchestrator is not None:
+            # [keep the existing comments and both calls verbatim]
+            self.orchestrator.setCellProducer(None)
+            self.orchestrator.clearQueue()
+        self._refreshSurveyStats()
+```
+
+Give `_startSlice` the pass-through parameter, leaving its docstring's existing reasoning intact and adding a line for the new argument:
+
+```python
+    def _startSlice(self, dirHandle=None) -> bool:
+```
+
+```python
+        self.slice = Slice(
+            fov=self._cameraFov(camera), constraints=constraints, dirHandle=dirHandle
+        )
+```
+
+`addRegionHere()`'s existing call stays `self._startSlice()`, which is what leaves its implicit slice with no directory.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests -q
+```
+
+Expected: all pass. The window fixture's fake manager may need `folderTypesConfig()` to include a `Slice` entry — add it there rather than special-casing production code.
+
+- [ ] **Step 7: Mutation-test the "discards nothing" assertion**
+
+It asserts state is *unchanged*, which is also true if the fixture never had that state.
+
+1. Move the `create_data_dir` call to *after* `self.cellPanel.clearCells()`.
+2. Run `-k discards_nothing`. **Expected: FAIL** — the cell is gone.
+3. Restore. Re-run: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add acq4/experiment/slice.py acq4/modules/Autopatch/Autopatch.py acq4/experiment/tests/test_slice.py acq4/modules/Autopatch/tests/test_window_integration.py && git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "feat: create a Slice data directory when the operator starts a slice"
+```
+
+---
+
+### Task 13: Gate Area 2 on a slice existing (acq4)
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/search_panel.py`
+- Modify: `acq4/modules/Autopatch/Autopatch.py`
+- Test: `acq4/modules/Autopatch/tests/test_search_panel.py`
+- Test: `acq4/modules/Autopatch/tests/test_window_integration.py`
+
+**Interfaces:**
+- Produces: `SearchPanel.setSliceReady(ready: bool) -> None`. `setInteractionLocked` keeps its existing signature and its existing signal wiring.
+
+**The hazard:** `setInteractionLocked` currently has exactly one writer, `statusPanel.sigInteractionLocked`. Adding "no slice yet" as a second reason to be locked would let a run finishing unlock a panel with no slice behind it. The two reasons are therefore stored separately and the effective lock derived from both.
+
+- [ ] **Step 1: Write the failing test — all four corners**
+
+Append to `acq4/modules/Autopatch/tests/test_search_panel.py`:
+
+```python
+def _controls(panel):
+    return (
+        panel.nearDepthSpin,
+        panel.farDepthSpin,
+        panel.minHealthSpin,
+        panel.maxDensitySpin,
+        panel.rescansCheck,
+        panel.addRegionBtn,
+        panel.shapeCombo,
+    )
+
+
+def test_locked_when_no_slice_and_not_running(qapp):
+    panel = SearchPanel()
+    panel.setSliceReady(False)
+    panel.setInteractionLocked(False)
+    assert all(not w.isEnabled() for w in _controls(panel))
+
+
+def test_locked_when_no_slice_and_running(qapp):
+    panel = SearchPanel()
+    panel.setSliceReady(False)
+    panel.setInteractionLocked(True)
+    assert all(not w.isEnabled() for w in _controls(panel))
+
+
+def test_locked_when_slice_ready_but_running(qapp):
+    panel = SearchPanel()
+    panel.setSliceReady(True)
+    panel.setInteractionLocked(True)
+    assert all(not w.isEnabled() for w in _controls(panel))
+
+
+def test_unlocked_only_when_slice_ready_and_not_running(qapp):
+    panel = SearchPanel()
+    panel.setSliceReady(True)
+    panel.setInteractionLocked(False)
+    assert all(w.isEnabled() for w in _controls(panel))
+
+
+def test_a_run_ending_does_not_unlock_a_panel_with_no_slice(qapp):
+    # The two-writers bug this design exists to prevent: sigInteractionLocked
+    # firing False at the end of a run must not override slice-readiness.
+    panel = SearchPanel()
+    panel.setSliceReady(False)
+    panel.setInteractionLocked(True)
+    panel.setInteractionLocked(False)
+    assert all(not w.isEnabled() for w in _controls(panel))
+
+
+def test_a_panel_starts_locked_before_any_slice_exists(qapp):
+    assert all(not w.isEnabled() for w in _controls(SearchPanel()))
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_search_panel.py -v -k "locked or slice_ready or unlocked"
+```
+
+Expected: FAIL with `AttributeError: 'SearchPanel' object has no attribute 'setSliceReady'`.
+
+- [ ] **Step 3: Implement the derived lock**
+
+In `SearchPanel.__init__`, alongside the two error strings:
+
+```python
+        # The two independent reasons this panel can be locked, kept apart for
+        # the same reason the two error strings are: neither writer can see the
+        # other's condition, so collapsing them into one boolean would let a run
+        # ending unlock a panel that still has no slice behind it. A panel with
+        # no slice starts locked -- New slice is what makes Area 2 usable, and
+        # the greyed-out controls are how the operator is told so.
+        self._runLocked = False
+        self._sliceReady = False
+```
+
+Rename the existing body and derive:
+
+```python
+    def setInteractionLocked(self, locked: bool) -> None:
+        """Disable editing while a run is in flight; the readout stays visible.
+
+        The constraints parameterise a producer that is already surveying, so
+        editing them mid-run would silently change the search under it.
+        """
+        self._runLocked = locked
+        self._applyLock()
+
+    def setSliceReady(self, ready: bool) -> None:
+        """Whether a slice exists for these controls to configure.
+
+        Area 2 parameterises a search over a slice, so with no slice there is
+        nothing for these values to mean; New slice is the button that makes
+        them live.
+        """
+        self._sliceReady = ready
+        self._applyLock()
+
+    def _applyLock(self) -> None:
+        locked = self._runLocked or not self._sliceReady
+        for w in (
+            self.nearDepthSpin,
+            self.farDepthSpin,
+            self.minHealthSpin,
+            self.maxDensitySpin,
+            self.rescansCheck,
+            self.addRegionBtn,
+            self.shapeCombo,
+        ):
+            w.setEnabled(not locked)
+```
+
+Call `self._applyLock()` at the end of `__init__` so a fresh panel starts locked.
+
+- [ ] **Step 4: Run to verify they pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_search_panel.py -q
+```
+
+Expected: all pass. Existing `setInteractionLocked` tests may now need a `setSliceReady(True)` first — that is the new behaviour, so update them.
+
+- [ ] **Step 5: Wire it in the window**
+
+In `Autopatch.py`, after `self.slice = Slice(...)` in `_startSlice`:
+
+```python
+        self.searchPanel.setSliceReady(True)
+```
+
+Append the window test to `test_window_integration.py`:
+
+```python
+def test_area_2_is_locked_until_a_slice_exists(win):
+    assert not win.searchPanel.addRegionBtn.isEnabled()
+    win.newSlice()
+    assert win.searchPanel.addRegionBtn.isEnabled()
+```
+
+**Note:** `addRegionHere()` starts with `if self.slice is None and not self._startSlice()`. With Area 2 locked, that path is unreachable from the UI, but leave the guard — it is cheap, and it keeps the method correct if called directly.
+
+- [ ] **Step 6: Run the whole suite**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests acq4/modules/Autopatch/tests -q
+```
+
+Expected: all pass, and **more than 510** tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add acq4/modules/Autopatch/search_panel.py acq4/modules/Autopatch/Autopatch.py acq4/modules/Autopatch/tests/test_search_panel.py acq4/modules/Autopatch/tests/test_window_integration.py && git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "feat: lock Area 2 until the operator starts a slice"
+```
+
+---
+
+### Task 14: Correct the design doc
+
+**Files:**
+- Modify: `/home/martin/src/acq4/acq4/autopatch-orchestration-design.md` (untracked in the main checkout, not in this worktree)
+
+The spec's section A.5 lists four corrections §3.6 needs. Making them keeps the design doc from teaching the next reader something the code no longer does.
+
+- [ ] **Step 1: Apply the four corrections**
+
+In §3.6:
+
+1. Replace the slice-wide `Slice.forceRescan()` description with the region-scoped form, including the local-motion caveat.
+2. Delete the claim that the producer's `_rescanned` allowance is re-armed; state that the existing producer is reused and `_rescanned` is untouched, which is what makes "not charged against `rescans_allowed`" literal.
+3. Rewrite step 3: the lost cell is an attempted cell and holds its own tile, so a rescan does **not** re-find it. Note that cell death is the expected common trigger.
+4. Add the mid-patch invariant: tracking failures during a patch (pipette occlusion) never reach this path and must never trigger a rescan.
+
+In §7 Area 1, record that New slice creates the directory before discarding anything, and that §7's "prompt when completed cells are present" open decision is resolved as **no prompt**.
+
+- [ ] **Step 2: Commit**
+
+The design doc is untracked in git. Do not `git add` it. Confirm with the operator whether they want it committed.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| A.0 mid-patch invariant | 14 (documented; holds by construction — no code change) |
+| A.1.1 `CellTrackingLost` | 1 |
+| A.1.2 re-verify raises with reason | 3 |
+| A.1.3 `validate_movement` | 2 |
+| A.2 `TrackingLost` | 4 |
+| A.2 `cellfie` translation | 6 |
+| A.2 `ExecutionContext.tissue_moved` | 5 |
+| A.2 `Slice.forceRescan` | 7 |
+| A.2 `clearProducerExhausted` | 8 |
+| A.3 no fresh producer / no re-arm | 7, 8 (by omission; asserted in Task 8) |
+| A.4 window hook, prompt, ordering, threading | 10 |
+| A.5 design-doc corrections | 14 |
+| B.1 `create_data_dir` | 11 |
+| B.2 `newSlice` ordering, `dirHandle` | 12 |
+| B.3 Area 2 gate | 13 |
+| B.4 no prompt, orchestrator not stopped | 12 (no code; `newSlice` keeps its existing behaviour) |
+| B.5 `searchPanel.setError` | 12 |
+| `CellPanel` attempted set | 9 |
+
+No gaps.
+
+**Type consistency:** `forceRescan(position, isAttempted) -> int` is defined in Task 7 and called in Task 10 with `(cell.position, self.cellPanel.isAttempted)`; `isAttempted(cell) -> bool` is defined in Task 9. `tissue_moved_hook` is called as `hook(ctx, reason)` in Task 5 and bound as `partial(tissueMoved, cell)` in Task 10, giving the window handler `(cell, ctx, reason)` — which is the signature Task 10 implements. `create_data_dir(manager, level, set_current)` is defined in Task 11 and called in Task 12 as `create_data_dir(self.manager, level="Slice")`.
+
+**Ordering:** Tasks 1-3 are the only cross-repo work and must land before Task 6, which imports `CellTrackingLost`. Task 6 also needs Task 5. Task 10 needs 5, 7, 8, and 9. Task 12 needs 11. Task 13 is independent of Piece A entirely and could be done first if the acq4-automation branch question blocks.

--- a/docs/superpowers/plans/2026-08-05-autopatch-p2c-2-tissue-motion-and-slice-dir.md
+++ b/docs/superpowers/plans/2026-08-05-autopatch-p2c-2-tissue-motion-and-slice-dir.md
@@ -71,17 +71,17 @@
 **Interfaces:**
 - Produces: `CellTrackingLost(ValueError)` with attribute `reason: str | None`. Importable as `from acq4_automation.feature_tracking import CellTrackingLost`. Tasks 2, 3, and 6 depend on this name and import path.
 
-- [ ] **Step 0: Resolve the branch question before touching anything**
+- [ ] **Step 0: Confirm the repo is where it should be**
 
-The repo is on `feature/smooth-vector-field-z` with a clean tracked tree (only untracked `best-segmenter` and `cellpose_grid_results.json`). The spec says the work belongs on `main`.
+Resolved with the operator: this checkout was switched to `main` and commits land directly on `main`. Their `feature/smooth-vector-field-z` work is committed and untouched on its own branch. `acq4_automation` is installed editable from this checkout, which is why a worktree was rejected — acq4's tests must see these changes.
 
-Run:
+Verify before starting:
 
 ```bash
-cd /home/martin/src/acq4/acq4-automation && git status -sb && git log --oneline -1 main
+cd /home/martin/src/acq4/acq4-automation && git status -sb | head -2
 ```
 
-**Stop and ask the operator** which they want: switch this checkout to `main`, or branch off `main` here. Do not switch branches in a repo with active feature work without being told to. Note that `acq4_automation` is installed editable from *this* checkout, so a separate worktree would not be visible to acq4's tests without a `PYTHONPATH` override.
+Expected: `## main...origin/main`, with only `best-segmenter` and `cellpose_grid_results.json` untracked. If the branch is anything other than `main`, stop and ask.
 
 - [ ] **Step 1: Write the failing test**
 

--- a/docs/superpowers/specs/2026-08-05-autopatch-p2c-2-tissue-motion-and-slice-dir-design.md
+++ b/docs/superpowers/specs/2026-08-05-autopatch-p2c-2-tissue-motion-and-slice-dir-design.md
@@ -1,0 +1,355 @@
+# Autopatch P2c-2 — Tissue-motion feedback loop & the New-slice data directory
+
+Date: 2026-08-05
+Status: approved, not yet implemented
+Predecessor: P2c-1 region shapes (merged, `4a3c82e0b`)
+
+Two independent pieces of P2c, sharing no code. They travel together because
+both are narrow and both are headless-testable.
+
+- **Piece A** — the tissue-motion feedback loop the main design doc specifies in
+  §3.6. Spans two repositories.
+- **Piece B** — **New slice** creating a real Data Manager directory (§7 Area 1),
+  plus the Area 2 gate that makes the button discoverable.
+
+This spec resolves several points where §3.6 and §7 disagree with the landed
+code. Where they disagree, this document wins and the main design doc is
+corrected to match.
+
+---
+
+## Piece A — tissue-motion feedback loop
+
+### A.0 What the signal actually means
+
+Three distinct tracking failures exist, and only one of them is tissue motion.
+
+| Condition | Where | Response |
+|---|---|---|
+| Re-verify finds no features at all | `Cell.initializeTracker` re-verify path | **Tissue-motion recovery.** Reference stacks are useless: the cell has drifted out of reach or died. |
+| Re-verify matches, but far away | `CellTracker._validate_movement` | **Adopt the new position and track from there.** If LK can find the features, we know where the cell is. |
+| Tracking fails mid-patch (pipette occluding features, etc.) | `Cell._trackingLoop` / ongoing `updatePosition` | **Nothing.** Already only logs a warning; must never trigger a rescan. |
+
+The third row is an invariant, not an accident: it holds today only because
+`_trackingLoop` catches broadly and `updatePosition` returns `False` rather than
+raising. It is written down here so a later change cannot quietly break it.
+
+**Cell death is expected to be the most common trigger**, not tissue movement.
+A significant physical bump ruins the experiment and nothing here detects it;
+small drift and tissue swelling are the common motion cases.
+
+### A.1 acq4-automation changes (branch: `main`)
+
+Three additive changes. No existing caller changes behaviour.
+
+**1. `CellTrackingLost(ValueError)`** — a named exception in
+`acq4_automation/feature_tracking/`. Subclassing `ValueError` is deliberate:
+`AutomationDebug/autopatch.py:319` already catches `ValueError` from
+`initializeTracker` and skips the cell, and that must keep working. The named
+class is what lets acq4 distinguish this domain condition from an unrelated
+`ValueError` out of the tracker stack.
+
+**2. `Cell.initializeTracker`'s re-verify path raises it**, carrying
+`self._tracker.last_result.reason_for_failure`. The current
+`raise ValueError("Cell moved too much to treat as tracked")` carries no reason,
+because `updatePosition` returns a bare bool and the reason is only logged.
+Reading `last_result` at the raise site avoids changing that bool return, which
+`_trackingLoop` depends on.
+
+The reason is not decoration: the operator is being asked to authorise a
+destructive rescan, and "why do we believe the tissue moved" is the entire basis
+for their answer.
+
+**3. `validate_movement: bool = True`** threaded through
+`Cell.updatePosition` → `CellTracker.track_next_frame` → `_validate_movement`.
+The re-verify call in `initializeTracker` passes `False`; every other caller
+keeps the default.
+
+Why the guard stays on everywhere else: `_validate_movement` compares against
+`_last_position`, which means it measures two different things depending on when
+it runs. During ongoing tracking, frames are seconds apart, a large jump is
+implausible, and `Cell.sigPositionChanged` drives pipette targets
+(`AutomationDebug/feature_tracking.py` wires it straight to
+`_updatePipetteTarget`) — there it is a hardware-safety guard. At re-verify,
+`_last_position` can be hours stale and legitimate accumulated drift can exceed
+the same threshold, which is a false alarm that would trigger a rescan we do not
+want.
+
+A blanket removal of the threshold is explicitly rejected.
+
+### A.2 acq4 engine changes
+
+**`TrackingLost(OrchestrationError)`** in `acq4/experiment/exceptions.py`, with
+`typeName = "TrackingLost"`.
+
+**`cellfie()`** (`acq4/experiment/actions/device.py`) catches `CellTrackingLost`
+from `ctx.cell.initializeTracker(...)` and calls `ctx.tissue_moved(reason)`.
+The precedent for translating a library exception at the action boundary is
+`find_surface` in the same module.
+
+**`ExecutionContext.tissue_moved(reason)`** — a bound hook, in the same family as
+`log`, `on_log_action`, and `next_cell_requested`.
+
+The hook needs the failing cell's position to scope the rescan, and takes only a
+`reason`. The cell is bound in by the window's context factory the same way `log`
+and `on_log_action` already bind theirs (`partial(hook, cell)`), so the action
+calling it needs no knowledge of slices or positions.
+
+> **It never returns normally.** Unbound (headless, tests), it raises
+> `TrackingLost` — the catch-all safety net then halts the run, which is the safe
+> default. Bound, it ends by raising `AdvanceToNextCell` via `ctx.next_cell()`.
+
+One contract with two implementations, so no caller ever branches on whether a
+hook is present. The engine keeps no slice knowledge; the orchestrator holds a
+plain callable and cannot do any of this itself.
+
+**`Slice.forceRescan(position, isAttempted)`** (`acq4/experiment/slice.py`):
+
+```
+here  = [r for r in self._regions if r.overlapsTile(position, self._fov)]
+stale = [t for t in self._covered if any(r.overlapsTile(t, self._fov) for r in here)]
+```
+
+Then, for each stale tile, de-register its **never-attempted** cells (via the
+existing `cellsNearTile`), and drop the stale tiles from `_covered`.
+
+**`isAttempted` is a caller-supplied predicate, and it has to be.** `Slice._cells`
+holds `Cell` objects; attempted-ness is orchestration state that lives in
+`CellPanel`, not on the cell and not in the engine's slice. Passing a predicate
+keeps `Slice` UI-agnostic and makes the behaviour testable with a plain lambda.
+
+`CellPanel` supplies it, backed by a set it records a cell into the first time
+that cell appears in **either** `sigCurrentCell` **or** `sigCellFinished`. Both,
+not just the latter: a cell interrupted mid-run has been attempted even though no
+terminal status was ever emitted for it, and `retry` is emitted mid-flight without
+being terminal. "Has the orchestrator ever started work on this cell" is the
+question, which sidesteps re-deriving the terminal-status list that the
+reuse-completed-cells spec still owes.
+
+This uses only the existing two-method `SearchRegion` contract (`bounds()` +
+`overlapsTile()`). That contract is deliberately narrow and documented as "the
+only two questions the tiler asks" — **do not add `contains(point)` to widen it.**
+
+- **`here` empty → no-op.** A hand-seeded cell outside every drawn region has no
+  coverage to invalidate; hand-added cells are outside the scanner's
+  responsibility.
+- **Attempted cells stay registered** at their old positions and keep counting
+  toward `CellProducer._isCrowded`. This pushes back on §3.6's "cells already
+  patched may be found again" hazard, which the prompt currently only warns about
+  — but it is **not a guarantee**: `_isCrowded` compares
+  `len(cellsNearTile) / tileVolume` against `max_cell_density`, so a tile holding
+  one attempted cell under a permissive cap is still re-imaged and that cell
+  re-detected. The mitigation is real but density-dependent, and should not be
+  described to the operator as a promise.
+- **Never-attempted cells are de-registered**, so their tiles become uncrowded,
+  get re-imaged, and the cells are re-detected at their current positions. That
+  is the entire point of the rescan.
+
+**Cost, and it belongs in `forceRescan`'s docstring:** region-scoping assumes the
+motion is *local*, but tissue motion is global. If the slice genuinely shifted,
+finished regions are stale too and we are deliberately not re-imaging them. We
+accept a stale-coverage risk in finished regions to avoid re-imaging and
+double-patching them. Same family as §3.6's existing "Caveat: the regions are
+stale too".
+
+**`Orchestrator.clearProducerExhausted()`** — the `_producerExhausted = False`
+assignment extracted out of `setCellProducer`, which now calls it. A producer
+that already reported exhaustion must be asked again, or the run ends on the
+now-refilled queue.
+
+### A.3 What is deliberately NOT built
+
+**No fresh producer, and no re-arming of `_rescanned`.** §3.6 asks for both.
+Both are unnecessary, and §3.6 only asks for them because it assumed
+`forceRescan` was slice-wide.
+
+`CellProducer` is stateless apart from `_rescanned`, and calls `slice.nextTile()`
+fresh on every call. Un-covering region 3's tiles is therefore sufficient on its
+own: the **existing** producer starts handing them out again. Nothing to re-arm,
+no generation counter, no slice→producer back-reference — which matters, because
+`Slice.makeCellProducer()` deliberately keeps no reference to what it hands back,
+to stay refcount-freeable rather than needing the cyclic GC.
+
+This also makes §3.6's "not charged against `rescans_allowed`" literally true
+rather than a special case: `_rescanned` is never touched, so the bonus-pass
+allowance is neither spent nor refunded. Constructing a fresh producer would have
+done the opposite — a fresh `_rescanned = False` re-arms the slice-wide
+`resetCoverage()` pass, buying a second full re-survey of every region whenever
+`rescans_allowed` is on.
+
+### A.4 The window's hook
+
+Supplied by the Autopatch window through its context factory, since the window is
+what owns the `Slice`, the detector, and the orchestrator together.
+
+1. `prompt()` the operator (non-modal and stop-aware; Stop stays available as the
+   third answer). "Rescan the slice" is first, and therefore the headless
+   default — driving a pipette to a known-stale coordinate is a hardware risk,
+   while patching a cell twice is a data-hygiene cost, so the cheaper mistake
+   goes first. The message includes the tracker's `reason_for_failure`.
+2. On **Rescan the slice**: `slice.forceRescan(cell.position, isAttempted)`,
+   `orchestrator.clearQueue()`, `orchestrator.clearProducerExhausted()`. The cell
+   comes from the factory binding (A.2); `isAttempted` from `CellPanel`.
+
+   Ordering note: `clearQueue()` runs **after** the operator answers, so a cell
+   the operator seeds by hand while the prompt is open is discarded too. Correct
+   — it is a coordinate in the same moved tissue — but worth knowing.
+3. On **Skip this cell only**: nothing.
+4. Both answers end with `ctx.next_cell()`.
+
+**Threading.** The hook runs on the worker thread, mid-cell. Queue and coverage
+mutations are single-step rebinds, consistent with the existing deque-atomicity
+discipline — no locks, per the check-then-act lessons from P2b. The survey-stats
+refresh afterwards is a GUI update and must be marshaled the way coverage updates
+already are, not called inline. No producer call can be in flight: refills happen
+only between cells with an empty queue, and this runs inside a cell.
+
+### A.5 Corrections to the main design doc
+
+- **§3.6 step 3 is wrong.** "if it is still there, the rescan finds it again as a
+  new `Cell`" no longer holds: the lost cell is an attempted cell, so it holds its
+  own tile down. Given cell death is the common trigger, not re-finding it is the
+  correct behaviour.
+- **§3.6's slice-wide `forceRescan()` is superseded** by the region-scoped form.
+- **§3.6's `_rescanned` re-arm is superseded** — see A.3.
+- **§3.6 does not state the mid-patch invariant** (A.0, third row). It should.
+
+---
+
+## Piece B — New slice creates a Data Manager directory
+
+### B.1 The storage helper
+
+`new_data_dir(ctx, level, set_current)` in `acq4/experiment/actions/storage.py`
+already performs exactly the `DataManagerModule.createNewFolder` logic — but it
+takes a `ctx`, and **New slice** is an operator click with no run in progress.
+
+Factor its body into **`create_data_dir(manager, level="Cell", set_current=True)`**
+in the same module; `new_data_dir` becomes its `ctx.log_action()` wrapper. Both
+callers share one implementation. A UI button must not fabricate an execution
+context to reach engine logic.
+
+Setting the current directory is load-bearing, not a courtesy: a protocol's own
+`new_data_dir(ctx, level="Cell")` picks its parent by walking up from the current
+directory, so per-cell data lands under this slice *because* New slice made it
+current.
+
+### B.2 `newSlice()` ordering
+
+**Create the directory first.** On failure, nothing is discarded — no cells
+cleared, no queue cleared, `self.slice` left exactly as it was. This matches the
+discipline `_startSlice()` already establishes for a missing camera or invalid
+constraints.
+
+Only on success does `newSlice()` proceed to its existing behaviour: clear the
+cell list, detach the producer, clear the queue.
+
+`Slice` gains **`dirHandle`**, set at construction. Slice-scoped state, and the
+handle §6b's `setInfo()`/`info()` persistence will need later.
+
+**Directory creation lives in `newSlice()` only, not `_startSlice()`.** The other
+caller is `addRegionHere()`, and a button labelled "add region" must not silently
+create a directory on disk and repoint where every subsequent write lands. A
+`Slice` born from `addRegionHere()` has `dirHandle = None`, which honestly
+represents "this tissue was never formally started" — and is not a new hole, since
+an operator who never pressed New slice is already writing into whatever the
+current directory happens to be.
+
+### B.3 Area 2 gates on a slice existing
+
+Because `dirHandle = None` is reachable only by skipping New slice, the UI should
+say so: **Area 2's controls are locked until a slice exists.**
+
+`SearchPanel` currently has one writer for its lock —
+`statusPanel.sigInteractionLocked`, wired directly. Adding "no slice yet" as a
+second reason puts two writers on one boolean, and a run finishing would unlock a
+panel with no slice behind it.
+
+So `SearchPanel` holds the two reasons **separately** and derives the effective
+lock (`locked or not sliceReady`). The existing signal wire is untouched; the new
+state gets its own setter.
+
+Two consequences:
+
+- **Constraints are read at creation time.** `_startSlice()` builds the `Slice`
+  from `searchPanel.constraints()`, but Area 2 is locked until New slice — so the
+  slice is born with defaults and the operator's edits land afterwards through
+  `_onConstraintsChanged`. Verify that handler pushes onto the live slice rather
+  than only being read at build time.
+- **Start stays unlocked.** Running a protocol over hand-seeded cells with no
+  slice is legitimate work; it is the *producer* that needs a slice, not the
+  orchestrator. Blocking Start would forbid something real.
+
+### B.4 Decisions taken
+
+- **No confirmation prompt on New slice.** The button is destructive by design and
+  is about to become the mandatory first click of every session; friction there is
+  friction on the common path. This resolves §7's open decision as "no prompt".
+- **New slice does not stop a running orchestrator.** It detaches the producer and
+  clears the queue, but the in-flight cell runs to completion: yanking a pipette
+  out mid-protocol is its own hazard. Stop remains the operator's tool for that.
+  Unchanged from the landed code, restated because it was questioned.
+
+### B.5 Error handling
+
+`manager.getCurrentDir()` raises
+`HelpfulException("Storage directory has not been set.")` when the operator has
+not chosen one — the likeliest first-use failure of this button.
+
+§5.1's Area 3 instruction band is phased P3 and unbuilt, so this surfaces through
+**`searchPanel.setError()`**, the existing Area 1/2 error channel already used for
+"Select a camera before starting a slice."
+
+---
+
+## Testing
+
+Headless throughout. `tile_detector.py`'s injected-detector seam is the precedent
+for the device-facing parts.
+
+**Piece A**
+
+- `forceRescan`: region-scoped un-covering; attempted cells retained in the
+  density record; never-attempted cells de-registered; the empty-`here` no-op;
+  overlapping regions. Driven by a lambda `isAttempted`, no UI involved.
+- `CellPanel`'s attempted set: a cell seen only via `sigCurrentCell` (interrupted,
+  never finished) counts as attempted.
+- **At a realistic stage coordinate**, not only at the origin — pure-geometry
+  tests written around the origin cannot see coordinate-magnitude float error.
+- `tissue_moved`: raises `TrackingLost` unbound; raises `AdvanceToNextCell` bound,
+  on **both** prompt answers; rescan side effects occur on one answer and not the
+  other.
+- `cellfie` translates `CellTrackingLost` and lets unrelated `ValueError`s
+  propagate untouched.
+- `clearProducerExhausted` lets an exhausted producer be asked again.
+- acq4-automation: `validate_movement=False` suppresses the jump guard;
+  the default keeps it; `CellTrackingLost` is caught by `except ValueError`.
+
+**Piece B**
+
+- `create_data_dir` called with no `ctx`; `new_data_dir` behaves identically
+  through the wrapper.
+- `newSlice` with a failing directory creation leaves slice, cells, and queue
+  untouched.
+- The `SearchPanel` lock at **all four corners** of (run-locked × slice-ready),
+  not just the two obvious ones.
+
+**Mutation-test the absence-assertions.** The de-registration test and the
+"nothing discarded on failure" test both assert a negative and would pass against
+broken code if the fixture cannot reach the distinguishing state. Proof required:
+remove the fix or apply the defect, observe the test fail, then restore. This has
+caught vacuous tests three times in this project.
+
+Also: no symmetric fixtures where an asymmetric mapping is under test — the
+region/tile fixtures must not be square, per the `EllipseRegion` `rx`/`ry` finding.
+
+---
+
+## Out of scope
+
+- Slice persistence via `DirHandle.setInfo()` (§6b — "not required for a first cut").
+- Area 1 ROI graphics, the mirror-to-Camera checkbox, the progress heatmap, and
+  the cross-repo `acq4_automation.Cell` expansion the heatmap would force.
+- §5.1's error surfacing (captured traceback, Area 5 error block, log link).
+- Reuse-completed-cells. §3.6's "Open" note — whether reuse should be blocked or
+  warned after a motion event — **stays open**, because reuse does not exist yet.


### PR DESCRIPTION
Two independent pieces of P2c, sharing no code.

**Piece A — the tissue-motion feedback loop (design §3.6).** When the cell tracker cannot re-find a cell against its own reference stacks, the coverage record claiming that ground was already searched is no longer trustworthy. The tracker now raises a named exception carrying its failure reason, `cellfie` routes it to a hook on the execution context, and the window prompts the operator and — on agreement — re-opens that region of the slice for imaging and discards the queued cells.

**Piece B — New slice creates a real data directory (design §7 Area 1).** The button now creates an ACQ4 managed `Slice` directory and makes it the current storage directory, so per-cell data lands underneath it. Area 2's controls are locked until a slice exists.

### ⚠️ Cross-repo dependency — read before merging

`cellfie` imports `CellTrackingLost` from `acq4_automation.feature_tracking`. **Those four commits are on local `main` in `acq4-automation` and are deliberately unpushed.** Until they land, this branch's `cellfie` raises `ImportError` at the point it catches a lost cell. The import is function-scoped, so nothing else breaks and the test suite is unaffected — but this should not merge ahead of the acq4-automation change.

### Where §3.6 was wrong, and why this differs from it

- **`forceRescan` is region-scoped, not slice-wide.** An operator working through their third region should not pay to re-image the two they finished, and re-imaging a finished region risks re-detecting cells already dealt with. This also removed the need for §3.6's fresh producer and `_rescanned` re-arm entirely: `CellProducer` re-reads `slice.nextTile()` on every call, so un-covering tiles is sufficient on its own. That makes "not charged against `rescans_allowed`" literally true rather than a special case.
- **§3.6 step 3 was wrong.** The lost cell is an *attempted* cell and stays in the density record, so a rescan does not re-find it. Cell death is the expected most-common trigger, which makes that the correct behaviour.
- **The movement guard is bypassed only on the re-verify path.** If the features matched at all, we know where the cell is, at any distance. The guard stays on for ongoing tracking, where `sigPositionChanged` drives pipette targets and a spuriously confident match is a hardware risk.
- **Tracking failures mid-patch never trigger a rescan.** A pipette occluding the features is not tissue motion. This held by construction already; it is now written down as an invariant rather than left as an accident of where a raise happens to live.

### Tests

563 passing in `acq4/experiment/tests` + `acq4/modules/Autopatch/tests`, up from 510. Headless throughout.

The geometry tests use realistic millimetre stage coordinates and non-square regions rather than origin-centred squares — origin-centred geometry cannot expose coordinate-magnitude float error, and a symmetric fixture cannot test an asymmetric mapping. Both have caused real bugs here.

### Review findings worth knowing about

Six vacuous assertions were caught and fixed over this branch's life — assertions whose expected value equalled the default, so they passed against broken code. The most instructive: `assert orchestrator._producerExhausted is False` proved nothing until the flag was primed `True` first.

The final review found four Important defects that per-task review structurally could not see, all since fixed:

1. `newSlice()` created and activated the Slice directory *before* validating the camera, so a camera-less click leaked an empty directory and silently repointed storage.
2. The rescan cleared the orchestrator's queue but not Area 5's rows, so the panel contradicted the prompt the operator had just answered.
3. The tracker's failure reason came out `None` on a reachable path — the real explanation sits on `result.decision.reason` and was being discarded. That reason is the entire basis for the operator's answer to a destructive prompt.
4. `newSlice()`'s bare `except Exception` disguised programming errors as storage guidance, and had silently no-op'd `newSlice()` inside the teardown test that exists to prevent exit segfaults.

### Out of scope

Slice persistence via `DirHandle.setInfo()`; Area 1's ROI graphics, mirror-to-Camera checkbox and progress heatmap; §5.1's error surfacing; reuse-completed-cells. §3.6's open question about reuse after a motion event stays open, since reuse does not exist yet.

### Not verified

No live GUI smoke test. The prompt's appearance and the operator flow through it are unexercised outside the headless suite.

🤖 Generated with [Claude Code](https://claude.ai/code)
