### PR TITLE
feat: make the .acqtrack Visualize button safe and stateful

### DIFF
--- a/acq4/filetypes/AcqTrackFile.py
+++ b/acq4/filetypes/AcqTrackFile.py
@@ -5,13 +5,15 @@ LiveTrackerVisualizer.
 import os
 
 from acq4.filetypes.FileType import FileType
+from acq4.logging_config import get_logger
 from acq4.util import Qt
+from acq4.util.task import QtFriendlyTask
 
-# Visualizer windows are top-level and parentless, so something must hold a Python
-# reference for them to stay on screen. It cannot be the AcqTrackWidget that opened
-# them: FileDataView.clear() closes, unparents and drops its widgets as soon as another
-# file is selected, which would take any window they owned down with them.
-_openVisualizers = []
+logger = get_logger(__name__)
+
+LOADING = 'loading'
+OPEN = 'open'
+FAILED = 'failed'
 
 
 def _loadHistory(path):
@@ -26,13 +28,114 @@ def _loadHistory(path):
 
 
 def _openVisualizer(tracker):
-    """Show a tracking history in its own visualizer window and keep it alive."""
+    """Show a tracking history in its own visualizer window."""
     from acq4_automation.feature_tracking.visualization import LiveTrackerVisualizer
 
     viz = LiveTrackerVisualizer(tracker)
-    _openVisualizers.append(viz)
     viz.show()
     return viz
+
+
+def _visualizerWindow(viz):
+    """The top-level window whose closing ends a visualizer's session."""
+    return viz.window
+
+
+class _VisualizerRegistry(Qt.QObject):
+    """Tracks, per file path, which tracking histories are being read and which already
+    have a visualizer window on screen.
+
+    This state cannot live on the AcqTrackWidget that starts it. Visualizer windows are
+    top-level and parentless, so something must hold a Python reference for them to stay
+    on screen, and FileDataView.clear() closes, unparents and drops its widgets as soon
+    as another file is selected -- which would take any window they owned down with
+    them. Keeping the registry at module scope also means a rebuilt widget still knows
+    that its file already has a window open.
+    """
+
+    sigChanged = Qt.Signal(object)  # path
+
+    def __init__(self):
+        Qt.QObject.__init__(self)
+        self._loading = {}  # path -> QtFriendlyTask reading the file
+        self._open = {}  # path -> visualizer
+        self._failed = set()  # paths whose last read raised
+
+    def stateOf(self, path):
+        """LOADING, OPEN, FAILED, or None if this path has no visualizer activity."""
+        if path in self._loading:
+            return LOADING
+        if path in self._open:
+            return OPEN
+        if path in self._failed:
+            return FAILED
+        return None
+
+    def load(self, path, readFn):
+        """Read a tracking history off the GUI thread and then visualize it.
+
+        Does nothing if this path is already loading or already visualized: a tracking
+        history holds every image and object stack the tracker saw, so a second read is
+        both slow and pointless.
+        """
+        if self.stateOf(path) in (LOADING, OPEN):
+            return
+        self._failed.discard(path)
+        # Construct, connect, then start: the read can finish before start() returns,
+        # and sigFinished only reaches a slot connected before that happens.
+        task = QtFriendlyTask(readFn, name=f"read {path}", start=False)
+        task.sigFinished.connect(self._readFinished)
+        self._loading[path] = task
+        self.sigChanged.emit(path)
+        task.start()
+
+    def _readFinished(self, task):
+        """Open the visualizer for a finished read.
+
+        Connected to a bound method of this GUI-thread QObject on purpose: the finish
+        callback fires on the worker thread, and the queued connection is what marshals
+        window construction back onto the GUI thread.
+        """
+        path = _keyFor(self._loading, task)
+        if path is None:
+            return
+        del self._loading[path]
+        try:
+            tracker = task.wait(0)
+        except Exception:
+            # Reported on the button rather than raised: this runs in a Qt slot, and the
+            # user's recourse is simply to click Visualize again.
+            logger.exception(f"Error loading tracking history {path!r}")
+            self._failed.add(path)
+            self.sigChanged.emit(path)
+            return
+        viz = _openVisualizer(tracker)
+        self._open[path] = viz
+        _visualizerWindow(viz).installEventFilter(self)
+        self.sigChanged.emit(path)
+
+    def eventFilter(self, obj, event):
+        """Retire a session when the user closes its window.
+
+        The visualizer is a plain object wrapping a QMainWindow, so there is no close
+        signal to connect to.
+        """
+        if event.type() == Qt.QEvent.Close:
+            path = _keyFor(self._open, obj, key=_visualizerWindow)
+            if path is not None:
+                del self._open[path]
+                obj.removeEventFilter(self)
+                self.sigChanged.emit(path)
+        return False
+
+
+def _keyFor(mapping, wanted, key=lambda v: v):
+    """The key whose value identifies *wanted*, or None. Mappings here hold one or two
+    entries, so a scan is cheaper than maintaining a reverse index."""
+    return next((k for k, v in mapping.items() if key(v) is wanted), None)
+
+
+visualizers = _VisualizerRegistry()
 
 
 class AcqTrackFile(FileType):
