### PR TITLE
fix: hold the pipette for every tracking acquisition, not every other one

### DIFF
--- a/acq4/devices/PatchPipette/states/_base.py
+++ b/acq4/devices/PatchPipette/states/_base.py
@@ -180,6 +180,7 @@ class PatchPipetteState(QtFriendlyTask):
         self._cleanupFuture = None
         self._pressureAdjustment = None
         self._pauseMovement = False
+        self._extendedTrackingDepth = 0
         # indicates state that should be transitioned to next, if any.
         # This is usually set by the return value of run(), and must be invoked by the state manager.
         self.nextState = {"state": self.config.get('fallbackState', None)}
@@ -433,7 +434,7 @@ class PatchPipetteState(QtFriendlyTask):
             )
 
         cell.enableTracking(True)
-        cell.sigTrackingMultipleFramesStart.connect(self._pausePipetteForExtendedTracking)
+        self._connectExtendedTrackingPause(cell)
         cell.sigPositionChanged.connect(self.dev.pipetteDevice.setTarget)
         cell._trackingFuture.sigFinished.connect(self._visualTargetTrackingFinished)
 
@@ -444,15 +445,31 @@ class PatchPipetteState(QtFriendlyTask):
         disconnect(self.dev.cell.sigTrackingMultipleFramesStart, self._pausePipetteForExtendedTracking)
         disconnect(self.dev.cell.sigTrackingMultipleFramesFinish, self._resumePipetteAfterExtendedTracking)
 
-    def _pausePipetteForExtendedTracking(self, cell):
-        self._pauseMovement = True
-        cell.sigTrackingMultipleFramesStart.disconnect(self._pausePipetteForExtendedTracking)
+    def _connectExtendedTrackingPause(self, cell):
+        """Hold the pipette still for as long as any multi-frame acquisition is running.
+
+        Both connections stay up for the life of the tracking run and a depth count
+        decides when to release, rather than the two handlers rewiring these signals
+        from inside each other. That latch dropped any Start arriving before the
+        matching Finish had been delivered, and the first Finish then released the
+        pipette while an acquisition was still going -- reachable whenever the
+        tracker takes a second reference stack straight after the first, since the
+        emitting tracking loop runs in its own thread.
+        """
+        self._extendedTrackingDepth = 0
+        cell.sigTrackingMultipleFramesStart.connect(self._pausePipetteForExtendedTracking)
         cell.sigTrackingMultipleFramesFinish.connect(self._resumePipetteAfterExtendedTracking)
 
+    def _pausePipetteForExtendedTracking(self, cell):
+        self._extendedTrackingDepth += 1
+        self._pauseMovement = True
+
     def _resumePipetteAfterExtendedTracking(self, cell):
