### PR TITLE
fix: derive mock detection pixel size from the loaded z-stack

### DIFF
--- a/acq4/modules/AutomationDebug/detection.py
+++ b/acq4/modules/AutomationDebug/detection.py
@@ -47,6 +47,24 @@ def _health_model_config(manager) -> dict:
     }
 
 
+def _mock_pixel_size(detection_stack, classification_stack):
+    """The XY pixel size of a loaded mock z-stack.
+
+    A mock stack is a file acquired elsewhere, so the live camera's pixel size says
+    nothing about it. Both channels image the same field and must agree; a mismatch
+    means one of the two loaded files is not the one it was taken to be.
+    """
+    pixel_size = detection_stack[0].info()["pixelSize"][0]
+    if classification_stack is not None:
+        classification_pixel_size = classification_stack[0].info()["pixelSize"][0]
+        if classification_pixel_size != pixel_size:
+            raise ValueError(
+                f"Mock detection stack pixel size ({pixel_size / µm:.4f} µm) does not match "
+                f"classification stack pixel size ({classification_pixel_size / µm:.4f} µm)."
+            )
+    return pixel_size
+
+
 class CellDetector:
     def __init__(self, window: AutomationDebugWindow):
         self._window = window
@@ -118,7 +136,7 @@ class CellDetector:
         win._current_detection_stack = None
         win._current_classification_stack = None
 
-        pixel_size = win.cameraDevice.getPixelSize()[0]  # Used for both real and mock
+        pixel_size = win.cameraDevice.getPixelSize()[0]  # mock overrides this from its stack
         man = win.module.manager
         models = _health_model_config(man)
         segmenter = models["segmenter"]
@@ -142,6 +160,7 @@ class CellDetector:
             detection_stack, classification_stack, step_z = win._mock_handler._mockNeuronStacks()
             if detection_stack is None:
                 raise RuntimeError("Failed to load mock detection stack.")
+            pixel_size = _mock_pixel_size(detection_stack, classification_stack)
 
         else:  # --- Real Acquisition ---
             surface = win.scopeDevice.findSurfaceDepth(win.cameraDevice)

--- a/acq4/modules/AutomationDebug/tests/test_mock_detection_pixel_size.py
+++ b/acq4/modules/AutomationDebug/tests/test_mock_detection_pixel_size.py
@@ -1,0 +1,62 @@
+"""Tests for mock detection's pixel size: it comes from the loaded z-stack.
+
+Cover that _mock_pixel_size reads the XY pixel size off the loaded mock detection
+stack rather than the live camera, and rejects a classification stack that
+disagrees with it.
+"""
+
+import numpy as np
+import pytest
+from pyqtgraph.units import µm
+
+import coorx
+from acq4.util.imaging import Frame
+
+from acq4.modules.AutomationDebug.detection import _mock_pixel_size
+
+
+def _make_stack(xy_px, n_frames=3, nrows=8, ncols=8, z_step=1e-6):
+    """A z-stack of Frames carrying `xy_px` as their pixel size, as a loaded mock
+    stack does."""
+    frames = []
+    for i in range(n_frames):
+        m = np.eye(4)
+        m[0, 0] = xy_px
+        m[1, 1] = xy_px
+        m[2, 2] = z_step
+        m[2, 3] = i * z_step
+        xform = coorx.AffineTransform.from_matrix(m, from_cs=f"frame_{i}.xyz", to_cs="global")
+        info = {"transform": xform, "pixelSize": (xy_px, xy_px)}
+        frames.append(Frame(np.zeros((nrows, ncols), dtype=np.float32), info))
+    return frames
+
+
+def test_pixel_size_comes_from_the_detection_stack():
+    """The mock stack was acquired on some other rig, so its pixel size is the only
+    one that describes it; the live camera's is unrelated."""
+    assert _mock_pixel_size(_make_stack(0.5 * µm), None) == 0.5 * µm
+
+
+def test_matching_classification_stack_is_accepted():
+    detection = _make_stack(0.5 * µm)
+    classification = _make_stack(0.5 * µm)
+    assert _mock_pixel_size(detection, classification) == 0.5 * µm
+
+
+def test_disagreeing_classification_stack_is_rejected():
+    """Two channels of the same field must share a pixel size; if they don't, one of
+    them is the wrong file and silently scaling by the detection stack's would put
+    the classification channel's cells in the wrong place."""
+    detection = _make_stack(0.5 * µm)
+    classification = _make_stack(0.25 * µm)
+    with pytest.raises(ValueError, match="does not match"):
+        _mock_pixel_size(detection, classification)
+
+
+def test_rejection_message_names_both_sizes_in_micrometres():
+    detection = _make_stack(0.5 * µm)
+    classification = _make_stack(0.25 * µm)
+    with pytest.raises(ValueError) as excinfo:
+        _mock_pixel_size(detection, classification)
+    assert "0.5000" in str(excinfo.value)
+    assert "0.2500" in str(excinfo.value)


### PR DESCRIPTION
## What

Mock cell detection scaled its results by the **live camera's** pixel size. A mock stack is a file acquired on some other rig, so the camera's value says nothing about it — detections came out at the wrong scale whenever the two differed.

This takes the XY pixel size off the loaded detection stack instead, and rejects a classification stack whose pixel size disagrees: both channels image the same field, so a mismatch means one of the loaded files isn't the one it was taken to be.

## Where this came from

This is a reapplication of `3a373882d`, stranded on a `worktree-mock-px-head` branch from 2026-06-18 that never landed. That branch predated the gentletask migration, so merging or cherry-picking it would have reverted a lot of newer work — only the ~10 relevant lines are carried over here.

## Design note

The original fix was inline in `_detectNeuronsZStack`, which can't be tested without standing up a live acquisition and most of `acq4_automation`. The logic is extracted into a module-level `_mock_pixel_size` helper next to `_health_model_config`, which gives it a test seam.

## Tests

Four new tests in `acq4/modules/AutomationDebug/tests/test_mock_detection_pixel_size.py`, written test-first and confirmed failing before the fix:

- pixel size comes from the detection stack, not the camera
- a matching classification stack is accepted
- a disagreeing classification stack raises `ValueError`
- the error message names both sizes in µm

Full suite: **1154 passed, 24 xfailed**.

🤖 Generated with [Claude Code](https://claude.ai/code)