@@ -57,17 +160,45 @@ class AcqTrackWidget(Qt.QWidget):
 
     Reading is deferred to the click. A tracking history holds every image and object
     stack the tracker saw, which is far too much to load just because a file was
-    selected in the tree.
+    selected in the tree -- and enough to hang the GUI, so the read runs on a worker
+    thread. The button reports the file's progress through that and stays disabled
+    until the window it opened is closed again.
     """
 
     def __init__(self, fileHandle, parent=None):
         Qt.QWidget.__init__(self, parent)
         self._fileHandle = fileHandle
+        self._path = fileHandle.name()
         layout = Qt.QVBoxLayout(self)
-        self.visualizeBtn = Qt.QPushButton("Visualize")
+        self.visualizeBtn = Qt.QPushButton()
         self.visualizeBtn.clicked.connect(self.visualize)
         layout.addWidget(self.visualizeBtn)
         layout.addStretch()
+        visualizers.sigChanged.connect(self._visualizerStateChanged)
+        self._updateButton()
 
     def visualize(self):
-        _openVisualizer(self._fileHandle.read())
+        visualizers.load(self._path, self._fileHandle.read)
+
+    def _visualizerStateChanged(self, path):
+        if path == self._path:
+            self._updateButton()
+
+    def _updateButton(self):
+        state = visualizers.stateOf(self._path)
+        if state == LOADING:
+            self.visualizeBtn.setText("Loading...")
+            self.visualizeBtn.setToolTip("Reading the tracking history")
+            self.visualizeBtn.setEnabled(False)
+        elif state == OPEN:
+            self.visualizeBtn.setText("Visualizer open")
+            self.visualizeBtn.setToolTip("Close the visualizer window to reopen it")
+            self.visualizeBtn.setEnabled(False)
+        elif state == FAILED:
+            self.visualizeBtn.setText("Load failed")
+            self.visualizeBtn.setToolTip("See the log for details; click to try again")
+            self.visualizeBtn.setEnabled(True)
+        else:
+            self.visualizeBtn.setText("Visualize")
+            self.visualizeBtn.setToolTip("")
+            self.visualizeBtn.setEnabled(True)

--- a/acq4/filetypes/tests/test_acqtrack_file.py
+++ b/acq4/filetypes/tests/test_acqtrack_file.py
@@ -1,9 +1,12 @@
 """Tests for AcqTrackFile: the .acqtrack FileType and its Data-tab Visualize widget.
 