-        self._pauseMovement = False
-        cell.sigTrackingMultipleFramesFinish.disconnect(self._resumePipetteAfterExtendedTracking)
-        cell.sigTrackingMultipleFramesStart.connect(self._pausePipetteForExtendedTracking)
+        # Floor at zero: a stop between the paired emissions can strand a Finish with
+        # no Start, and that must not leave the count negative and the pause stuck on.
+        self._extendedTrackingDepth = max(0, self._extendedTrackingDepth - 1)
+        if self._extendedTrackingDepth == 0:
+            self._pauseMovement = False
 
     def _waitForMoveWhileTargetChanges(self, position_fn, speed, continuous, interval=None, step=None, move_restart_threshold=3.0):
         """Wait for a move to complete while also monitoring for changes in the target position.

--- a/acq4/devices/PatchPipette/tests/test_extended_tracking_pause.py
+++ b/acq4/devices/PatchPipette/tests/test_extended_tracking_pause.py
@@ -1,0 +1,94 @@
+"""Tests that the pipette stays still for every multi-frame tracking acquisition.
+
+The pause used to be a one-shot latch that rewired its own two signals from inside
+their handlers. A Start arriving before the matching Finish had been delivered was
+silently dropped, and the first Finish then released the pause while an acquisition
+was still running -- which is what a second reference stack taken straight after the
+first produces, leaving the pipette free to move during it.
+"""
+
+import pytest
+from acq4.util import Qt
+
+from acq4.devices.PatchPipette.states._base import PatchPipetteState
+
+
+class _FakeSignal:
+    def connect(self, *args, **kwargs):
+        pass
+
+    def disconnect(self, *args, **kwargs):
+        pass
+
+    def emit(self, *args, **kwargs):
+        pass
+
+
+class _FakeDev:
+    def __init__(self):
+        self.sigTargetChanged = _FakeSignal()
+        self.sigActiveChanged = _FakeSignal()
+
+
+class _Cell(Qt.QObject):
+    """Just the two signals Cell.updatePosition brackets a multi-frame step with."""
+
+    sigTrackingMultipleFramesStart = Qt.Signal(object)
+    sigTrackingMultipleFramesFinish = Qt.Signal(object)
+
+
+@pytest.fixture
+def state_and_cell(qapp):
+    state = PatchPipetteState(_FakeDev(), config={})
+    cell = _Cell()
+    state._connectExtendedTrackingPause(cell)
+    return state, cell
+
+
+def test_a_multi_frame_step_pauses_the_pipette(state_and_cell):
+    state, cell = state_and_cell
+    cell.sigTrackingMultipleFramesStart.emit(cell)
+    assert state._pauseMovement is True
+
+
+def test_the_pipette_resumes_when_the_step_finishes(state_and_cell):
+    state, cell = state_and_cell
+    cell.sigTrackingMultipleFramesStart.emit(cell)
+    cell.sigTrackingMultipleFramesFinish.emit(cell)
+    assert state._pauseMovement is False
+
+
+def test_consecutive_steps_each_pause(state_and_cell):
+    """Two reference stacks in a row: the second must pause as the first did."""
+    state, cell = state_and_cell
+    for _ in range(2):
+        cell.sigTrackingMultipleFramesStart.emit(cell)
+        assert state._pauseMovement is True
+        cell.sigTrackingMultipleFramesFinish.emit(cell)
+        assert state._pauseMovement is False
+
+
+def test_a_second_start_before_the_first_finish_keeps_the_pause(state_and_cell):
+    """The reported failure. Whatever the interleaving, the pipette must not be
+    released while an acquisition is outstanding."""
+    state, cell = state_and_cell
+    cell.sigTrackingMultipleFramesStart.emit(cell)
+    cell.sigTrackingMultipleFramesStart.emit(cell)
+    cell.sigTrackingMultipleFramesFinish.emit(cell)
+    assert state._pauseMovement is True, "released while a second stack was running"
+    cell.sigTrackingMultipleFramesFinish.emit(cell)
+    assert state._pauseMovement is False
+
+
+def test_an_unmatched_finish_does_not_raise(state_and_cell):
+    """A stop between the two emissions can strand a Finish with no Start."""
+    state, cell = state_and_cell
+    cell.sigTrackingMultipleFramesFinish.emit(cell)
+    assert state._pauseMovement is False
+    cell.sigTrackingMultipleFramesStart.emit(cell)
+    assert state._pauseMovement is True
+
+
+def test_the_pause_starts_released(qapp):
+    state = PatchPipetteState(_FakeDev(), config={})
+    assert state._pauseMovement is False


### PR DESCRIPTION
## Problem

The pipette pause around multi-frame tracking acquisitions was a one-shot latch: each handler disconnected its own signal and connected the other's. A `sigTrackingMultipleFramesStart` emitted before the matching `Finish` had been delivered therefore hit a disconnected signal and was dropped — and the first `Finish` then released the pipette while that second acquisition was still running.

The tracking loop emits these from its own thread, so the ordering is reachable whenever two multi-frame steps run close together. A reference refresh did exactly that on every occurrence, until the tracker stopped taking a second stack.

## Fix

Keep both connections up for the life of the tracking run and count acquisition depth instead, releasing only when the count returns to zero. The count floors at zero so a `Finish` stranded by a stop cannot drive it negative and wedge the pause on.

## Tests

New `acq4/devices/PatchPipette/tests/test_extended_tracking_pause.py` — 6 tests covering nested Start/Finish, the stranded-Finish floor, and release only at depth zero. All pass on this base.

## Provenance

This fix was originally committed straight onto `_staging` by a debugging session that was working out of an `acq4-automation` worktree and had no `acq4` branch of its own. `_staging` is an aggregate of branches under review, not a place work lands, so the commit has been cherry-picked here to reach `_reviewed` by the normal route and `_staging` has been rewound. Content is byte-identical to the original.

🤖 Generated with [Claude Code](https://claude.ai/code)