-Cover extension matching, write/read delegation to the tracking-history seams, and
-that the widget defers every read until Visualize is clicked.
+Cover extension matching, write/read delegation to the tracking-history seams, and the
+Visualize button's contract: no read until clicked, the read runs off the GUI thread,
+and one visualizer window per file with the button reflecting its state.
 """
+import logging
 import os
+import threading
 
 import pytest
 
@@ -36,6 +39,27 @@ class _FakeFileHandle:
     def read(self):
         self.readCount += 1
         return self._data
+
+
+class _BlockingFileHandle(_FakeFileHandle):
+    """A file handle whose read parks until released, so a test can observe the widget
+    mid-load. Records the thread it was read on."""
+
+    def __init__(self, path, data=None):
+        super().__init__(path, data)
+        self.release = threading.Event()
+        self.readThread = None
+
+    def read(self):
+        self.readThread = threading.current_thread()
+        assert self.release.wait(10), "read was never released"
+        return super().read()
+
+
+class _FailingFileHandle(_FakeFileHandle):
+    def read(self):
+        super().read()
+        raise ValueError("corrupt history")
 
 
 class _FakeDirHandle:
@@ -184,6 +208,57 @@ class TestRealRoundTrip:
         assert replay.motion_estimator.current_object_stack.data.shape == original.shape
 
 
+class _FakeVisualizer:
+    """Stands in for a LiveTrackerVisualizer, with a real top-level window so the
+    close detection under test has a real close event to see."""
+
+    def __init__(self, tracker):
+        self.tracker = tracker
+        self.builtOn = threading.current_thread()
+        self.window = Qt.QMainWindow()
+
+    def show(self):
+        self.window.show()
+
+    def close(self):
+        self.window.close()
+
+
+@pytest.fixture
+def openedVisualizers(qapp, monkeypatch):
+    """Replace the real visualizer with a stand-in and yield the list of ones opened.
+
+    Teardown closes them through the real close path, which also empties the
+    module-level registry that outlives any one widget.
+    """
+    opened = []
+
+    def fakeOpen(tracker):
+        viz = _FakeVisualizer(tracker)
+        opened.append(viz)
+        viz.show()
+        return viz
+
+    monkeypatch.setattr(acqtrack, "_openVisualizer", fakeOpen)
+    yield opened
+    for viz in opened:
+        viz.close()
+    Qt.QTest.qWait(10)
+
+
+def _settle(path, timeout=10.0):
+    """Pump the GUI event loop until *path* is no longer loading.
+
+    The read runs on a worker thread and reports back through a queued signal, so the
+    loop has to keep turning for the result to land.
+    """
+    waited = 0.0
+    while acqtrack.visualizers.stateOf(path) == acqtrack.LOADING and waited < timeout:
+        Qt.QTest.qWait(10)
+        waited += 0.01
+    Qt.QTest.qWait(10)
+
+
 class TestAcqTrackWidget:
     def test_has_visualize_button(self, qapp, tmp_path):
         w = AcqTrackWidget(_FakeFileHandle(tmp_path / "tracking_history.acqtrack"))
@@ -194,14 +269,111 @@ class TestAcqTrackWidget:
         AcqTrackWidget(fh)
         assert fh.readCount == 0
 
-    def test_click_opens_visualizer_with_loaded_history(self, qapp, tmp_path, monkeypatch):
+    def test_click_opens_visualizer_with_loaded_history(self, qapp, tmp_path, openedVisualizers):
         history = object()
         fh = _FakeFileHandle(tmp_path / "tracking_history.acqtrack", data=history)
-        opened = []
-        monkeypatch.setattr(acqtrack, "_openVisualizer", opened.append)
 
         w = AcqTrackWidget(fh)
-        w.findChildren(Qt.QPushButton)[0].click()
+        w.visualizeBtn.click()
+        _settle(fh.name())
 
-        assert opened == [history]
+        assert [viz.tracker for viz in openedVisualizers] == [history]
         assert fh.readCount == 1
+
+    def test_reads_off_the_gui_thread(self, qapp, tmp_path, openedVisualizers):
+        fh = _BlockingFileHandle(tmp_path / "tracking_history.acqtrack", data=object())
+
+        w = AcqTrackWidget(fh)
+        w.visualizeBtn.click()
+        fh.release.set()
+        _settle(fh.name())
+
+        assert fh.readThread is not None
+        assert fh.readThread is not threading.main_thread()
+
+    def test_visualizer_is_built_on_the_gui_thread(self, qapp, tmp_path, openedVisualizers):
+        """The read is handed back through a queued signal precisely so the window it
+        produces is constructed where Qt allows widgets to be built."""
+        fh = _BlockingFileHandle(tmp_path / "tracking_history.acqtrack", data=object())
+
+        w = AcqTrackWidget(fh)
+        w.visualizeBtn.click()
+        fh.release.set()
+        _settle(fh.name())
+
+        assert openedVisualizers[0].builtOn is threading.main_thread()
+
+    def test_button_reports_loading_while_the_read_runs(self, qapp, tmp_path, openedVisualizers):
+        fh = _BlockingFileHandle(tmp_path / "tracking_history.acqtrack", data=object())
+        w = AcqTrackWidget(fh)
+
+        w.visualizeBtn.click()
+
+        assert w.visualizeBtn.text() == "Loading..."
+        assert not w.visualizeBtn.isEnabled()
+        fh.release.set()
+        _settle(fh.name())
+
+    def test_button_reports_open_once_the_visualizer_is_up(self, qapp, tmp_path, openedVisualizers):
+        fh = _FakeFileHandle(tmp_path / "tracking_history.acqtrack", data=object())
+        w = AcqTrackWidget(fh)
+
+        w.visualizeBtn.click()
+        _settle(fh.name())
+
+        assert w.visualizeBtn.text() == "Visualizer open"
+        assert not w.visualizeBtn.isEnabled()
+
+    def test_second_visualize_opens_no_second_window(self, qapp, tmp_path, openedVisualizers):
+        fh = _FakeFileHandle(tmp_path / "tracking_history.acqtrack", data=object())
+        w = AcqTrackWidget(fh)
+        w.visualizeBtn.click()
+        _settle(fh.name())
+
+        w.visualize()  # bypasses the disabled button, as a stray programmatic call would
+        _settle(fh.name())
+
+        assert len(openedVisualizers) == 1
+        assert fh.readCount == 1
+
+    def test_closing_the_visualizer_re_enables_the_button(self, qapp, tmp_path, openedVisualizers):
+        fh = _FakeFileHandle(tmp_path / "tracking_history.acqtrack", data=object())
+        w = AcqTrackWidget(fh)
+        w.visualizeBtn.click()
+        _settle(fh.name())
+
+        openedVisualizers[0].close()
+        Qt.QTest.qWait(10)
+
+        assert w.visualizeBtn.text() == "Visualize"
+        assert w.visualizeBtn.isEnabled()
+
+    def test_a_rebuilt_widget_sees_the_window_its_predecessor_opened(
+        self, qapp, tmp_path, openedVisualizers
+    ):
+        """FileDataView drops and rebuilds these widgets whenever the file selection
+        changes, so 'already open' cannot be remembered on the widget itself."""
+        path = tmp_path / "tracking_history.acqtrack"
+        first = AcqTrackWidget(_FakeFileHandle(path, data=object()))
+        first.visualizeBtn.click()
+        _settle(str(path))
+
+        second = AcqTrackWidget(_FakeFileHandle(path, data=object()))
+
+        assert second.visualizeBtn.text() == "Visualizer open"
+        assert not second.visualizeBtn.isEnabled()
+
+    def test_a_failed_read_reports_the_error_and_allows_a_retry(
+        self, qapp, tmp_path, openedVisualizers, caplog
+    ):
+        fh = _FailingFileHandle(tmp_path / "tracking_history.acqtrack")
+        w = AcqTrackWidget(fh)
+
+        with caplog.at_level(logging.ERROR, logger="acq4.filetypes.AcqTrackFile"):
+            w.visualizeBtn.click()
+            _settle(fh.name())
+
+        assert openedVisualizers == []
+        assert w.visualizeBtn.text() == "Load failed"
+        assert w.visualizeBtn.isEnabled()
+        assert "corrupt history" in caplog.text


### PR DESCRIPTION
## What

The Data tab's Visualize button for `.acqtrack` files now loads off the GUI thread, opens at most one visualizer window per file, and reports its state on the button face.

Per-path state moved out of `AcqTrackWidget` into a module-level `_VisualizerRegistry` (instance `visualizers`) that emits `sigChanged(path)`. It replaces the old `_openVisualizers` list.

| State | Button |
|---|---|
| idle | `Visualize`, enabled |
| reading | `Loading...`, disabled |
| window up | `Visualizer open`, disabled |
| read raised | `Load failed`, enabled (retry) |

## Why

Reading a tracking history deserializes every image and object stack the tracker saw. Previously that ran synchronously in the click handler — the app froze for the duration — and nothing stopped a second click from stacking up duplicate windows.

## How

- **Off-thread read**: `load()` wraps `fileHandle.read` in a `QtFriendlyTask` using the construct → connect → start pattern, so a fast read can't finish before `sigFinished` is wired.
- **Back on the GUI thread**: the finish callback fires on the worker thread, but it's connected to a bound method of the registry — a GUI-thread `QObject` — so the queued connection marshals `LiveTrackerVisualizer` construction to the thread where Qt permits widget creation. There's a test asserting exactly this.
- **One window**: `load()` is a no-op while a path is `LOADING` or `OPEN`.
- **Close detection**: the visualizer is a plain object wrapping a `QMainWindow`, with no close signal to connect to, so the registry installs an event filter and retires the session on `QEvent.Close`.
- **Failures** are logged and shown on the button rather than raised — this runs inside a Qt slot, and the user's recourse is simply another click.

## Reviewer notes

- **State had to leave the widget.** `FileDataView.clear()` closes, unparents and drops its widgets on every selection change. A widget-owned flag would forget an already-open window when the widget is rebuilt, and a widget-owned reference would take the parentless visualizer window down with it.
- **"One window" is scoped per file path**, not globally — two different `.acqtrack` files can each have a visualizer up. Happy to tighten to a single global window if that's preferred.
- `AcqTrackFile` now imports `acq4.util.task`, and `filetypes.listFileTypes()` imports every module in the package at startup. gentletask and pyqtgraph are already pulled in broadly elsewhere, so this shouldn't move startup cost.

## Tests

11 widget tests, written first and watched fail: the three button states, read happens off the main thread, visualizer built *on* the main thread, no second window from a stray programmatic `visualize()`, close re-enables, a rebuilt widget sees its predecessor's window, and a failed read logs and offers a retry. A blocking fake file handle makes the mid-load state deterministic; the fake visualizer wraps a real `QMainWindow` so the close path is genuinely exercised.

```
QT_QPA_PLATFORM=offscreen pytest acq4/filetypes acq4/modules/DataManager -q
24 passed
```

🧙 Built with [WOZCODE](https://wozcode.com)