### PR TITLE
Autopatch Area 1: draw, shape, and mirror the slice's search regions

### DIFF
--- a/acq4/experiment/search_grid.py
+++ b/acq4/experiment/search_grid.py
@@ -6,12 +6,20 @@ from __future__ import annotations
 import math
 
 
-def _axis_centers(lo: float, hi: float, fov: float, overlap: float) -> list[float]:
-    """Tile centers along one axis whose union covers [lo, hi].
+def _axis_step(fov: float, overlap: float) -> float:
+    """The distance between adjacent tile centers along one axis."""
+    step = fov - overlap
+    if step <= 0:
+        # Degrade gracefully if the overlap swallows the whole FOV.
+        step = fov
+    return step
 
-    Step between tiles is ``fov - overlap``; the tile count is the smallest that
-    spans the extent, and the tiles are centered over it so the union fully
-    covers [lo, hi] (the outermost tiles may extend past the edges).
+
+def _axis_count(lo: float, hi: float, fov: float, overlap: float) -> int:
+    """How many tiles along one axis it takes to cover [lo, hi].
+
+    Step between tiles is ``fov - overlap``, and the count is the smallest that
+    spans the extent.
 
     ``extent`` is computed as ``hi - lo``, and ``lo``/``hi`` may be as large as a
     stage's absolute travel range while ``fov``/``step`` are tiny by comparison,
@@ -23,23 +31,32 @@ def _axis_centers(lo: float, hi: float, fov: float, overlap: float) -> list[floa
     being rounded up to one more tile.
     """
     extent = hi - lo
-    step = fov - overlap
-    if step <= 0:
-        # Degrade gracefully if the overlap swallows the whole FOV.
-        step = fov
+    step = _axis_step(fov, overlap)
     scale = max(abs(lo), abs(hi), fov, step)
     length_tol = scale * 1e-9
     if extent <= fov + length_tol:
-        return [(lo + hi) / 2.0]
+        return 1
     ratio = (extent - fov) / step
     ratio_tol = length_tol / step
     rounded_ratio = round(ratio)
     if abs(ratio - rounded_ratio) <= ratio_tol:
-        n = int(rounded_ratio) + 1
-    else:
-        n = math.ceil(ratio) + 1
+        return int(rounded_ratio) + 1
+    return math.ceil(ratio) + 1
+
+
+def _axis_centers(lo: float, hi: float, fov: float, overlap: float) -> list[float]:
+    """Tile centers along one axis whose union covers [lo, hi].
+
+    The tiles are centered over the extent so their union fully covers [lo, hi]
+    (the outermost tiles may extend past the edges). A single tile at the
+    midpoint covers an extent no larger than one FOV.
+    """
+    n = _axis_count(lo, hi, fov, overlap)
+    if n == 1:
+        return [(lo + hi) / 2.0]
+    step = _axis_step(fov, overlap)
     covered = fov + (n - 1) * step
-    extra = covered - extent
+    extra = covered - (hi - lo)
     start = lo + fov / 2.0 - extra / 2.0
     return [start + i * step for i in range(n)]
 
@@ -69,6 +86,30 @@ def plan_grid(
         for cx in row:
             grid.append((cx, cy))
     return grid
+
+
+def count_grid(
+    x0: float,
+    y0: float,
+    x1: float,
+    y1: float,
+    fov_w: float,
+    fov_h: float,
+    overlap: float,
+) -> int:
+    """How many tiles ``plan_grid`` would return for this rectangle.
+
+    Arithmetic, so a caller can find out how big a grid is before deciding
+    whether to build it: ``plan_grid`` materialises every center, which is
+    minutes of compute and a list to match once a rectangle is large enough
+    relative to the field of view.
+
+    Shares ``_axis_count`` with ``plan_grid`` rather than re-deriving the count,
+    so the two cannot disagree about where a tolerance-sized extent falls.
+    """
+    return _axis_count(min(x0, x1), max(x0, x1), fov_w, overlap) * _axis_count(
+        min(y0, y1), max(y0, y1), fov_h, overlap
+    )
 
 
 def _is_visited(

--- a/acq4/experiment/search_region.py
+++ b/acq4/experiment/search_region.py
@@ -3,6 +3,7 @@ rect-vs-shape overlap tests that decide which planned tiles are worth imaging.""
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 
@@ -47,13 +48,32 @@ class SearchRegion:
 @dataclass(frozen=True)
 class _BoxRegion(SearchRegion):
     """Shared base for the shapes a bounding box defines: the corner
-    normalization and validation, which are identical for both.
+    normalization and validation, which are identical for both, and the angle
+    that turns the box off the axes.
+
+    `angle` is in **degrees counter-clockwise about the `(x0, y0)` corner**, and
+    every part of that is measured rather than chosen. Degrees and that pivot are
+    what `pg.ROI` itself uses: `ROI.setAngle` records degrees and, given no
+    explicit centre, turns the ROI about its local origin -- which is exactly
+    what `ROI.pos()` reports, and which it leaves untouched. Matching it lets
+    `regionForRoi(roiForRegion(r))` read `pos()` and `size()` back with the same
+    arithmetic it used at zero angle, so the round trip is exact at every angle.
+    A centre pivot cannot be: recovering a corner from a centre costs a halving
+    and its inverse, which over 2000 measured regions failed to return the
+    original float about half the time -- including at zero angle, where it would
+    move regions nobody rotated. Counter-clockwise is the direction Qt's
+    transform turns a point in these coordinates, checked corner by corner
+    against `[[cos, -sin], [sin, cos]]`.
+
+    Angle zero is a shape's ordinary state and takes the axis-aligned path
+    throughout, returning the same floats as a region with no angle at all.
     """
 
     x0: float
     y0: float
     x1: float
     y1: float
+    angle: float = 0.0
 
     def __post_init__(self):
         lo_x, hi_x = min(self.x0, self.x1), max(self.x0, self.x1)
@@ -68,21 +88,87 @@ class _BoxRegion(SearchRegion):
         object.__setattr__(self, "x1", hi_x)
         object.__setattr__(self, "y1", hi_y)
 
-    def bounds(self) -> tuple[float, float, float, float]:
+    def box(self) -> tuple[float, float, float, float]:
+        """The unrotated (x0, y0, x1, y1) box this shape is inscribed in.
+
+        Distinct from `bounds()` as soon as there is an angle: this is the box
+        the operator sized, which an ROI is rebuilt from, while `bounds()` is the
+        axis-aligned extent of the turned shape, which the tiler plans over.
+        """
         return (self.x0, self.y0, self.x1, self.y1)
+
+    def _cosSin(self) -> tuple[float, float]:
+        th = math.radians(self.angle)
+        return (math.cos(th), math.sin(th))
+
+    def _turn(self, x: float, y: float) -> tuple[float, float]:
+        """`(x, y)` turned by this region's angle about its pivot."""
+        c, s = self._cosSin()
+        dx, dy = x - self.x0, y - self.y0
+        return (self.x0 + dx * c - dy * s, self.y0 + dx * s + dy * c)
+
+    def _boxCorners(self) -> tuple:
+        """The four corners of the turned box, counter-clockwise from the pivot."""
+        corners = (
+            (self.x0, self.y0),
+            (self.x1, self.y0),
+            (self.x1, self.y1),
+            (self.x0, self.y1),
+        )
+        if self.angle == 0.0:
+            return corners
+        return tuple(self._turn(x, y) for x, y in corners)
+
+    def _center(self) -> tuple[float, float]:
+        """The shape's centre, after the turn."""
+        cx, cy = (self.x0 + self.x1) / 2, (self.y0 + self.y1) / 2
+        return (cx, cy) if self.angle == 0.0 else self._turn(cx, cy)
+
+
+def _project(points, ax: float, ay: float) -> tuple[float, float]:
+    """The (low, high) shadow `points` cast on the direction `(ax, ay)`."""
+    dots = [px * ax + py * ay for px, py in points]
+    return (min(dots), max(dots))
 
 
 class RectRegion(_BoxRegion):
-    """A rectangular region: the shape "Add region here" seeds, and the shape for
-    which tile filtering is provably a no-op (every tile plan_grid plans over a
-    rectangle overlaps that rectangle).
+    """A rectangular region: the shape "Add region here" seeds, and -- while it
+    sits on the axes -- the shape for which tile filtering is provably a no-op
+    (every tile plan_grid plans over an axis-aligned rectangle overlaps that
+    rectangle). Turn it and that stops being true: the grid is planned over the
+    turned rectangle's larger axis-aligned bounds, whose corners stick out past
+    the shape, so the filter starts earning its place.
     """
+
+    def bounds(self) -> tuple[float, float, float, float]:
+        if self.angle == 0.0:
+            return self.box()
+        corners = self._boxCorners()
+        xs = [p[0] for p in corners]
+        ys = [p[1] for p in corners]
+        return (min(xs), min(ys), max(xs), max(ys))
 
     def overlapsTile(self, center: tuple[float, float], fov: tuple[float, float]) -> bool:
         tx0, ty0, tx1, ty1 = tile_rect(center, fov)
-        return (
-            tx0 <= self.x1 and tx1 >= self.x0 and ty0 <= self.y1 and ty1 >= self.y0
-        )
+        if self.angle == 0.0:
+            return (
+                tx0 <= self.x1 and tx1 >= self.x0 and ty0 <= self.y1 and ty1 >= self.y0
+            )
+        # Two convex boxes miss each other only if some direction separates
+        # them, and for two rectangles the only directions that can are their own
+        # edge normals: the tile's two axes and this rectangle's two. So four
+        # projections settle it exactly, with no iteration and no epsilon --
+        # every comparison is between two shadows cast on the same direction,
+        # which is the scale-freedom `_segment_touches_rect` was written for.
+        corners = self._boxCorners()
+        tileCorners = ((tx0, ty0), (tx1, ty0), (tx1, ty1), (tx0, ty1))
+        c, s = self._cosSin()
+        for ax, ay in ((1.0, 0.0), (0.0, 1.0), (c, s), (-s, c)):
+            lo, hi = _project(corners, ax, ay)
+            tlo, thi = _project(tileCorners, ax, ay)
+            if hi < tlo or thi < lo:
+                return False
+        return True
 
 
 class EllipseRegion(_BoxRegion):
@@ -91,24 +177,62 @@ class EllipseRegion(_BoxRegion):
 
     Overlap is exact and needs no iteration: mapping the tile into the frame where
     the ellipse is the unit circle at the origin turns "does this rect reach the
-    ellipse" into "is the closest point of a rect to the origin within 1". An
-    axis-aligned rect stays axis-aligned under that (per-axis) scaling, which is
-    what makes the closest point a per-axis clamp rather than a search.
+    ellipse" into "is the closest point of a rect to the origin within 1". While
+    the ellipse sits on the axes, an axis-aligned rect stays axis-aligned under
+    that (per-axis) scaling, which is what makes the closest point a per-axis
+    clamp rather than a search. Turn the ellipse and the map gains a rotation, so
+    the tile arrives as a parallelogram and the clamp gives way to the distance
+    from the origin to that quadrilateral -- still closed form, still one pass.
     """
 
+    def bounds(self) -> tuple[float, float, float, float]:
+        if self.angle == 0.0:
+            return self.box()
+        # A turned ellipse is strictly narrower than the box it was inscribed in,
+        # so hulling the four turned corners would plan a ring of tiles that can
+        # never touch it. These half-extents are the exact support of the ellipse
+        # along each axis, in closed form.
+        rx = (self.x1 - self.x0) / 2
+        ry = (self.y1 - self.y0) / 2
+        c, s = self._cosSin()
+        hw = math.hypot(rx * c, ry * s)
+        hh = math.hypot(rx * s, ry * c)
+        cx, cy = self._center()
+        return (cx - hw, cy - hh, cx + hw, cy + hh)
+
     def overlapsTile(self, center: tuple[float, float], fov: tuple[float, float]) -> bool:
-        cx = (self.x0 + self.x1) / 2
-        cy = (self.y0 + self.y1) / 2
         rx = (self.x1 - self.x0) / 2
         ry = (self.y1 - self.y0) / 2
         tx0, ty0, tx1, ty1 = tile_rect(center, fov)
-        ax0, ax1 = (tx0 - cx) / rx, (tx1 - cx) / rx
-        ay0, ay1 = (ty0 - cy) / ry, (ty1 - cy) / ry
-        # Clamp the origin into the mapped rect: the result is the rect's closest
-        # point to the ellipse center, and zero on an axis the center falls within.
-        dx = max(ax0, min(0.0, ax1))
-        dy = max(ay0, min(0.0, ay1))
-        return dx * dx + dy * dy <= 1.0
+        if self.angle == 0.0:
+            cx = (self.x0 + self.x1) / 2
+            cy = (self.y0 + self.y1) / 2
+            ax0, ax1 = (tx0 - cx) / rx, (tx1 - cx) / rx
+            ay0, ay1 = (ty0 - cy) / ry, (ty1 - cy) / ry
+            # Clamp the origin into the mapped rect: the result is the rect's
+            # closest point to the ellipse center, and zero on an axis the center
+            # falls within.
+            dx = max(ax0, min(0.0, ax1))
+            dy = max(ay0, min(0.0, ay1))
+            return dx * dx + dy * dy <= 1.0
+        cx, cy = self._center()
+        c, s = self._cosSin()
+        # Into the ellipse's own frame -- translate to its centre, turn back by
+        # the angle, then divide each axis by its radius. The map is affine, so
+        # the tile arrives as a parallelogram with its corners in the same cyclic
+        # order, and the ellipse arrives as the unit circle at the origin.
+        quad = []
+        for px, py in ((tx0, ty0), (tx1, ty0), (tx1, ty1), (tx0, ty1)):
+            dx, dy = px - cx, py - cy
+            quad.append(((dx * c + dy * s) / rx, (-dx * s + dy * c) / ry))
+        # Which leaves one question: is the origin within 1 of that quadrilateral.
+        # Zero when it is inside, and otherwise the nearest point lies on an edge.
+        if _point_in_polygon(0.0, 0.0, quad):
+            return True
+        return any(
+            _point_segment_distance_sq(0.0, 0.0, quad[i], quad[(i + 1) % 4]) <= 1.0
+            for i in range(4)
+        )
 
 
 def _segment_touches_rect(
@@ -145,6 +269,27 @@ def _segment_touches_rect(
                 return False
             t1 = min(t1, t)
     return True
+
+
+def _point_segment_distance_sq(
+    px: float, py: float, a: tuple[float, float], b: tuple[float, float]
+) -> float:
+    """The squared distance from `(px, py)` to the segment `a`->`b`.
+
+    Squared, because every caller compares it against a squared radius and the
+    square root would only cost precision on the way to the same answer.
+    """
+    ax, ay = a
+    bx, by = b
+    dx, dy = bx - ax, by - ay
+    lengthSq = dx * dx + dy * dy
+    if lengthSq == 0.0:
+        t = 0.0
+    else:
+        # Where the perpendicular foot falls along the segment, clamped to it.
+        t = min(1.0, max(0.0, ((px - ax) * dx + (py - ay) * dy) / lengthSq))
+    nx, ny = px - (ax + t * dx), py - (ay + t * dy)
+    return nx * nx + ny * ny
 
 
 def _point_in_polygon(px: float, py: float, vertices) -> bool:

--- a/acq4/experiment/slice.py
+++ b/acq4/experiment/slice.py
@@ -114,6 +114,19 @@ class Slice:
         """The search regions, as a copy: mutating the result changes nothing."""
         return list(self._regions)
 
+    def setRegions(self, regions) -> None:
+        """Replace the regions to survey, in one step. Coverage is untouched.
+
+        Rebinding the attribute rather than mutating the list is what makes this
+        safe to call from the GUI thread while a producer is reading regions on
+        the worker thread: `tileGrid()` binds its loop to whichever list object
+        was current when it started, so a reader sees either the whole old set
+        or the whole new one and never a list changing under its own iteration.
+        The same "make it one step" discipline `Orchestrator._refillQueue`
+        applies to the producer reference.
+        """
+        self._regions = list(regions)
+
     def addRegion(self, region: SearchRegion) -> None:
         """Add a shape to survey, in global coordinates. Coverage is untouched.
 
@@ -122,7 +135,7 @@ class Slice:
         searching, is the ordinary reason to outline a region at all. A rectangle
         is `RectRegion(x0, y0, x1, y1)`.
         """
-        self._regions.append(region)
+        self.setRegions(self._regions + [region])
 
     # ---- tiles and coverage ----
     @property
@@ -156,7 +169,9 @@ class Slice:
         """
         grid: list[tuple[float, float]] = []
         fov_w, fov_h = self._fov
-        for region in self._regions:
+        # Bound once: setRegions() can land from the GUI thread while this runs.
+        regions = self._regions
+        for region in regions:
             x0, y0, x1, y1 = region.bounds()
             planned = plan_grid(x0, y0, x1, y1, fov_w, fov_h, self._overlap)
             grid.extend(c for c in planned if region.overlapsTile(c, self._fov))
@@ -219,7 +234,8 @@ class Slice:
         # the overlap question. Narrowing to a plain (x, y) tuple also lets
         # this accept a coorx.Point, a Cell.position, or a bare tuple alike.
         xy = (position[0], position[1])
-        here = [r for r in self._regions if r.overlapsTile(xy, self._fov)]
+        regions = self._regions
+        here = [r for r in regions if r.overlapsTile(xy, self._fov)]
         if not here:
             return 0
         stale = [

--- a/acq4/experiment/slice.py
+++ b/acq4/experiment/slice.py
@@ -5,8 +5,25 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .search_grid import count_covered, plan_grid, select_next
+from .search_grid import count_covered, count_grid, plan_grid, select_next
 from .search_region import SearchRegion
+
+# The most tiles one region's bounding box may plan. At a 130 um field a
+# generous 10 mm slice is about 77x77 = 5,900 tiles, so this is roughly an
+# 18 mm square: past any tissue that fits on a rig, and still three orders of
+# magnitude short of what one mis-drag plans -- the 0.687 m x 0.873 m polygon
+# that prompted this cap planned 35,208,476 tiles at a 130.6 um field, minutes
+# of compute per ROI edit and a list of that length to hold.
+MAX_PLANNED_TILES = 20_000
+
+
+class RegionTooLarge(ValueError):
+    """A region whose bounding box would plan more than MAX_PLANNED_TILES tiles.
+
+    A ValueError because it is a rejected argument, not an orchestration state:
+    nothing routes it to an exception handler, and the only caller that catches
+    it is the UI seam that refuses the operator's edit.
+    """
 
 
 @dataclass(frozen=True)
@@ -124,8 +141,35 @@ class Slice:
         or the whole new one and never a list changing under its own iteration.
         The same "make it one step" discipline `Orchestrator._refillQueue`
         applies to the producer reference.
+
+        Raises RegionTooLarge, leaving the current regions in place, if any of
+        `regions` would plan more tiles than a survey can sensibly hold. Every
+        region reaches a slice through here, which is why the check lives here
+        rather than in the UI: the count is checked before the swap, so a
+        refused list changes nothing at all.
         """
-        self._regions = list(regions)
+        regions = list(regions)
+        for region in regions:
+            self._checkPlannedTiles(region)
+        self._regions = regions
+
+    def _checkPlannedTiles(self, region: SearchRegion) -> None:
+        """Raise RegionTooLarge if `region` would plan more than the cap allows.
+
+        Counted arithmetically rather than by planning, because the count is the
+        hazard: `tileGrid()` has `plan_grid` build the whole bounding-box grid
+        before any of it is filtered against the shape, so a check that planned
+        first would spend exactly the time and memory it exists to prevent.
+        """
+        x0, y0, x1, y1 = region.bounds()
+        fov_w, fov_h = self._fov
+        planned = count_grid(x0, y0, x1, y1, fov_w, fov_h, self._overlap)
+        if planned > MAX_PLANNED_TILES:
+            raise RegionTooLarge(
+                f"a region of {abs(x1 - x0):.3g} m x {abs(y1 - y0):.3g} m would "
+                f"plan {planned} tiles at this field of view, over the "
+                f"{MAX_PLANNED_TILES} tile limit"
+            )
 
     def addRegion(self, region: SearchRegion) -> None:
         """Add a shape to survey, in global coordinates. Coverage is untouched.
@@ -134,6 +178,9 @@ class Slice:
         rectangular: a slice with a damaged corner, or one cortical layer worth
         searching, is the ordinary reason to outline a region at all. A rectangle
         is `RectRegion(x0, y0, x1, y1)`.
+
+        Raises RegionTooLarge, adding nothing, for a region past the tile cap --
+        this goes through setRegions(), which is where that check lives.
         """
         self.setRegions(self._regions + [region])
 

--- a/acq4/experiment/tests/test_search_grid.py
+++ b/acq4/experiment/tests/test_search_grid.py
@@ -3,9 +3,12 @@ covers a rectangle, and choosing the next un-imaged tile."""
 
 import math
 
+import pytest
+
 from acq4.experiment.search_grid import (
     _is_visited,
     count_covered,
+    count_grid,
     plan_grid,
     select_next,
 )
@@ -126,6 +129,40 @@ def test_tile_count_holds_at_a_coordinate_whose_magnitude_dwarfs_the_tile_geomet
     x1, y1 = off + fov + (n_tiles - 1) * step, off + fov
     grid = plan_grid(x0, y0, x1, y1, fov, fov, overlap=0.0)
     assert len(grid) == n_tiles
+
+
+# Rectangles that between them exercise every branch of the axis tile count:
+# smaller than one FOV, an exact multiple, a ragged remainder, an extent that is
+# one FOV only to within float error at a realistic stage coordinate, and one
+# large enough that building the tile list is the thing worth avoiding.
+_COUNT_CASES = [
+    (10.0, 10.0, 60.0, 60.0, 100.0, 100.0, 20.0),
+    (0.0, 0.0, 200.0, 200.0, 100.0, 100.0, 20.0),
+    (0.0, 0.0, 250.0, 130.0, 100.0, 100.0, 20.0),
+    (1e-3, 2e-3, 1e-3 + 100e-6, 2e-3 + 50e-6, 100e-6, 50e-6, 0.0),
+    (1.5e-3, -2.5e-3, 1.5e-3 + 3.1e-3, -2.5e-3 + 2.7e-3, 130.6e-6, 130.6e-6, 0.0),
+]
+
+
+@pytest.mark.parametrize("x0,y0,x1,y1,fov_w,fov_h,overlap", _COUNT_CASES)
+def test_count_grid_matches_what_plan_grid_actually_produces(
+    x0, y0, x1, y1, fov_w, fov_h, overlap
+):
+    # count_grid() exists so a caller can find out how big a grid would be
+    # without building it, and it is worth nothing unless it is the same number.
+    # Checked against plan_grid itself rather than against hand-computed counts,
+    # which could drift from it.
+    assert count_grid(x0, y0, x1, y1, fov_w, fov_h, overlap) == len(
+        plan_grid(x0, y0, x1, y1, fov_w, fov_h, overlap)
+    )
+
+
+def test_count_grid_normalizes_its_corners_the_way_plan_grid_does():
+    # An ROI resized past its own origin reports a negative size, so the corners
+    # can arrive either way round.
+    assert count_grid(200, 200, 0, 0, 100, 100, 20) == count_grid(
+        0, 0, 200, 200, 100, 100, 20
+    )
 
 
 def test_is_visited_false_when_nothing_visited():

--- a/acq4/experiment/tests/test_search_region.py
+++ b/acq4/experiment/tests/test_search_region.py
@@ -470,8 +470,9 @@ def test_rotating_a_region_changes_which_tiles_it_selects(regionClass):
     assert turnedPattern != straightPattern
     # Named tiles, so this cannot be satisfied by an off-by-one in tile count:
     # each is selected by exactly one of the two orientations.
-    onlyTurned = [c for c, t, s in zip(centers, turnedPattern, straightPattern) if t and not s]
-    onlyStraight = [c for c, t, s in zip(centers, turnedPattern, straightPattern) if s and not t]
+    both = list(zip(centers, turnedPattern, straightPattern))
+    onlyTurned = [c for c, turnedHit, straightHit in both if turnedHit and not straightHit]
+    onlyStraight = [c for c, turnedHit, straightHit in both if straightHit and not turnedHit]
     assert onlyTurned and onlyStraight
 
 

--- a/acq4/experiment/tests/test_search_region.py
+++ b/acq4/experiment/tests/test_search_region.py
@@ -1,6 +1,8 @@
 """Tests for search-region shapes: the bounding box a survey plans its tiles over,
 and the exact rect-vs-shape overlap test that decides which of those tiles to image."""
 
+import math
+
 import pytest
 
 from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion, SearchRegion, tile_rect
@@ -310,3 +312,203 @@ def test_the_polygon_tile_pattern_is_neither_everything_nor_nothing():
 )
 def test_polygon_tile_selection_is_identical_at_every_magnitude(scale, off):
     assert _polygon_pattern(scale, off) == _polygon_pattern(1.0, 0.0)
+
+
+# ---- rotation ----
+# 30 degrees, and boxes that are not square: a square fixture cannot tell an x
+# axis from a y one, and a right angle is as symmetric as a square, so either
+# would let a swapped sin/cos or a swapped rx/ry pass.
+ANGLE = 30.0
+BOX = (1.0e-3, 2.0e-3, 1.6e-3, 2.4e-3)
+
+
+def _turned(px, py, x, y, deg):
+    """`(x, y)` turned `deg` degrees counter-clockwise about `(px, py)`.
+
+    Written out here rather than imported, so the tests state the convention
+    they are pinning instead of agreeing with the implementation by sharing it.
+    """
+    th = math.radians(deg)
+    c, s = math.cos(th), math.sin(th)
+    dx, dy = x - px, y - py
+    return (px + dx * c - dy * s, py + dx * s + dy * c)
+
+
+def _turned_oracle(region, center, fov, samples=60):
+    """Independent oracle for a rotated region: densely sample the tile, turn
+    each sample point *back* about the pivot, and ask the unrotated shape.
+
+    A different method from either implementation -- point sampling against the
+    axis-aligned membership test, rather than separating axes or a distance to a
+    mapped parallelogram -- so agreement is evidence rather than a tautology.
+    """
+    x0, y0, x1, y1 = region.box()
+    cx, cy = (x0 + x1) / 2, (y0 + y1) / 2
+    rx, ry = (x1 - x0) / 2, (y1 - y0) / 2
+    isEllipse = isinstance(region, EllipseRegion)
+    tx0, ty0, tx1, ty1 = tile_rect(center, fov)
+    for i in range(samples + 1):
+        px = tx0 + (tx1 - tx0) * i / samples
+        for j in range(samples + 1):
+            py = ty0 + (ty1 - ty0) * j / samples
+            ux, uy = _turned(x0, y0, px, py, -region.angle)
+            if isEllipse:
+                if ((ux - cx) / rx) ** 2 + ((uy - cy) / ry) ** 2 <= 1.0:
+                    return True
+            elif x0 <= ux <= x1 and y0 <= uy <= y1:
+                return True
+    return False
+
+
+@pytest.mark.parametrize("regionClass", [RectRegion, EllipseRegion])
+def test_a_region_is_unrotated_unless_told_otherwise(regionClass):
+    # Four-argument construction is every existing caller, and it must keep
+    # meaning the axis-aligned shape it has always meant.
+    assert regionClass(*BOX).angle == 0.0
+    assert regionClass(*BOX) == regionClass(*BOX, 0.0)
+
+
+@pytest.mark.parametrize("regionClass", [RectRegion, EllipseRegion])
+def test_the_angle_is_part_of_the_shape(regionClass):
+    # Two regions over the same box at different angles cover different tissue,
+    # so a region list must never treat one as the other.
+    assert regionClass(*BOX, ANGLE) != regionClass(*BOX)
+
+
+@pytest.mark.parametrize("regionClass", [RectRegion, EllipseRegion])
+def test_the_pivot_is_the_first_corner(regionClass):
+    # The convention `pg.ROI.setAngle` uses by default -- rotation about the
+    # ROI's local origin, which is `pos()` -- and matching it is what lets a
+    # rotated ROI round-trip exactly.
+    #
+    # Read off the centre of `bounds()`, which is the shape's own centre for
+    # both of these: a turned ellipse's extent is symmetric about it by the
+    # closed form, and a turned rectangle's four corners hull to a box centred
+    # on it. Turning about the corner carries that centre somewhere new, which
+    # is precisely what a centre pivot would not do.
+    x0, y0, x1, y1 = BOX
+    bx0, by0, bx1, by1 = regionClass(*BOX, ANGLE).bounds()
+    boxCenter = ((x0 + x1) / 2, (y0 + y1) / 2)
+    assert ((bx0 + bx1) / 2, (by0 + by1) / 2) == pytest.approx(
+        _turned(x0, y0, *boxCenter, ANGLE)
+    )
+    assert ((bx0 + bx1) / 2, (by0 + by1) / 2) != pytest.approx(boxCenter)
+
+
+def test_a_rotated_rect_bounds_the_box_of_its_turned_corners(): 
+    region = RectRegion(*BOX, ANGLE)
+    x0, y0, x1, y1 = BOX
+    turned = [
+        _turned(x0, y0, cx, cy, ANGLE)
+        for cx, cy in ((x0, y0), (x1, y0), (x1, y1), (x0, y1))
+    ]
+    assert region.bounds() == pytest.approx(
+        (
+            min(p[0] for p in turned),
+            min(p[1] for p in turned),
+            max(p[0] for p in turned),
+            max(p[1] for p in turned),
+        )
+    )
+    # And it is genuinely wider than the box it came from, or the test above
+    # would pass on an implementation that ignored the angle.
+    assert region.bounds() != pytest.approx(BOX)
+
+
+def test_a_rotated_ellipse_bounds_by_the_closed_form_half_extents():
+    region = EllipseRegion(*BOX, ANGLE)
+    x0, y0, x1, y1 = BOX
+    rx, ry = (x1 - x0) / 2, (y1 - y0) / 2
+    th = math.radians(ANGLE)
+    hw = math.hypot(rx * math.cos(th), ry * math.sin(th))
+    hh = math.hypot(rx * math.sin(th), ry * math.cos(th))
+    cx, cy = _turned(x0, y0, (x0 + x1) / 2, (y0 + y1) / 2, ANGLE)
+    assert region.bounds() == pytest.approx((cx - hw, cy - hh, cx + hw, cy + hh))
+    # A rotated ellipse is strictly narrower than its rotated bounding *box*,
+    # which is what makes the closed form worth having rather than reusing the
+    # rectangle's four-corner hull.
+    assert hw < max(
+        abs(_turned(x0, y0, c, d, ANGLE)[0] - cx)
+        for c, d in ((x0, y0), (x1, y0), (x1, y1), (x0, y1))
+    )
+
+
+@pytest.mark.parametrize("regionClass", [RectRegion, EllipseRegion])
+def test_a_rotated_region_agrees_with_a_sampled_oracle_over_a_grid(regionClass):
+    # A whole grid rather than a handful of tiles: rotation moves the boundary
+    # past a different set of tiles on every side, and only the tiles near that
+    # boundary can tell a correct implementation from an almost-correct one.
+    fov_len = 100e-6
+    region = regionClass(*BOX, ANGLE)
+    fov = (fov_len, fov_len)
+    bx0, by0, bx1, by1 = region.bounds()
+    for gy in range(12):
+        for gx in range(12):
+            center = (bx0 + (gx + 0.5) * fov_len, by0 + (gy + 0.5) * fov_len)
+            assert region.overlapsTile(center, fov) == _turned_oracle(
+                region, center, fov
+            ), (regionClass.__name__, gx, gy)
+
+
+@pytest.mark.parametrize("regionClass", [RectRegion, EllipseRegion])
+def test_rotating_a_region_changes_which_tiles_it_selects(regionClass):
+    # The property that makes this feature worth anything: an implementation
+    # that quietly dropped the angle would tile the operator's tissue at the
+    # wrong orientation, and would pass any test that only counted tiles.
+    fov_len = 100e-6
+    fov = (fov_len, fov_len)
+    turned = regionClass(*BOX, ANGLE)
+    straight = regionClass(*BOX)
+    bx0, by0, bx1, by1 = turned.bounds()
+    centers = [
+        (bx0 + (gx + 0.5) * fov_len, by0 + (gy + 0.5) * fov_len)
+        for gy in range(12)
+        for gx in range(12)
+    ]
+    turnedPattern = tuple(turned.overlapsTile(c, fov) for c in centers)
+    straightPattern = tuple(straight.overlapsTile(c, fov) for c in centers)
+    assert turnedPattern != straightPattern
+    # Named tiles, so this cannot be satisfied by an off-by-one in tile count:
+    # each is selected by exactly one of the two orientations.
+    onlyTurned = [c for c, t, s in zip(centers, turnedPattern, straightPattern) if t and not s]
+    onlyStraight = [c for c, t, s in zip(centers, turnedPattern, straightPattern) if s and not t]
+    assert onlyTurned and onlyStraight
+
+
+@pytest.mark.parametrize("fov_len,off", [(1.0, 0.0), (1e-6, 3.0), (1e3, -2e4)])
+def test_rotated_tile_selection_is_identical_at_every_magnitude(fov_len, off):
+    # The same scale-invariance property the axis-aligned shapes are held to.
+    # The separating-axis and mapped-parallelogram tests were chosen over a
+    # Qt-based one precisely so this holds; asserting it is what keeps an
+    # absolute tolerance from creeping back in.
+    def pattern(regionClass, fov_len, off):
+        side = 9 * fov_len
+        region = regionClass(off, off, off + side, off + side * 0.6, ANGLE)
+        fov = (fov_len, fov_len)
+        bx0, by0, _, _ = region.bounds()
+        return tuple(
+            region.overlapsTile(
+                (bx0 + (gx + 0.5) * fov_len, by0 + (gy + 0.5) * fov_len), fov
+            )
+            for gy in range(12)
+            for gx in range(12)
+        )
+
+    for regionClass in (RectRegion, EllipseRegion):
+        assert pattern(regionClass, fov_len, off) == pattern(regionClass, 1.0, 0.0)
+
+
+def test_the_rotated_ellipse_still_maps_each_axis_to_its_own_radius():
+    # A 4:1 ellipse turned a quarter of the way to upright. A swapped rx/ry
+    # survived every symmetric ellipse test on this branch once already; at this
+    # angle the two radii do not exchange roles, so the swap has nowhere to hide.
+    region = EllipseRegion(0.0, 0.0, 40e-6, 10e-6, ANGLE)
+    speck = (1e-12, 1e-12)
+    cx, cy = _turned(0.0, 0.0, 20e-6, 5e-6, ANGLE)
+    # 18 um along the turned semi-major axis: inside. 7 um along the turned
+    # semi-minor axis: outside.
+    th = math.radians(ANGLE)
+    major = (cx + 18e-6 * math.cos(th), cy + 18e-6 * math.sin(th))
+    minor = (cx - 7e-6 * math.sin(th), cy + 7e-6 * math.cos(th))
+    assert region.overlapsTile(major, speck) is True
+    assert region.overlapsTile(minor, speck) is False

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -8,7 +8,12 @@ import coorx
 import pytest
 
 from acq4.experiment.search_grid import plan_grid
-from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
+from acq4.experiment.search_region import (
+    EllipseRegion,
+    PolygonRegion,
+    RectRegion,
+    SearchRegion,
+)
 from acq4.experiment.slice import SearchConstraints, Slice
 
 
@@ -548,4 +553,82 @@ def test_force_rescan_uncovers_every_overlapping_region():
     s.forceRescan((1e-3 + 30e-6, 2e-3 + 15e-6), lambda cell: False)
 
     assert s.coveredTiles == []
+
+
+class _EditsTheSliceMidScan(SearchRegion):
+    """A region that replaces its slice's region list from inside the tiler's
+    own iteration -- what a GUI-thread setRegions() landing in the middle of a
+    worker-thread tileGrid() does.
+
+    Deterministic on purpose: driving this with real threads would reproduce the
+    hazard only sometimes, and a test that fails one run in fifty is not a test.
+    """
+
+    def __init__(self, slice_, replacement):
+        self._slice = slice_
+        self._replacement = replacement
+        self.calls = 0
+
+    def bounds(self):
+        return (0.0, 0.0, 400e-6, 200e-6)
+
+    def overlapsTile(self, center, fov):
+        self.calls += 1
+        if self.calls == 1:
+            self._slice.setRegions(self._replacement)
+        return True
+
+
+def test_an_edit_during_tilegrid_does_not_drop_the_regions_behind_it():
+    # The whole point of the swap. With the list mutated in place instead, the
+    # for-loop's index walks off the end of a shortened list and every region
+    # after the one being scanned is silently dropped from the survey.
+    sl = Slice(fov=(100e-6, 50e-6))
+    later = RectRegion(1e-3, 1e-3, 1.4e-3, 1.2e-3)
+    mutator = _EditsTheSliceMidScan(sl, [])
+    sl.setRegions([mutator, later])
+
+    grid = sl.tileGrid()
+
+    laterTiles = [c for c in grid if c[0] > 0.5e-3]
+    assert laterTiles, "the region after the edited one was dropped mid-scan"
+
+
+def test_the_edit_itself_takes_effect_on_the_next_call():
+    # The swap must not be a no-op in the other direction: the point of editing
+    # regions is that the next tile the producer asks for reflects the edit.
+    sl = Slice(fov=(100e-6, 50e-6))
+    mutator = _EditsTheSliceMidScan(sl, [])
+    sl.setRegions([mutator, RectRegion(1e-3, 1e-3, 1.4e-3, 1.2e-3)])
+    sl.tileGrid()
+
+    assert sl.regions == []
+    assert sl.tileGrid() == []
+
+
+def test_setregions_copies_so_the_callers_list_is_not_live():
+    # The panel hands over a list it goes on mutating as the operator draws.
+    sl = Slice(fov=(100e-6, 50e-6))
+    handed = [RectRegion(0.0, 0.0, 400e-6, 200e-6)]
+    sl.setRegions(handed)
+    handed.append(RectRegion(1e-3, 1e-3, 1.4e-3, 1.2e-3))
+
+    assert len(sl.regions) == 1
+
+
+def test_deleting_a_region_leaves_coverage_alone():
+    # Coverage records ground already imaged, not ground still wanted. Pruning
+    # it when a region goes away would make a region redrawn over surveyed
+    # tissue re-image it, and coverage is shared by every producer this slice
+    # makes -- it is not a per-region tally.
+    sl = Slice(fov=(100e-6, 50e-6))
+    sl.setRegions([RectRegion(0.0, 0.0, 400e-6, 200e-6)])
+    covered = sl.tileGrid()[0]
+    sl.markCovered(covered)
+
+    sl.setRegions([])
+
+    assert sl.tileGrid() == []
+    sl.setRegions([RectRegion(0.0, 0.0, 400e-6, 200e-6)])
+    assert sl.nextTile() != covered
 

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -7,14 +7,19 @@ import weakref
 import coorx
 import pytest
 
-from acq4.experiment.search_grid import plan_grid
+from acq4.experiment.search_grid import count_grid, plan_grid
 from acq4.experiment.search_region import (
     EllipseRegion,
     PolygonRegion,
     RectRegion,
     SearchRegion,
 )
-from acq4.experiment.slice import SearchConstraints, Slice
+from acq4.experiment.slice import (
+    MAX_PLANNED_TILES,
+    RegionTooLarge,
+    SearchConstraints,
+    Slice,
+)
 
 
 def test_defaults_are_a_usable_search():
@@ -632,3 +637,101 @@ def test_deleting_a_region_leaves_coverage_alone():
     sl.setRegions([RectRegion(0.0, 0.0, 400e-6, 200e-6)])
     assert sl.nextTile() != covered
 
+
+
+# A polygon the size of the one a mis-drag actually produced on the rig, at the
+# field of view it was drawn at: a 0.687 m x 0.873 m bounding box against a
+# 130.6 um field plans about 35 million tiles, which measured out at minutes of
+# GUI-thread compute per ROI edit. The vertices are this test's own -- only the
+# bounding box was recorded from the rig.
+_MISDRAG_FOV = (130.6e-6, 130.6e-6)
+_MISDRAG_REGION = PolygonRegion(
+    ((0.0, 0.0), (0.687, 0.021), (0.687, 0.873), (0.013, 0.851))
+)
+
+
+def test_a_mis_dragged_region_is_refused_rather_than_planned():
+    sl = Slice(fov=_MISDRAG_FOV)
+    with pytest.raises(RegionTooLarge):
+        sl.setRegions([_MISDRAG_REGION])
+
+
+def test_the_refusal_names_the_size_and_the_tile_count():
+    # The operator has to be told what they drew and why it was rejected; a bare
+    # "too large" leaves them re-dragging blind.
+    sl = Slice(fov=_MISDRAG_FOV)
+    with pytest.raises(RegionTooLarge) as excinfo:
+        sl.setRegions([_MISDRAG_REGION])
+    message = str(excinfo.value)
+    assert "0.687" in message
+    assert "0.873" in message
+    assert str(MAX_PLANNED_TILES) in message.replace(",", "")
+    # The count reported is the grid that would actually have been planned, not
+    # the cap it exceeded, and it is the tens-of-millions figure that makes the
+    # refusal worth reading.
+    planned = count_grid(*_MISDRAG_REGION.bounds(), *_MISDRAG_FOV, 0.0)
+    assert planned > 35_000_000
+    assert str(planned) in message.replace(",", "")
+
+
+def test_a_refused_region_does_not_reach_the_slice():
+    # Refusing is not the same as accepting-and-not-surveying: a slice left
+    # holding the region would plan it on the very next tileGrid() call.
+    sl = Slice(fov=_MISDRAG_FOV)
+    kept = RectRegion(1e-3, 2e-3, 1.4e-3, 2.1e-3)
+    sl.setRegions([kept])
+
+    with pytest.raises(RegionTooLarge):
+        sl.setRegions([kept, _MISDRAG_REGION])
+
+    assert sl.regions == [kept]
+
+
+def test_add_region_is_guarded_too():
+    # addRegion() is the other way in, and "Add region here" reaches the slice
+    # through it.
+    sl = Slice(fov=_MISDRAG_FOV)
+    with pytest.raises(RegionTooLarge):
+        sl.addRegion(_MISDRAG_REGION)
+    assert sl.regions == []
+
+
+def test_the_guard_counts_the_tiles_without_planning_them():
+    # The count is the whole hazard: plan_grid materialises every center before
+    # tileGrid() filters any of them, so a guard that planned first would still
+    # spend the minutes and the memory it exists to avoid. Proven by making the
+    # planner unusable rather than by timing anything.
+    import acq4.experiment.slice as slice_module
+
+    def boom(*args, **kwargs):
+        raise AssertionError("the guard planned the grid it was refusing")
+
+    original, slice_module.plan_grid = slice_module.plan_grid, boom
+    try:
+        sl = Slice(fov=_MISDRAG_FOV)
+        with pytest.raises(RegionTooLarge):
+            sl.setRegions([_MISDRAG_REGION])
+    finally:
+        slice_module.plan_grid = original
+
+
+def test_a_large_but_plausible_region_is_still_accepted():
+    # 20 mm x 4.95 mm at a 100 x 50 um field is 19,800 tiles -- larger than any
+    # real slice and still under the cap, so the cap cannot be what stops an
+    # operator outlining a whole piece of tissue. Asymmetric on both axes so a
+    # guard that counted one axis twice would be caught.
+    sl = Slice(fov=(100e-6, 50e-6))
+    sl.addRegion(RectRegion(1e-3, 2e-3, 1e-3 + 20e-3, 2e-3 + 4.95e-3))
+
+    planned = len(sl.tileGrid())
+    assert planned == 19800
+    assert planned <= MAX_PLANNED_TILES
+
+
+def test_the_cap_is_measured_against_the_grid_that_would_actually_be_planned():
+    # One more tile row past the case above crosses the cap, and the guard's
+    # arithmetic must agree with plan_grid's about exactly where that is.
+    sl = Slice(fov=(100e-6, 50e-6))
+    with pytest.raises(RegionTooLarge) as excinfo:
+        sl.addRegion(RectRegion(1e-3, 2e-3, 1e-3 + 20e-3, 2e-3 + 5.05e-3))
+    assert "20200" in str(excinfo.value).replace(",", "")

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -235,28 +235,43 @@ class AutopatchWindow(Qt.QWidget):
 
         A signal is not a permission check: Area 1's controls are gated on a
         slice existing, but arriving here without one must not raise on the GUI
-        thread.
+        thread. The editing gate is read for the same reason -- RegionPanel
+        locks every editing surface it owns, and this is the second line of that
+        defence, since committing an edit while a producer may be reading the
+        regions on the worker thread is what the gate exists to prevent. A torn
+        down window refuses for a third: teardown() waits on the orchestrator
+        with the Qt event loop still pumping, so an ROI drag released during
+        that wait arrives here after the session it belongs to has ended.
 
         Area 1 is deliberately not redrawn from here: this arrives *from* the
         panel, and RegionPanel.setRegions() rebuilds every ROI, which would
         discard the very handle the operator is holding.
         """
-        if self.slice is None:
+        if self._tornDown or self.slice is None or not self.regionPanel.isEditable():
             return
         self.slice.setRegions(regions)
         self._cameraMirror.setRegions(regions)
         self._refreshSurveyStats()
 
     def _canStartSlice(self) -> bool:
-        """Whether the camera and search constraints currently support
-        starting a slice, reporting the reason through SearchPanel exactly as
-        _startSlice() itself does.
+        """Whether a slice can be started right now, reporting the reason
+        through SearchPanel exactly as _startSlice() itself does.
 
         Split out so newSlice() can run this check before create_data_dir()
         commits to a new storage directory -- constructing the Slice remains
         _startSlice()'s job alone, called only once directory creation has
         already succeeded.
+
+        A torn-down window can never start one again. teardown() waits on the
+        orchestrator with the Qt event loop still pumping (see
+        _stopAndReleaseOrchestrator), so New slice and Add region here stay
+        clickable for as long as that wait lasts, and a slice built then would
+        re-bind PinnedFrameMirror to the Camera module's long-lived ImagingCtrl
+        with nothing left to release it: _tornDown is already True, so the
+        closeEvent that follows returns early.
         """
+        if self._tornDown:
+            return False
         camera = self.cameraSelector.getSelectedObj()
         if camera is None:
             self.searchPanel.setError("Select a camera before starting a slice.")
@@ -307,7 +322,15 @@ class AutopatchWindow(Qt.QWidget):
         Bound here rather than at construction because this is the first point
         at which a camera is known to be selected, and both routes into a slice
         pass through it.
+
+        Every path unbinds first, including the two that find nothing to bind
+        to. Switching from a camera the Camera module has an interface for to
+        one it does not -- or starting a slice after the Camera module has been
+        closed -- would otherwise leave Area 1 mirroring the previous camera's
+        frames: imagery of tissue that is no longer under the objective, with
+        regions being drawn over it.
         """
+        self._pinnedFrameMirror.unbind()
         window = self._cameraWindow()
         if window is None:
             return
@@ -627,6 +650,16 @@ class AutopatchWindow(Qt.QWidget):
         outlive this window, and would otherwise be left holding graphics
         belonging to a session that has ended.
 
+        The mirrors are released *after* the orchestrator, not before, because
+        stopping it means waiting on it with the Qt event loop still pumping
+        (see _stopAndReleaseOrchestrator). The window is still up and every
+        Area 1 control still connected for the length of that wait, so anything
+        the operator clicks in it -- Mirror to Camera, the end of an ROI drag --
+        lands while teardown is in progress. Releasing last is what makes those
+        clicks harmless rather than a mirror re-armed after its own cleanup.
+        `_tornDown` above closes the other half: it is set before the wait, so
+        nothing clicked during it can start a slice or commit a region edit.
+
         Idempotent: safe to call more than once (e.g. once explicitly from
         Autopatch.quit() and again via closeEvent() when the operator closes
         the window directly).
@@ -634,10 +667,10 @@ class AutopatchWindow(Qt.QWidget):
         if self._tornDown:
             return
         self._tornDown = True
-        self._pinnedFrameMirror.unbind()
-        self._cameraMirror.clear()
         if self.orchestrator is not None:
             self._stopAndReleaseOrchestrator(self.orchestrator)
+        self._pinnedFrameMirror.unbind()
+        self._cameraMirror.clear()
         self.statusPanel.unbindOrchestrator()
         self.cellPanel.unbindOrchestrator()
         self.cellPanel.clearCells()

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -334,15 +334,22 @@ class AutopatchWindow(Qt.QWidget):
             return False
         camera = self.cameraSelector.getSelectedObj()
         constraints = self.searchPanel.constraints()
-        self.slice = Slice(
-            fov=self._cameraFov(camera), constraints=constraints, dirHandle=dirHandle
-        )
+        fov = self._cameraFov(camera)
+        self.slice = Slice(fov=fov, constraints=constraints, dirHandle=dirHandle)
         self.searchPanel.setSliceReady(True)
         self.regionPanel.setSliceReady(True)
         # A fresh Slice has no regions, and an outline left from the last one is
         # a coordinate on tissue that may no longer be there.
         self.regionPanel.setRegions([])
         self._cameraMirror.setRegions([])
+        # A fresh pg.ViewBox spans about a metre, and Area 1's units are global
+        # metres, so an operator clicking in an empty view lands a vertex half a
+        # metre out. Ten fields around where the camera is looking puts the
+        # first click on tissue-sized coordinates; "roi" mode throughout, for
+        # the same reason addRegionHere() uses it.
+        self.regionPanel.setViewport(
+            camera.globalCenterPosition("roi")[:2], (fov[0] * 10, fov[1] * 10)
+        )
         self._bindPinnedFrames(camera)
         # There is a camera now, so retract the message above if it is up.
         self.searchPanel.setError("")

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -353,13 +353,12 @@ class AutopatchWindow(Qt.QWidget):
         try:
             dirHandle = create_data_dir(self.manager, level="Slice")
         except HelpfulException as exc:
-            # Area 3's instruction band does not exist yet, so this goes where
-            # the operator already reads "Select a camera before starting a
-            # slice". Narrowed to HelpfulException -- the "Storage directory
-            # has not been set." case -- so a genuine programming error (a
+            # Guidance, not a failure report: the operator has not chosen a
+            # storage directory, and Area 3's band is where instructions go.
+            # Narrowed to HelpfulException so a genuine programming error (a
             # missing manager, say) propagates instead of being reported as
             # storage guidance.
-            self.searchPanel.setError(str(exc))
+            self.statusPanel.setInstruction(str(exc))
             return
         if not self._startSlice(dirHandle=dirHandle):
             return
@@ -369,6 +368,7 @@ class AutopatchWindow(Qt.QWidget):
         # that no longer exists once the operator has physically swapped in
         # new tissue.
         self.statusPanel.clearError()
+        self.statusPanel.clearInstruction()
         if self.orchestrator is not None:
             # Detached before the queue is cleared, not after: a refill still
             # in flight on the worker thread reads the producer and enqueues

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -9,7 +9,7 @@ from acq4.experiment.actions.prompt import prompt
 from acq4.experiment.actions.storage import create_data_dir
 from acq4.experiment.orchestrator import Orchestrator
 from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
-from acq4.experiment.slice import Slice
+from acq4.experiment.slice import RegionTooLarge, Slice
 from acq4.experiment.tile_detector import make_tile_detector
 from acq4.modules.Module import Module
 from acq4.util import Qt
@@ -150,6 +150,9 @@ class AutopatchWindow(Qt.QWidget):
         # on the orchestrator's worker thread and must not read a selector.
         self._cachedCamera = None
         self._cachedScope = None
+        # Whether Area 3's instruction band is currently carrying a message this
+        # window's Area 1 handlers put there -- see _setRegionInstruction().
+        self._regionInstruction = False
         self._tornDown = False
         self.protocolPanel.sigProtocolLoaded.connect(self._onProtocolLoaded)
         # Area 4 (the protocol picker/Reload) must not be usable while a
@@ -243,15 +246,44 @@ class AutopatchWindow(Qt.QWidget):
         with the Qt event loop still pumping, so an ROI drag released during
         that wait arrives here after the session it belongs to has ended.
 
-        Area 1 is deliberately not redrawn from here: this arrives *from* the
-        panel, and RegionPanel.setRegions() rebuilds every ROI, which would
-        discard the very handle the operator is holding.
+        Area 1 is deliberately not redrawn from here on the accepted path: this
+        arrives *from* the panel, and RegionPanel.setRegions() rebuilds every
+        ROI, which would discard the very handle the operator is holding. A
+        refused edit is the exception, and rebuilding is the point there: the
+        ROI has to go back to the size the slice still holds.
         """
         if self._tornDown or self.slice is None or not self.regionPanel.isEditable():
             return
-        self.slice.setRegions(regions)
+        try:
+            self.slice.setRegions(regions)
+        except RegionTooLarge as exc:
+            # Refuse the whole edit rather than dropping the one region: a
+            # survey that quietly ignores outlined tissue is the failure mode
+            # this module keeps ruling out. Area 3's band takes the message --
+            # it is guidance about a control, with no traceback to show.
+            self._setRegionInstruction(str(exc))
+            self.regionPanel.setRegions(self.slice.regions)
+            return
+        self._setRegionInstruction("")
         self._cameraMirror.setRegions(regions)
         self._refreshSurveyStats()
+
+    def _setRegionInstruction(self, text: str) -> None:
+        """Put Area 1's guidance in Area 3's band, or retract what it last put
+        there.
+
+        Area 1 has one guidance slot: a later message replaces an earlier one.
+        Whether this window is currently using that slot is tracked rather than
+        written straight through, because newSlice() writes into the same band
+        for its own reason -- an unchosen storage directory -- and clearing
+        Area 1's message must not erase guidance whose condition still holds.
+        """
+        if text:
+            self._regionInstruction = True
+            self.statusPanel.setInstruction(text)
+        elif self._regionInstruction:
+            self._regionInstruction = False
+            self.statusPanel.clearInstruction()
 
     def _canStartSlice(self) -> bool:
         """Whether a slice can be started right now, reporting the reason
@@ -381,6 +413,11 @@ class AutopatchWindow(Qt.QWidget):
             # Narrowed to HelpfulException so a genuine programming error (a
             # missing manager, say) propagates instead of being reported as
             # storage guidance.
+            #
+            # The band is this handler's now, not Area 1's, so a later region
+            # edit must not treat retracting its own message as licence to
+            # retract this one (see _setRegionInstruction).
+            self._regionInstruction = False
             self.statusPanel.setInstruction(str(exc))
             return
         if not self._startSlice(dirHandle=dirHandle):
@@ -391,6 +428,9 @@ class AutopatchWindow(Qt.QWidget):
         # that no longer exists once the operator has physically swapped in
         # new tissue.
         self.statusPanel.clearError()
+        # Whichever handler filled the band, what it was about went with the
+        # tissue just discarded.
+        self._regionInstruction = False
         self.statusPanel.clearInstruction()
         if self.orchestrator is not None:
             # Detached before the queue is cleared, not after: a refill still
@@ -446,7 +486,15 @@ class AutopatchWindow(Qt.QWidget):
         else:
             regionClass = EllipseRegion if shape == "ellipse" else RectRegion
             region = regionClass(x0, y0, x1, y1)
-        self.slice.addRegion(region)
+        try:
+            self.slice.addRegion(region)
+        except RegionTooLarge as exc:
+            # 3x3 fields is nine tiles whatever the field of view, so this
+            # button cannot trip the slice's tile cap as it stands. Caught
+            # anyway because a traceback raised out of a button's slot is not a
+            # failure mode this window should have at all.
+            self._setRegionInstruction(str(exc))
+            return
         self.regionPanel.setRegions(self.slice.regions)
         self._cameraMirror.setRegions(self.slice.regions)
         self._refreshSurveyStats()

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -2,12 +2,13 @@
 orchestration engine (acq4/experiment/). See autopatch-orchestration-design.md."""
 from __future__ import annotations
 
+import functools
 import os
 
 from acq4.experiment.actions.prompt import prompt
 from acq4.experiment.actions.storage import create_data_dir
 from acq4.experiment.orchestrator import Orchestrator
-from acq4.experiment.search_region import EllipseRegion, RectRegion
+from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
 from acq4.experiment.slice import Slice
 from acq4.experiment.tile_detector import make_tile_detector
 from acq4.modules.Module import Module
@@ -19,6 +20,8 @@ from .cell_panel import CellPanel
 from .context_factory import make_context_factory
 from .example_protocols import install_example_protocols
 from .protocol_panel import ProtocolPanel
+from .region_mirrors import CameraMirror, PinnedFrameMirror
+from .region_panel import RegionPanel
 from .search_panel import SearchPanel
 from .status_panel import StatusPanel
 
@@ -52,18 +55,26 @@ class AutopatchWindow(Qt.QWidget):
         for box in (self.area1Box, self.area2Box, self.area3Box, self.area4Box, self.area5Box):
             box.setLayout(Qt.QVBoxLayout())
 
-        leftCol = Qt.QVBoxLayout()
+        # A splitter, not a fixed box layout: Area 1 is a view of a whole slice,
+        # and drawing a region in a strip the operator cannot enlarge is an
+        # exercise in patience.
+        leftCol = Qt.QSplitter(Qt.Qt.Vertical)
         leftCol.addWidget(self.area1Box)
         leftCol.addWidget(self.area2Box)
+        # Area 1 is the view; Area 2 is four spin boxes and a readout.
+        leftCol.setStretchFactor(0, 3)
+        leftCol.setStretchFactor(1, 1)
 
         rightCol = Qt.QVBoxLayout()
         rightCol.addWidget(self.area3Box)
         rightCol.addWidget(self.area4Box)
         rightCol.addWidget(self.area5Box)
+        rightColWidget = Qt.QWidget()
+        rightColWidget.setLayout(rightCol)
 
         outer = Qt.QHBoxLayout()
-        outer.addLayout(leftCol)
-        outer.addLayout(rightCol)
+        outer.addWidget(leftCol, 2)
+        outer.addWidget(rightColWidget, 1)
         self.setLayout(outer)
 
         if protocolDir is None:
@@ -94,14 +105,24 @@ class AutopatchWindow(Qt.QWidget):
         self.statusPanel = StatusPanel()
         self.area3Box.layout().addWidget(self.statusPanel)
 
-        # Area 1 holds only New slice: region graphics and the progress heatmap
-        # are Area 1's remaining content and are not built here.
         self.newSliceBtn = Qt.QPushButton("New slice")
         self.newSliceBtn.setToolTip(
             "Discard the current slice -- its regions, coverage, and queued "
             "cells -- and start a fresh one for newly mounted tissue."
         )
+        self.regionPanel = RegionPanel()
         self.area1Box.layout().addWidget(self.newSliceBtn)
+        self.area1Box.layout().addWidget(self.regionPanel)
+
+        self._pinnedFrameMirror = PinnedFrameMirror(self.regionPanel.view)
+        # The getter is closed over the manager alone, never over this window:
+        # the mirror is reachable both from here and from mirrorCheck's
+        # connection to it below, so a getter that held the window would close a
+        # reference cycle -- the kind teardown() exists to keep out of this
+        # window, and which no amount of tearing down afterwards can undo.
+        self._cameraMirror = CameraMirror(
+            functools.partial(self._cameraModuleWindow, self.manager)
+        )
 
         self.searchPanel = SearchPanel()
         self.area2Box.layout().addWidget(self.searchPanel)
@@ -140,11 +161,17 @@ class AutopatchWindow(Qt.QWidget):
         # elsewhere are careful to avoid.
         self.statusPanel.sigInteractionLocked.connect(self.protocolPanel.setInteractionLocked)
         self.newSliceBtn.clicked.connect(self.newSlice)
-        self.searchPanel.sigAddRegionRequested.connect(self.addRegionHere)
+        self.regionPanel.sigAddRegionRequested.connect(self.addRegionHere)
+        self.regionPanel.sigRegionsChanged.connect(self._onRegionsEdited)
+        self.regionPanel.mirrorCheck.toggled.connect(self._cameraMirror.setEnabled)
         self.searchPanel.sigConstraintsChanged.connect(self._onConstraintsChanged)
         self.statusPanel.sigInteractionLocked.connect(
             self.searchPanel.setInteractionLocked
         )
+        self.statusPanel.sigInteractionLocked.connect(
+            self.regionPanel.setInteractionLocked
+        )
+        self.statusPanel.sigStatusChanged.connect(self.regionPanel.setRunStatus)
         self.statusPanel.sigInteractionLocked.connect(
             self.cellPanel.setInteractionLocked
         )
@@ -168,6 +195,56 @@ class AutopatchWindow(Qt.QWidget):
         # window and presses Start immediately still gets a run.
         if self.protocolPanel.protocolFile is not None:
             self._onProtocolLoaded(self.protocolPanel.protocolFile)
+
+    @staticmethod
+    def _cameraModuleWindow(manager):
+        """The Camera module's window under `manager`, or None if there is none.
+
+        Not having one is ordinary -- a rig with the module unloaded, or a
+        headless test -- and both mirrors treat it as nothing to do rather than
+        as a failure.
+
+        Asked of the loaded modules rather than of Manager.getModule alone,
+        which loads a module that is not already open: this is reached from
+        every mirror redraw, including the one behind "Add region here", and a
+        button that adds a region must not also start the Camera module.
+
+        Static, taking the manager as an argument, so that the Camera mirror can
+        be handed a getter that holds no reference to this window -- see where
+        it is constructed.
+        """
+        if manager is None:
+            return None
+        try:
+            if "Camera" not in manager.listModules():
+                return None
+            return manager.getModule("Camera").window()
+        except Exception:
+            return None
+
+    def _cameraWindow(self):
+        """The Camera module's window, or None if there is not one."""
+        return self._cameraModuleWindow(self.manager)
+
+    def _onRegionsEdited(self, regions) -> None:
+        """Take Area 1's edited region list as the slice's regions.
+
+        A wholesale swap, which is what makes this safe to do while a producer
+        may be reading regions on the worker thread (see Slice.setRegions).
+
+        A signal is not a permission check: Area 1's controls are gated on a
+        slice existing, but arriving here without one must not raise on the GUI
+        thread.
+
+        Area 1 is deliberately not redrawn from here: this arrives *from* the
+        panel, and RegionPanel.setRegions() rebuilds every ROI, which would
+        discard the very handle the operator is holding.
+        """
+        if self.slice is None:
+            return
+        self.slice.setRegions(regions)
+        self._cameraMirror.setRegions(regions)
+        self._refreshSurveyStats()
 
     def _canStartSlice(self) -> bool:
         """Whether the camera and search constraints currently support
@@ -213,9 +290,31 @@ class AutopatchWindow(Qt.QWidget):
             fov=self._cameraFov(camera), constraints=constraints, dirHandle=dirHandle
         )
         self.searchPanel.setSliceReady(True)
+        self.regionPanel.setSliceReady(True)
+        # A fresh Slice has no regions, and an outline left from the last one is
+        # a coordinate on tissue that may no longer be there.
+        self.regionPanel.setRegions([])
+        self._cameraMirror.setRegions([])
+        self._bindPinnedFrames(camera)
         # There is a camera now, so retract the message above if it is up.
         self.searchPanel.setError("")
         return True
+
+    def _bindPinnedFrames(self, camera) -> None:
+        """Mirror `camera`'s pinned frames into Area 1's view.
+
+        Bound here rather than at construction because this is the first point
+        at which a camera is known to be selected, and both routes into a slice
+        pass through it.
+        """
+        window = self._cameraWindow()
+        if window is None:
+            return
+        try:
+            imagingCtrl = window.getInterfaceForDevice(camera.name()).imagingCtrl
+        except (KeyError, AttributeError):
+            return
+        self._pinnedFrameMirror.bind(imagingCtrl)
 
     def newSlice(self) -> None:
         """Start a fresh slice, discarding the current one and everything on it.
@@ -296,7 +395,7 @@ class AutopatchWindow(Qt.QWidget):
         to hold it. Built directly rather than by way of newSlice(): that is the
         discard-everything path, and an operator who seeded cells by hand and
         then asked only for a region must not lose them. The shape seeded is
-        whichever one Area 2's selector currently has picked.
+        whichever one Area 1's selector currently has picked.
         """
         if self.slice is None and not self._startSlice():
             return
@@ -309,17 +408,23 @@ class AutopatchWindow(Qt.QWidget):
         # off-center for a cropped camera ROI.
         cx, cy = camera.globalCenterPosition("roi")[:2]
         w, h = fov_w * 3, fov_h * 3
-        # Area 2 owns the shape; this button owns the placement. An ellipse is
+        # Area 1 owns the shape; this button owns the placement. An ellipse is
         # inscribed in the same box, so both shapes cover the same 3x3 fields and
         # only the corners differ.
-        regionClass = (
-            EllipseRegion
-            if self.searchPanel.regionShape() == "ellipse"
-            else RectRegion
-        )
-        self.slice.addRegion(
-            regionClass(cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2)
-        )
+        shape = self.regionPanel.regionShape()
+        x0, y0, x1, y1 = cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2
+        if shape == "polygon":
+            # The same box, as a polygon: the button places a region of a known
+            # size, and the shape selector says what kind. A four-vertex seed is
+            # also the readiest thing to reshape into the outline actually
+            # wanted, which is the point of choosing polygon at all.
+            region = PolygonRegion(((x0, y0), (x1, y0), (x1, y1), (x0, y1)))
+        else:
+            regionClass = EllipseRegion if shape == "ellipse" else RectRegion
+            region = regionClass(x0, y0, x1, y1)
+        self.slice.addRegion(region)
+        self.regionPanel.setRegions(self.slice.regions)
+        self._cameraMirror.setRegions(self.slice.regions)
         self._refreshSurveyStats()
 
     @staticmethod
@@ -516,6 +621,11 @@ class AutopatchWindow(Qt.QWidget):
         orchestrator and severs every one of those connections up front, so the
         remaining objects are plain refcounted and go away immediately.
 
+        Also releases Area 1's two mirrors, whose items and signal connection
+        live in the *Camera* module's window and imaging control -- objects that
+        outlive this window, and would otherwise be left holding graphics
+        belonging to a session that has ended.
+
         Idempotent: safe to call more than once (e.g. once explicitly from
         Autopatch.quit() and again via closeEvent() when the operator closes
         the window directly).
@@ -523,6 +633,8 @@ class AutopatchWindow(Qt.QWidget):
         if self._tornDown:
             return
         self._tornDown = True
+        self._pinnedFrameMirror.unbind()
+        self._cameraMirror.clear()
         if self.orchestrator is not None:
             self._stopAndReleaseOrchestrator(self.orchestrator)
         self.statusPanel.unbindOrchestrator()

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -667,10 +667,16 @@ class AutopatchWindow(Qt.QWidget):
         if self._tornDown:
             return
         self._tornDown = True
-        if self.orchestrator is not None:
-            self._stopAndReleaseOrchestrator(self.orchestrator)
-        self._pinnedFrameMirror.unbind()
-        self._cameraMirror.clear()
+        try:
+            if self.orchestrator is not None:
+                self._stopAndReleaseOrchestrator(self.orchestrator)
+        finally:
+            # In a finally because these are the releases that reach *outside*
+            # this window: a raise while stopping the orchestrator would
+            # otherwise leave the Camera module holding this session's outlines
+            # and its imaging control still connected to a dead mirror.
+            self._pinnedFrameMirror.unbind()
+            self._cameraMirror.clear()
         self.statusPanel.unbindOrchestrator()
         self.cellPanel.unbindOrchestrator()
         self.cellPanel.clearCells()

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -167,7 +167,16 @@ class AutopatchWindow(Qt.QWidget):
         self.newSliceBtn.clicked.connect(self.newSlice)
         self.regionPanel.sigAddRegionRequested.connect(self.addRegionHere)
         self.regionPanel.sigRegionsChanged.connect(self._onRegionsEdited)
-        self.regionPanel.mirrorCheck.toggled.connect(self._cameraMirror.setEnabled)
+        self.regionPanel.mirrorCheck.toggled.connect(self._onMirrorToggled)
+        if self.manager is not None:
+            # Both Area 1 mirrors resolve the Camera module through
+            # _cameraModuleWindow, which reports None while that module is not
+            # open -- so a mirror armed before the operator opens it binds to
+            # nothing. Manager announces every module load and quit here, which
+            # is the one event that can change that answer. Disconnected in
+            # teardown(); a window built with no module (the headless/test mode)
+            # has no manager to listen to.
+            self.manager.sigModulesChanged.connect(self._onModulesChanged)
         self.searchPanel.sigConstraintsChanged.connect(self._onConstraintsChanged)
         self.statusPanel.sigInteractionLocked.connect(
             self.searchPanel.setInteractionLocked
@@ -229,6 +238,47 @@ class AutopatchWindow(Qt.QWidget):
     def _cameraWindow(self):
         """The Camera module's window, or None if there is not one."""
         return self._cameraModuleWindow(self.manager)
+
+    def _onMirrorToggled(self, enabled: bool) -> None:
+        """Turn the outline mirror on or off, saying so if there is nowhere to
+        draw.
+
+        A tick with no Camera module open is otherwise a silent no-op: the
+        checkbox stays ticked, nothing appears anywhere, and nothing
+        distinguishes that from a mirror that is broken. The message is
+        accurate about what happens next -- _onModulesChanged() re-runs this
+        handler when a module is opened, so the outlines really do appear then.
+        """
+        self._cameraMirror.setEnabled(enabled)
+        if enabled and self._cameraWindow() is None:
+            self._setRegionInstruction(
+                "Mirror to Camera: no Camera module is open. The outlines will "
+                "appear if one is opened."
+            )
+        else:
+            self._setRegionInstruction("")
+
+    def _onModulesChanged(self) -> None:
+        """Re-resolve Area 1's two mirrors against the modules now loaded.
+
+        Both of them find the Camera module once and keep the answer: the
+        outline mirror at the moment the checkbox is ticked, the pinned-frame
+        mirror at the moment a slice starts. Either can happen before the
+        Camera module is open, and Manager emits this whenever that changes.
+
+        Refuses once the window is torn down. teardown() waits on the
+        orchestrator with the Qt event loop still pumping, so a module loaded in
+        those seconds is announced while teardown is in progress, and re-binding
+        then would leave the Camera module holding a closed session's graphics.
+        """
+        if self._tornDown:
+            return
+        # Re-runs the checkbox's own handler, which redraws the outlines against
+        # whatever window there is now and raises or retracts its message.
+        self._onMirrorToggled(self.regionPanel.mirrorCheck.isChecked())
+        camera = self.cameraSelector.getSelectedObj()
+        if self.slice is not None and camera is not None:
+            self._bindPinnedFrames(camera)
 
     def _onRegionsEdited(self, regions) -> None:
         """Take Area 1's edited region list as the slice's regions.
@@ -730,6 +780,16 @@ class AutopatchWindow(Qt.QWidget):
             # this window: a raise while stopping the orchestrator would
             # otherwise leave the Camera module holding this session's outlines
             # and its imaging control still connected to a dead mirror.
+            #
+            # The manager goes first, and for the same reason the mirrors go
+            # last: the manager outlives this window, so a connection left on it
+            # would go on calling this window's handler at every later module
+            # load or quit, re-arming the mirrors the next two lines release.
+            # Dropping it here closes that off for good; anything announced
+            # during the wait above was already refused by _onModulesChanged's
+            # own torn-down check.
+            if self.manager is not None:
+                Qt.disconnect(self.manager.sigModulesChanged, self._onModulesChanged)
             self._pinnedFrameMirror.unbind()
             self._cameraMirror.clear()
         self.statusPanel.unbindOrchestrator()

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -115,11 +115,12 @@ class AutopatchWindow(Qt.QWidget):
         self.area1Box.layout().addWidget(self.regionPanel)
 
         self._pinnedFrameMirror = PinnedFrameMirror(self.regionPanel.view)
-        # The getter is closed over the manager alone, never over this window:
-        # the mirror is reachable both from here and from mirrorCheck's
-        # connection to it below, so a getter that held the window would close a
-        # reference cycle -- the kind teardown() exists to keep out of this
-        # window, and which no amount of tearing down afterwards can undo.
+        # The getter is closed over the manager alone, never over this window.
+        # A bound self._cameraModuleWindow would give mirror -> window while
+        # self._cameraMirror gives window -> mirror, and teardown() never drops
+        # that attribute, so the pair would outlive teardown and be reclaimable
+        # only by the cyclic collector -- the same shape as the exit segfault
+        # this module's deterministic teardown was written to prevent.
         self._cameraMirror = CameraMirror(
             functools.partial(self._cameraModuleWindow, self.manager)
         )

--- a/acq4/modules/Autopatch/region_mirrors.py
+++ b/acq4/modules/Autopatch/region_mirrors.py
@@ -119,12 +119,24 @@ def _pathForRegion(region) -> Qt.QPainterPath:
             path.lineTo(x, y)
         path.closeSubpath()
         return path
-    x0, y0, x1, y1 = region.bounds()
+    # `box()`, not `bounds()`: once a region has an angle those differ, and it is
+    # the box the operator sized that gets drawn and then turned. Drawing
+    # `bounds()` would put the axis-aligned hull on screen instead of the shape.
+    x0, y0, x1, y1 = region.box()
     rect = Qt.QRectF(x0, y0, x1 - x0, y1 - y0)
     if isinstance(region, EllipseRegion):
         path.addEllipse(rect)
     else:
         path.addRect(rect)
+    if region.angle:
+        # About the (x0, y0) corner, the region's own pivot. `QTransform.rotate`
+        # is the same call `pg.ROI.setAngle` makes, so the mirrored outline and
+        # the editable ROI in Area 1 turn together by construction.
+        turn = Qt.QTransform()
+        turn.translate(x0, y0)
+        turn.rotate(region.angle)
+        turn.translate(-x0, -y0)
+        path = turn.map(path)
     return path
 
 

--- a/acq4/modules/Autopatch/region_mirrors.py
+++ b/acq4/modules/Autopatch/region_mirrors.py
@@ -40,10 +40,21 @@ class PinnedFrameMirror:
         self.refresh()
 
     def unbind(self) -> None:
-        """Stop mirroring and take the copies out of the view."""
-        if self._source is not None:
-            Qt.disconnect(self._source.sigPinnedFramesChanged, self.refresh)
-            self._source = None
+        """Stop mirroring and take the copies out of the view.
+
+        Tolerant of a source Qt has already destroyed. pg.disconnect swallows
+        the RuntimeError a dead connection raises, but the signal is read off
+        the source before it can be handed to pg.disconnect at all, and that
+        read raises through a wrapper whose C++ object is gone. A raise here
+        would abandon the rest of AutopatchWindow.teardown(), leaving every
+        panel still wired to the orchestrator it had just stopped.
+        """
+        source, self._source = self._source, None
+        if source is not None:
+            try:
+                Qt.disconnect(source.sigPinnedFramesChanged, self.refresh)
+            except RuntimeError:
+                pass
         self._clearItems()
 
     def refresh(self) -> None:
@@ -59,6 +70,18 @@ class PinnedFrameMirror:
         for original in self._source.pinnedFrames:
             copy = pg.ImageItem(original.image)
             copy.setTransform(original.transform())
+            # A real pinned frame is built with its levels and lookup table
+            # spelled out (ImagingCtrl.pinCurrentFrame, Frame.imageItem), and an
+            # ImageItem given neither scales itself to its own contents. Copies
+            # left to do that would each pick their own scale, so adjacent
+            # frames in one mosaic would not match, and a 16-bit frame with a
+            # narrow range would render near-flat. Both are optional on the way
+            # in, so an absent one is left absent rather than invented.
+            levels = original.getLevels()
+            if levels is not None:
+                copy.setLevels(levels)
+            if original.lut is not None:
+                copy.setLookupTable(original.lut)
             # addItem() must run before setZValue(): ViewBox.addItem() raises
             # an incoming item's z-value to the view's own if the item's is
             # lower, which would clobber a pinned frame's deliberately

--- a/acq4/modules/Autopatch/region_mirrors.py
+++ b/acq4/modules/Autopatch/region_mirrors.py
@@ -1,0 +1,69 @@
+"""The two one-way mirrors either side of Area 1's view: the Camera module's
+pinned frames coming in, and read-only region outlines going out."""
+
+from __future__ import annotations
+
+import pyqtgraph as pg
+
+from acq4.util import Qt
+
+
+class PinnedFrameMirror:
+    """Shows the Camera module's pinned frames in another view.
+
+    A pg.ImageItem belongs to exactly one QGraphicsScene, so displaying the
+    pinned frames in both places cannot mean showing the same objects twice --
+    adding the Camera module's own items here would take them out of the Camera
+    module's view. This builds its own item per pinned frame instead, from the
+    same image array and the same global transform.
+
+    Display only: it holds no region state and nothing depends on it existing.
+    """
+
+    def __init__(self, view):
+        self._view = view
+        self._source = None
+        self.items: list[pg.ImageItem] = []
+
+    def bind(self, imagingCtrl) -> None:
+        """Mirror `imagingCtrl`'s pinned frames, replacing any current binding.
+
+        Draws what is already pinned rather than waiting for the next change:
+        pinning frames before opening this window is as ordinary as after.
+        """
+        self.unbind()
+        self._source = imagingCtrl
+        imagingCtrl.sigPinnedFramesChanged.connect(self.refresh)
+        self.refresh()
+
+    def unbind(self) -> None:
+        """Stop mirroring and take the copies out of the view."""
+        if self._source is not None:
+            Qt.disconnect(self._source.sigPinnedFramesChanged, self.refresh)
+            self._source = None
+        self._clearItems()
+
+    def refresh(self) -> None:
+        """Rebuild the mirrored items from the source's current set.
+
+        Rebuilding wholesale rather than diffing: the set is a handful of frames
+        changed by operator clicks, and a diff would be state to keep correct
+        for no measurable gain.
+        """
+        self._clearItems()
+        if self._source is None:
+            return
+        for original in self._source.pinnedFrames:
+            copy = pg.ImageItem(original.image)
+            copy.setTransform(original.transform())
+            # Added before setZValue: ViewBox.addItem() raises an incoming
+            # item's z-value to its own if the item's is lower, which would
+            # otherwise clobber a pinned frame's deliberately very-low z.
+            self._view.addItem(copy)
+            copy.setZValue(original.zValue())
+            self.items.append(copy)
+
+    def _clearItems(self) -> None:
+        for item in self.items:
+            self._view.removeItem(item)
+        self.items = []

--- a/acq4/modules/Autopatch/region_mirrors.py
+++ b/acq4/modules/Autopatch/region_mirrors.py
@@ -56,9 +56,10 @@ class PinnedFrameMirror:
         for original in self._source.pinnedFrames:
             copy = pg.ImageItem(original.image)
             copy.setTransform(original.transform())
-            # Added before setZValue: ViewBox.addItem() raises an incoming
-            # item's z-value to its own if the item's is lower, which would
-            # otherwise clobber a pinned frame's deliberately very-low z.
+            # addItem() must run before setZValue(): ViewBox.addItem() raises
+            # an incoming item's z-value to the view's own if the item's is
+            # lower, which would clobber a pinned frame's deliberately
+            # very-low z if the z-value were already set beforehand.
             self._view.addItem(copy)
             copy.setZValue(original.zValue())
             self.items.append(copy)

--- a/acq4/modules/Autopatch/region_mirrors.py
+++ b/acq4/modules/Autopatch/region_mirrors.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 
 import pyqtgraph as pg
 
+from acq4.experiment.search_region import EllipseRegion, PolygonRegion
 from acq4.util import Qt
+
+from .region_panel import REGION_PEN
 
 
 class PinnedFrameMirror:
@@ -68,3 +71,88 @@ class PinnedFrameMirror:
         for item in self.items:
             self._view.removeItem(item)
         self.items = []
+
+
+# Above the camera frame image so an outline is visible over tissue, below the
+# pipette target and its arrows at z=5000 so those stay on top -- the same band
+# the AutomationDebug survey ROI sits in.
+_MIRROR_Z = 4000
+
+
+def _pathForRegion(region) -> Qt.QPainterPath:
+    """The outline of `region`, in global metres.
+
+    A QPainterPath is the right tool for drawing an outline even though P2c-1
+    removed QPainterPath from the *overlap* test: that finding is about asking
+    Qt to decide whether a rect and a shape intersect, where its clipper's
+    absolute tolerances misreport tiles at SI-metre magnitudes. Drawing asks Qt
+    no such question.
+    """
+    path = Qt.QPainterPath()
+    if isinstance(region, PolygonRegion):
+        first = region.vertices[0]
+        path.moveTo(first[0], first[1])
+        for x, y in region.vertices[1:]:
+            path.lineTo(x, y)
+        path.closeSubpath()
+        return path
+    x0, y0, x1, y1 = region.bounds()
+    rect = Qt.QRectF(x0, y0, x1 - x0, y1 - y0)
+    if isinstance(region, EllipseRegion):
+        path.addEllipse(rect)
+    else:
+        path.addRect(rect)
+    return path
+
+
+class CameraMirror:
+    """Draws read-only outlines of Autopatch's regions in the Camera window.
+
+    Outlines are QGraphicsPathItems, not ROIs, and that is what makes them
+    read-only structurally rather than by policy: there is no handle to grab and
+    no second copy of a region's state to reconcile. Autopatch stays the only
+    place a region is edited.
+
+    Holds no region state of its own -- it is told what to draw. A Camera module
+    that is not loaded is ordinary, not an error: this is a display preference.
+    """
+
+    def __init__(self, cameraWindowGetter):
+        self._cameraWindow = cameraWindowGetter
+        self._enabled = False
+        self._regions = []
+        self.items = []
+
+    def setEnabled(self, enabled: bool) -> None:
+        self._enabled = enabled
+        self._redraw()
+
+    def setRegions(self, regions) -> None:
+        self._regions = list(regions)
+        self._redraw()
+
+    def clear(self) -> None:
+        """Take every outline out of the Camera window.
+
+        Separate from setEnabled(False) because teardown has to remove them
+        without changing what the operator asked for.
+        """
+        window = self._cameraWindow()
+        for item in self.items:
+            if window is not None:
+                window.removeItem(item)
+        self.items = []
+
+    def _redraw(self) -> None:
+        self.clear()
+        if not self._enabled:
+            return
+        window = self._cameraWindow()
+        if window is None:
+            return
+        for region in self._regions:
+            item = Qt.QGraphicsPathItem(_pathForRegion(region))
+            item.setPen(REGION_PEN)
+            item.setAcceptedMouseButtons(Qt.Qt.NoButton)
+            window.addItem(item, z=_MIRROR_Z)
+            self.items.append(item)

--- a/acq4/modules/Autopatch/region_panel.py
+++ b/acq4/modules/Autopatch/region_panel.py
@@ -98,6 +98,14 @@ class RegionPanel(Qt.QWidget):
         super().__init__()
         self._rois: list[pg.ROI] = []
 
+        # The three independent reasons editing can be off, kept apart because
+        # no writer can see another's condition: collapsing them into one
+        # boolean would let a run ending unlock a panel that still has no slice
+        # behind it. Same split SearchPanel already makes.
+        self._runLocked = False
+        self._sliceReady = False
+        self._runStatus = None
+
         self.graphicsView = pg.GraphicsView()
         self.graphicsView.setObjectName("Autopatch_regionView")
         self.view = pg.ViewBox()
@@ -151,6 +159,8 @@ class RegionPanel(Qt.QWidget):
         self.addRegionBtn.clicked.connect(self.sigAddRegionRequested)
         self.fitBtn.clicked.connect(self.fitToRegions)
 
+        self._applyLock()
+
     # ---- regions ----
     def regions(self) -> list[SearchRegion]:
         """The regions currently drawn, in the order they were added.
@@ -179,6 +189,7 @@ class RegionPanel(Qt.QWidget):
         self.view.addItem(roi)
         roi.sigRegionChangeFinished.connect(self._onRoiEdited)
         roi.sigRemoveRequested.connect(self._onRoiRemoved)
+        self._applyRoiLock(roi)
 
     def _detachRoi(self, roi: pg.ROI) -> None:
         Qt.disconnect(roi.sigRegionChangeFinished, self._onRoiEdited)
@@ -194,6 +205,66 @@ class RegionPanel(Qt.QWidget):
     def _onRoiRemoved(self, roi) -> None:
         self._detachRoi(roi)
         self.sigRegionsChanged.emit(self.regions())
+
+    # ---- editing gate ----
+    def setInteractionLocked(self, locked: bool) -> None:
+        """Disable editing while a run is in flight; the regions stay visible.
+
+        The operator watching a run must still see what is being surveyed, so
+        this is about editing, not about hiding.
+        """
+        self._runLocked = locked
+        self._applyLock()
+
+    def setSliceReady(self, ready: bool) -> None:
+        """Whether a slice exists for these regions to belong to.
+
+        New slice is what makes Area 1 usable, and the greyed-out controls are
+        how the operator is told that it is the first step.
+        """
+        self._sliceReady = ready
+        self._applyLock()
+
+    def setRunStatus(self, status: str) -> None:
+        """The bound run's last reported status.
+
+        Only "paused" matters here, and only the *emitted* status will do.
+        Orchestrator._checkPause() runs at the top of the run loop, before the
+        refill check, so a Pause clicked during a survey does not stop that
+        survey -- the producer goes on imaging tiles and reading regions for as
+        long as it takes, and the loop parks at the next iteration. But
+        sigStatus("paused") is emitted from inside _checkPause, immediately
+        before it blocks, so while that status is current the worker is parked
+        there and cannot be inside a refill. That is what makes editing safe.
+        """
+        self._runStatus = status
+        self._applyLock()
+
+    def _editable(self) -> bool:
+        if not self._sliceReady:
+            return False
+        return not self._runLocked or self._runStatus == "paused"
+
+    def _applyLock(self) -> None:
+        editable = self._editable()
+        self.addRegionBtn.setEnabled(editable)
+        self.shapeCombo.setEnabled(editable)
+        for roi in self._rois:
+            self._applyRoiLock(roi)
+
+    def _applyRoiLock(self, roi: pg.ROI) -> None:
+        """Make one ROI match the current gate.
+
+        Every affordance, not just the drag: leaving the handles live would let
+        a locked region be resized, and leaving `removable` on would let it be
+        deleted from the context menu.
+        """
+        editable = self._editable()
+        roi.translatable = editable
+        roi.resizable = editable
+        roi.removable = editable
+        for handle in roi.getHandles():
+            handle.setVisible(editable)
 
     # ---- view ----
     def regionShape(self) -> str:

--- a/acq4/modules/Autopatch/region_panel.py
+++ b/acq4/modules/Autopatch/region_panel.py
@@ -18,33 +18,22 @@ from acq4.util import Qt
 REGION_PEN = pg.mkPen("y", width=2)
 
 
-class _AxisAlignedEllipseROI(pg.EllipseROI):
-    """A pg.EllipseROI with its rotate handle replaced by a second scale handle.
-
-    `rotatable=False` is what actually stops a rotation (see roiForRegion), and
-    it already makes pg.EllipseROI's stock rotate handle inert. Replacing the
-    handle as well is about the affordance rather than the geometry: a handle
-    the operator can grab and drag, that then does nothing at all, is a control
-    that lies. The replacement scales along the other axis, so the ellipse gains
-    the width and height handles the rectangle already has.
-    """
-
-    def _addHandles(self):
-        self.addScaleHandle([1.0, 0.5], [0.5, 0.5])
-        self.addScaleHandle([0.5, 1.0], [0.5, 0.5])
-
-
 def roiForRegion(region: SearchRegion) -> pg.ROI:
     """The editable ROI that draws `region`.
 
-    `rotatable=False` on every shape. No region can express a rotation --
-    RectRegion and EllipseRegion are axis-aligned boxes, and PolygonRegion's
-    vertices are read back through the ROI's own transform -- so a rotated ROI
-    either round-trips as an unrotated box displaced by the rotation, or as a
-    polygon somewhere else entirely. Either way the operator outlines one patch
-    of tissue and the survey tiles another. Dropping the rotate *handle* does
-    not reach this: pg.MouseDragHandler enters rotate mode on an Alt-modified
-    drag of the ROI body, with no handle involved, and consults this flag alone.
+    Rotatable, on every shape, because every shape can now record the result: a
+    box region carries an angle, and a polygon's vertices are read back through
+    the ROI's own transform, which a rotation is part of. The stock
+    `pg.EllipseROI` is used as it ships, rotate handle and all, since that handle
+    now does what it looks like it does.
+
+    Sized from `box()` rather than `bounds()`: those differ once there is an
+    angle, and it is the box the operator sized -- not the larger axis-aligned
+    extent the tiler plans over -- that the ROI is drawn from and turned.
+
+    `setAngle` with no explicit centre turns the ROI about its local origin and
+    leaves `pos()` where it is, which is the pivot `_BoxRegion` documents. That
+    correspondence is what makes `regionForRoi` below its exact inverse.
     """
     if isinstance(region, PolygonRegion):
         return pg.PolyLineROI(
@@ -52,13 +41,16 @@ def roiForRegion(region: SearchRegion) -> pg.ROI:
             closed=True,
             pen=REGION_PEN,
             removable=True,
-            rotatable=False,
+            rotatable=True,
         )
-    x0, y0, x1, y1 = region.bounds()
-    roiClass = _AxisAlignedEllipseROI if isinstance(region, EllipseRegion) else pg.RectROI
-    return roiClass(
-        (x0, y0), (x1 - x0, y1 - y0), pen=REGION_PEN, removable=True, rotatable=False
+    x0, y0, x1, y1 = region.box()
+    roiClass = pg.EllipseROI if isinstance(region, EllipseRegion) else pg.RectROI
+    roi = roiClass(
+        (x0, y0), (x1 - x0, y1 - y0), pen=REGION_PEN, removable=True, rotatable=True
     )
+    if region.angle:
+        roi.setAngle(region.angle)
+    return roi
 
 
 def regionForRoi(roi: pg.ROI) -> SearchRegion | None:
@@ -73,10 +65,16 @@ def regionForRoi(roi: pg.ROI) -> SearchRegion | None:
     returning None rather than by raising a traceback out of a slot -- the same
     choice `SearchPanel.constraints()` makes, and for the same reason.
 
-    Corner normalization is left to `_BoxRegion.__post_init__`, which already
-    orders its corners -- an ROI resized past its own origin reports a negative
-    size, and both paths through that hazard should agree by construction rather
-    than by two implementations happening to match.
+    An ROI resized past its own origin reports a negative size, so the corner
+    `pos()` sits on is no longer the region's `(x0, y0)`. That matters more than
+    it used to: `(x0, y0)` is the pivot, so handing the region the wrong corner
+    would turn the shape about the wrong point and draw it somewhere else. The
+    box's lowest corner is found in ROI-local coordinates and mapped out through
+    the ROI's transform, which is the corner that is its own image under the turn
+    and therefore the one the region's convention wants.
+
+    A polygon needs none of this: its vertices go through `mapToParent`
+    individually, so a rotation arrives baked into the coordinates.
     """
     try:
         if isinstance(roi, pg.PolyLineROI):
@@ -85,11 +83,19 @@ def regionForRoi(roi: pg.ROI) -> SearchRegion | None:
                 globalPos = roi.mapToParent(localPos)
                 vertices.append((globalPos.x(), globalPos.y()))
             return PolygonRegion(tuple(vertices))
-        pos = roi.pos()
         size = roi.size()
-        x0, y0 = pos.x(), pos.y()
+        w, h = size.x(), size.y()
+        localX = 0.0 if w >= 0 else w
+        localY = 0.0 if h >= 0 else h
+        if localX == 0.0 and localY == 0.0:
+            # The ordinary case, read straight off `pos()` so that an unrotated
+            # region round-trips through exactly the floats it was built from.
+            corner = roi.pos()
+        else:
+            corner = roi.mapToParent(Qt.QPointF(localX, localY))
+        x0, y0 = corner.x(), corner.y()
         regionClass = EllipseRegion if isinstance(roi, pg.EllipseROI) else RectRegion
-        return regionClass(x0, y0, x0 + size.x(), y0 + size.y())
+        return regionClass(x0, y0, x0 + abs(w), y0 + abs(h), roi.angle())
     except ValueError:
         return None
 
@@ -292,13 +298,15 @@ class RegionPanel(Qt.QWidget):
         locked polygon with live segments is one click away from a reshaped
         region reaching the slice mid-survey.
 
-        `rotatable` is deliberately not touched: it is off from construction for
-        every shape (see roiForRegion) and is not the gate's to hand back, since
-        no region can express a rotation whether a run is in flight or not.
+        `rotatable` belongs in that list now that a region can record an angle:
+        it is a fourth way to change the tissue a survey is about to image, and
+        pg.MouseDragHandler enters rotate mode on an Alt-modified drag of the ROI
+        *body* -- no handle involved -- so hiding the handles does not reach it.
         """
         editable = self.isEditable()
         roi.translatable = editable
         roi.resizable = editable
+        roi.rotatable = editable
         roi.removable = editable
         for handle in roi.getHandles():
             handle.setVisible(editable)

--- a/acq4/modules/Autopatch/region_panel.py
+++ b/acq4/modules/Autopatch/region_panel.py
@@ -335,6 +335,30 @@ class RegionPanel(Qt.QWidget):
             rect = itemRect if rect is None else rect.united(itemRect)
         return rect
 
+    def setViewport(self, center, span) -> None:
+        """Frame the view on `center` across `span`, both in global metres.
+
+        A fresh pg.ViewBox reports a range of about [[-0.167, 1.167], [0, 1]],
+        and this view's units are global metres, so an operator clicking in an
+        empty Area 1 lands a polygon vertex half a metre out and a small drag is
+        hundreds of millimetres. The window calls this when a slice starts, so
+        the first click lands on tissue-sized coordinates.
+
+        Takes a coordinate and a span rather than a camera: this panel renders a
+        region list and holds no devices. The view is aspect-locked, so the
+        axis that does not match the widget's shape is widened past `span`.
+
+        `fitToRegions` is the later re-framing, once there is something drawn to
+        frame; this is the one that has to work with nothing drawn at all.
+        """
+        cx, cy = center
+        w, h = span
+        self.view.setRange(
+            xRange=(cx - w / 2, cx + w / 2),
+            yRange=(cy - h / 2, cy + h / 2),
+            padding=0,
+        )
+
     def fitToRegions(self) -> None:
         """Frame every drawn region and the imagery drawn under them.
 

--- a/acq4/modules/Autopatch/region_panel.py
+++ b/acq4/modules/Autopatch/region_panel.py
@@ -19,12 +19,14 @@ REGION_PEN = pg.mkPen("y", width=2)
 
 
 class _AxisAlignedEllipseROI(pg.EllipseROI):
-    """A pg.EllipseROI with no rotate handle.
+    """A pg.EllipseROI with its rotate handle replaced by a second scale handle.
 
-    EllipseRegion is the ellipse inscribed in an axis-aligned bounding box, so
-    there is no region for a rotated ROI to map back to: regionForRoi reads the
-    ROI's position and size, and a rotation would be dropped without trace --
-    the operator would draw one shape and the survey would tile another.
+    `rotatable=False` is what actually stops a rotation (see roiForRegion), and
+    it already makes pg.EllipseROI's stock rotate handle inert. Replacing the
+    handle as well is about the affordance rather than the geometry: a handle
+    the operator can grab and drag, that then does nothing at all, is a control
+    that lies. The replacement scales along the other axis, so the ellipse gains
+    the width and height handles the rectangle already has.
     """
 
     def _addHandles(self):
@@ -33,30 +35,43 @@ class _AxisAlignedEllipseROI(pg.EllipseROI):
 
 
 def roiForRegion(region: SearchRegion) -> pg.ROI:
-    """The editable ROI that draws `region`."""
+    """The editable ROI that draws `region`.
+
+    `rotatable=False` on every shape. No region can express a rotation --
+    RectRegion and EllipseRegion are axis-aligned boxes, and PolygonRegion's
+    vertices are read back through the ROI's own transform -- so a rotated ROI
+    either round-trips as an unrotated box displaced by the rotation, or as a
+    polygon somewhere else entirely. Either way the operator outlines one patch
+    of tissue and the survey tiles another. Dropping the rotate *handle* does
+    not reach this: pg.MouseDragHandler enters rotate mode on an Alt-modified
+    drag of the ROI body, with no handle involved, and consults this flag alone.
+    """
     if isinstance(region, PolygonRegion):
         return pg.PolyLineROI(
             [list(v) for v in region.vertices],
             closed=True,
             pen=REGION_PEN,
             removable=True,
+            rotatable=False,
         )
     x0, y0, x1, y1 = region.bounds()
     roiClass = _AxisAlignedEllipseROI if isinstance(region, EllipseRegion) else pg.RectROI
     return roiClass(
-        (x0, y0), (x1 - x0, y1 - y0), pen=REGION_PEN, removable=True
+        (x0, y0), (x1 - x0, y1 - y0), pen=REGION_PEN, removable=True, rotatable=False
     )
 
 
 def regionForRoi(roi: pg.ROI) -> SearchRegion | None:
     """The region `roi` currently describes, or None if it does not describe one.
 
-    An ROI can be dragged flat, and its handles can be dragged collinear;
-    SearchRegion rejects both, since a region with no extent has no tiles. This
-    is reached from a Qt signal while the operator is mid-drag, so it reports
-    the failure by returning None rather than by raising a traceback out of a
-    slot -- the same choice `SearchPanel.constraints()` makes, and for the same
-    reason.
+    An ROI can be dragged flat, and a polygon's handles can be dragged onto a
+    horizontal or vertical line; SearchRegion rejects both, since what it checks
+    is the axis-aligned bounding box and a box with no extent has no tiles. A
+    polygon flattened onto a *diagonal* is not rejected -- its bounding box
+    still has extent -- and tiles along that line. This is reached from a Qt
+    signal while the operator is mid-drag, so it reports the failure by
+    returning None rather than by raising a traceback out of a slot -- the same
+    choice `SearchPanel.constraints()` makes, and for the same reason.
 
     Corner normalization is left to `_BoxRegion.__post_init__`, which already
     orders its corners -- an ROI resized past its own origin reports a negative
@@ -197,7 +212,14 @@ class RegionPanel(Qt.QWidget):
         self._rois.remove(roi)
         self.view.removeItem(roi)
 
-    def _onRoiEdited(self, _roi) -> None:
+    def _onRoiEdited(self, roi) -> None:
+        # Re-applied first, because an edit can grow the ROI's own handle list:
+        # PolyLineROI.segmentClicked adds one, and a handle is born visible and
+        # draggable whatever the gate currently says. Keeping "an ROI that has
+        # just reported an edit matches the gate" true here makes it a local
+        # property of this panel rather than a survey of every pyqtgraph path
+        # that can add a handle.
+        self._applyRoiLock(roi)
         # On sigRegionChangeFinished, not sigRegionChanged: a drag in progress
         # is not a decision, and every emission costs the slice a full retile.
         self.sigRegionsChanged.emit(self.regions())
@@ -240,13 +262,18 @@ class RegionPanel(Qt.QWidget):
         self._runStatus = status
         self._applyLock()
 
-    def _editable(self) -> bool:
+    def isEditable(self) -> bool:
+        """Whether regions may currently be edited.
+
+        Public because the window reads it too: it drops region edits that
+        arrive while this is False, since a signal is not a permission check.
+        """
         if not self._sliceReady:
             return False
         return not self._runLocked or self._runStatus == "paused"
 
     def _applyLock(self) -> None:
-        editable = self._editable()
+        editable = self.isEditable()
         self.addRegionBtn.setEnabled(editable)
         self.shapeCombo.setEnabled(editable)
         for roi in self._rois:
@@ -258,33 +285,75 @@ class RegionPanel(Qt.QWidget):
         Every affordance, not just the drag: leaving the handles live would let
         a locked region be resized, and leaving `removable` on would let it be
         deleted from the context menu.
+
+        A polygon carries one more surface than the flags reach. Its edges are
+        separate child items, each created accepting left clicks and wired to
+        segmentClicked, which inserts a vertex where the edge was clicked. So a
+        locked polygon with live segments is one click away from a reshaped
+        region reaching the slice mid-survey.
+
+        `rotatable` is deliberately not touched: it is off from construction for
+        every shape (see roiForRegion) and is not the gate's to hand back, since
+        no region can express a rotation whether a run is in flight or not.
         """
-        editable = self._editable()
+        editable = self.isEditable()
         roi.translatable = editable
         roi.resizable = editable
         roi.removable = editable
         for handle in roi.getHandles():
             handle.setVisible(editable)
+        for segment in getattr(roi, "segments", []):
+            segment.setAcceptedMouseButtons(
+                Qt.Qt.LeftButton if editable else Qt.Qt.NoButton
+            )
 
     # ---- view ----
     def regionShape(self) -> str:
         """The shape key for the next region drawn: rect, ellipse, or polygon."""
         return self.shapeCombo.currentData()
 
-    def fitToRegions(self) -> None:
-        """Frame every drawn region.
+    def _mirroredImageryBounds(self) -> Qt.QRectF | None:
+        """The extent of everything in the view that is not a region ROI, or
+        None if there is nothing else there.
 
-        With nothing drawn this does nothing: autoranging over an empty set is
-        how a view ends up at a scale the operator cannot recover from, and the
-        button is live before anything has been drawn.
+        In practice the mirrored pinned frames. Read off the view rather than
+        from PinnedFrameMirror: the panel renders regions and knows nothing
+        about what else is put in its view, and a back-reference to the mirror
+        would make the two mutually dependent for a bounding box.
+
+        Region ROIs are skipped because their bounds come from `regions()`,
+        which drops an ROI squashed to no extent -- and a zero-extent rectangle
+        is exactly what would frame the view at a scale nobody can recover from.
         """
-        bounds = [region.bounds() for region in self.regions()]
-        if not bounds:
+        rect = None
+        for item in self.view.addedItems:
+            if item in self._rois:
+                continue
+            itemRect = item.mapRectToView(item.boundingRect()).normalized()
+            rect = itemRect if rect is None else rect.united(itemRect)
+        return rect
+
+    def fitToRegions(self) -> None:
+        """Frame every drawn region and the imagery drawn under them.
+
+        Both, because a panel with pinned frames mirrored in and no region
+        seeded yet is the ordinary first state: a fresh viewport spans about a
+        metre, which renders a field of view sub-pixel, and this button is the
+        only one-click way back.
+
+        With neither this does nothing: autoranging over an empty set is how a
+        view ends up at a scale the operator cannot recover from, and the button
+        is live before anything has been drawn.
+        """
+        rect = self._mirroredImageryBounds()
+        for region in self.regions():
+            x0, y0, x1, y1 = region.bounds()
+            regionRect = Qt.QRectF(x0, y0, x1 - x0, y1 - y0)
+            rect = regionRect if rect is None else rect.united(regionRect)
+        if rect is None:
             return
-        x0 = min(b[0] for b in bounds)
-        y0 = min(b[1] for b in bounds)
-        x1 = max(b[2] for b in bounds)
-        y1 = max(b[3] for b in bounds)
         self.view.setRange(
-            xRange=(x0, x1), yRange=(y0, y1), padding=0.1
+            xRange=(rect.left(), rect.right()),
+            yRange=(rect.top(), rect.bottom()),
+            padding=0.1,
         )

--- a/acq4/modules/Autopatch/region_panel.py
+++ b/acq4/modules/Autopatch/region_panel.py
@@ -322,8 +322,10 @@ class RegionPanel(Qt.QWidget):
         would make the two mutually dependent for a bounding box.
 
         Region ROIs are skipped because their bounds come from `regions()`,
-        which drops an ROI squashed to no extent -- and a zero-extent rectangle
-        is exactly what would frame the view at a scale nobody can recover from.
+        which drops an ROI squashed to no extent. Framing one would re-centre
+        the view on a shape that is not a region: ViewBox.setRange keeps the
+        current span when a range has none of its own, so the scale survives,
+        but the operator is moved somewhere they did not ask to go.
         """
         rect = None
         for item in self.view.addedItems:

--- a/acq4/modules/Autopatch/region_panel.py
+++ b/acq4/modules/Autopatch/region_panel.py
@@ -1,0 +1,78 @@
+"""RegionPanel: Area 1's global-coordinate view of the slice -- the pinned
+imagery to draw over, and the search regions drawn on it as editable ROIs."""
+
+from __future__ import annotations
+
+import pyqtgraph as pg
+
+from acq4.experiment.search_region import (
+    EllipseRegion,
+    PolygonRegion,
+    RectRegion,
+    SearchRegion,
+)
+
+# Yellow at 2px, matching the survey ROI the AutomationDebug bench already
+# draws, so the same shape reads the same way in either module.
+REGION_PEN = pg.mkPen("y", width=2)
+
+
+class _AxisAlignedEllipseROI(pg.EllipseROI):
+    """A pg.EllipseROI with no rotate handle.
+
+    EllipseRegion is the ellipse inscribed in an axis-aligned bounding box, so
+    there is no region for a rotated ROI to map back to: regionForRoi reads the
+    ROI's position and size, and a rotation would be dropped without trace --
+    the operator would draw one shape and the survey would tile another.
+    """
+
+    def _addHandles(self):
+        self.addScaleHandle([1.0, 0.5], [0.5, 0.5])
+        self.addScaleHandle([0.5, 1.0], [0.5, 0.5])
+
+
+def roiForRegion(region: SearchRegion) -> pg.ROI:
+    """The editable ROI that draws `region`."""
+    if isinstance(region, PolygonRegion):
+        return pg.PolyLineROI(
+            [list(v) for v in region.vertices],
+            closed=True,
+            pen=REGION_PEN,
+            removable=True,
+        )
+    x0, y0, x1, y1 = region.bounds()
+    roiClass = _AxisAlignedEllipseROI if isinstance(region, EllipseRegion) else pg.RectROI
+    return roiClass(
+        (x0, y0), (x1 - x0, y1 - y0), pen=REGION_PEN, removable=True
+    )
+
+
+def regionForRoi(roi: pg.ROI) -> SearchRegion | None:
+    """The region `roi` currently describes, or None if it does not describe one.
+
+    An ROI can be dragged flat, and its handles can be dragged collinear;
+    SearchRegion rejects both, since a region with no extent has no tiles. This
+    is reached from a Qt signal while the operator is mid-drag, so it reports
+    the failure by returning None rather than by raising a traceback out of a
+    slot -- the same choice `SearchPanel.constraints()` makes, and for the same
+    reason.
+
+    Corner normalization is left to `_BoxRegion.__post_init__`, which already
+    orders its corners -- an ROI resized past its own origin reports a negative
+    size, and both paths through that hazard should agree by construction rather
+    than by two implementations happening to match.
+    """
+    try:
+        if isinstance(roi, pg.PolyLineROI):
+            vertices = []
+            for _, localPos in roi.getLocalHandlePositions():
+                globalPos = roi.mapToParent(localPos)
+                vertices.append((globalPos.x(), globalPos.y()))
+            return PolygonRegion(tuple(vertices))
+        pos = roi.pos()
+        size = roi.size()
+        x0, y0 = pos.x(), pos.y()
+        regionClass = EllipseRegion if isinstance(roi, pg.EllipseROI) else RectRegion
+        return regionClass(x0, y0, x0 + size.x(), y0 + size.y())
+    except ValueError:
+        return None

--- a/acq4/modules/Autopatch/region_panel.py
+++ b/acq4/modules/Autopatch/region_panel.py
@@ -11,6 +11,7 @@ from acq4.experiment.search_region import (
     RectRegion,
     SearchRegion,
 )
+from acq4.util import Qt
 
 # Yellow at 2px, matching the survey ROI the AutomationDebug bench already
 # draws, so the same shape reads the same way in either module.
@@ -76,3 +77,143 @@ def regionForRoi(roi: pg.ROI) -> SearchRegion | None:
         return regionClass(x0, y0, x0 + size.x(), y0 + size.y())
     except ValueError:
         return None
+
+
+class RegionPanel(Qt.QWidget):
+    """Area 1's view of the slice: the imagery to draw over, and the search
+    regions drawn on it as ROIs the operator can move, resize, and delete.
+
+    Renders a list of regions and reports a list of regions. It holds no Slice
+    and never touches one -- the window is what binds the two -- which is what
+    lets it be built and tested with no slice, no camera, and no orchestrator,
+    and what would let region drawing move into the Camera window later without
+    any of this changing.
+    """
+
+    # The complete region list after an edit that originated here.
+    sigRegionsChanged = Qt.Signal(object)
+    sigAddRegionRequested = Qt.Signal()
+
+    def __init__(self):
+        super().__init__()
+        self._rois: list[pg.ROI] = []
+
+        self.graphicsView = pg.GraphicsView()
+        self.graphicsView.setObjectName("Autopatch_regionView")
+        self.view = pg.ViewBox()
+        self.view.enableAutoRange(x=False, y=False)
+        # Tissue is not distorted by the widget's aspect ratio, and a region
+        # drawn over a squashed view would not be the region surveyed.
+        self.view.setAspectLocked(True)
+        self.graphicsView.setCentralItem(self.view)
+        # The view is the panel's content, not a strip above its controls: a
+        # region spans a slice, and the operator resizes the window to draw.
+        self.graphicsView.setSizePolicy(
+            Qt.QSizePolicy.Expanding, Qt.QSizePolicy.Expanding
+        )
+        self.graphicsView.setMinimumSize(300, 300)
+
+        # Item data, not display text, is what regionShape() returns: the window
+        # maps it to a region class, and a label is a label.
+        self.shapeCombo = Qt.QComboBox()
+        for label, key in (
+            ("Rectangle", "rect"),
+            ("Ellipse", "ellipse"),
+            ("Polygon", "polygon"),
+        ):
+            self.shapeCombo.addItem(label, key)
+        self.shapeCombo.setToolTip('The shape "Add region here" seeds.')
+
+        self.addRegionBtn = Qt.QPushButton("Add region here")
+        self.addRegionBtn.setToolTip(
+            "Add a search region covering roughly 3x3 fields of view around the "
+            "camera's current center."
+        )
+        self.fitBtn = Qt.QPushButton("Fit to regions")
+        self.mirrorCheck = Qt.QCheckBox("Mirror to Camera")
+        self.mirrorCheck.setToolTip(
+            "Draw these regions in the Camera module's view as well. They stay "
+            "editable only here."
+        )
+
+        controls = Qt.QHBoxLayout()
+        controls.addWidget(self.shapeCombo)
+        controls.addWidget(self.addRegionBtn)
+        controls.addWidget(self.fitBtn)
+        controls.addWidget(self.mirrorCheck)
+        controls.addStretch()
+
+        layout = Qt.QVBoxLayout()
+        layout.addLayout(controls)
+        layout.addWidget(self.graphicsView)
+        self.setLayout(layout)
+
+        self.addRegionBtn.clicked.connect(self.sigAddRegionRequested)
+        self.fitBtn.clicked.connect(self.fitToRegions)
+
+    # ---- regions ----
+    def regions(self) -> list[SearchRegion]:
+        """The regions currently drawn, in the order they were added.
+
+        An ROI the operator has squashed flat describes no region, and is left
+        out rather than reported or raised over: it stays on screen to be pulled
+        back into shape, and contributes no tiles until it is.
+        """
+        return [r for r in (regionForRoi(roi) for roi in self._rois) if r is not None]
+
+    def setRegions(self, regions) -> None:
+        """Draw `regions`, replacing whatever is drawn now.
+
+        Deliberately silent: this is how the slice's state reaches the panel, so
+        echoing it back would have the window write it straight into the slice
+        again, and a New slice that cleared this panel would be told by the
+        panel it just cleared that the regions are empty.
+        """
+        for roi in list(self._rois):
+            self._detachRoi(roi)
+        for region in regions:
+            self._attachRoi(roiForRegion(region))
+
+    def _attachRoi(self, roi: pg.ROI) -> None:
+        self._rois.append(roi)
+        self.view.addItem(roi)
+        roi.sigRegionChangeFinished.connect(self._onRoiEdited)
+        roi.sigRemoveRequested.connect(self._onRoiRemoved)
+
+    def _detachRoi(self, roi: pg.ROI) -> None:
+        Qt.disconnect(roi.sigRegionChangeFinished, self._onRoiEdited)
+        Qt.disconnect(roi.sigRemoveRequested, self._onRoiRemoved)
+        self._rois.remove(roi)
+        self.view.removeItem(roi)
+
+    def _onRoiEdited(self, _roi) -> None:
+        # On sigRegionChangeFinished, not sigRegionChanged: a drag in progress
+        # is not a decision, and every emission costs the slice a full retile.
+        self.sigRegionsChanged.emit(self.regions())
+
+    def _onRoiRemoved(self, roi) -> None:
+        self._detachRoi(roi)
+        self.sigRegionsChanged.emit(self.regions())
+
+    # ---- view ----
+    def regionShape(self) -> str:
+        """The shape key for the next region drawn: rect, ellipse, or polygon."""
+        return self.shapeCombo.currentData()
+
+    def fitToRegions(self) -> None:
+        """Frame every drawn region.
+
+        With nothing drawn this does nothing: autoranging over an empty set is
+        how a view ends up at a scale the operator cannot recover from, and the
+        button is live before anything has been drawn.
+        """
+        bounds = [region.bounds() for region in self.regions()]
+        if not bounds:
+            return
+        x0 = min(b[0] for b in bounds)
+        y0 = min(b[1] for b in bounds)
+        x1 = max(b[2] for b in bounds)
+        y1 = max(b[3] for b in bounds)
+        self.view.setRange(
+            xRange=(x0, x1), yRange=(y0, y1), padding=0.1
+        )

--- a/acq4/modules/Autopatch/search_panel.py
+++ b/acq4/modules/Autopatch/search_panel.py
@@ -1,5 +1,5 @@
 """SearchPanel: Area 2's cell-finding config -- the search constraints that
-parameterise a cell producer, plus region seeding and a survey progress readout."""
+parameterise a cell producer, and a survey progress readout."""
 
 from __future__ import annotations
 
@@ -18,18 +18,16 @@ _CELLS_PER_NL_TO_M3 = 1e12
 
 
 class SearchPanel(Qt.QWidget):
-    """The four Area 2 search constraints, a region-seeding button, and a readout.
+    """The four Area 2 search constraints and a survey progress readout.
 
     Emits `sigConstraintsChanged` with a fresh SearchConstraints on every edit,
     or with None when the widget values do not describe a valid search (an
     operator dragging a spinbox passes through invalid intermediate values, and
-    that must not raise on the GUI thread). Region *graphics* are not this
-    panel's job: it asks its owner to seed a region and shows how much of the
-    result has been surveyed.
+    that must not raise on the GUI thread). Regions belong to Area 1; this panel
+    only reports how much of the result has been surveyed.
     """
 
     sigConstraintsChanged = Qt.Signal(object)  # SearchConstraints, or None if invalid
-    sigAddRegionRequested = Qt.Signal()
 
     def __init__(self):
         super().__init__()
@@ -90,22 +88,6 @@ class SearchPanel(Qt.QWidget):
         self.rescansCheck = Qt.QCheckBox("Rescans allowed")
         self.rescansCheck.setChecked(defaults.rescans_allowed)
 
-        # Item data, not display text, is what regionShape() returns: the window
-        # maps it to a region class, and a label is a label.
-        self.shapeCombo = Qt.QComboBox()
-        for label, key in (("Rectangle", "rect"), ("Ellipse", "ellipse")):
-            self.shapeCombo.addItem(label, key)
-        self.shapeCombo.setToolTip(
-            'The shape "Add region here" seeds. An ellipse is inscribed in the '
-            "same 3x3-field box as the rectangle, so it searches the rounded "
-            "middle and skips the corners."
-        )
-
-        self.addRegionBtn = Qt.QPushButton("Add region here")
-        self.addRegionBtn.setToolTip(
-            "Add a search region covering roughly 3x3 fields of view around the "
-            "camera's current center."
-        )
         self.surveyLabel = Qt.QLabel("no region")
         self.errorLabel = Qt.QLabel("")
         self.errorLabel.setStyleSheet("color: red;")
@@ -115,12 +97,10 @@ class SearchPanel(Qt.QWidget):
         form.addRow("Depth from surface, far", self.farDepthSpin)
         form.addRow("Minimum health", self.minHealthSpin)
         form.addRow("Maximum cell density", self.maxDensitySpin)
-        form.addRow("Region shape", self.shapeCombo)
 
         layout = Qt.QVBoxLayout()
         layout.addLayout(form)
         layout.addWidget(self.rescansCheck)
-        layout.addWidget(self.addRegionBtn)
         layout.addWidget(self.surveyLabel)
         layout.addWidget(self.errorLabel)
         self.setLayout(layout)
@@ -133,7 +113,6 @@ class SearchPanel(Qt.QWidget):
         ):
             spin.valueChanged.connect(self._onEdited)
         self.rescansCheck.toggled.connect(self._onEdited)
-        self.addRegionBtn.clicked.connect(self.sigAddRegionRequested)
 
         self._applyLock()
 
@@ -175,10 +154,6 @@ class SearchPanel(Qt.QWidget):
         self._constraintError = ""
         self._showError()
         return constraints
-
-    def regionShape(self) -> str:
-        """The shape key for the next seeded region: "rect" or "ellipse"."""
-        return self.shapeCombo.currentData()
 
     def setError(self, message: str) -> None:
         """Show a message from this panel's owner on the panel's error line.
@@ -238,7 +213,5 @@ class SearchPanel(Qt.QWidget):
             self.minHealthSpin,
             self.maxDensitySpin,
             self.rescansCheck,
-            self.addRegionBtn,
-            self.shapeCombo,
         ):
             w.setEnabled(not locked)

--- a/acq4/modules/Autopatch/status_panel.py
+++ b/acq4/modules/Autopatch/status_panel.py
@@ -37,6 +37,11 @@ class StatusPanel(Qt.QWidget):
         # producer raising during a refill has no cell and opens no log_action,
         # so there would be nothing to hang the band's headline on.
         self._lastError = None
+        # Operator guidance about a control, as opposed to a failure that halted
+        # a run. Held separately from _lastError so neither erases the other:
+        # they have different writers, and neither can see the other's
+        # condition.
+        self._instruction = ""
 
         self.startBtn = Qt.QPushButton("Start")
         self.stopBtn = Qt.QPushButton("Stop")
@@ -187,12 +192,41 @@ class StatusPanel(Qt.QWidget):
         self._lastError = None
         self._updateErrorBand()
 
+    def setInstruction(self, text: str) -> None:
+        """Show operator guidance in the band -- what to do, not what broke.
+
+        For a control that could not proceed, `AutopatchWindow.newSlice()` with
+        no storage directory chosen being the case this exists for. An
+        instruction is deliberately not a RunErrorRecord: no traceback, no Copy,
+        and no Show in log, because no run happened and there is nothing in the
+        log to show.
+        """
+        self._instruction = text
+        self._updateErrorBand()
+
+    def clearInstruction(self) -> None:
+        self._instruction = ""
+        self._updateErrorBand()
+
+    def instruction(self) -> str:
+        """The guidance currently showing, or an empty string."""
+        return self._instruction
+
     def _updateErrorBand(self) -> None:
+        """Render whichever of the two the band is carrying, the error first.
+
+        A failure that halted a run is about tissue and a pipette in it;
+        guidance about a button is not. The instruction is still held and comes
+        back once the error is cleared, since whatever it asked for has not been
+        done in the meantime.
+        """
         record = self._lastError
-        self.instructionLabel.setText(
-            "" if record is None else f"{record.exc_type}: {record.exc_message}"
-        )
-        self.instructionLabel.setVisible(record is not None)
+        if record is not None:
+            self.instructionLabel.setText(f"{record.exc_type}: {record.exc_message}")
+        else:
+            self.instructionLabel.setText(self._instruction)
+        showing = record is not None or bool(self._instruction)
+        self.instructionLabel.setVisible(showing)
         self.showInLogBtn.setVisible(record is not None)
 
     def _onShowInLogClicked(self) -> None:

--- a/acq4/modules/Autopatch/tests/test_region_adapters.py
+++ b/acq4/modules/Autopatch/tests/test_region_adapters.py
@@ -1,6 +1,8 @@
 """Tests for the mapping between a Slice's SearchRegion shapes and the
 pyqtgraph ROIs Area 1 draws them with."""
 
+import math
+
 import pytest
 
 from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
@@ -109,28 +111,24 @@ def test_a_rect_and_an_ellipse_map_to_different_roi_types(qapp):
     assert not isinstance(roiForRegion(RECT), pg.EllipseROI)
 
 
-def test_an_ellipse_roi_has_no_rotate_handle(qapp):
-    # pg.EllipseROI ships one, and it is the only affordance on any of these
-    # ROIs that offers a rotation the region cannot express. Being inert
-    # (rotatable=False) is not enough on its own: a handle the operator can
-    # grab and that then does nothing is a control that lies.
+def test_an_ellipse_roi_has_a_rotate_handle(qapp):
+    # pg.EllipseROI ships one, and now that a region can record an angle it
+    # tells the truth: grabbing it turns the ellipse and the turn reaches the
+    # slice. The rectangle offers the same gesture through an Alt-drag of its
+    # body, which needs no handle.
     from acq4.modules.Autopatch.region_panel import roiForRegion
 
     handles = roiForRegion(ELLIPSE).handles
-    assert not any(h["type"] == "r" for h in handles)
+    assert any(h["type"] == "r" for h in handles)
 
 
 @pytest.mark.parametrize("region", [RECT, ELLIPSE, TRIANGLE])
-def test_no_region_roi_can_be_rotated(qapp, region):
-    # Every region is an axis-aligned box or a list of vertices, so a rotation
-    # has nowhere to be recorded: regionForRoi reads pos and size, and a rotated
-    # box round-trips as an unrotated box somewhere else entirely -- the
-    # operator outlines one patch of tissue and the survey tiles another.
-    #
-    # Driven through the drag handler rather than through roi.setAngle(), which
-    # is the programmatic setter and honours no flag: `rotatable` gates
-    # MouseDragHandler's rotate mode and ROI.movePoint's 'r' handles, and the
-    # Alt-drag below is the one of those two that needs no handle at all.
+def test_a_rotation_gesture_reaches_the_region(qapp, region):
+    # The gesture the operator actually makes: pg.MouseDragHandler enters rotate
+    # mode on an Alt-modified drag of the ROI body, with no handle involved. The
+    # turn has to arrive in the region, because a region that quietly stayed
+    # axis-aligned would have the survey tile tissue the operator did not
+    # outline -- displaced by up to half a field of view.
     from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
 
     roi = roiForRegion(region)
@@ -138,8 +136,8 @@ def test_no_region_roi_can_be_rotated(qapp, region):
 
     altDragRoi(roi)
 
-    assert roi.angle() == 0
-    assert regionForRoi(roi) == before
+    assert roi.angle() != 0
+    assert regionForRoi(roi) != before
 
 
 def test_a_roi_dragged_past_its_own_origin_still_makes_a_region(qapp):
@@ -205,3 +203,119 @@ def test_a_moved_polygon_reports_its_vertices_in_global_coordinates(qapp):
     assert moved.vertices == tuple(
         (x + 0.5e-3, y + 0.25e-3) for x, y in TRIANGLE.vertices
     )
+
+
+# ---- rotation ----
+# Non-trivial angles over a box that is neither square nor axis-symmetric: a
+# right angle would let a swapped sin/cos through, and a square fixture cannot
+# tell an x axis from a y one.
+ROTATED = [
+    RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3, 30.0),
+    EllipseRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3, 30.0),
+    RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3, 37.0),
+    EllipseRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3, -37.0),
+]
+
+
+def turned(px, py, x, y, deg):
+    """`(x, y)` turned `deg` degrees counter-clockwise about `(px, py)`.
+
+    Spelled out here rather than imported from the region, so these tests state
+    the convention they pin instead of agreeing with it by sharing its code.
+    """
+    th = math.radians(deg)
+    c, s = math.cos(th), math.sin(th)
+    dx, dy = x - px, y - py
+    return (px + dx * c - dy * s, py + dx * s + dy * c)
+
+
+def roiCorners(roi):
+    """The four corners of an ROI's box, in parent (global) coordinates.
+
+    Flattened to a plain list of numbers, because `pytest.approx` compares
+    sequences of scalars and refuses nested ones.
+    """
+    size = roi.size()
+    flat = []
+    for lx, ly in ((0.0, 0.0), (size.x(), 0.0), (size.x(), size.y()), (0.0, size.y())):
+        p = roi.mapToParent(Qt.QPointF(lx, ly))
+        flat += [p.x(), p.y()]
+    return flat
+
+
+def flat(points):
+    """`[(x, y), ...]` as `[x, y, ...]`, for the same reason."""
+    return [c for point in points for c in point]
+
+
+@pytest.mark.parametrize("region", ROTATED)
+def test_a_rotated_region_round_trips_through_its_roi(qapp, region):
+    # Exactly, not approximately. This is the whole reason the region's pivot is
+    # the (x0, y0) corner rather than the shape's centre: the corner is what
+    # pg.ROI.setAngle leaves `pos()` sitting on, so the read back is the same
+    # arithmetic the axis-aligned case has always used. A centre pivot has to
+    # halve and un-halve, and measurably does not return the original float.
+    from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
+
+    assert regionForRoi(roiForRegion(region)) == region
+
+
+@pytest.mark.parametrize("region", ROTATED)
+def test_the_rotated_roi_is_drawn_where_the_region_says(qapp, region):
+    # Round-tripping equal objects would still pass if both directions shared
+    # the same wrong pivot. Checking the ROI's own painted corners against the
+    # turn the region describes is what pins the convention to the screen -- and
+    # a displaced outline is exactly the failure this feature exists to avoid.
+    from acq4.modules.Autopatch.region_panel import roiForRegion
+
+    x0, y0, x1, y1 = region.box()
+    expected = flat(
+        turned(x0, y0, cx, cy, region.angle)
+        for cx, cy in ((x0, y0), (x1, y0), (x1, y1), (x0, y1))
+    )
+    assert roiCorners(roiForRegion(region)) == pytest.approx(expected)
+
+
+def test_a_rotated_roi_dragged_past_its_own_origin_still_describes_its_shape(qapp):
+    # An ROI resized past its origin reports a negative size, and the region
+    # normalizes its corners. With the pivot living on the (x0, y0) corner, a
+    # naive read would hand the region the wrong pivot and displace the shape.
+    from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
+
+    roi = roiForRegion(RectRegion(1.4e-3, 2.1e-3, 1.8e-3, 2.2e-3, 37.0))
+    before = roiCorners(roi)
+    # The opposite corner *as drawn*, not as the box was typed: the ROI turns
+    # about its local origin, so putting the origin on the corner's unrotated
+    # position would pivot the shape somewhere else entirely.
+    roi.setPos((before[4], before[5]))
+    roi.setSize((-0.4e-3, -0.1e-3))
+
+    # Same four corners, so the operator sees the same rectangle...
+    assert sorted(roiCorners(roi)) == pytest.approx(sorted(before))
+    # ...and rebuilding from the region it reports draws that same rectangle.
+    assert sorted(roiCorners(roiForRegion(regionForRoi(roi)))) == pytest.approx(
+        sorted(before)
+    )
+
+
+def test_a_rotated_polygon_reports_its_turned_vertices(qapp):
+    # A polygon needs no angle field: regionForRoi maps every vertex through
+    # roi.mapToParent, which already includes the ROI's own transform, so a
+    # rotation arrives baked into the coordinates. Pinned here because that is
+    # load-bearing rather than incidental -- reading the vertices raw would put
+    # the region back where it started.
+    from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
+
+    roi = roiForRegion(TRIANGLE)
+    altDragRoi(roi)
+    pivot = roi.mapToParent(roi.boundingRect().center())
+
+    reported = regionForRoi(roi)
+    assert flat(reported.vertices) == pytest.approx(
+        flat(
+            turned(pivot.x(), pivot.y(), x, y, roi.angle())
+            for x, y in TRIANGLE.vertices
+        )
+    )
+    # And that turned polygon survives being drawn again.
+    assert regionForRoi(roiForRegion(reported)) == reported

--- a/acq4/modules/Autopatch/tests/test_region_adapters.py
+++ b/acq4/modules/Autopatch/tests/test_region_adapters.py
@@ -1,0 +1,128 @@
+"""Tests for the mapping between a Slice's SearchRegion shapes and the
+pyqtgraph ROIs Area 1 draws them with."""
+
+import pytest
+
+from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+# Deliberately asymmetric, at real SI magnitudes: a square fixture cannot test
+# an axis mapping, which is exactly how a swapped rx/ry survived every ellipse
+# test in P2c-1.
+RECT = RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+ELLIPSE = EllipseRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+TRIANGLE = PolygonRegion(((1.0e-3, 2.0e-3), (1.4e-3, 2.02e-3), (1.1e-3, 2.1e-3)))
+
+
+@pytest.mark.parametrize("region", [RECT, ELLIPSE, TRIANGLE])
+def test_a_region_round_trips_through_its_roi(qapp, region):
+    from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
+
+    assert regionForRoi(roiForRegion(region)) == region
+
+
+@pytest.mark.parametrize("region", [RECT, ELLIPSE, TRIANGLE])
+def test_the_roi_lands_on_the_regions_own_bounds(qapp, region):
+    # Round-tripping equal objects would still pass if both directions shared
+    # the same wrong convention (origin vs centre, say). Checking the ROI's own
+    # geometry against the region's bounds is what pins the convention.
+    from acq4.modules.Autopatch.region_panel import roiForRegion
+
+    roi = roiForRegion(region)
+    x0, y0, x1, y1 = region.bounds()
+    rect = roi.boundingRect()
+    pos = roi.pos()
+    assert pos.x() + rect.x() == pytest.approx(x0)
+    assert pos.y() + rect.y() == pytest.approx(y0)
+    assert rect.width() == pytest.approx(x1 - x0)
+    assert rect.height() == pytest.approx(y1 - y0)
+
+
+def test_a_rect_and_an_ellipse_map_to_different_roi_types(qapp):
+    import pyqtgraph as pg
+
+    from acq4.modules.Autopatch.region_panel import roiForRegion
+
+    assert isinstance(roiForRegion(ELLIPSE), pg.EllipseROI)
+    assert not isinstance(roiForRegion(RECT), pg.EllipseROI)
+
+
+def test_an_ellipse_roi_cannot_be_rotated(qapp):
+    # EllipseRegion is inscribed in an axis-aligned box, so a rotate handle
+    # would let the operator draw a shape that has no region to map back to:
+    # regionForRoi reads pos and size and would drop the rotation silently.
+    from acq4.modules.Autopatch.region_panel import roiForRegion
+
+    handles = roiForRegion(ELLIPSE).handles
+    assert not any(h["type"] == "r" for h in handles)
+
+
+def test_a_roi_dragged_past_its_own_origin_still_makes_a_region(qapp):
+    # An ROI resized past its origin reports a negative size; the region built
+    # from it must still describe the box the operator sees on screen.
+    from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
+
+    roi = roiForRegion(RECT)
+    roi.setPos((1.4e-3, 2.1e-3))
+    roi.setSize((-0.4e-3, -0.1e-3))
+
+    assert regionForRoi(roi) == RECT
+
+
+@pytest.mark.parametrize("size", [(0.0, 0.1e-3), (0.4e-3, 0.0), (0.0, 0.0)])
+def test_an_roi_squashed_flat_reports_no_region(qapp, size):
+    # A pg.RectROI can be dragged to zero extent, and SearchRegion raises on
+    # that. Raising here would surface as a traceback on the GUI thread from
+    # inside a signal handler, mid-drag. One case per axis: a check that only
+    # looks at width passes a test that only squashes height.
+    from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
+
+    roi = roiForRegion(RECT)
+    roi.setSize(size)
+
+    assert regionForRoi(roi) is None
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        # Three vertices on a line: a bounding box with no extent in one axis.
+        [[1.0e-3, 2.0e-3], [1.2e-3, 2.0e-3], [1.4e-3, 2.0e-3]],
+        # Two vertices left after the operator removes handles from a triangle.
+        [[1.0e-3, 2.0e-3], [1.4e-3, 2.02e-3]],
+    ],
+)
+def test_a_polygon_with_no_area_reports_no_region(qapp, points):
+    # The polygon equivalents of a squashed box. Built by construction rather
+    # than by calling roi.setPoints() on a triangle: setPoints() reaches
+    # clearPoints() -> removeHandle() -> removeSegment(), which calls
+    # self.scene().removeItem() and raises AttributeError on an ROI that is not
+    # in a scene. Constructing is the path with no such requirement.
+    import pyqtgraph as pg
+
+    from acq4.modules.Autopatch.region_panel import regionForRoi
+
+    roi = pg.PolyLineROI(points, closed=True)
+
+    assert regionForRoi(roi) is None
+
+
+def test_a_moved_polygon_reports_its_vertices_in_global_coordinates(qapp):
+    # A PolyLineROI holds its vertices in ROI-local coordinates, so dragging the
+    # body moves the shape without touching them. Reading them raw would put the
+    # region back where it started and survey the wrong tissue.
+    from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
+
+    roi = roiForRegion(TRIANGLE)
+    roi.setPos((0.5e-3, 0.25e-3))
+
+    moved = regionForRoi(roi)
+    assert moved.vertices == tuple(
+        (x + 0.5e-3, y + 0.25e-3) for x, y in TRIANGLE.vertices
+    )

--- a/acq4/modules/Autopatch/tests/test_region_adapters.py
+++ b/acq4/modules/Autopatch/tests/test_region_adapters.py
@@ -20,6 +20,62 @@ ELLIPSE = EllipseRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
 TRIANGLE = PolygonRegion(((1.0e-3, 2.0e-3), (1.4e-3, 2.02e-3), (1.1e-3, 2.1e-3)))
 
 
+class _AltDragEvent:
+    """One event of the Alt-modified body drag pyqtgraph turns into a rotation.
+
+    No handle is involved: pg.MouseDragHandler.mouseDragEvent reads the modifier
+    off the event and enters rotate mode if `roi.rotatable`, so dropping the
+    rotate handle does not reach this gesture -- only the flag does.
+
+    Rotation is driven by the horizontal scene-position delta and centred on
+    `buttonDownPos`, so those are the only coordinates that have to be real; the
+    rest is the QGraphicsSceneMouseEvent surface the handler touches.
+    """
+
+    def __init__(self, roi, dx, finish=False):
+        self._finish = finish
+        self._dx = dx
+        # Grabbed at the shape's own centre, the way a body drag is. In local
+        # coordinates, which is what centerLocal wants.
+        self._downPos = roi.boundingRect().center()
+
+    def isStart(self):
+        return not self._finish
+
+    def isFinish(self):
+        return self._finish
+
+    def button(self):
+        return Qt.Qt.LeftButton
+
+    def modifiers(self):
+        return Qt.Qt.AltModifier
+
+    def buttonDownPos(self, *args):
+        return self._downPos
+
+    def pos(self):
+        return self._downPos
+
+    def buttonDownScenePos(self, *args):
+        return Qt.QPointF(0.0, 0.0)
+
+    def scenePos(self):
+        return Qt.QPointF(self._dx, 0.0)
+
+    def accept(self):
+        pass
+
+    def ignore(self):
+        pass
+
+
+def altDragRoi(roi, dx=60.0):
+    """Alt-drag `roi`'s body -- pyqtgraph's rotate gesture -- and release."""
+    roi.mouseDragEvent(_AltDragEvent(roi, dx))
+    roi.mouseDragEvent(_AltDragEvent(roi, dx, finish=True))
+
+
 @pytest.mark.parametrize("region", [RECT, ELLIPSE, TRIANGLE])
 def test_a_region_round_trips_through_its_roi(qapp, region):
     from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
@@ -53,14 +109,37 @@ def test_a_rect_and_an_ellipse_map_to_different_roi_types(qapp):
     assert not isinstance(roiForRegion(RECT), pg.EllipseROI)
 
 
-def test_an_ellipse_roi_cannot_be_rotated(qapp):
-    # EllipseRegion is inscribed in an axis-aligned box, so a rotate handle
-    # would let the operator draw a shape that has no region to map back to:
-    # regionForRoi reads pos and size and would drop the rotation silently.
+def test_an_ellipse_roi_has_no_rotate_handle(qapp):
+    # pg.EllipseROI ships one, and it is the only affordance on any of these
+    # ROIs that offers a rotation the region cannot express. Being inert
+    # (rotatable=False) is not enough on its own: a handle the operator can
+    # grab and that then does nothing is a control that lies.
     from acq4.modules.Autopatch.region_panel import roiForRegion
 
     handles = roiForRegion(ELLIPSE).handles
     assert not any(h["type"] == "r" for h in handles)
+
+
+@pytest.mark.parametrize("region", [RECT, ELLIPSE, TRIANGLE])
+def test_no_region_roi_can_be_rotated(qapp, region):
+    # Every region is an axis-aligned box or a list of vertices, so a rotation
+    # has nowhere to be recorded: regionForRoi reads pos and size, and a rotated
+    # box round-trips as an unrotated box somewhere else entirely -- the
+    # operator outlines one patch of tissue and the survey tiles another.
+    #
+    # Driven through the drag handler rather than through roi.setAngle(), which
+    # is the programmatic setter and honours no flag: `rotatable` gates
+    # MouseDragHandler's rotate mode and ROI.movePoint's 'r' handles, and the
+    # Alt-drag below is the one of those two that needs no handle at all.
+    from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
+
+    roi = roiForRegion(region)
+    before = regionForRoi(roi)
+
+    altDragRoi(roi)
+
+    assert roi.angle() == 0
+    assert regionForRoi(roi) == before
 
 
 def test_a_roi_dragged_past_its_own_origin_still_makes_a_region(qapp):

--- a/acq4/modules/Autopatch/tests/test_region_mirrors.py
+++ b/acq4/modules/Autopatch/tests/test_region_mirrors.py
@@ -164,10 +164,11 @@ def test_unbinding_disconnects_from_the_source_signal(qapp):
 
 
 def test_pinning_three_frames_preserves_their_relative_z_order(qapp):
-    # addItem()-then-setZValue() is what keeps a pinned frame's z-value
-    # intact instead of being raised to the view's own; with only one frame
-    # pinned, every previous test above would still pass even if that
-    # ordering collapsed all z-values to the same number.
+    # Pinned frames stack, and which one is on top is the operator's record of
+    # what they imaged last. A single-frame test already catches an absolute
+    # z-value being clobbered; what needs three is the relative order surviving
+    # -- a mirror that rebuilt its items in the wrong sequence would give every
+    # one of them a plausible z and still stack the mosaic wrongly.
     source = FakeImagingCtrl()
     source.pin(makeFrameItem(1.0, 1e-3, 2e-3))
     source.pin(makeFrameItem(2.0, 3e-3, 4e-3))

--- a/acq4/modules/Autopatch/tests/test_region_mirrors.py
+++ b/acq4/modules/Autopatch/tests/test_region_mirrors.py
@@ -291,11 +291,11 @@ def test_a_polygon_outline_has_a_vertex_per_vertex(qapp):
 
 
 def test_the_outline_keeps_its_assigned_z_value(qapp):
-    # pg.ViewBox.addItem() raises an incoming item's z to the view's own when
-    # the item's is lower. CameraWindow.addItem() calls view.addItem() and
-    # only then applies the z it was given, so the outline's z survives that
-    # raise instead of being fixed to it -- the same hazard PinnedFrameMirror
-    # had to order around, met here from the opposite side of the call.
+    # What this pins is that CameraMirror hands its z to the window rather than
+    # setting it itself: the fake records whatever it is passed. It cannot show
+    # the z surviving pg.ViewBox.addItem()'s raise-if-lower rule, which is real
+    # but lives in CameraWindow.addItem() -- that calls view.addItem() first and
+    # applies the given z after, so the order is already right on the real path.
     from acq4.modules.Autopatch.region_mirrors import _MIRROR_Z
 
     window = FakeCameraWindow()

--- a/acq4/modules/Autopatch/tests/test_region_mirrors.py
+++ b/acq4/modules/Autopatch/tests/test_region_mirrors.py
@@ -81,6 +81,7 @@ def test_a_frame_unpinned_disappears(qapp):
     source.pin(item)
     mirror, _view = makeMirror()
     mirror.bind(source)
+    assert len(mirror.items) == 1
 
     source.unpin(item)
 
@@ -120,6 +121,7 @@ def test_unbinding_clears_the_view_and_stops_listening(qapp):
     source.pin(makeFrameItem(1.0, 1e-3, 2e-3))
     mirror, _view = makeMirror()
     mirror.bind(source)
+    assert len(mirror.items) == 1
 
     mirror.unbind()
     source.pin(makeFrameItem(2.0, 3e-3, 4e-3))
@@ -142,3 +144,36 @@ def test_unbinding_releases_the_source(qapp):
         assert ref() is None
     finally:
         gc.enable()
+
+
+def test_unbinding_disconnects_from_the_source_signal(qapp):
+    # test_unbinding_releases_the_source only proves the last Python
+    # reference to the source is dropped, which follows from `self._source =
+    # None` alone regardless of whether the Qt connection was severed. This
+    # test instead inspects the connection itself: a long-lived source (the
+    # real Camera module's ImagingCtrl) would otherwise keep calling a
+    # torn-down mirror's refresh() forever.
+    source = FakeImagingCtrl()
+    mirror, _view = makeMirror()
+    mirror.bind(source)
+    assert source.receivers(source.sigPinnedFramesChanged) == 1
+
+    mirror.unbind()
+
+    assert source.receivers(source.sigPinnedFramesChanged) == 0
+
+
+def test_pinning_three_frames_preserves_their_relative_z_order(qapp):
+    # addItem()-then-setZValue() is what keeps a pinned frame's z-value
+    # intact instead of being raised to the view's own; with only one frame
+    # pinned, every previous test above would still pass even if that
+    # ordering collapsed all z-values to the same number.
+    source = FakeImagingCtrl()
+    source.pin(makeFrameItem(1.0, 1e-3, 2e-3))
+    source.pin(makeFrameItem(2.0, 3e-3, 4e-3))
+    source.pin(makeFrameItem(3.0, 5e-3, 6e-3))
+    mirror, _view = makeMirror()
+
+    mirror.bind(source)
+
+    assert [item.zValue() for item in mirror.items] == [-10000, -9999, -9998]

--- a/acq4/modules/Autopatch/tests/test_region_mirrors.py
+++ b/acq4/modules/Autopatch/tests/test_region_mirrors.py
@@ -36,15 +36,21 @@ class FakeImagingCtrl(Qt.QObject):
         self.sigPinnedFramesChanged.emit()
 
 
-def makeFrameItem(value, x, y):
+def makeFrameItem(value, x, y, levels=None, lut=None):
     # Asymmetric image on purpose: a transposed copy of a square array is
     # indistinguishable from the original.
-    item = pg.ImageItem(np.full((4, 7), value, dtype=float))
+    item = pg.ImageItem(np.full((4, 7), value, dtype=float), levels=levels, lut=lut)
     transform = Qt.QTransform()
     transform.translate(x, y)
     transform.scale(1e-6, 2e-6)
     item.setTransform(transform)
     return item
+
+
+def makeLut():
+    """A lookup table like the one ImagingCtrl.pinCurrentFrame takes off the
+    contrast histogram."""
+    return np.repeat(np.arange(256, dtype=np.ubyte)[:, np.newaxis], 3, axis=1)
 
 
 def makeMirror():
@@ -91,8 +97,16 @@ def test_a_frame_unpinned_disappears(qapp):
 def test_the_mirrored_item_carries_the_same_pixels_and_placement(qapp):
     # A mirror that showed the right image in the wrong place would have the
     # operator draw regions over tissue that is somewhere else.
+    #
+    # Levels and lut are part of the placement problem, not a cosmetic
+    # preference: a real pinned frame is built with both spelled out
+    # (ImagingCtrl.pinCurrentFrame, Frame.imageItem), and an item given neither
+    # scales itself to its own contents. Every mirrored frame in a mosaic would
+    # then get its own independent auto-scale, and a 16-bit frame with a narrow
+    # range renders near-flat -- which is not a backdrop anyone can draw on.
+    lut = makeLut()
     source = FakeImagingCtrl()
-    original = makeFrameItem(3.0, 1e-3, 2e-3)
+    original = makeFrameItem(3.0, 1e-3, 2e-3, levels=(1.0, 9.0), lut=lut)
     source.pin(original)
     mirror, _view = makeMirror()
     mirror.bind(source)
@@ -101,6 +115,22 @@ def test_the_mirrored_item_carries_the_same_pixels_and_placement(qapp):
     assert np.array_equal(copy.image, original.image)
     assert copy.transform() == original.transform()
     assert copy.zValue() == original.zValue()
+    assert np.array_equal(copy.getLevels(), original.getLevels())
+    assert np.array_equal(copy.lut, lut)
+
+
+def test_a_frame_with_no_levels_or_lut_is_mirrored_anyway(qapp):
+    # Both are optional on the way in -- Frame.imageItem passes None for each
+    # when a frame carries no contrast info -- so copying them must not turn an
+    # absent one into a failure.
+    source = FakeImagingCtrl()
+    source.pin(makeFrameItem(3.0, 1e-3, 2e-3))
+    mirror, _view = makeMirror()
+
+    mirror.bind(source)
+
+    assert len(mirror.items) == 1
+    assert mirror.items[0].lut is None
 
 
 def test_the_mirrored_item_is_a_distinct_object_in_this_view(qapp):
@@ -161,6 +191,38 @@ def test_unbinding_disconnects_from_the_source_signal(qapp):
     mirror.unbind()
 
     assert source.receivers(source.sigPinnedFramesChanged) == 0
+
+
+class DeletedImagingCtrl:
+    """A source whose underlying C++ object Qt has already destroyed.
+
+    The Python wrapper outlives it and raises RuntimeError on every attribute
+    reached through it -- including the signal, which is why pg.disconnect
+    swallowing RuntimeError is not enough on its own: the signal has to be read
+    before it can be handed to pg.disconnect at all.
+
+    Written as a stand-in rather than by actually deleting a QObject so the test
+    says which behaviour it depends on, and does not depend on which Qt binding
+    acq4 was imported with.
+    """
+
+    @property
+    def sigPinnedFramesChanged(self):
+        raise RuntimeError("wrapped C/C++ object of type ImagingCtrl has been deleted")
+
+
+def test_unbinding_survives_a_source_whose_c_object_is_gone(qapp):
+    # unbind() is the first thing AutopatchWindow.teardown() reaches for, so a
+    # raise here would leave the orchestrator running and every panel still
+    # wired to it. An application shutdown that destroys the Camera module
+    # before Autopatch is an ordinary way to arrive here.
+    mirror, _view = makeMirror()
+    mirror._source = DeletedImagingCtrl()
+
+    mirror.unbind()
+
+    assert mirror._source is None
+    assert mirror.items == []
 
 
 def test_pinning_three_frames_preserves_their_relative_z_order(qapp):

--- a/acq4/modules/Autopatch/tests/test_region_mirrors.py
+++ b/acq4/modules/Autopatch/tests/test_region_mirrors.py
@@ -178,3 +178,153 @@ def test_pinning_three_frames_preserves_their_relative_z_order(qapp):
     mirror.bind(source)
 
     assert [item.zValue() for item in mirror.items] == [-10000, -9999, -9998]
+
+
+from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
+
+RECT = RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+ELLIPSE = EllipseRegion(3.0e-3, 1.0e-3, 3.6e-3, 1.2e-3)
+TRIANGLE = PolygonRegion(((1.0e-3, 2.0e-3), (1.4e-3, 2.02e-3), (1.1e-3, 2.1e-3)))
+
+
+class FakeCameraWindow:
+    """Stands in for the Camera module's window: the addItem/removeItem pair
+    Autopatch reaches it through."""
+
+    def __init__(self):
+        self.items = []
+
+    def addItem(self, item, pos=(0, 0), scale=(1, 1), z=None, **kwds):
+        self.items.append(item)
+        if z is not None:
+            item.setZValue(z)
+
+    def removeItem(self, item):
+        self.items.remove(item)
+
+
+def makeCameraMirror(window):
+    from acq4.modules.Autopatch.region_mirrors import CameraMirror
+
+    return CameraMirror(lambda: window)
+
+
+def test_disabled_by_default_nothing_reaches_the_camera(qapp):
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+
+    mirror.setRegions([RECT, ELLIPSE])
+
+    assert window.items == []
+
+
+def test_enabling_draws_the_regions_already_set(qapp):
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setRegions([RECT, ELLIPSE])
+
+    mirror.setEnabled(True)
+
+    assert len(window.items) == 2
+
+
+def test_regions_set_while_enabled_are_drawn(qapp):
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+
+    mirror.setRegions([RECT, ELLIPSE, TRIANGLE])
+
+    assert len(window.items) == 3
+
+
+def test_disabling_takes_them_out_again(qapp):
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+    mirror.setRegions([RECT])
+
+    mirror.setEnabled(False)
+
+    assert window.items == []
+
+
+def test_the_outlines_cannot_be_grabbed(qapp):
+    # Autopatch is the only place a region is edited. A mirrored outline that
+    # accepted a mouse press would be a second, silent editing surface.
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+    mirror.setRegions([RECT])
+
+    assert window.items[0].acceptedMouseButtons() == Qt.Qt.NoButton
+
+
+@pytest.mark.parametrize(
+    "region,expected",
+    [(RECT, (1.0e-3, 2.0e-3, 0.4e-3, 0.1e-3)), (ELLIPSE, (3.0e-3, 1.0e-3, 0.6e-3, 0.2e-3))],
+)
+def test_an_outline_lands_on_its_regions_bounds(qapp, region, expected):
+    # Asymmetric bounds on both shapes: a square outline cannot catch a width
+    # and height that have been swapped.
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+    mirror.setRegions([region])
+
+    rect = window.items[0].path().boundingRect()
+    assert (rect.x(), rect.y(), rect.width(), rect.height()) == pytest.approx(expected)
+
+
+def test_a_polygon_outline_has_a_vertex_per_vertex(qapp):
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+    mirror.setRegions([TRIANGLE])
+
+    path = window.items[0].path()
+    drawn = {(path.elementAt(i).x, path.elementAt(i).y) for i in range(path.elementCount())}
+    for vertex in TRIANGLE.vertices:
+        assert any(
+            abs(x - vertex[0]) < 1e-12 and abs(y - vertex[1]) < 1e-12 for x, y in drawn
+        )
+
+
+def test_the_outline_keeps_its_assigned_z_value(qapp):
+    # pg.ViewBox.addItem() raises an incoming item's z to the view's own when
+    # the item's is lower. CameraWindow.addItem() calls view.addItem() and
+    # only then applies the z it was given, so the outline's z survives that
+    # raise instead of being fixed to it -- the same hazard PinnedFrameMirror
+    # had to order around, met here from the opposite side of the call.
+    from acq4.modules.Autopatch.region_mirrors import _MIRROR_Z
+
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+    mirror.setRegions([RECT])
+
+    assert window.items[0].zValue() == _MIRROR_Z
+
+
+def test_no_camera_window_is_not_an_error(qapp):
+    # A rig with the Camera module unloaded is ordinary; the checkbox is a
+    # display preference, not a requirement.
+    from acq4.modules.Autopatch.region_mirrors import CameraMirror
+
+    mirror = CameraMirror(lambda: None)
+    mirror.setEnabled(True)
+    mirror.setRegions([RECT])
+
+    assert mirror.items == []
+
+
+def test_clear_removes_everything_it_put_there(qapp):
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+    mirror.setRegions([RECT, ELLIPSE])
+
+    mirror.clear()
+
+    assert window.items == []
+    assert mirror.items == []

--- a/acq4/modules/Autopatch/tests/test_region_mirrors.py
+++ b/acq4/modules/Autopatch/tests/test_region_mirrors.py
@@ -390,3 +390,36 @@ def test_clear_removes_everything_it_put_there(qapp):
 
     assert window.items == []
     assert mirror.items == []
+
+
+@pytest.mark.parametrize("regionClass", ["rect", "ellipse"])
+def test_a_turned_regions_outline_is_drawn_turned(qapp, regionClass):
+    # The mirror is the same region seen from the Camera window, and an outline
+    # drawn from bounds() would be the axis-aligned box around the shape rather
+    # than the shape: bigger than the tissue outlined, and at the wrong angle.
+    # The operator would be looking at two different regions in two windows.
+    import math
+
+    from acq4.experiment.search_region import EllipseRegion, RectRegion
+    from acq4.modules.Autopatch.region_mirrors import _pathForRegion
+
+    cls = EllipseRegion if regionClass == "ellipse" else RectRegion
+    box = (1.0e-3, 2.0e-3, 1.6e-3, 2.4e-3)
+    angle = 30.0
+    turnedPath = _pathForRegion(cls(*box, angle))
+    straightPath = _pathForRegion(cls(*box))
+
+    assert turnedPath != straightPath
+    # Every point of the turned outline is the matching point of the straight
+    # one, turned about the (x0, y0) corner -- the region's own pivot.
+    th = math.radians(angle)
+    assert turnedPath.elementCount() == straightPath.elementCount()
+    for i in range(straightPath.elementCount()):
+        straight = straightPath.elementAt(i)
+        dx, dy = straight.x - box[0], straight.y - box[1]
+        expected = (
+            box[0] + dx * math.cos(th) - dy * math.sin(th),
+            box[1] + dx * math.sin(th) + dy * math.cos(th),
+        )
+        turned = turnedPath.elementAt(i)
+        assert (turned.x, turned.y) == pytest.approx(expected), i

--- a/acq4/modules/Autopatch/tests/test_region_mirrors.py
+++ b/acq4/modules/Autopatch/tests/test_region_mirrors.py
@@ -1,0 +1,144 @@
+"""Tests for Area 1's two one-way mirrors: the Camera module's pinned frames
+coming in, and region outlines going out."""
+
+import gc
+import weakref
+
+import numpy as np
+import pyqtgraph as pg
+import pytest
+
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+class FakeImagingCtrl(Qt.QObject):
+    """Stands in for the Camera module's ImagingCtrl: a list of pinned image
+    items and the signal that says it changed."""
+
+    sigPinnedFramesChanged = Qt.Signal()
+
+    def __init__(self):
+        super().__init__()
+        self.pinnedFrames = []
+
+    def pin(self, item):
+        item.setZValue(-10000 + len(self.pinnedFrames))
+        self.pinnedFrames.append(item)
+        self.sigPinnedFramesChanged.emit()
+
+    def unpin(self, item):
+        self.pinnedFrames.remove(item)
+        self.sigPinnedFramesChanged.emit()
+
+
+def makeFrameItem(value, x, y):
+    # Asymmetric image on purpose: a transposed copy of a square array is
+    # indistinguishable from the original.
+    item = pg.ImageItem(np.full((4, 7), value, dtype=float))
+    transform = Qt.QTransform()
+    transform.translate(x, y)
+    transform.scale(1e-6, 2e-6)
+    item.setTransform(transform)
+    return item
+
+
+def makeMirror():
+    from acq4.modules.Autopatch.region_mirrors import PinnedFrameMirror
+
+    view = pg.ViewBox()
+    return PinnedFrameMirror(view), view
+
+
+def test_binding_shows_the_frames_already_pinned(qapp):
+    # The operator pins frames before opening Autopatch as often as after.
+    source = FakeImagingCtrl()
+    source.pin(makeFrameItem(1.0, 1e-3, 2e-3))
+    mirror, _view = makeMirror()
+
+    mirror.bind(source)
+
+    assert len(mirror.items) == 1
+
+
+def test_a_frame_pinned_later_appears(qapp):
+    source = FakeImagingCtrl()
+    mirror, _view = makeMirror()
+    mirror.bind(source)
+
+    source.pin(makeFrameItem(1.0, 1e-3, 2e-3))
+
+    assert len(mirror.items) == 1
+
+
+def test_a_frame_unpinned_disappears(qapp):
+    source = FakeImagingCtrl()
+    item = makeFrameItem(1.0, 1e-3, 2e-3)
+    source.pin(item)
+    mirror, _view = makeMirror()
+    mirror.bind(source)
+
+    source.unpin(item)
+
+    assert mirror.items == []
+
+
+def test_the_mirrored_item_carries_the_same_pixels_and_placement(qapp):
+    # A mirror that showed the right image in the wrong place would have the
+    # operator draw regions over tissue that is somewhere else.
+    source = FakeImagingCtrl()
+    original = makeFrameItem(3.0, 1e-3, 2e-3)
+    source.pin(original)
+    mirror, _view = makeMirror()
+    mirror.bind(source)
+
+    copy = mirror.items[0]
+    assert np.array_equal(copy.image, original.image)
+    assert copy.transform() == original.transform()
+    assert copy.zValue() == original.zValue()
+
+
+def test_the_mirrored_item_is_a_distinct_object_in_this_view(qapp):
+    # An ImageItem lives in exactly one scene, so re-adding the Camera module's
+    # own item would take it out of the Camera module's view.
+    source = FakeImagingCtrl()
+    original = makeFrameItem(3.0, 1e-3, 2e-3)
+    source.pin(original)
+    mirror, view = makeMirror()
+    mirror.bind(source)
+
+    assert mirror.items[0] is not original
+    assert mirror.items[0] in view.addedItems
+
+
+def test_unbinding_clears_the_view_and_stops_listening(qapp):
+    source = FakeImagingCtrl()
+    source.pin(makeFrameItem(1.0, 1e-3, 2e-3))
+    mirror, _view = makeMirror()
+    mirror.bind(source)
+
+    mirror.unbind()
+    source.pin(makeFrameItem(2.0, 3e-3, 4e-3))
+
+    assert mirror.items == []
+
+
+def test_unbinding_releases_the_source(qapp):
+    # A connection outliving its owner is this module's most-repeated defect:
+    # a mirror still listening after teardown draws into a dead view.
+    source = FakeImagingCtrl()
+    mirror, _view = makeMirror()
+    mirror.bind(source)
+    ref = weakref.ref(source)
+
+    mirror.unbind()
+    del source
+    gc.disable()
+    try:
+        assert ref() is None
+    finally:
+        gc.enable()

--- a/acq4/modules/Autopatch/tests/test_region_panel.py
+++ b/acq4/modules/Autopatch/tests/test_region_panel.py
@@ -517,3 +517,42 @@ def test_a_region_added_while_locked_is_locked_too(qapp, region):
         segment.acceptedMouseButtons() == Qt.Qt.NoButton
         for segment in getattr(roi, "segments", [])
     )
+
+
+def test_a_fresh_viewport_spans_about_a_metre(qapp):
+    # The reason setViewport() exists, pinned so it cannot quietly stop being
+    # true: pg.ViewBox's default range is in this view's own units, which are
+    # global metres. A click in an empty Area 1 therefore lands a polygon vertex
+    # half a metre out, and a "small" drag is hundreds of millimetres.
+    panel = makePanel()
+
+    (vx0, vx1), (vy0, vy1) = panel.view.viewRange()
+
+    assert (vx1 - vx0) > 0.1
+    assert (vy1 - vy0) > 0.1
+
+
+def test_set_viewport_centres_the_view_where_it_is_told(qapp):
+    panel = makePanel()
+
+    panel.setViewport((1.5e-3, -2.5e-3), (200e-6, 120e-6))
+
+    (vx0, vx1), (vy0, vy1) = panel.view.viewRange()
+    assert (vx0 + vx1) / 2 == pytest.approx(1.5e-3)
+    assert (vy0 + vy1) / 2 == pytest.approx(-2.5e-3)
+
+
+def test_set_viewport_frames_the_span_it_is_given(qapp):
+    # The span is what makes a field of view visible rather than sub-pixel. The
+    # view is aspect-locked, so one axis may be widened to fit the widget; both
+    # must at least contain what was asked for, and neither may still be at the
+    # metre scale a fresh viewport starts at.
+    panel = makePanel()
+
+    panel.setViewport((1.5e-3, -2.5e-3), (200e-6, 120e-6))
+
+    (vx0, vx1), (vy0, vy1) = panel.view.viewRange()
+    assert (vx1 - vx0) >= 200e-6
+    assert (vy1 - vy0) >= 120e-6
+    assert (vx1 - vx0) < 10e-3
+    assert (vy1 - vy0) < 10e-3

--- a/acq4/modules/Autopatch/tests/test_region_panel.py
+++ b/acq4/modules/Autopatch/tests/test_region_panel.py
@@ -15,12 +15,31 @@ def qapp():
 RECT = RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
 OTHER = RectRegion(3.0e-3, 1.0e-3, 3.6e-3, 1.2e-3)
 ELLIPSE = EllipseRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+TRIANGLE = PolygonRegion(((1.0e-3, 2.0e-3), (1.4e-3, 2.02e-3), (1.1e-3, 2.1e-3)))
+
+# The gate has to hold for every shape, and the three ROI classes behind them
+# have three different editing surfaces: a rect's handles, an ellipse's handles,
+# and a polygon's clickable edges on top of its handles.
+SHAPES = [RECT, ELLIPSE, TRIANGLE]
 
 
 def makePanel():
     from acq4.modules.Autopatch.region_panel import RegionPanel
 
     return RegionPanel()
+
+
+def clickSegment(roi, segment, pos):
+    """Left-click one of a polygon's edges the way the scene would deliver it.
+
+    QGraphicsScene routes a press only to an item whose acceptedMouseButtons
+    include that button, so a segment set to NoButton never sees the event at
+    all. That dispatch is the whole mechanism behind locking a polygon, and
+    calling roi.segmentClicked() directly steps straight over it.
+    """
+    if not (segment.acceptedMouseButtons() & Qt.Qt.LeftButton):
+        return
+    roi.segmentClicked(segment, pos=pos)
 
 
 def test_a_fresh_panel_holds_no_regions(qapp):
@@ -151,7 +170,9 @@ def test_an_roi_squashed_flat_stays_on_screen_but_is_not_reported(qapp):
 
 def test_fit_to_regions_ignores_a_squashed_roi(qapp):
     # regions() drops it, so fitToRegions must read through regions() rather
-    # than the ROI list, or it frames a bounding box it cannot compute.
+    # than the ROI list, or it frames a bounding box it cannot compute -- and
+    # framing a zero-extent ROI is itself the unrecoverable scale the empty-set
+    # case below is careful to avoid.
     panel = makePanel()
     panel.setRegions([RECT])
     panel._rois[0].setSize((0.0, 0.0))
@@ -212,6 +233,56 @@ def test_fit_to_regions_with_nothing_drawn_is_a_no_op(qapp):
     assert panel.view.viewRange() == before
 
 
+def makePinnedFrameItem(x, y, w, h):
+    """An image item standing in for one mirrored pinned frame, placed and
+    scaled to cover (x, y) to (x + w, y + h) in global metres."""
+    import numpy as np
+    import pyqtgraph as pg
+
+    # Asymmetric on purpose: a square array cannot catch a swapped axis.
+    item = pg.ImageItem(np.zeros((4, 7), dtype=float))
+    # Scaled off the item's own bounding rect rather than off the array shape,
+    # which is not the same thing: pg.ImageItem's default column-major axis
+    # order makes shape (4, 7) an item 4 wide and 7 tall.
+    pixels = item.boundingRect()
+    transform = Qt.QTransform()
+    transform.translate(x, y)
+    transform.scale(w / pixels.width(), h / pixels.height())
+    item.setTransform(transform)
+    return item
+
+
+def test_fit_to_regions_frames_pinned_frames_when_nothing_is_drawn(qapp):
+    # The ordinary first state: imagery mirrored in, no region seeded yet. A
+    # fresh viewport spans about a metre, so 200um of tissue is rendered
+    # sub-pixel and there is no other one-click way to reach it.
+    panel = makePanel()
+    panel.view.addItem(makePinnedFrameItem(1.0e-3, 2.0e-3, 0.2e-3, 0.1e-3))
+
+    panel.fitToRegions()
+
+    (vx0, vx1), (vy0, vy1) = panel.view.viewRange()
+    assert vx0 <= 1.0e-3 and vx1 >= 1.2e-3
+    assert vy0 <= 2.0e-3 and vy1 >= 2.1e-3
+    # And framed, not merely containing it: a viewport still a metre wide
+    # contains those bounds too.
+    assert (vx1 - vx0) < 1.0e-3
+
+
+def test_fit_to_regions_frames_the_regions_and_the_pinned_frames_together(qapp):
+    # Both, not whichever it finds first: a region drawn beside the imagery it
+    # was drawn from must not push that imagery off screen.
+    panel = makePanel()
+    panel.view.addItem(makePinnedFrameItem(3.0e-3, 1.0e-3, 0.2e-3, 0.1e-3))
+    panel.setRegions([RECT])
+
+    panel.fitToRegions()
+
+    (vx0, vx1), (vy0, vy1) = panel.view.viewRange()
+    assert vx0 <= 1.0e-3 and vx1 >= 3.2e-3
+    assert vy0 <= 1.0e-3 and vy1 >= 2.1e-3
+
+
 def test_a_panel_with_no_slice_cannot_be_drawn_on(qapp):
     # New slice is what makes Area 1 usable, and greyed-out controls are how the
     # operator is told so -- the same treatment Area 2 already gets.
@@ -229,35 +300,146 @@ def test_a_slice_makes_the_controls_live(qapp):
     assert panel.shapeCombo.isEnabled()
 
 
-def test_a_running_run_locks_editing(qapp):
+@pytest.mark.parametrize("region", SHAPES)
+def test_a_running_run_locks_editing(qapp, region):
     # The regions parameterise a search already underway on the worker thread.
     panel = makePanel()
     panel.setSliceReady(True)
-    panel.setRegions([RECT])
+    panel.setRegions([region])
     panel.setInteractionLocked(True)
     panel.setRunStatus("running")
 
+    roi = panel._rois[0]
     assert not panel.addRegionBtn.isEnabled()
-    assert not panel._rois[0].translatable
-    assert not panel._rois[0].resizable
-    assert not panel._rois[0].removable
+    assert not roi.translatable
+    assert not roi.resizable
+    assert not roi.removable
+    assert not roi.rotatable
+    assert not any(handle.isVisible() for handle in roi.getHandles())
+    assert all(
+        segment.acceptedMouseButtons() == Qt.Qt.NoButton
+        for segment in getattr(roi, "segments", [])
+    )
 
 
-def test_a_paused_run_unlocks_editing(qapp):
+@pytest.mark.parametrize("region", SHAPES)
+def test_a_paused_run_unlocks_editing(qapp, region):
     # The other side of the same invariant. A one-sided test on a two-sided
     # invariant passes happily while the other side is broken -- which is how
     # CellPanel's flush regressed in both directions across P2b's reviews.
     panel = makePanel()
     panel.setSliceReady(True)
-    panel.setRegions([RECT])
+    panel.setRegions([region])
     panel.setInteractionLocked(True)
     panel.setRunStatus("running")
     panel.setRunStatus("paused")
 
+    roi = panel._rois[0]
     assert panel.addRegionBtn.isEnabled()
-    assert panel._rois[0].translatable
-    assert panel._rois[0].resizable
-    assert panel._rois[0].removable
+    assert roi.translatable
+    assert roi.resizable
+    assert roi.removable
+    assert all(
+        segment.acceptedMouseButtons() == Qt.Qt.LeftButton
+        for segment in getattr(roi, "segments", [])
+    )
+
+
+@pytest.mark.parametrize("region", SHAPES)
+def test_a_paused_run_does_not_hand_back_a_rotation(qapp, region):
+    # Unlocking restores every affordance the ROI shipped with -- except this
+    # one, which it never had. `rotatable` is off by construction and is not the
+    # gate's to give back: no region can express a rotation whatever the run is
+    # doing. Its own test because unlocking sets three sibling flags to True and
+    # a fourth set alongside them would look like it belonged.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setRegions([region])
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("paused")
+
+    assert not panel._rois[0].rotatable
+
+
+@pytest.mark.parametrize("region", SHAPES)
+def test_a_locked_roi_cannot_be_rotated(qapp, region):
+    # The lock's flags stop a drag and a resize; an Alt-drag is a third gesture
+    # that needs no handle, and a rotation reported to the slice mid-run is an
+    # edit the gate is supposed to make impossible.
+    from .test_region_adapters import altDragRoi
+
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setRegions([region])
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("running")
+    seen = []
+    panel.sigRegionsChanged.connect(seen.append)
+    before = panel.regions()
+
+    altDragRoi(panel._rois[0])
+
+    assert panel._rois[0].angle() == 0
+    assert panel.regions() == before
+    assert seen == []
+
+
+def test_a_locked_polygons_edge_cannot_be_clicked_into_a_new_vertex(qapp):
+    # A polygon's editing surface is not only its handles: pyqtgraph gives every
+    # edge its own item that takes left clicks and inserts a vertex there. Left
+    # live, one click on a locked polygon reshapes the region and hands the whole
+    # list to the window -- mid-survey, which is the one thing the gate exists to
+    # prevent.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setRegions([TRIANGLE])
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("running")
+    seen = []
+    panel.sigRegionsChanged.connect(seen.append)
+    roi = panel._rois[0]
+
+    clickSegment(roi, roi.segments[0], Qt.QPointF(1.2e-3, 2.01e-3))
+
+    assert len(panel.regions()[0].vertices) == 3
+    assert seen == []
+
+
+def test_an_unlocked_polygons_edge_still_inserts_a_vertex(qapp):
+    # The other side: gating the segments must not leave a polygon permanently
+    # unreshapeable, which is the only reason to choose polygon at all.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setRegions([TRIANGLE])
+    roi = panel._rois[0]
+
+    clickSegment(roi, roi.segments[0], Qt.QPointF(1.2e-3, 2.01e-3))
+
+    assert len(panel.regions()[0].vertices) == 4
+
+
+def test_a_handle_that_appears_while_locked_is_hidden_too(qapp):
+    # An edit can grow an ROI's own handle list -- segmentClicked adds one --
+    # and a handle is born visible and draggable whatever the gate says. So the
+    # gate is re-applied whenever an ROI reports a change, keeping "an ROI that
+    # has just reported an edit matches the gate" a local property of this panel
+    # rather than a survey of every pyqtgraph path that can add a handle.
+    #
+    # Driven straight through segmentClicked, past the dispatch that stops a
+    # locked polygon reaching here at all (see the test above), because that is
+    # the only way to reach this repair from a locked panel. It reaches the
+    # handle and not the segment: pyqtgraph adds the handle -- which is what
+    # emits -- before it builds the segment.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setRegions([TRIANGLE])
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("running")
+    roi = panel._rois[0]
+
+    roi.segmentClicked(roi.segments[0], pos=Qt.QPointF(1.2e-3, 2.01e-3))
+
+    assert not any(handle.isVisible() for handle in roi.getHandles())
 
 
 def test_surveying_locks_editing_even_though_pause_was_pressed(qapp):
@@ -273,16 +455,37 @@ def test_surveying_locks_editing_even_though_pause_was_pressed(qapp):
     assert not panel.addRegionBtn.isEnabled()
 
 
-def test_resuming_from_paused_locks_editing_again(qapp):
+@pytest.mark.parametrize("region", SHAPES)
+def test_resuming_from_paused_locks_editing_again(qapp, region):
     panel = makePanel()
     panel.setSliceReady(True)
-    panel.setRegions([RECT])
+    panel.setRegions([region])
     panel.setInteractionLocked(True)
     panel.setRunStatus("paused")
     panel.setRunStatus("running")
 
+    roi = panel._rois[0]
     assert not panel.addRegionBtn.isEnabled()
-    assert not panel._rois[0].translatable
+    assert not roi.translatable
+    assert all(
+        segment.acceptedMouseButtons() == Qt.Qt.NoButton
+        for segment in getattr(roi, "segments", [])
+    )
+
+
+def test_the_gate_is_readable_from_outside(qapp):
+    # The window drops region edits that arrive while the panel is locked, and
+    # asking the panel is how it knows. Public because a second reader of a
+    # private predicate is a private predicate with two owners.
+    panel = makePanel()
+    assert not panel.isEditable()
+
+    panel.setSliceReady(True)
+    assert panel.isEditable()
+
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("running")
+    assert not panel.isEditable()
 
 
 def test_regions_drawn_while_locked_are_still_shown(qapp):
@@ -298,13 +501,19 @@ def test_regions_drawn_while_locked_are_still_shown(qapp):
     assert panel.regions() == [RECT, OTHER]
 
 
-def test_a_region_added_while_locked_is_locked_too(qapp):
+@pytest.mark.parametrize("region", SHAPES)
+def test_a_region_added_while_locked_is_locked_too(qapp, region):
     # setRegions builds fresh ROIs, which default to editable; a gate applied
     # only on the transition would leave them draggable mid-run.
     panel = makePanel()
     panel.setSliceReady(True)
     panel.setInteractionLocked(True)
     panel.setRunStatus("running")
-    panel.setRegions([RECT])
+    panel.setRegions([region])
 
-    assert not panel._rois[0].translatable
+    roi = panel._rois[0]
+    assert not roi.translatable
+    assert all(
+        segment.acceptedMouseButtons() == Qt.Qt.NoButton
+        for segment in getattr(roi, "segments", [])
+    )

--- a/acq4/modules/Autopatch/tests/test_region_panel.py
+++ b/acq4/modules/Autopatch/tests/test_region_panel.py
@@ -170,9 +170,9 @@ def test_an_roi_squashed_flat_stays_on_screen_but_is_not_reported(qapp):
 
 def test_fit_to_regions_ignores_a_squashed_roi(qapp):
     # regions() drops it, so fitToRegions must read through regions() rather
-    # than the ROI list, or it frames a bounding box it cannot compute -- and
-    # framing a zero-extent ROI is itself the unrecoverable scale the empty-set
-    # case below is careful to avoid.
+    # than the ROI list. Framing a zero-extent ROI would not wreck the scale --
+    # ViewBox.setRange keeps the current span for a range with none -- but it
+    # would re-centre the view on a shape the survey is ignoring.
     panel = makePanel()
     panel.setRegions([RECT])
     panel._rois[0].setSize((0.0, 0.0))

--- a/acq4/modules/Autopatch/tests/test_region_panel.py
+++ b/acq4/modules/Autopatch/tests/test_region_panel.py
@@ -346,19 +346,20 @@ def test_a_paused_run_unlocks_editing(qapp, region):
 
 
 @pytest.mark.parametrize("region", SHAPES)
-def test_a_paused_run_does_not_hand_back_a_rotation(qapp, region):
-    # Unlocking restores every affordance the ROI shipped with -- except this
-    # one, which it never had. `rotatable` is off by construction and is not the
-    # gate's to give back: no region can express a rotation whatever the run is
-    # doing. Its own test because unlocking sets three sibling flags to True and
-    # a fourth set alongside them would look like it belonged.
+def test_a_paused_run_hands_rotation_back(qapp, region):
+    # A region can record an angle now, so rotation is an ordinary edit and the
+    # gate owes it the same treatment as dragging and resizing: off while a run
+    # is in flight (asserted above), on again once the run parks at a pause.
+    # Its own test because the locked side is the one that protects a survey,
+    # and a one-sided test on a two-sided invariant passes happily while the
+    # other side is broken.
     panel = makePanel()
     panel.setSliceReady(True)
     panel.setRegions([region])
     panel.setInteractionLocked(True)
     panel.setRunStatus("paused")
 
-    assert not panel._rois[0].rotatable
+    assert panel._rois[0].rotatable
 
 
 @pytest.mark.parametrize("region", SHAPES)

--- a/acq4/modules/Autopatch/tests/test_region_panel.py
+++ b/acq4/modules/Autopatch/tests/test_region_panel.py
@@ -1,0 +1,211 @@
+"""Tests for Area 1's region view: what it draws, what it reports back when the
+operator edits a region, and what it lets them touch."""
+
+import pytest
+
+from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+RECT = RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+OTHER = RectRegion(3.0e-3, 1.0e-3, 3.6e-3, 1.2e-3)
+ELLIPSE = EllipseRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+
+
+def makePanel():
+    from acq4.modules.Autopatch.region_panel import RegionPanel
+
+    return RegionPanel()
+
+
+def test_a_fresh_panel_holds_no_regions(qapp):
+    assert makePanel().regions() == []
+
+
+def test_setregions_draws_one_roi_per_region(qapp):
+    panel = makePanel()
+    panel.setRegions([RECT, OTHER])
+
+    assert len(panel._rois) == 2
+    assert panel.regions() == [RECT, OTHER]
+
+
+def test_setregions_replaces_rather_than_appends(qapp):
+    # The window pushes the slice's whole region list on every refresh, so a
+    # panel that appended would redraw the same region once per refresh.
+    panel = makePanel()
+    panel.setRegions([RECT, OTHER])
+    panel.setRegions([ELLIPSE])
+
+    assert len(panel._rois) == 1
+    assert panel.regions() == [ELLIPSE]
+
+
+def test_setregions_does_not_echo_back(qapp):
+    # setRegions is how the slice's state reaches the panel. Echoing it would
+    # write straight back into the slice, and a New slice that cleared the panel
+    # would be told by that panel that its regions are empty.
+    panel = makePanel()
+    seen = []
+    panel.sigRegionsChanged.connect(seen.append)
+    panel.setRegions([RECT])
+
+    assert seen == []
+
+
+def test_dragging_a_region_reports_the_whole_list(qapp):
+    # The window replaces the slice's regions wholesale, so an edit to one has
+    # to arrive with its neighbours intact rather than on its own.
+    panel = makePanel()
+    panel.setRegions([RECT, OTHER])
+    seen = []
+    panel.sigRegionsChanged.connect(seen.append)
+
+    roi = panel._rois[0]
+    # finish=False: setPos's own default (finish=True) already emits
+    # sigRegionChangeFinished, which is what a real drag never does mid-gesture
+    # (pg.MouseDragHandler always moves with finish=False and fires the signal
+    # exactly once, from _moveFinished, on release) -- so the explicit emit
+    # below is what stands in for that release.
+    roi.setPos((2.0e-3, 5.0e-3), finish=False)
+    roi.sigRegionChangeFinished.emit(roi)
+
+    assert len(seen) == 1
+    moved, untouched = seen[0]
+    # bounds(), compared with approx: pos + size round-trips through the same
+    # subtraction and re-addition RectRegion's own fixture construction does,
+    # and at these magnitudes that is not bit-exact (2.0e-3 + (1.4e-3 - 1.0e-3)
+    # is 2.4000000000000002e-3 on this interpreter, not 2.4e-3).
+    assert moved.bounds() == pytest.approx((2.0e-3, 5.0e-3, 2.4e-3, 5.1e-3))
+    assert untouched == OTHER
+
+
+def test_removing_a_region_reports_the_list_without_it(qapp):
+    panel = makePanel()
+    panel.setRegions([RECT, OTHER])
+    seen = []
+    panel.sigRegionsChanged.connect(seen.append)
+
+    panel._rois[0].sigRemoveRequested.emit(panel._rois[0])
+
+    assert seen == [[OTHER]]
+    assert panel.regions() == [OTHER]
+
+
+def test_a_removed_roi_leaves_the_view(qapp):
+    # Dropping it from the list but leaving the item in the scene would keep a
+    # deleted region on screen, and keep it alive.
+    panel = makePanel()
+    panel.setRegions([RECT])
+    roi = panel._rois[0]
+
+    roi.sigRemoveRequested.emit(roi)
+
+    assert roi.scene() is None
+
+
+def test_adding_a_polygon_vertex_reaches_the_reported_region(qapp):
+    # Reshaping a polygon is pyqtgraph's own segmentClicked inserting a handle
+    # where an edge was clicked -- the mechanism that makes outlining a cortical
+    # layer possible without any drawing code of ours. Pinned here because the
+    # panel depends on it: a handle added this way has to arrive in the region
+    # the panel reports, in global coordinates.
+    #
+    # segments[0] is the *closing* edge (last vertex back to first), not the
+    # first one, so the new vertex lands between the triangle's third and first
+    # points. Membership rather than a position is asserted for that reason --
+    # pyqtgraph's ordering is its own business as long as handle order,
+    # getState()['points'], and shape() agree, which they do.
+    triangle = PolygonRegion(
+        ((1.0e-3, 2.0e-3), (1.4e-3, 2.02e-3), (1.1e-3, 2.1e-3))
+    )
+    panel = makePanel()
+    panel.setRegions([triangle])
+    roi = panel._rois[0]
+
+    roi.segmentClicked(roi.segments[0], pos=Qt.QPointF(1.2e-3, 2.01e-3))
+
+    reported = panel.regions()[0]
+    assert len(reported.vertices) == 4
+    assert (1.2e-3, 2.01e-3) in [
+        (pytest.approx(x), pytest.approx(y)) for x, y in reported.vertices
+    ]
+
+
+def test_an_roi_squashed_flat_stays_on_screen_but_is_not_reported(qapp):
+    # Removing it would delete the operator's work mid-drag; reporting it would
+    # hand the slice a region with no tiles. It stays visible and uncounted.
+    panel = makePanel()
+    panel.setRegions([RECT, OTHER])
+
+    panel._rois[0].setSize((0.0, 0.1e-3))
+
+    assert len(panel._rois) == 2
+    assert panel.regions() == [OTHER]
+
+
+def test_fit_to_regions_ignores_a_squashed_roi(qapp):
+    # regions() drops it, so fitToRegions must read through regions() rather
+    # than the ROI list, or it frames a bounding box it cannot compute.
+    panel = makePanel()
+    panel.setRegions([RECT])
+    panel._rois[0].setSize((0.0, 0.0))
+    before = panel.view.viewRange()
+
+    panel.fitToRegions()
+
+    assert panel.view.viewRange() == before
+
+
+def test_the_shape_selector_offers_all_three_shapes(qapp):
+    # PolygonRegion has been implemented and tested since P2c-1 with no control
+    # able to produce one; a cortical layer is the reason regions became shapes.
+    panel = makePanel()
+    shapes = [panel.shapeCombo.itemData(i) for i in range(panel.shapeCombo.count())]
+
+    assert shapes == ["rect", "ellipse", "polygon"]
+
+
+def test_the_shape_selector_reports_item_data_not_its_label(qapp):
+    panel = makePanel()
+    panel.shapeCombo.setCurrentIndex(panel.shapeCombo.findData("polygon"))
+
+    assert panel.regionShape() == "polygon"
+
+
+def test_the_add_region_button_asks_its_owner(qapp):
+    # The panel does not know where the camera is pointing; the window does.
+    panel = makePanel()
+    requests = []
+    panel.sigAddRegionRequested.connect(lambda: requests.append(True))
+
+    panel.addRegionBtn.click()
+
+    assert requests == [True]
+
+
+def test_fit_to_regions_frames_every_region(qapp):
+    panel = makePanel()
+    panel.setRegions([RECT, OTHER])
+
+    panel.fitToRegions()
+
+    (vx0, vx1), (vy0, vy1) = panel.view.viewRange()
+    assert vx0 <= 1.0e-3 and vx1 >= 3.6e-3
+    assert vy0 <= 1.0e-3 and vy1 >= 2.1e-3
+
+
+def test_fit_to_regions_with_nothing_drawn_is_a_no_op(qapp):
+    # The button is live before the operator has drawn anything, and autoranging
+    # over an empty set is how a view ends up at an unrecoverable scale.
+    panel = makePanel()
+    before = panel.view.viewRange()
+
+    panel.fitToRegions()
+
+    assert panel.view.viewRange() == before

--- a/acq4/modules/Autopatch/tests/test_region_panel.py
+++ b/acq4/modules/Autopatch/tests/test_region_panel.py
@@ -181,6 +181,7 @@ def test_the_shape_selector_reports_item_data_not_its_label(qapp):
 def test_the_add_region_button_asks_its_owner(qapp):
     # The panel does not know where the camera is pointing; the window does.
     panel = makePanel()
+    panel.setSliceReady(True)
     requests = []
     panel.sigAddRegionRequested.connect(lambda: requests.append(True))
 
@@ -209,3 +210,101 @@ def test_fit_to_regions_with_nothing_drawn_is_a_no_op(qapp):
     panel.fitToRegions()
 
     assert panel.view.viewRange() == before
+
+
+def test_a_panel_with_no_slice_cannot_be_drawn_on(qapp):
+    # New slice is what makes Area 1 usable, and greyed-out controls are how the
+    # operator is told so -- the same treatment Area 2 already gets.
+    panel = makePanel()
+
+    assert not panel.addRegionBtn.isEnabled()
+    assert not panel.shapeCombo.isEnabled()
+
+
+def test_a_slice_makes_the_controls_live(qapp):
+    panel = makePanel()
+    panel.setSliceReady(True)
+
+    assert panel.addRegionBtn.isEnabled()
+    assert panel.shapeCombo.isEnabled()
+
+
+def test_a_running_run_locks_editing(qapp):
+    # The regions parameterise a search already underway on the worker thread.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setRegions([RECT])
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("running")
+
+    assert not panel.addRegionBtn.isEnabled()
+    assert not panel._rois[0].translatable
+    assert not panel._rois[0].resizable
+    assert not panel._rois[0].removable
+
+
+def test_a_paused_run_unlocks_editing(qapp):
+    # The other side of the same invariant. A one-sided test on a two-sided
+    # invariant passes happily while the other side is broken -- which is how
+    # CellPanel's flush regressed in both directions across P2b's reviews.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setRegions([RECT])
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("running")
+    panel.setRunStatus("paused")
+
+    assert panel.addRegionBtn.isEnabled()
+    assert panel._rois[0].translatable
+    assert panel._rois[0].resizable
+    assert panel._rois[0].removable
+
+
+def test_surveying_locks_editing_even_though_pause_was_pressed(qapp):
+    # "surveying" is what a run reports while the producer images tiles, and a
+    # Pause pressed during one does not park the loop until that refill is done.
+    # Unlocking on anything short of the emitted "paused" would let an edit land
+    # while the producer is reading regions.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("surveying")
+
+    assert not panel.addRegionBtn.isEnabled()
+
+
+def test_resuming_from_paused_locks_editing_again(qapp):
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setRegions([RECT])
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("paused")
+    panel.setRunStatus("running")
+
+    assert not panel.addRegionBtn.isEnabled()
+    assert not panel._rois[0].translatable
+
+
+def test_regions_drawn_while_locked_are_still_shown(qapp):
+    # Locking is about editing, not about hiding: the operator watching a run
+    # must still see what is being surveyed.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("running")
+    panel.setRegions([RECT, OTHER])
+
+    assert len(panel._rois) == 2
+    assert panel.regions() == [RECT, OTHER]
+
+
+def test_a_region_added_while_locked_is_locked_too(qapp):
+    # setRegions builds fresh ROIs, which default to editable; a gate applied
+    # only on the transition would leave them draggable mid-run.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("running")
+    panel.setRegions([RECT])
+
+    assert not panel._rois[0].translatable

--- a/acq4/modules/Autopatch/tests/test_search_panel.py
+++ b/acq4/modules/Autopatch/tests/test_search_panel.py
@@ -205,19 +205,6 @@ def test_an_empty_message_retracts_an_externally_set_error(qapp):
     assert panel.errorLabel.text() == ""
 
 
-def test_add_region_button_emits_a_request(qapp):
-    panel = makePanel()
-    # A disabled button does not deliver clicks; this test is about the
-    # button's wiring, not the no-slice lock, so give it a slice.
-    panel.setSliceReady(True)
-    requests = []
-    panel.sigAddRegionRequested.connect(lambda: requests.append(True))
-
-    panel.addRegionBtn.click()
-
-    assert requests == [True]
-
-
 def test_survey_stats_are_shown(qapp):
     panel = makePanel()
     panel.setSurveyStats(9, 3, 100 / 3)
@@ -239,15 +226,13 @@ def test_survey_stats_with_no_region_read_as_no_region(qapp):
         "minHealthSpin",
         "maxDensitySpin",
         "rescansCheck",
-        "addRegionBtn",
-        "shapeCombo",
     ],
 )
 def test_locking_disables_editing_but_not_the_readout(qapp, widgetName):
     # A run in flight parameterises a producer that is already surveying, so
-    # editing any constraint control or the add-region button mid-run would
-    # silently change the search underneath it; the lock must reach every one
-    # of them, in both directions, while leaving the readout alone.
+    # editing any constraint control mid-run would silently change the search
+    # underneath it; the lock must reach every one of them, in both directions,
+    # while leaving the readout alone.
     panel = makePanel()
     widget = getattr(panel, widgetName)
     # A slice already exists here: this test is about the run-lock reaching
@@ -262,21 +247,6 @@ def test_locking_disables_editing_but_not_the_readout(qapp, widgetName):
     assert widget.isEnabled()
 
 
-def test_the_region_shape_defaults_to_a_rectangle(qapp):
-    # The shape every existing survey used, so the default must not change what
-    # pressing the button has always done.
-    panel = makePanel()
-    assert panel.regionShape() == "rect"
-
-
-def test_the_region_shape_reports_a_key_not_the_combo_label(qapp):
-    # The window maps this to a region class; keying on display text would break
-    # the first time the label is reworded.
-    panel = makePanel()
-    panel.shapeCombo.setCurrentIndex(panel.shapeCombo.findData("ellipse"))
-    assert panel.regionShape() == "ellipse"
-
-
 def _controls(panel):
     return (
         panel.nearDepthSpin,
@@ -284,8 +254,6 @@ def _controls(panel):
         panel.minHealthSpin,
         panel.maxDensitySpin,
         panel.rescansCheck,
-        panel.addRegionBtn,
-        panel.shapeCombo,
     )
 
 

--- a/acq4/modules/Autopatch/tests/test_status_panel.py
+++ b/acq4/modules/Autopatch/tests/test_status_panel.py
@@ -532,3 +532,70 @@ def test_show_in_log_button_raises_the_log_window(qapp, monkeypatch):
     orch.sigRunError.emit(_record())
     panel.showInLogBtn.click()
     assert raised == [True]
+
+
+def test_an_instruction_shows_in_the_band(qapp):
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+
+    panel.setInstruction("Storage directory has not been set.")
+
+    assert panel.instructionLabel.isVisibleTo(panel)
+    assert panel.instructionLabel.text() == "Storage directory has not been set."
+
+
+def test_an_instruction_offers_no_log_link(qapp):
+    # Show in log narrows the log to a run's records. An instruction is
+    # guidance about a click that never started a run, so there is nothing
+    # there to show and a button that led nowhere would be worse than none.
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+
+    panel.setInstruction("Storage directory has not been set.")
+
+    assert not panel.showInLogBtn.isVisibleTo(panel)
+
+
+def test_clearing_an_instruction_empties_the_band(qapp):
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+    panel.setInstruction("Storage directory has not been set.")
+
+    panel.clearInstruction()
+
+    assert panel.instruction() == ""
+    assert not panel.instructionLabel.isVisibleTo(panel)
+
+
+def test_a_run_error_still_wins_the_band(qapp):
+    # A failure that halted a run is about tissue and a pipette in it; guidance
+    # about a button is not. The error is the more urgent of the two and must
+    # not be displaced by a stale instruction.
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+    record = _record()
+    panel.setInstruction("Storage directory has not been set.")
+
+    panel._onRunError(record)
+
+    assert record.exc_message in panel.instructionLabel.text()
+    assert panel.showInLogBtn.isVisibleTo(panel)
+
+
+def test_the_instruction_comes_back_once_the_error_clears(qapp):
+    # The band holds two independent things. Whatever the instruction asked for
+    # has not been done in the meantime, so it is held rather than overwritten.
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+    panel.setInstruction("Storage directory has not been set.")
+    panel._onRunError(_record())
+
+    panel.clearError()
+
+    assert panel.instructionLabel.text() == "Storage directory has not been set."
+    assert not panel.showInLogBtn.isVisibleTo(panel)

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -1904,6 +1904,37 @@ def test_teardown_releases_the_camera_mirror_after_its_wait_not_before(win):
     assert drawn == []
 
 
+def test_a_raise_while_stopping_the_orchestrator_still_releases_the_mirrors(win):
+    # The mirrors are the only part of teardown that reaches outside this
+    # window: their items live in the Camera module's window and their
+    # connection on its imaging control, both of which outlive the session. If
+    # stopping the orchestrator raises, releasing them is exactly what must
+    # still happen -- otherwise a closed session's outlines stay in a window
+    # nobody will clean up.
+    drawn = []
+    fakeCameraWindow = SimpleNamespace(
+        addItem=lambda item, **kwds: drawn.append(item),
+        removeItem=drawn.remove,
+    )
+    win._cameraMirror._cameraWindow = lambda: fakeCameraWindow
+    win.newSlice()
+    win.addRegionHere()
+    win.regionPanel.mirrorCheck.setChecked(True)
+    assert drawn, "nothing was mirrored, so teardown has nothing to release"
+    win.statusPanel.unbindOrchestrator()
+    win.cellPanel.unbindOrchestrator()
+
+    def boom(_orchestrator):
+        raise RuntimeError("stop failed")
+
+    win._stopAndReleaseOrchestrator = boom
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        win.teardown()
+
+    assert drawn == []
+
+
 def test_the_camera_window_getter_finds_a_loaded_camera_module(win):
     cameraWindow = SimpleNamespace()
     win.manager.listModules = lambda: ["Camera", "Data Manager"]

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -1399,7 +1399,10 @@ def test_new_slice_lets_a_programming_error_propagate(qapp, tmp_path):
         win.newSlice()
 
 
-def test_new_slice_reports_a_missing_storage_directory_in_area_2(win):
+def test_new_slice_reports_a_missing_storage_directory_as_an_instruction(win):
+    # The likeliest first use of New slice is by an operator who has not chosen
+    # a storage directory. They get an instruction in Area 3, and Area 2's error
+    # line -- which is about the search constraints -- stays out of it.
     from acq4.util.HelpfulException import HelpfulException
 
     def boom(*a, **k):
@@ -1408,7 +1411,26 @@ def test_new_slice_reports_a_missing_storage_directory_in_area_2(win):
     win.manager.getCurrentDir = boom
     win.newSlice()
 
-    assert "Storage directory" in win.searchPanel.errorLabel.text()
+    assert "Storage directory" in win.statusPanel.instruction()
+    assert "Storage directory" not in win.searchPanel.errorLabel.text()
+
+
+def test_a_successful_new_slice_retracts_the_instruction(win):
+    # The instruction says what to do next; once it has been done it is a lie.
+    from acq4.util.HelpfulException import HelpfulException
+
+    def boom(*a, **k):
+        raise HelpfulException("Storage directory has not been set.")
+
+    original = win.manager.getCurrentDir
+    win.manager.getCurrentDir = boom
+    win.newSlice()
+    assert win.statusPanel.instruction() != ""
+
+    win.manager.getCurrentDir = original
+    win.newSlice()
+
+    assert win.statusPanel.instruction() == ""
 
 
 def test_add_region_here_does_not_create_a_directory(win):

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -686,14 +686,13 @@ def test_add_region_here_without_a_slice_starts_one(qapp, tmp_path):
     assert len(win.slice.tileGrid()) > 1
 
 
-def test_add_region_here_builds_the_shape_area_2_selects(qapp, tmp_path):
-    # Until Area 1 can draw ROIs, this selector is the only way to seed a
-    # non-rectangular region, so the button has to read it rather than always
-    # building a rectangle.
+def test_add_region_here_builds_the_shape_area_1_selects(qapp, tmp_path):
+    # The button has to read the selector rather than always building a
+    # rectangle.
     win = _makeWindow(tmp_path)
     win.newSlice()
-    win.searchPanel.shapeCombo.setCurrentIndex(
-        win.searchPanel.shapeCombo.findData("ellipse")
+    win.regionPanel.shapeCombo.setCurrentIndex(
+        win.regionPanel.shapeCombo.findData("ellipse")
     )
 
     win.addRegionHere()
@@ -1420,9 +1419,9 @@ def test_add_region_here_does_not_create_a_directory(win):
 
 
 def test_area_2_is_locked_until_a_slice_exists(win):
-    assert not win.searchPanel.addRegionBtn.isEnabled()
+    assert not win.searchPanel.nearDepthSpin.isEnabled()
     win.newSlice()
-    assert win.searchPanel.addRegionBtn.isEnabled()
+    assert win.searchPanel.nearDepthSpin.isEnabled()
 
 
 def test_a_run_in_flight_locks_area_5s_reuse_button(qapp, tmp_path):
@@ -1535,3 +1534,162 @@ def test_reused_cells_run_a_second_protocol_as_the_same_objects(qapp, tmp_path):
         assert win.cellPanel.isAttempted(cell) is True
     finally:
         win.teardown()
+
+
+def test_a_new_slice_leaves_area_1_empty_and_live(win):
+    # A Slice is fresh tissue with no regions, and Area 1 has to say so: an
+    # outline left from the last slice is a coordinate the operator might trust.
+    win.addRegionHere()
+    assert win.regionPanel.regions()
+
+    win.newSlice()
+
+    assert win.regionPanel.regions() == []
+    assert win.regionPanel.addRegionBtn.isEnabled()
+
+
+def test_seeding_a_region_draws_it_in_area_1(win):
+    win.addRegionHere()
+
+    assert len(win.regionPanel.regions()) == 1
+    assert win.regionPanel.regions() == win.slice.regions
+
+
+def test_add_region_here_seeds_a_polygon_when_area_1_asks_for_one(win):
+    # PolygonRegion has had no control able to produce it since P2c-1.
+    from acq4.experiment.search_region import PolygonRegion
+
+    win.newSlice()
+    win.regionPanel.shapeCombo.setCurrentIndex(
+        win.regionPanel.shapeCombo.findData("polygon")
+    )
+
+    win.addRegionHere()
+
+    region = win.slice.regions[0]
+    assert isinstance(region, PolygonRegion)
+    # Four corners of the same 3x3-field box the other two shapes get, so the
+    # button places a region of a known size whichever shape is selected.
+    assert len(region.vertices) == 4
+    assert len(win.slice.tileGrid()) > 1
+
+
+def test_editing_a_region_in_area_1_reaches_the_slice(win):
+    win.newSlice()
+    edited = RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+
+    win.regionPanel.sigRegionsChanged.emit([edited])
+
+    assert win.slice.regions == [edited]
+
+
+def test_editing_a_region_refreshes_the_survey_readout(win):
+    # The readout counts tiles over the regions, so an edit that did not refresh
+    # it would go on reporting the survey's size for a region that is gone.
+    win.newSlice()
+    win.addRegionHere()
+    before = win.searchPanel.surveyLabel.text()
+
+    win.regionPanel.sigRegionsChanged.emit(
+        [RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)]
+    )
+
+    assert win.searchPanel.surveyLabel.text() != before
+
+
+def test_a_region_edit_with_no_slice_is_ignored(win):
+    # Area 1's controls are gated on a slice existing, but a signal is not a
+    # permission check, and a traceback on the GUI thread is not a second line
+    # of defence.
+    assert win.slice is None
+
+    win.regionPanel.sigRegionsChanged.emit([])
+
+    assert win.slice is None
+
+
+def test_area_1_is_locked_until_a_slice_exists(win):
+    assert not win.regionPanel.addRegionBtn.isEnabled()
+
+    win.newSlice()
+
+    assert win.regionPanel.addRegionBtn.isEnabled()
+
+
+def test_a_running_run_locks_area_1(win):
+    win.newSlice()
+
+    win.statusPanel.sigInteractionLocked.emit(True)
+    win.statusPanel.sigStatusChanged.emit("running")
+
+    assert not win.regionPanel.addRegionBtn.isEnabled()
+
+
+def test_a_paused_run_unlocks_area_1(win):
+    # The other side of the gate, wired through the same two window-level
+    # connections rather than by calling the panel directly.
+    win.newSlice()
+    win.statusPanel.sigInteractionLocked.emit(True)
+    win.statusPanel.sigStatusChanged.emit("running")
+
+    win.statusPanel.sigStatusChanged.emit("paused")
+
+    assert win.regionPanel.addRegionBtn.isEnabled()
+
+
+def test_the_mirror_checkbox_drives_the_camera_mirror(win):
+    win.newSlice()
+    win.addRegionHere()
+
+    win.regionPanel.mirrorCheck.setChecked(True)
+
+    assert win._cameraMirror._enabled
+    assert win._cameraMirror._regions == win.slice.regions
+
+
+def test_teardown_takes_the_mirrored_outlines_out_of_the_camera_window(win):
+    # A camera window has to be supplied for this to test anything: _FakeManager
+    # has no Camera module, so _cameraWindow() returns None and the mirror holds
+    # nothing whether or not teardown clears it. Asserting an empty list against
+    # a mirror that was never able to draw is asserting a default.
+    drawn = []
+    fakeCameraWindow = SimpleNamespace(
+        addItem=lambda item, **kwds: drawn.append(item),
+        removeItem=drawn.remove,
+    )
+    win._cameraMirror._cameraWindow = lambda: fakeCameraWindow
+    win.newSlice()
+    win.addRegionHere()
+    win.regionPanel.mirrorCheck.setChecked(True)
+    assert drawn, "nothing was mirrored, so teardown has nothing to prove"
+
+    win.teardown()
+
+    assert drawn == []
+
+
+def test_the_camera_window_getter_finds_a_loaded_camera_module(win):
+    cameraWindow = SimpleNamespace()
+    win.manager.listModules = lambda: ["Camera", "Data Manager"]
+    win.manager.getModule = lambda name: SimpleNamespace(window=lambda: cameraWindow)
+
+    assert win._cameraWindow() is cameraWindow
+
+
+def test_the_camera_window_getter_does_not_load_the_camera_module(win):
+    # Manager.getModule loads a module that is not already open, and this getter
+    # is called on every mirror redraw -- including from "Add region here". A
+    # button that adds a region must not also start the Camera module, and the
+    # window it would hand back is a different instance from the one any
+    # already-drawn outline belongs to.
+    loaded = []
+
+    def getModule(name):
+        loaded.append(name)
+        return SimpleNamespace(window=SimpleNamespace)
+
+    win.manager.listModules = lambda: ["Data Manager"]
+    win.manager.getModule = getModule
+
+    assert win._cameraWindow() is None
+    assert loaded == []

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -2071,3 +2071,49 @@ def test_add_region_here_reports_a_refusal_rather_than_raising(win):
 
     assert "999999" in win.statusPanel.instruction()
     assert win.regionPanel.regions() == []
+
+
+def test_starting_a_slice_frames_area_1_on_the_camera(win):
+    """A fresh pg.ViewBox spans about a metre, and Area 1's units are global
+    metres. Left there, an operator's first click in an empty view lands a
+    polygon vertex half a metre out -- which is how a region big enough to plan
+    35 million tiles gets drawn in the first place.
+
+    Computed off the fake camera directly (its "roi" boundary and centre) so a
+    bug in _cameraFov() is caught rather than echoed back."""
+    camera = win.cameraSelector.getSelectedObj()
+    _, _, fov_w, fov_h = camera.getBoundary(globalCoords=True, mode="roi")
+    cx, cy, _ = camera.globalCenterPosition("roi")
+
+    try:
+        win.newSlice()
+
+        (vx0, vx1), (vy0, vy1) = win.regionPanel.view.viewRange()
+        assert (vx0 + vx1) / 2 == pytest.approx(cx)
+        assert (vy0 + vy1) / 2 == pytest.approx(cy)
+        # Ten fields across, so the camera's own field is a visible fraction of
+        # the view rather than sub-pixel. Aspect lock may widen one axis, so
+        # this is the floor on each, and a ceiling well short of the metre the
+        # viewport started at.
+        assert (vx1 - vx0) >= 10 * fov_w
+        assert (vy1 - vy0) >= 10 * fov_h
+        assert (vx1 - vx0) < 1e-3
+        assert (vy1 - vy0) < 1e-3
+    finally:
+        win.teardown()
+
+
+def test_add_region_here_without_a_slice_frames_area_1_too(win):
+    # The other route into a slice, and the one an operator is most likely to
+    # take first.
+    camera = win.cameraSelector.getSelectedObj()
+    cx, cy, _ = camera.globalCenterPosition("roi")
+
+    try:
+        win.addRegionHere()
+
+        (vx0, vx1), (vy0, vy1) = win.regionPanel.view.viewRange()
+        assert (vx0 + vx1) / 2 == pytest.approx(cx)
+        assert (vy0 + vy1) / 2 == pytest.approx(cy)
+    finally:
+        win.teardown()

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -1960,3 +1960,114 @@ def test_the_camera_window_getter_does_not_load_the_camera_module(win):
 
     assert win._cameraWindow() is None
     assert loaded == []
+
+
+# 200 x 150 fields of the fake camera's 12 x 8 um ROI: 30,000 tiles, past the
+# 20,000-tile cap. Asymmetric in both axes and at a realistic stage coordinate,
+# so a guard that read one axis twice would be caught.
+_OVERSIZED_REGION = RectRegion(1e-3, 2e-3, 1e-3 + 2.4e-3, 2e-3 + 1.2e-3)
+
+
+def test_an_edit_that_would_plan_too_many_tiles_is_refused(win):
+    # The defect this exists for: an ROI dragged out to 0.687 m x 0.873 m at a
+    # 130 um field planned 35 million tiles, and _refreshSurveyStats runs on
+    # every edit -- minutes of frozen GUI per drag.
+    win.newSlice()
+    win.addRegionHere()
+    seeded = list(win.slice.regions)
+
+    win.regionPanel.sigRegionsChanged.emit([_OVERSIZED_REGION])
+
+    assert win.slice.regions == seeded
+
+
+def test_a_refused_edit_says_why_in_area_3s_band(win):
+    # Silently dropping it would leave the operator with an outline on screen
+    # that no survey will ever tile.
+    win.newSlice()
+
+    win.regionPanel.sigRegionsChanged.emit([_OVERSIZED_REGION])
+
+    message = win.statusPanel.instruction()
+    assert "30000" in message.replace(",", "")
+    assert "tile" in message
+
+
+def test_a_refused_edit_snaps_area_1_back_to_the_slices_regions(win):
+    # The ROI the operator is still holding has to go back where it was: an
+    # outline left at a size the slice refused is a lie about what will be
+    # surveyed.
+    win.newSlice()
+    win.addRegionHere()
+    seeded = list(win.slice.regions)
+
+    win.regionPanel.sigRegionsChanged.emit([_OVERSIZED_REGION])
+
+    assert win.regionPanel.regions() == seeded
+
+
+def test_a_refused_edit_does_not_reach_the_camera_mirror(win):
+    # The mirror draws what the slice holds; an outline of the refused shape in
+    # the Camera window would be the same lie in the other view.
+    win.newSlice()
+    win.addRegionHere()
+    win.regionPanel.mirrorCheck.setChecked(True)
+    seeded = list(win.slice.regions)
+
+    win.regionPanel.sigRegionsChanged.emit([_OVERSIZED_REGION])
+
+    assert win._cameraMirror._regions == seeded
+
+
+def test_the_next_good_edit_retracts_the_refusal(win):
+    # The message says what to fix; once it has been fixed it is a lie.
+    win.newSlice()
+    win.regionPanel.sigRegionsChanged.emit([_OVERSIZED_REGION])
+    assert win.statusPanel.instruction() != ""
+
+    win.regionPanel.sigRegionsChanged.emit([RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)])
+
+    assert win.statusPanel.instruction() == ""
+    assert len(win.slice.regions) == 1
+
+
+def test_a_refused_edit_does_not_erase_the_storage_instruction(win):
+    """Area 3's band has two Area 1 writers with different conditions, and
+    neither can see the other's. A region edit retracting its own refusal must
+    not also retract newSlice()'s "choose a storage directory", which is still
+    just as true as it was."""
+    from acq4.util.HelpfulException import HelpfulException
+
+    win.addRegionHere()  # a slice, without going through create_data_dir
+
+    def boom(*a, **k):
+        raise HelpfulException("Storage directory has not been set.")
+
+    win.manager.getCurrentDir = boom
+    win.newSlice()
+    assert "Storage directory" in win.statusPanel.instruction()
+
+    win.regionPanel.sigRegionsChanged.emit([RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)])
+
+    assert "Storage directory" in win.statusPanel.instruction()
+
+
+def test_add_region_here_reports_a_refusal_rather_than_raising(win):
+    """"Add region here" seeds 3x3 fields, which is nine tiles whatever the
+    field of view, so it cannot trip the cap as it stands. The refusal is
+    caught anyway because a traceback out of a button's slot is not a failure
+    mode this window should have at all -- driven here by making the slice
+    refuse, since the geometry itself will not."""
+    from acq4.experiment.slice import RegionTooLarge
+
+    win.newSlice()
+
+    def refuse(region):
+        raise RegionTooLarge("that region would plan 999999 tiles")
+
+    win.slice.addRegion = refuse
+
+    win.addRegionHere()
+
+    assert "999999" in win.statusPanel.instruction()
+    assert win.regionPanel.regions() == []

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -154,13 +154,22 @@ class _FakeCameraWithDevice(Qt.QWidget):
 _FOLDER_TYPES = {"Slice": {"name": "Slice_%Y%m%d_%H%M%S", "experimentalUnit": False}}
 
 
-class _FakeManager:
+class _FakeManager(Qt.QObject):
     """Stands in for Manager: backed by a real DirHandle (on tmp_path) so
     create_data_dir's mkdir/setInfo calls land on an actual directory, the way
     they would through the real Manager AutopatchWindow otherwise gets from
-    its module."""
+    its module.
+
+    A QObject carrying sigModulesChanged, because the real Manager is one and
+    emits that signal whenever a module is loaded or quits -- which is how
+    Area 1's two mirrors find a Camera module that was not open when they were
+    first resolved.
+    """
+
+    sigModulesChanged = Qt.Signal()
 
     def __init__(self, root_dir):
+        super().__init__()
         self._current_dir = root_dir
 
     def getCurrentDir(self):
@@ -2117,3 +2126,165 @@ def test_add_region_here_without_a_slice_frames_area_1_too(win):
         assert (vy0 + vy1) / 2 == pytest.approx(cy)
     finally:
         win.teardown()
+
+
+def _cameraModuleAppears(win, cameraWindow=None):
+    """Have `win`'s manager start reporting a loaded Camera module, and announce
+    it the way Manager.loadModule() does.
+
+    Returns the window that module hands out, and the list of items drawn into
+    it, so a caller can see what the outline mirror put there."""
+    drawn = []
+    if cameraWindow is None:
+        cameraWindow = SimpleNamespace(
+            addItem=lambda item, **kwds: drawn.append(item),
+            removeItem=drawn.remove,
+        )
+    win.manager.listModules = lambda: ["Camera"]
+    win.manager.getModule = lambda name: SimpleNamespace(window=lambda: cameraWindow)
+    win.manager.sigModulesChanged.emit()
+    return cameraWindow, drawn
+
+
+def test_outlines_appear_when_the_camera_module_is_opened_after_the_tick(win):
+    """Both mirrors resolved the Camera module once, at a moment that can
+    precede the module being open, and nothing retried. On the rig this showed
+    up as a ticked "Mirror to Camera" that drew nothing until some later region
+    edit happened to redraw it."""
+    win.newSlice()
+    win.addRegionHere()
+
+    win.regionPanel.mirrorCheck.setChecked(True)
+    _cameraWindow, drawn = _cameraModuleAppears(win)
+
+    assert len(drawn) == len(win.slice.regions) == 1
+
+
+def test_no_outlines_appear_when_the_checkbox_is_not_ticked(win):
+    # The other side: a module change is not a reason to start mirroring
+    # something the operator never asked to mirror.
+    win.newSlice()
+    win.addRegionHere()
+
+    _cameraWindow, drawn = _cameraModuleAppears(win)
+
+    assert drawn == []
+
+
+def test_pinned_frames_bind_when_the_camera_module_is_opened_after_the_slice(win):
+    """_bindPinnedFrames runs only from _startSlice, so a Camera module opened
+    afterwards was never picked up: on the rig, PinnedFrameMirror._source was
+    None with a frame already pinned and waiting."""
+    win.newSlice()
+    assert win._pinnedFrameMirror._source is None
+
+    source = _withPinnedFrameSource(win)
+    win.manager.sigModulesChanged.emit()
+
+    assert win._pinnedFrameMirror._source is source
+    assert source.receivers(source.sigPinnedFramesChanged) == 1
+
+
+def test_a_camera_module_opening_with_no_slice_binds_nothing(win):
+    # Nothing is being drawn over yet, and _startSlice binds on its own way
+    # through -- so there is nothing here to retry.
+    source = _withPinnedFrameSource(win)
+
+    win.manager.sigModulesChanged.emit()
+
+    assert win._pinnedFrameMirror._source is None
+    assert source.receivers(source.sigPinnedFramesChanged) == 0
+
+
+def test_a_camera_module_quitting_releases_the_pinned_frame_mirror(win):
+    # sigModulesChanged is also how a module going away is announced, and a
+    # mirror left bound to a dead Camera module would go on showing imagery of
+    # tissue nobody is looking at.
+    source = _withPinnedFrameSource(win)
+    win.newSlice()
+    assert win._pinnedFrameMirror._source is source
+
+    win._cameraWindow = lambda: None
+    win.manager.sigModulesChanged.emit()
+
+    assert win._pinnedFrameMirror._source is None
+    assert source.receivers(source.sigPinnedFramesChanged) == 0
+
+
+def test_teardown_stops_listening_for_module_changes(win):
+    # The manager outlives this window by a long way, so a connection left on it
+    # would go on calling a torn-down window's handler at every later module
+    # load or quit -- re-arming the mirrors teardown had just released.
+    assert win.manager.receivers(win.manager.sigModulesChanged) == 1
+
+    win.teardown()
+
+    assert win.manager.receivers(win.manager.sigModulesChanged) == 0
+
+
+def test_a_module_change_during_teardowns_wait_cannot_re_arm_the_mirrors(win):
+    # teardown() waits on the orchestrator with the Qt event loop still pumping,
+    # so a Camera module loading in those seconds is announced while teardown is
+    # in progress -- and must not bind this closing session's mirrors to it.
+    source = _withPinnedFrameSource(win)
+    win.newSlice()
+    win.regionPanel.mirrorCheck.setChecked(True)
+    win._pinnedFrameMirror.unbind()
+    win.statusPanel.unbindOrchestrator()
+    win.cellPanel.unbindOrchestrator()
+    win.orchestrator = _ReentrantOrchestrator(win.manager.sigModulesChanged.emit)
+
+    win.teardown()
+
+    assert win._pinnedFrameMirror._source is None
+    assert source.receivers(source.sigPinnedFramesChanged) == 0
+
+
+def test_a_headless_window_with_no_manager_still_starts_a_slice(qapp, tmp_path):
+    # module=None is the constructor's documented headless mode: there is no
+    # manager to listen to, and that must not be an error.
+    from acq4.modules.Autopatch.Autopatch import AutopatchWindow
+
+    _write_protocol(tmp_path, "demo.py", _NOOP_PROTOCOL)
+    win = AutopatchWindow(
+        module=None,
+        protocolDir=str(tmp_path),
+        pipetteSelector=_FakePipetteSelector(),
+        cameraSelector=_FakeCameraWithDevice(),
+    )
+    try:
+        win.protocolPanel.fileCombo.setCurrentText("demo")
+        assert win._startSlice() is True
+    finally:
+        win.teardown()
+
+
+def test_ticking_the_mirror_with_no_camera_module_open_says_so(win):
+    # Otherwise the tick is a silent no-op: the checkbox stays ticked and
+    # nothing appears anywhere, with no way to tell that from a broken mirror.
+    win.newSlice()
+
+    win.regionPanel.mirrorCheck.setChecked(True)
+
+    assert "Camera" in win.statusPanel.instruction()
+
+
+def test_the_message_goes_once_a_camera_module_is_open(win):
+    win.newSlice()
+    win.addRegionHere()
+    win.regionPanel.mirrorCheck.setChecked(True)
+    assert win.statusPanel.instruction() != ""
+
+    _cameraModuleAppears(win)
+
+    assert win.statusPanel.instruction() == ""
+
+
+def test_unticking_the_mirror_retracts_the_message(win):
+    win.newSlice()
+    win.regionPanel.mirrorCheck.setChecked(True)
+    assert win.statusPanel.instruction() != ""
+
+    win.regionPanel.mirrorCheck.setChecked(False)
+
+    assert win.statusPanel.instruction() == ""

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -1690,6 +1690,220 @@ def test_teardown_takes_the_mirrored_outlines_out_of_the_camera_window(win):
     assert drawn == []
 
 
+def test_a_region_edit_while_locked_is_dropped(win):
+    # The panel gates every editing surface it owns, but the window is where an
+    # edit becomes the slice's regions, and _onRegionsEdited's own docstring
+    # says a signal is not a permission check. This is the second line of that
+    # defence: a run is in flight, a producer may be reading the regions on the
+    # worker thread, and an edit arriving here anyway is dropped rather than
+    # committed.
+    win.newSlice()
+    win.addRegionHere()
+    seeded = list(win.slice.regions)
+    win.statusPanel.sigInteractionLocked.emit(True)
+    win.statusPanel.sigStatusChanged.emit("running")
+
+    win.regionPanel.sigRegionsChanged.emit([RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)])
+
+    assert win.slice.regions == seeded
+
+
+def test_a_region_edit_while_paused_still_reaches_the_slice(win):
+    # The other side: the paused exception is the whole point of the gate, and a
+    # window that dropped everything during a run would make it unreachable.
+    win.newSlice()
+    win.statusPanel.sigInteractionLocked.emit(True)
+    win.statusPanel.sigStatusChanged.emit("paused")
+    edited = RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+
+    win.regionPanel.sigRegionsChanged.emit([edited])
+
+    assert win.slice.regions == [edited]
+
+
+class _FakePinnedFrameSource(Qt.QObject):
+    """Stands in for the Camera module's ImagingCtrl: the pinned-frame list and
+    the signal Area 1 mirrors it through."""
+
+    sigPinnedFramesChanged = Qt.Signal()
+
+    def __init__(self):
+        super().__init__()
+        self.pinnedFrames = []
+
+
+def _withPinnedFrameSource(win, hasInterface=True):
+    """Point `win` at a Camera window offering one imaging control, and return
+    the control it would bind to."""
+    source = _FakePinnedFrameSource()
+
+    def getInterfaceForDevice(name):
+        if not hasInterface:
+            raise KeyError(name)
+        return SimpleNamespace(imagingCtrl=source)
+
+    win._cameraWindow = lambda: SimpleNamespace(
+        getInterfaceForDevice=getInterfaceForDevice
+    )
+    return source
+
+
+def test_starting_a_slice_mirrors_the_cameras_pinned_frames(win):
+    source = _withPinnedFrameSource(win)
+
+    win.newSlice()
+
+    assert win._pinnedFrameMirror._source is source
+    assert source.receivers(source.sigPinnedFramesChanged) == 1
+
+
+def test_teardown_stops_mirroring_the_cameras_pinned_frames(win):
+    # The riskier half of the pair CameraMirror already has a teardown test for:
+    # this connection lives on the Camera module's own ImagingCtrl, which
+    # outlives this window by design, and a live connection on it would go on
+    # calling a torn-down window's mirror -- and keep the window reachable.
+    source = _withPinnedFrameSource(win)
+    win.newSlice()
+    assert source.receivers(source.sigPinnedFramesChanged) == 1
+
+    win.teardown()
+
+    assert source.receivers(source.sigPinnedFramesChanged) == 0
+    assert win._pinnedFrameMirror._source is None
+
+
+def test_a_camera_with_no_imaging_control_stops_the_previous_mirror(win):
+    # Switching to a camera the Camera module has no interface for must not
+    # leave Area 1 showing the previous camera's frames: those are imagery of
+    # different tissue, and regions get drawn over them.
+    first = _withPinnedFrameSource(win)
+    win.newSlice()
+    assert win._pinnedFrameMirror._source is first
+
+    _withPinnedFrameSource(win, hasInterface=False)
+    win.newSlice()
+
+    assert win._pinnedFrameMirror._source is None
+    assert first.receivers(first.sigPinnedFramesChanged) == 0
+
+
+def test_a_closed_camera_window_stops_the_previous_mirror(win):
+    # The same hazard by the other route: the Camera module has been closed
+    # since the last slice was started.
+    first = _withPinnedFrameSource(win)
+    win.newSlice()
+    assert win._pinnedFrameMirror._source is first
+
+    win._cameraWindow = lambda: None
+    win.newSlice()
+
+    assert win._pinnedFrameMirror._source is None
+    assert first.receivers(first.sigPinnedFramesChanged) == 0
+
+
+class _ReentrantOrchestrator:
+    """An orchestrator whose bounded wait runs `duringWait`.
+
+    Not a contrivance: _stopAndReleaseOrchestrator waits with updates=True,
+    which deliberately pumps the Qt event loop, and teardown() calls it with the
+    window still visible and every Area 1 control still connected. Anything the
+    operator clicks in those five seconds lands exactly here.
+    """
+
+    def __init__(self, duringWait):
+        self._duringWait = duringWait
+        self.producer = "installed"
+
+    def stop(self):
+        pass
+
+    def wait(self, timeout=None, updates=False):
+        self._duringWait()
+
+    def setCellProducer(self, producer):
+        self.producer = producer
+
+    def setParent(self, parent):
+        pass
+
+
+def test_teardown_cannot_be_re_armed_by_a_click_during_its_wait(win):
+    # New slice during that window is the worst of them: it would build a fresh
+    # Slice and re-connect PinnedFrameMirror to the Camera module's long-lived
+    # ImagingCtrl, and _tornDown is already True by then, so closeEvent returns
+    # early and none of it is ever cleaned up again.
+    source = _withPinnedFrameSource(win)
+    win.statusPanel.unbindOrchestrator()
+    win.cellPanel.unbindOrchestrator()
+    win.orchestrator = _ReentrantOrchestrator(win.newSlice)
+
+    win.teardown()
+
+    assert win.slice is None
+    assert win._pinnedFrameMirror._source is None
+    assert source.receivers(source.sigPinnedFramesChanged) == 0
+
+
+def test_teardown_cannot_be_re_armed_by_add_region_here_during_its_wait(win):
+    # The same window, through the other control that can build a slice.
+    source = _withPinnedFrameSource(win)
+    win.statusPanel.unbindOrchestrator()
+    win.cellPanel.unbindOrchestrator()
+    win.orchestrator = _ReentrantOrchestrator(win.addRegionHere)
+
+    win.teardown()
+
+    assert win.slice is None
+    assert win._pinnedFrameMirror._source is None
+    assert source.receivers(source.sigPinnedFramesChanged) == 0
+
+
+def test_teardown_cannot_be_handed_a_region_edit_during_its_wait(win):
+    # An ROI drag released during that wait: the panel is still editable by its
+    # own rules -- there is a slice and no run -- so only the window's own
+    # torn-down check stops the edit being committed to a slice whose session
+    # has ended.
+    win.newSlice()
+    win.addRegionHere()
+    seeded = list(win.slice.regions)
+    win.statusPanel.unbindOrchestrator()
+    win.cellPanel.unbindOrchestrator()
+    win.orchestrator = _ReentrantOrchestrator(
+        lambda: win.regionPanel.sigRegionsChanged.emit(
+            [RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)]
+        )
+    )
+
+    win.teardown()
+
+    assert win.slice.regions == seeded
+
+
+def test_teardown_releases_the_camera_mirror_after_its_wait_not_before(win):
+    # Mirror to Camera is not gated on _tornDown -- it is a display preference,
+    # not a slice -- so a click on it during teardown's wait genuinely draws
+    # outlines into the Camera module's window. Releasing the mirrors after the
+    # orchestrator rather than before is what takes those back out; the other
+    # order leaves a closed session's graphics in a window that outlives it.
+    drawn = []
+    fakeCameraWindow = SimpleNamespace(
+        addItem=lambda item, **kwds: drawn.append(item),
+        removeItem=drawn.remove,
+    )
+    win._cameraMirror._cameraWindow = lambda: fakeCameraWindow
+    win.newSlice()
+    win.addRegionHere()
+    win.statusPanel.unbindOrchestrator()
+    win.cellPanel.unbindOrchestrator()
+    win.orchestrator = _ReentrantOrchestrator(
+        lambda: win.regionPanel.mirrorCheck.setChecked(True)
+    )
+
+    win.teardown()
+
+    assert drawn == []
+
+
 def test_the_camera_window_getter_finds_a_loaded_camera_module(win):
     cameraWindow = SimpleNamespace()
     win.manager.listModules = lambda: ["Camera", "Data Manager"]

--- a/acq4/modules/Autopatch/tests/test_window_skeleton.py
+++ b/acq4/modules/Autopatch/tests/test_window_skeleton.py
@@ -94,19 +94,25 @@ def test_default_pipette_selector_is_built_for_the_patchpipette_interface(qapp, 
 
 def test_areas_are_arranged_in_two_columns(qapp, tmp_path):
     """Left column (top->bottom): Area 1, Area 2. Right column (top->bottom):
-    Area 3, Area 4, Area 5."""
+    Area 3, Area 4, Area 5.
+
+    The left column is a splitter rather than a plain box layout, so that the
+    operator can give Area 1's view of the slice as much of the window as
+    drawing a region over tissue needs.
+    """
     win = _makeWindow(tmp_path)
 
     outer = win.layout()
     assert isinstance(outer, Qt.QHBoxLayout)
     assert outer.count() == 2
 
-    leftCol = outer.itemAt(0).layout()
-    rightCol = outer.itemAt(1).layout()
+    leftCol = outer.itemAt(0).widget()
+    rightCol = outer.itemAt(1).widget().layout()
 
+    assert isinstance(leftCol, Qt.QSplitter)
     assert leftCol.count() == 2
-    assert leftCol.itemAt(0).widget() is win.area1Box
-    assert leftCol.itemAt(1).widget() is win.area2Box
+    assert leftCol.widget(0) is win.area1Box
+    assert leftCol.widget(1) is win.area2Box
 
     assert rightCol.count() == 3
     assert rightCol.itemAt(0).widget() is win.area3Box

--- a/acq4/util/imaging/imaging_ctrl.py
+++ b/acq4/util/imaging/imaging_ctrl.py
@@ -42,6 +42,7 @@ class ImagingCtrl(Qt.QWidget):
     sigStopVideoClicked = Qt.Signal()
     sigAcquireFrameClicked = Qt.Signal(object)  # mode
     sigUpdateUi = Qt.Signal()
+    sigPinnedFramesChanged = Qt.Signal()  # a frame was pinned or unpinned
 
     frameDisplayClass = FrameDisplay  # let subclasses override this class
 
@@ -282,12 +283,14 @@ class ImagingCtrl(Qt.QWidget):
         view = self.frameDisplay.imageItem().getViewBox()
         if view is not None:
             view.addItem(im)
+        self.sigPinnedFramesChanged.emit()
 
     def removePinnedFrame(self, fr):
         self.pinnedFrames.remove(fr)
         if fr.scene() is not None:
             fr.scene().removeItem(fr)
         fr.sigRemoveRequested.disconnect(self.removePinnedFrame)
+        self.sigPinnedFramesChanged.emit()
 
     def clearPinnedFramesClicked(self):
         query = Qt.QMessageBox.question(

--- a/docs/superpowers/plans/2026-08-10-autopatch-area1-region-graphics.md
+++ b/docs/superpowers/plans/2026-08-10-autopatch-area1-region-graphics.md
@@ -1,0 +1,2609 @@
+# Autopatch Area 1 Region Graphics Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the Autopatch module an Area 1 view where the operator sees the Camera module's pinned frames, draws and edits search regions over them in three shapes, and optionally mirrors those regions into the Camera window.
+
+**Architecture:** A new `RegionPanel` owns a `pg.GraphicsView`/`pg.ViewBox` in global metres and renders a list of `SearchRegion` objects as pyqtgraph ROIs, emitting the whole list back on any edit. `AutopatchWindow` is the only thing that knows about both the panel and the `Slice`, and pushes edits into `Slice.setRegions()` — a wholesale list swap, because the cell producer reads regions on the worker thread. Two one-way mirrors (Camera pinned frames in, region outlines out) are display-only objects with no state of their own.
+
+**Tech Stack:** Python 3.12, PyQt via `acq4.util.Qt`, pyqtgraph (local checkout at `/home/martin/src/acq4/pyqtgraph`), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-08-10-autopatch-area1-region-graphics-design.md`
+
+## Global Constraints
+
+- Python interpreter is `/home/martin/.miniforge3/envs/acq4-gl/bin/python`. Never `acq4-torch`.
+- Branch is `claude/autopatch-ui-next-ecbf00`, based on `_reviewed` @ `00c75e269`. Before **every** `git commit`, verify `git rev-parse --show-toplevel` ends in `.claude/worktrees/happy-easley-8b68a0` and `git branch --show-current` is `claude/autopatch-ui-next-ecbf00`. Committing into the main checkout on `_staging` has happened repeatedly and destroys the work.
+- Every commit uses the project footer. Use the heredoc form given in each Commit step — a single-line `git commit -m` silently drops the footer, which is how 18 commits on an earlier branch ended up without it.
+- Commit author: `--author="Martin Chase (claude) <outofculture@gmail.com>"`.
+- Test output must be pristine. No `pytest.ini` ignores, no skips, no warnings introduced.
+- All coordinates are global metres. Never pixels, never stage-native units.
+- Every geometry fixture must be **asymmetric** — distinct width and height. A square fixture cannot test an axis mapping, which is how a swapped `rx`/`ry` survived 324 tests in P2c-1.
+- Comments describe the code as it is. No references to "new", "improved", or what changed.
+
+## File Structure
+
+**Created:**
+
+| path | responsibility |
+|---|---|
+| `acq4/modules/Autopatch/region_panel.py` | `RegionPanel` widget, the shape↔ROI adapters, and `_DrawingViewBox`. |
+| `acq4/modules/Autopatch/region_mirrors.py` | `PinnedFrameMirror` (Camera→Autopatch) and `CameraMirror` (Autopatch→Camera). Display only, no region state. |
+| `acq4/modules/Autopatch/tests/test_region_adapters.py` | Shape↔ROI round-trips. |
+| `acq4/modules/Autopatch/tests/test_region_panel.py` | Panel rendering, edit signals, gating. |
+| `acq4/modules/Autopatch/tests/test_region_drawing.py` | The draw state machine. |
+| `acq4/modules/Autopatch/tests/test_region_mirrors.py` | Both mirrors, including teardown. |
+
+**Modified:**
+
+| path | change |
+|---|---|
+| `acq4/experiment/slice.py` | `setRegions()`; `addRegion` reimplemented on it; readers snapshot. |
+| `acq4/util/imaging/imaging_ctrl.py` | Additive `sigPinnedFramesChanged`. |
+| `acq4/modules/Autopatch/search_panel.py` | Loses `shapeCombo`, `addRegionBtn`, `sigAddRegionRequested`, `regionShape()`. |
+| `acq4/modules/Autopatch/status_panel.py` | `setInstruction()` / `clearInstruction()`. |
+| `acq4/modules/Autopatch/Autopatch.py` | Mounts `RegionPanel` in Area 1, splitter layout, wiring, teardown. |
+| `acq4/experiment/tests/test_slice.py`, `acq4/modules/Autopatch/tests/test_search_panel.py`, `.../test_status_panel.py`, `.../test_window_integration.py` | Follow the changes above. |
+
+---
+
+### Task 1: `Slice.setRegions()` — the atomic swap
+
+**Files:**
+- Modify: `acq4/experiment/slice.py` (`addRegion` at ~line 115, `tileGrid` at ~line 138, `forceRescan` at ~line 220)
+- Test: `acq4/experiment/tests/test_slice.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `Slice.setRegions(regions: Iterable[SearchRegion]) -> None`. `Slice.addRegion(region)` keeps its existing signature and behaviour.
+
+**Why:** `CellProducer` reaches `slice.nextTile()` → `tileGrid()` on the worker thread while the operator edits regions on the GUI thread, and `tileGrid()` iterates `self._regions` directly. Rebinding the attribute means an in-progress loop keeps iterating the list it started on; mutating it in place means the loop silently skips regions.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `acq4/experiment/tests/test_slice.py`:
+
+```python
+class _EditsTheSliceMidScan(SearchRegion):
+    """A region that replaces its slice's region list from inside the tiler's
+    own iteration -- what a GUI-thread setRegions() landing in the middle of a
+    worker-thread tileGrid() does.
+
+    Deterministic on purpose: driving this with real threads would reproduce the
+    hazard only sometimes, and a test that fails one run in fifty is not a test.
+    """
+
+    def __init__(self, slice_, replacement):
+        self._slice = slice_
+        self._replacement = replacement
+        self.calls = 0
+
+    def bounds(self):
+        return (0.0, 0.0, 400e-6, 200e-6)
+
+    def overlapsTile(self, center, fov):
+        self.calls += 1
+        if self.calls == 1:
+            self._slice.setRegions(self._replacement)
+        return True
+
+
+def test_an_edit_during_tilegrid_does_not_drop_the_regions_behind_it():
+    # The whole point of the swap. With the list mutated in place instead, the
+    # for-loop's index walks off the end of a shortened list and every region
+    # after the one being scanned is silently dropped from the survey.
+    sl = Slice(fov=(100e-6, 50e-6))
+    later = RectRegion(1e-3, 1e-3, 1.4e-3, 1.2e-3)
+    mutator = _EditsTheSliceMidScan(sl, [])
+    sl.setRegions([mutator, later])
+
+    grid = sl.tileGrid()
+
+    laterTiles = [c for c in grid if c[0] > 0.5e-3]
+    assert laterTiles, "the region after the edited one was dropped mid-scan"
+
+
+def test_the_edit_itself_takes_effect_on_the_next_call():
+    # The swap must not be a no-op in the other direction: the point of editing
+    # regions is that the next tile the producer asks for reflects the edit.
+    sl = Slice(fov=(100e-6, 50e-6))
+    mutator = _EditsTheSliceMidScan(sl, [])
+    sl.setRegions([mutator, RectRegion(1e-3, 1e-3, 1.4e-3, 1.2e-3)])
+    sl.tileGrid()
+
+    assert sl.regions == []
+    assert sl.tileGrid() == []
+
+
+def test_setregions_copies_so_the_callers_list_is_not_live():
+    # The panel hands over a list it goes on mutating as the operator draws.
+    sl = Slice(fov=(100e-6, 50e-6))
+    handed = [RectRegion(0.0, 0.0, 400e-6, 200e-6)]
+    sl.setRegions(handed)
+    handed.append(RectRegion(1e-3, 1e-3, 1.4e-3, 1.2e-3))
+
+    assert len(sl.regions) == 1
+
+
+def test_deleting_a_region_leaves_coverage_alone():
+    # Coverage records ground already imaged, not ground still wanted. Pruning
+    # it when a region goes away would make a region redrawn over surveyed
+    # tissue re-image it, and coverage is shared by every producer this slice
+    # makes -- it is not a per-region tally.
+    sl = Slice(fov=(100e-6, 50e-6))
+    sl.setRegions([RectRegion(0.0, 0.0, 400e-6, 200e-6)])
+    covered = sl.tileGrid()[0]
+    sl.markCovered(covered)
+
+    sl.setRegions([])
+
+    assert sl.tileGrid() == []
+    sl.setRegions([RectRegion(0.0, 0.0, 400e-6, 200e-6)])
+    assert sl.nextTile() != covered
+```
+
+Add `SearchRegion` to the existing `search_region` import at the top of the file if it is not already there.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -k "mid_scan or takes_effect or copies_so" -v`
+
+Expected: FAIL — `AttributeError: 'Slice' object has no attribute 'setRegions'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `acq4/experiment/slice.py`, replace `addRegion` with:
+
+```python
+    def setRegions(self, regions) -> None:
+        """Replace the regions to survey, in one step. Coverage is untouched.
+
+        Rebinding the attribute rather than mutating the list is what makes this
+        safe to call from the GUI thread while a producer is reading regions on
+        the worker thread: `tileGrid()` binds its loop to whichever list object
+        was current when it started, so a reader sees either the whole old set
+        or the whole new one and never a list changing under its own iteration.
+        The same "make it one step" discipline `Orchestrator._refillQueue`
+        applies to the producer reference.
+        """
+        self._regions = list(regions)
+
+    def addRegion(self, region: SearchRegion) -> None:
+        """Add a shape to survey, in global coordinates. Coverage is untouched.
+
+        Takes a SearchRegion rather than four floats because tissue is not
+        rectangular: a slice with a damaged corner, or one cortical layer worth
+        searching, is the ordinary reason to outline a region at all. A rectangle
+        is `RectRegion(x0, y0, x1, y1)`.
+        """
+        self.setRegions(self._regions + [region])
+```
+
+In `tileGrid()`, bind the list once before the loop:
+
+```python
+        grid: list[tuple[float, float]] = []
+        fov_w, fov_h = self._fov
+        # Bound once: setRegions() can land from the GUI thread while this runs.
+        regions = self._regions
+        for region in regions:
+```
+
+In `forceRescan()`, do the same:
+
+```python
+        regions = self._regions
+        here = [r for r in regions if r.overlapsTile(xy, self._fov)]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/ -q`
+
+Expected: PASS, no failures, no new warnings.
+
+- [ ] **Step 5: Prove the test can fail (mutation)**
+
+Temporarily change `setRegions` to mutate in place:
+
+```python
+        self._regions[:] = list(regions)
+```
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -k mid_scan -v`
+
+Expected: FAIL at the `assert laterTiles` line. **Record the file and line number of the failure in your report** — a mutation that fails at a different line has proven something else. Then revert the mutation and re-run to confirm green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/experiment/slice.py acq4/experiment/tests/test_slice.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'MSG'
+feat: replace a slice's regions in one step
+
+Rebinding the list rather than mutating it lets the GUI thread edit regions
+while a producer iterates them on the worker thread.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+MSG
+```
+
+---
+
+### Task 2: Shape ↔ ROI adapters
+
+**Files:**
+- Create: `acq4/modules/Autopatch/region_panel.py`
+- Test: `acq4/modules/Autopatch/tests/test_region_adapters.py`
+
+**Interfaces:**
+- Consumes: `acq4.experiment.search_region.{SearchRegion, RectRegion, EllipseRegion, PolygonRegion}`.
+- Produces:
+  - `roiForRegion(region: SearchRegion) -> pg.ROI`
+  - `regionForRoi(roi: pg.ROI) -> SearchRegion`
+  - `REGION_PEN` — the pen every region ROI draws with.
+  - `_AxisAlignedEllipseROI(pg.EllipseROI)`
+
+**Why the ellipse subclass:** `pg.EllipseROI._addHandles` adds a **rotate** handle. `EllipseRegion` is an ellipse inscribed in an axis-aligned box, so a rotated ROI maps back to a region that silently ignores the rotation — the operator would draw one thing and survey another.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `acq4/modules/Autopatch/tests/test_region_adapters.py`:
+
+```python
+"""Tests for the mapping between a Slice's SearchRegion shapes and the
+pyqtgraph ROIs Area 1 draws them with."""
+
+import pytest
+
+from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+# Deliberately asymmetric, at real SI magnitudes: a square fixture cannot test
+# an axis mapping, which is exactly how a swapped rx/ry survived every ellipse
+# test in P2c-1.
+RECT = RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+ELLIPSE = EllipseRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+TRIANGLE = PolygonRegion(((1.0e-3, 2.0e-3), (1.4e-3, 2.02e-3), (1.1e-3, 2.1e-3)))
+
+
+@pytest.mark.parametrize("region", [RECT, ELLIPSE, TRIANGLE])
+def test_a_region_round_trips_through_its_roi(qapp, region):
+    from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
+
+    assert regionForRoi(roiForRegion(region)) == region
+
+
+@pytest.mark.parametrize("region", [RECT, ELLIPSE, TRIANGLE])
+def test_the_roi_lands_on_the_regions_own_bounds(qapp, region):
+    # Round-tripping equal objects would still pass if both directions shared
+    # the same wrong convention (origin vs centre, say). Checking the ROI's own
+    # geometry against the region's bounds is what pins the convention.
+    from acq4.modules.Autopatch.region_panel import roiForRegion
+
+    roi = roiForRegion(region)
+    x0, y0, x1, y1 = region.bounds()
+    rect = roi.boundingRect()
+    pos = roi.pos()
+    assert pos.x() + rect.x() == pytest.approx(x0)
+    assert pos.y() + rect.y() == pytest.approx(y0)
+    assert rect.width() == pytest.approx(x1 - x0)
+    assert rect.height() == pytest.approx(y1 - y0)
+
+
+def test_a_rect_and_an_ellipse_map_to_different_roi_types(qapp):
+    import pyqtgraph as pg
+
+    from acq4.modules.Autopatch.region_panel import roiForRegion
+
+    assert isinstance(roiForRegion(ELLIPSE), pg.EllipseROI)
+    assert not isinstance(roiForRegion(RECT), pg.EllipseROI)
+
+
+def test_an_ellipse_roi_cannot_be_rotated(qapp):
+    # EllipseRegion is inscribed in an axis-aligned box, so a rotate handle
+    # would let the operator draw a shape that has no region to map back to:
+    # regionForRoi reads pos and size and would drop the rotation silently.
+    from acq4.modules.Autopatch.region_panel import roiForRegion
+
+    handles = roiForRegion(ELLIPSE).handles
+    assert not any(h["type"] == "r" for h in handles)
+
+
+def test_a_roi_dragged_past_its_own_origin_still_makes_a_region(qapp):
+    # An ROI resized past its origin reports a negative size; the region built
+    # from it must still describe the box the operator sees on screen.
+    from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
+
+    roi = roiForRegion(RECT)
+    roi.setPos((1.4e-3, 2.1e-3))
+    roi.setSize((-0.4e-3, -0.1e-3))
+
+    assert regionForRoi(roi) == RECT
+
+
+def test_a_moved_polygon_reports_its_vertices_in_global_coordinates(qapp):
+    # A PolyLineROI holds its vertices in ROI-local coordinates, so dragging the
+    # body moves the shape without touching them. Reading them raw would put the
+    # region back where it started and survey the wrong tissue.
+    from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
+
+    roi = roiForRegion(TRIANGLE)
+    roi.setPos((0.5e-3, 0.25e-3))
+
+    moved = regionForRoi(roi)
+    assert moved.vertices == tuple(
+        (x + 0.5e-3, y + 0.25e-3) for x, y in TRIANGLE.vertices
+    )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_region_adapters.py -v`
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'acq4.modules.Autopatch.region_panel'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `acq4/modules/Autopatch/region_panel.py`:
+
+```python
+"""RegionPanel: Area 1's global-coordinate view of the slice -- the pinned
+imagery to draw over, and the search regions drawn on it as editable ROIs."""
+
+from __future__ import annotations
+
+import pyqtgraph as pg
+
+from acq4.experiment.search_region import (
+    EllipseRegion,
+    PolygonRegion,
+    RectRegion,
+    SearchRegion,
+)
+
+# Yellow at 2px, matching the survey ROI the AutomationDebug bench already
+# draws, so the same shape reads the same way in either module.
+REGION_PEN = pg.mkPen("y", width=2)
+
+
+class _AxisAlignedEllipseROI(pg.EllipseROI):
+    """A pg.EllipseROI with no rotate handle.
+
+    EllipseRegion is the ellipse inscribed in an axis-aligned bounding box, so
+    there is no region for a rotated ROI to map back to: regionForRoi reads the
+    ROI's position and size, and a rotation would be dropped without trace --
+    the operator would draw one shape and the survey would tile another.
+    """
+
+    def _addHandles(self):
+        self.addScaleHandle([1.0, 0.5], [0.5, 0.5])
+        self.addScaleHandle([0.5, 1.0], [0.5, 0.5])
+
+
+def roiForRegion(region: SearchRegion) -> pg.ROI:
+    """The editable ROI that draws `region`."""
+    if isinstance(region, PolygonRegion):
+        return pg.PolyLineROI(
+            [list(v) for v in region.vertices],
+            closed=True,
+            pen=REGION_PEN,
+            removable=True,
+        )
+    x0, y0, x1, y1 = region.bounds()
+    roiClass = _AxisAlignedEllipseROI if isinstance(region, EllipseRegion) else pg.RectROI
+    return roiClass(
+        (x0, y0), (x1 - x0, y1 - y0), pen=REGION_PEN, removable=True
+    )
+
+
+def regionForRoi(roi: pg.ROI) -> SearchRegion:
+    """The region `roi` currently describes, in global metres.
+
+    Corner normalization is left to `_BoxRegion.__post_init__`, which already
+    orders its corners -- an ROI resized past its own origin reports a negative
+    size, and both paths through that hazard should agree by construction rather
+    than by two implementations happening to match.
+    """
+    if isinstance(roi, pg.PolyLineROI):
+        vertices = []
+        for _, localPos in roi.getLocalHandlePositions():
+            globalPos = roi.mapToParent(localPos)
+            vertices.append((globalPos.x(), globalPos.y()))
+        return PolygonRegion(tuple(vertices))
+    pos = roi.pos()
+    size = roi.size()
+    x0, y0 = pos.x(), pos.y()
+    regionClass = EllipseRegion if isinstance(roi, pg.EllipseROI) else RectRegion
+    return regionClass(x0, y0, x0 + size.x(), y0 + size.y())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_region_adapters.py -v`
+
+Expected: PASS, all 10 cases.
+
+- [ ] **Step 5: Prove the asymmetry tests bite (mutation)**
+
+Temporarily swap the width and height in `roiForRegion`'s box branch:
+
+```python
+    return roiClass((x0, y0), (y1 - y0, x1 - x0), pen=REGION_PEN, removable=True)
+```
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_region_adapters.py -v`
+
+Expected: FAIL in `test_a_region_round_trips_through_its_roi` and `test_the_roi_lands_on_the_regions_own_bounds`. **Record the failing line numbers.** Revert and re-run green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/modules/Autopatch/region_panel.py acq4/modules/Autopatch/tests/test_region_adapters.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'MSG'
+feat: map search regions to editable ROIs and back
+
+Rectangles, ellipses, and polygons round-trip through pyqtgraph ROIs. The
+ellipse drops its rotate handle, having no rotated region to map back to.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+MSG
+```
+
+---
+
+### Task 3: `RegionPanel` — the view and the region list
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/region_panel.py`
+- Test: `acq4/modules/Autopatch/tests/test_region_panel.py`
+
+**Interfaces:**
+- Consumes: `roiForRegion`, `regionForRoi`, `REGION_PEN` from Task 2.
+- Produces:
+  - `RegionPanel(Qt.QWidget)` with `sigRegionsChanged(object)` (a `list[SearchRegion]`) and `sigAddRegionRequested()`
+  - `RegionPanel.setRegions(regions)` — render, **without** re-emitting
+  - `RegionPanel.regions() -> list[SearchRegion]`
+  - `RegionPanel.regionShape() -> str` — `"rect"` / `"ellipse"` / `"polygon"`
+  - `RegionPanel.fitToRegions() -> None`
+  - Widgets: `graphicsView`, `view` (the `ViewBox`), `shapeCombo`, `addRegionBtn`, `mirrorCheck`, `fitBtn`
+
+**Note on the no-echo rule:** `setRegions()` is how the window pushes the slice's state *into* the panel. If it re-emitted `sigRegionsChanged`, the window would write straight back into the slice on every refresh — and a New slice that cleared the panel would immediately be told the regions are empty by the panel it just cleared. The panel emits only for edits that originate in it.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `acq4/modules/Autopatch/tests/test_region_panel.py`:
+
+```python
+"""Tests for Area 1's region view: what it draws, what it reports back when the
+operator edits a region, and what it lets them touch."""
+
+import pytest
+
+from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+RECT = RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+OTHER = RectRegion(3.0e-3, 1.0e-3, 3.6e-3, 1.2e-3)
+ELLIPSE = EllipseRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+
+
+def makePanel():
+    from acq4.modules.Autopatch.region_panel import RegionPanel
+
+    return RegionPanel()
+
+
+def test_a_fresh_panel_holds_no_regions(qapp):
+    assert makePanel().regions() == []
+
+
+def test_setregions_draws_one_roi_per_region(qapp):
+    panel = makePanel()
+    panel.setRegions([RECT, OTHER])
+
+    assert len(panel._rois) == 2
+    assert panel.regions() == [RECT, OTHER]
+
+
+def test_setregions_replaces_rather_than_appends(qapp):
+    # The window pushes the slice's whole region list on every refresh, so a
+    # panel that appended would redraw the same region once per refresh.
+    panel = makePanel()
+    panel.setRegions([RECT, OTHER])
+    panel.setRegions([ELLIPSE])
+
+    assert len(panel._rois) == 1
+    assert panel.regions() == [ELLIPSE]
+
+
+def test_setregions_does_not_echo_back(qapp):
+    # setRegions is how the slice's state reaches the panel. Echoing it would
+    # write straight back into the slice, and a New slice that cleared the panel
+    # would be told by that panel that its regions are empty.
+    panel = makePanel()
+    seen = []
+    panel.sigRegionsChanged.connect(seen.append)
+    panel.setRegions([RECT])
+
+    assert seen == []
+
+
+def test_dragging_a_region_reports_the_whole_list(qapp):
+    # The window replaces the slice's regions wholesale, so an edit to one has
+    # to arrive with its neighbours intact rather than on its own.
+    panel = makePanel()
+    panel.setRegions([RECT, OTHER])
+    seen = []
+    panel.sigRegionsChanged.connect(seen.append)
+
+    roi = panel._rois[0]
+    roi.setPos((2.0e-3, 5.0e-3))
+    roi.sigRegionChangeFinished.emit(roi)
+
+    assert len(seen) == 1
+    moved, untouched = seen[0]
+    assert moved == RectRegion(2.0e-3, 5.0e-3, 2.4e-3, 5.1e-3)
+    assert untouched == OTHER
+
+
+def test_removing_a_region_reports_the_list_without_it(qapp):
+    panel = makePanel()
+    panel.setRegions([RECT, OTHER])
+    seen = []
+    panel.sigRegionsChanged.connect(seen.append)
+
+    panel._rois[0].sigRemoveRequested.emit(panel._rois[0])
+
+    assert seen == [[OTHER]]
+    assert panel.regions() == [OTHER]
+
+
+def test_a_removed_roi_leaves_the_view(qapp):
+    # Dropping it from the list but leaving the item in the scene would keep a
+    # deleted region on screen, and keep it alive.
+    panel = makePanel()
+    panel.setRegions([RECT])
+    roi = panel._rois[0]
+
+    roi.sigRemoveRequested.emit(roi)
+
+    assert roi.scene() is None
+
+
+def test_the_shape_selector_offers_all_three_shapes(qapp):
+    # PolygonRegion has been implemented and tested since P2c-1 with no control
+    # able to produce one; a cortical layer is the reason regions became shapes.
+    panel = makePanel()
+    shapes = [panel.shapeCombo.itemData(i) for i in range(panel.shapeCombo.count())]
+
+    assert shapes == ["rect", "ellipse", "polygon"]
+
+
+def test_the_shape_selector_reports_item_data_not_its_label(qapp):
+    panel = makePanel()
+    panel.shapeCombo.setCurrentIndex(panel.shapeCombo.findData("polygon"))
+
+    assert panel.regionShape() == "polygon"
+
+
+def test_the_add_region_button_asks_its_owner(qapp):
+    # The panel does not know where the camera is pointing; the window does.
+    panel = makePanel()
+    requests = []
+    panel.sigAddRegionRequested.connect(lambda: requests.append(True))
+
+    panel.addRegionBtn.click()
+
+    assert requests == [True]
+
+
+def test_fit_to_regions_frames_every_region(qapp):
+    panel = makePanel()
+    panel.setRegions([RECT, OTHER])
+
+    panel.fitToRegions()
+
+    (vx0, vx1), (vy0, vy1) = panel.view.viewRange()
+    assert vx0 <= 1.0e-3 and vx1 >= 3.6e-3
+    assert vy0 <= 1.0e-3 and vy1 >= 2.1e-3
+
+
+def test_fit_to_regions_with_nothing_drawn_is_a_no_op(qapp):
+    # The button is live before the operator has drawn anything, and autoranging
+    # over an empty set is how a view ends up at an unrecoverable scale.
+    panel = makePanel()
+    before = panel.view.viewRange()
+
+    panel.fitToRegions()
+
+    assert panel.view.viewRange() == before
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_region_panel.py -v`
+
+Expected: FAIL — `ImportError: cannot import name 'RegionPanel'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `acq4/modules/Autopatch/region_panel.py`:
+
+```python
+class RegionPanel(Qt.QWidget):
+    """Area 1's view of the slice: the imagery to draw over, and the search
+    regions drawn on it as ROIs the operator can move, resize, and delete.
+
+    Renders a list of regions and reports a list of regions. It holds no Slice
+    and never touches one -- the window is what binds the two -- which is what
+    lets it be built and tested with no slice, no camera, and no orchestrator,
+    and what would let region drawing move into the Camera window later without
+    any of this changing.
+    """
+
+    # The complete region list after an edit that originated here.
+    sigRegionsChanged = Qt.Signal(object)
+    sigAddRegionRequested = Qt.Signal()
+
+    def __init__(self):
+        super().__init__()
+        self._rois: list[pg.ROI] = []
+
+        self.graphicsView = pg.GraphicsView()
+        self.graphicsView.setObjectName("Autopatch_regionView")
+        self.view = pg.ViewBox()
+        self.view.enableAutoRange(x=False, y=False)
+        # Tissue is not distorted by the widget's aspect ratio, and a region
+        # drawn over a squashed view would not be the region surveyed.
+        self.view.setAspectLocked(True)
+        self.graphicsView.setCentralItem(self.view)
+        # The view is the panel's content, not a strip above its controls: a
+        # region spans a slice, and the operator resizes the window to draw.
+        self.graphicsView.setSizePolicy(
+            Qt.QSizePolicy.Expanding, Qt.QSizePolicy.Expanding
+        )
+        self.graphicsView.setMinimumSize(300, 300)
+
+        # Item data, not display text, is what regionShape() returns: the window
+        # maps it to a region class, and a label is a label.
+        self.shapeCombo = Qt.QComboBox()
+        for label, key in (
+            ("Rectangle", "rect"),
+            ("Ellipse", "ellipse"),
+            ("Polygon", "polygon"),
+        ):
+            self.shapeCombo.addItem(label, key)
+        self.shapeCombo.setToolTip(
+            "The shape drawn by dragging in the view, and the shape "
+            '"Add region here" seeds.'
+        )
+
+        self.addRegionBtn = Qt.QPushButton("Add region here")
+        self.addRegionBtn.setToolTip(
+            "Add a search region covering roughly 3x3 fields of view around the "
+            "camera's current center."
+        )
+        self.fitBtn = Qt.QPushButton("Fit to regions")
+        self.mirrorCheck = Qt.QCheckBox("Mirror to Camera")
+        self.mirrorCheck.setToolTip(
+            "Draw these regions in the Camera module's view as well. They stay "
+            "editable only here."
+        )
+
+        controls = Qt.QHBoxLayout()
+        controls.addWidget(self.shapeCombo)
+        controls.addWidget(self.addRegionBtn)
+        controls.addWidget(self.fitBtn)
+        controls.addWidget(self.mirrorCheck)
+        controls.addStretch()
+
+        layout = Qt.QVBoxLayout()
+        layout.addLayout(controls)
+        layout.addWidget(self.graphicsView)
+        self.setLayout(layout)
+
+        self.addRegionBtn.clicked.connect(self.sigAddRegionRequested)
+        self.fitBtn.clicked.connect(self.fitToRegions)
+
+    # ---- regions ----
+    def regions(self) -> list[SearchRegion]:
+        """The regions currently drawn, in the order they were added."""
+        return [regionForRoi(roi) for roi in self._rois]
+
+    def setRegions(self, regions) -> None:
+        """Draw `regions`, replacing whatever is drawn now.
+
+        Deliberately silent: this is how the slice's state reaches the panel, so
+        echoing it back would have the window write it straight into the slice
+        again, and a New slice that cleared this panel would be told by the
+        panel it just cleared that the regions are empty.
+        """
+        for roi in list(self._rois):
+            self._detachRoi(roi)
+        for region in regions:
+            self._attachRoi(roiForRegion(region))
+
+    def _attachRoi(self, roi: pg.ROI) -> None:
+        self._rois.append(roi)
+        self.view.addItem(roi)
+        roi.sigRegionChangeFinished.connect(self._onRoiEdited)
+        roi.sigRemoveRequested.connect(self._onRoiRemoved)
+
+    def _detachRoi(self, roi: pg.ROI) -> None:
+        Qt.disconnect(roi.sigRegionChangeFinished, self._onRoiEdited)
+        Qt.disconnect(roi.sigRemoveRequested, self._onRoiRemoved)
+        self._rois.remove(roi)
+        self.view.removeItem(roi)
+
+    def _onRoiEdited(self, _roi) -> None:
+        # On sigRegionChangeFinished, not sigRegionChanged: a drag in progress
+        # is not a decision, and every emission costs the slice a full retile.
+        self.sigRegionsChanged.emit(self.regions())
+
+    def _onRoiRemoved(self, roi) -> None:
+        self._detachRoi(roi)
+        self.sigRegionsChanged.emit(self.regions())
+
+    # ---- view ----
+    def regionShape(self) -> str:
+        """The shape key for the next region drawn: rect, ellipse, or polygon."""
+        return self.shapeCombo.currentData()
+
+    def fitToRegions(self) -> None:
+        """Frame every drawn region.
+
+        With nothing drawn this does nothing: autoranging over an empty set is
+        how a view ends up at a scale the operator cannot recover from, and the
+        button is live before anything has been drawn.
+        """
+        if not self._rois:
+            return
+        bounds = [regionForRoi(roi).bounds() for roi in self._rois]
+        x0 = min(b[0] for b in bounds)
+        y0 = min(b[1] for b in bounds)
+        x1 = max(b[2] for b in bounds)
+        y1 = max(b[3] for b in bounds)
+        self.view.setRange(
+            xRange=(x0, x1), yRange=(y0, y1), padding=0.1
+        )
+```
+
+Add `from acq4.util import Qt` to the imports at the top of the file.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_region_panel.py -v`
+
+Expected: PASS, all 13 cases.
+
+- [ ] **Step 5: Prove the no-echo test bites (mutation)**
+
+Temporarily add `self.sigRegionsChanged.emit(self.regions())` as the last line of `setRegions`.
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_region_panel.py -k echo -v`
+
+Expected: FAIL at `assert seen == []`. **Record the failing line number.** Revert and re-run green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/modules/Autopatch/region_panel.py acq4/modules/Autopatch/tests/test_region_panel.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'MSG'
+feat: draw a slice's search regions in Area 1
+
+RegionPanel renders a region list as editable ROIs in a global-coordinate
+view and reports the whole list back on any edit made in it.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+MSG
+```
+
+---
+
+### Task 4: Drawing regions with the mouse
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/region_panel.py`
+- Test: `acq4/modules/Autopatch/tests/test_region_drawing.py`
+
+**Interfaces:**
+- Consumes: `RegionPanel`, `regionShape()`, `_attachRoi`, `roiForRegion` from Tasks 2–3.
+- Produces:
+  - `_DrawingViewBox(pg.ViewBox)` with `sigRegionDrawn(object)` (a `SearchRegion`), `setDrawShape(shape: str | None)`, and the four plain entry points `beginDraw(pt)`, `dragDraw(pt)`, `endDraw(pt)`, `addVertex(pt)`, `closePolygon()` — all taking `(x, y)` tuples in global metres.
+  - `RegionPanel.view` becomes a `_DrawingViewBox`.
+
+**Why plain entry points:** the Qt handlers (`mouseDragEvent`, `mouseClickEvent`) do one thing — map the event's scene position into view coordinates and call one of these. All the state and all the geometry live behind methods a test can call directly with metre coordinates, so the drawing rules are covered without synthesising Qt mouse events. This is the same injected-seam split that made `tile_detector` testable.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `acq4/modules/Autopatch/tests/test_region_drawing.py`:
+
+```python
+"""Tests for drawing a region with the mouse: the drag and click state machine
+behind Area 1's view, driven directly in global coordinates."""
+
+import pytest
+
+from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+def makeBox(shape):
+    from acq4.modules.Autopatch.region_panel import _DrawingViewBox
+
+    box = _DrawingViewBox()
+    box.setDrawShape(shape)
+    return box
+
+
+def drawn(box):
+    seen = []
+    box.sigRegionDrawn.connect(seen.append)
+    return seen
+
+
+def test_dragging_out_a_rectangle_reports_one(qapp):
+    box = makeBox("rect")
+    seen = drawn(box)
+
+    box.beginDraw((1.0e-3, 2.0e-3))
+    box.dragDraw((1.2e-3, 2.05e-3))
+    box.endDraw((1.4e-3, 2.1e-3))
+
+    assert seen == [RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)]
+
+
+def test_dragging_out_an_ellipse_reports_one(qapp):
+    box = makeBox("ellipse")
+    seen = drawn(box)
+
+    box.beginDraw((1.0e-3, 2.0e-3))
+    box.endDraw((1.4e-3, 2.1e-3))
+
+    assert seen == [EllipseRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)]
+
+
+def test_a_drag_that_ends_where_it_started_reports_nothing(qapp):
+    # A region needs extent in both axes -- SearchRegion raises without it --
+    # and a stray click in the view is the ordinary way to produce this. It has
+    # to be dropped here, silently: nothing in this panel may raise on the GUI
+    # thread.
+    box = makeBox("rect")
+    seen = drawn(box)
+
+    box.beginDraw((1.0e-3, 2.0e-3))
+    box.endDraw((1.0e-3, 2.0e-3))
+
+    assert seen == []
+
+
+def test_a_drag_with_no_height_reports_nothing(qapp):
+    # Zero extent in either axis alone is still not a region. Tested per axis:
+    # a check that only looks at width passes a test that only drags a point.
+    box = makeBox("rect")
+    seen = drawn(box)
+
+    box.beginDraw((1.0e-3, 2.0e-3))
+    box.endDraw((1.4e-3, 2.0e-3))
+
+    assert seen == []
+
+
+def test_a_drag_with_no_width_reports_nothing(qapp):
+    box = makeBox("rect")
+    seen = drawn(box)
+
+    box.beginDraw((1.0e-3, 2.0e-3))
+    box.endDraw((1.0e-3, 2.1e-3))
+
+    assert seen == []
+
+
+def test_a_backwards_drag_still_reports_the_box_drawn(qapp):
+    # Dragging up and to the left is as ordinary as down and to the right.
+    box = makeBox("rect")
+    seen = drawn(box)
+
+    box.beginDraw((1.4e-3, 2.1e-3))
+    box.endDraw((1.0e-3, 2.0e-3))
+
+    assert seen == [RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)]
+
+
+def test_clicking_three_vertices_and_closing_reports_a_polygon(qapp):
+    box = makeBox("polygon")
+    seen = drawn(box)
+
+    box.addVertex((1.0e-3, 2.0e-3))
+    box.addVertex((1.4e-3, 2.02e-3))
+    box.addVertex((1.1e-3, 2.1e-3))
+    box.closePolygon()
+
+    assert seen == [
+        PolygonRegion(((1.0e-3, 2.0e-3), (1.4e-3, 2.02e-3), (1.1e-3, 2.1e-3)))
+    ]
+
+
+def test_closing_a_polygon_with_two_vertices_reports_nothing(qapp):
+    box = makeBox("polygon")
+    seen = drawn(box)
+
+    box.addVertex((1.0e-3, 2.0e-3))
+    box.addVertex((1.4e-3, 2.02e-3))
+    box.closePolygon()
+
+    assert seen == []
+
+
+def test_closing_a_polygon_clears_it_for_the_next_one(qapp):
+    # Vertices carried over would splice two regions the operator drew
+    # separately into one shape spanning both.
+    box = makeBox("polygon")
+    seen = drawn(box)
+
+    for pt in ((1.0e-3, 2.0e-3), (1.4e-3, 2.02e-3), (1.1e-3, 2.1e-3)):
+        box.addVertex(pt)
+    box.closePolygon()
+    for pt in ((3.0e-3, 1.0e-3), (3.6e-3, 1.02e-3), (3.2e-3, 1.2e-3)):
+        box.addVertex(pt)
+    box.closePolygon()
+
+    assert len(seen) == 2
+    assert seen[1].vertices == (
+        (3.0e-3, 1.0e-3),
+        (3.6e-3, 1.02e-3),
+        (3.2e-3, 1.2e-3),
+    )
+
+
+def test_with_no_shape_set_dragging_reports_nothing(qapp):
+    # No draw shape is the panel locked, or a slice that does not exist yet.
+    # The drag has to fall through to the ViewBox so the view still pans.
+    box = makeBox(None)
+    seen = drawn(box)
+
+    box.beginDraw((1.0e-3, 2.0e-3))
+    box.endDraw((1.4e-3, 2.1e-3))
+
+    assert seen == []
+
+
+def test_a_drawn_region_reaches_the_panel(qapp):
+    from acq4.modules.Autopatch.region_panel import RegionPanel
+
+    panel = RegionPanel()
+    panel.shapeCombo.setCurrentIndex(panel.shapeCombo.findData("rect"))
+    seen = []
+    panel.sigRegionsChanged.connect(seen.append)
+
+    panel.view.beginDraw((1.0e-3, 2.0e-3))
+    panel.view.endDraw((1.4e-3, 2.1e-3))
+
+    assert seen == [[RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)]]
+    assert len(panel._rois) == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_region_drawing.py -v`
+
+Expected: FAIL — `ImportError: cannot import name '_DrawingViewBox'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Insert `_DrawingViewBox` into `acq4/modules/Autopatch/region_panel.py`, above `RegionPanel`:
+
+```python
+class _DrawingViewBox(pg.ViewBox):
+    """The Area 1 view box, in the two modes a region view needs.
+
+    With no draw shape set it is an ordinary ViewBox: drags pan, wheels zoom.
+    With one set, a drag lays out a rectangle or ellipse and clicks lay out a
+    polygon's vertices.
+
+    The Qt handlers do exactly one thing -- map an event's scene position into
+    view coordinates and call one of the plain entry points below. Every rule
+    about what counts as a region lives behind those methods, so the drawing
+    logic is exercised in global metres without synthesising mouse events.
+    """
+
+    sigRegionDrawn = Qt.Signal(object)  # SearchRegion
+
+    def __init__(self, *args, **kwds):
+        super().__init__(*args, **kwds)
+        self._drawShape = None
+        self._dragStart = None
+        self._vertices: list[tuple[float, float]] = []
+
+    def setDrawShape(self, shape) -> None:
+        """Draw `shape` ("rect"/"ellipse"/"polygon") on drag, or None to pan.
+
+        Switching shape abandons a polygon in progress: its half-drawn vertices
+        belong to the shape the operator was drawing, not the next one.
+        """
+        self._drawShape = shape
+        self._dragStart = None
+        self._vertices = []
+
+    # ---- entry points ----
+    def beginDraw(self, pt) -> None:
+        self._dragStart = (pt[0], pt[1])
+
+    def dragDraw(self, pt) -> None:
+        """Called for each intermediate position of a drag.
+
+        Nothing is reported mid-drag: a drag in progress is not a decision.
+        """
+
+    def endDraw(self, pt) -> None:
+        start, self._dragStart = self._dragStart, None
+        if self._drawShape not in ("rect", "ellipse") or start is None:
+            return
+        x0, y0 = start
+        x1, y1 = pt[0], pt[1]
+        if x0 == x1 or y0 == y1:
+            # A region needs extent in both axes. A stray click in the view is
+            # the ordinary way to produce this, so it is dropped rather than
+            # raised: nothing here may raise on the GUI thread.
+            return
+        regionClass = EllipseRegion if self._drawShape == "ellipse" else RectRegion
+        # The corners arrive in whatever order they were dragged; _BoxRegion
+        # orders them.
+        self.sigRegionDrawn.emit(regionClass(x0, y0, x1, y1))
+
+    def addVertex(self, pt) -> None:
+        if self._drawShape != "polygon":
+            return
+        self._vertices.append((pt[0], pt[1]))
+
+    def closePolygon(self) -> None:
+        """Close the polygon under construction and report it, if it is one.
+
+        The vertices are cleared either way: carried over, they would splice the
+        abandoned shape onto the next one the operator draws.
+        """
+        vertices, self._vertices = self._vertices, []
+        if self._drawShape != "polygon" or len(vertices) < 3:
+            return
+        xs = [x for x, _ in vertices]
+        ys = [y for _, y in vertices]
+        if min(xs) == max(xs) or min(ys) == max(ys):
+            return
+        self.sigRegionDrawn.emit(PolygonRegion(tuple(vertices)))
+
+    # ---- Qt handlers ----
+    def mouseDragEvent(self, ev, axis=None):
+        if self._drawShape not in ("rect", "ellipse"):
+            super().mouseDragEvent(ev, axis=axis)
+            return
+        ev.accept()
+        pt = self.mapSceneToView(ev.scenePos())
+        if ev.isStart():
+            self.beginDraw((pt.x(), pt.y()))
+        elif ev.isFinish():
+            self.endDraw((pt.x(), pt.y()))
+        else:
+            self.dragDraw((pt.x(), pt.y()))
+
+    def mouseClickEvent(self, ev):
+        if self._drawShape != "polygon":
+            super().mouseClickEvent(ev)
+            return
+        ev.accept()
+        pt = self.mapSceneToView(ev.scenePos())
+        if ev.double():
+            self.closePolygon()
+        else:
+            self.addVertex((pt.x(), pt.y()))
+```
+
+In `RegionPanel.__init__`, build the drawing view box and wire it:
+
+```python
+        self.view = _DrawingViewBox()
+```
+
+and, after the other connections:
+
+```python
+        self.view.sigRegionDrawn.connect(self._onRegionDrawn)
+        self.shapeCombo.currentIndexChanged.connect(self._applyDrawShape)
+        self._applyDrawShape()
+```
+
+Add the two methods to `RegionPanel`:
+
+```python
+    def _onRegionDrawn(self, region) -> None:
+        self._attachRoi(roiForRegion(region))
+        self.sigRegionsChanged.emit(self.regions())
+
+    def _applyDrawShape(self, *_args) -> None:
+        self.view.setDrawShape(self.regionShape())
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/ -q`
+
+Expected: PASS, no failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/modules/Autopatch/region_panel.py acq4/modules/Autopatch/tests/test_region_drawing.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'MSG'
+feat: draw regions with the mouse in Area 1
+
+Drag lays out a rectangle or ellipse, clicks lay out a polygon's vertices,
+and a shape with no extent in both axes is dropped rather than raised.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+MSG
+```
+
+---
+
+### Task 5: The editing gate
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/region_panel.py`
+- Test: `acq4/modules/Autopatch/tests/test_region_panel.py`
+
+**Interfaces:**
+- Consumes: `RegionPanel` from Tasks 3–4.
+- Produces:
+  - `RegionPanel.setInteractionLocked(locked: bool)`
+  - `RegionPanel.setSliceReady(ready: bool)`
+  - `RegionPanel.setRunStatus(status: str)`
+
+**The rule:** editing is enabled when `sliceReady and (not runLocked or status == "paused")`.
+
+**Why the status and not the click:** `Orchestrator._checkPause()` runs at the *top* of `_runLoopBody`, before `_shouldRefill()`. Clicking Pause during a survey does not stop the survey — the producer goes on imaging tiles for seconds to minutes, reading `slice._regions` throughout, and the loop parks only at the next iteration. But `sigStatus("paused")` is emitted from *inside* `_checkPause`, immediately before `_pauseEvent.wait()`, so while that status is current the worker is blocked there and cannot be inside `_refillQueue`. The status is a guarantee; the click is not.
+
+The three locks are kept as three separate flags for the same reason `SearchPanel` keeps `_runLocked` and `_sliceReady` apart: no writer can see another's condition, so collapsing them into one boolean lets a run ending unlock a panel that still has no slice behind it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `acq4/modules/Autopatch/tests/test_region_panel.py`:
+
+```python
+def test_a_panel_with_no_slice_cannot_be_drawn_on(qapp):
+    # New slice is what makes Area 1 usable, and greyed-out controls are how the
+    # operator is told so -- the same treatment Area 2 already gets.
+    panel = makePanel()
+
+    assert not panel.addRegionBtn.isEnabled()
+    assert not panel.shapeCombo.isEnabled()
+    assert panel.view._drawShape is None
+
+
+def test_a_slice_makes_the_controls_live(qapp):
+    panel = makePanel()
+    panel.setSliceReady(True)
+
+    assert panel.addRegionBtn.isEnabled()
+    assert panel.shapeCombo.isEnabled()
+    assert panel.view._drawShape == "rect"
+
+
+def test_a_running_run_locks_editing(qapp):
+    # The regions parameterise a search already underway on the worker thread.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setRegions([RECT])
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("running")
+
+    assert not panel.addRegionBtn.isEnabled()
+    assert panel.view._drawShape is None
+    assert not panel._rois[0].translatable
+    assert not panel._rois[0].resizable
+    assert not panel._rois[0].removable
+
+
+def test_a_paused_run_unlocks_editing(qapp):
+    # The other side of the same invariant. A one-sided test on a two-sided
+    # invariant passes happily while the other side is broken -- which is how
+    # CellPanel's flush regressed in both directions across P2b's reviews.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setRegions([RECT])
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("running")
+    panel.setRunStatus("paused")
+
+    assert panel.addRegionBtn.isEnabled()
+    assert panel.view._drawShape == "rect"
+    assert panel._rois[0].translatable
+    assert panel._rois[0].resizable
+    assert panel._rois[0].removable
+
+
+def test_surveying_locks_editing_even_though_pause_was_pressed(qapp):
+    # "surveying" is what a run reports while the producer images tiles, and a
+    # Pause pressed during one does not park the loop until that refill is done.
+    # Unlocking on anything short of the emitted "paused" would let an edit land
+    # while the producer is reading regions.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("surveying")
+
+    assert not panel.addRegionBtn.isEnabled()
+    assert panel.view._drawShape is None
+
+
+def test_resuming_from_paused_locks_editing_again(qapp):
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setRegions([RECT])
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("paused")
+    panel.setRunStatus("running")
+
+    assert not panel.addRegionBtn.isEnabled()
+    assert not panel._rois[0].translatable
+
+
+def test_regions_drawn_while_locked_are_still_shown(qapp):
+    # Locking is about editing, not about hiding: the operator watching a run
+    # must still see what is being surveyed.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("running")
+    panel.setRegions([RECT, OTHER])
+
+    assert len(panel._rois) == 2
+    assert panel.regions() == [RECT, OTHER]
+
+
+def test_a_region_added_while_locked_is_locked_too(qapp):
+    # setRegions builds fresh ROIs, which default to editable; a gate applied
+    # only on the transition would leave them draggable mid-run.
+    panel = makePanel()
+    panel.setSliceReady(True)
+    panel.setInteractionLocked(True)
+    panel.setRunStatus("running")
+    panel.setRegions([RECT])
+
+    assert not panel._rois[0].translatable
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_region_panel.py -k "slice or lock or paused or surveying or resuming" -v`
+
+Expected: FAIL — `AttributeError: 'RegionPanel' object has no attribute 'setSliceReady'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `RegionPanel.__init__`, before the connections:
+
+```python
+        # The three independent reasons editing can be off, kept apart because
+        # no writer can see another's condition: collapsing them into one
+        # boolean would let a run ending unlock a panel that still has no slice
+        # behind it. Same split SearchPanel already makes.
+        self._runLocked = False
+        self._sliceReady = False
+        self._runStatus = None
+```
+
+and call `self._applyLock()` at the end of `__init__` instead of `self._applyDrawShape()`.
+
+Add to `RegionPanel`:
+
+```python
+    def setInteractionLocked(self, locked: bool) -> None:
+        """Disable editing while a run is in flight; the regions stay visible.
+
+        The operator watching a run must still see what is being surveyed, so
+        this is about editing, not about hiding.
+        """
+        self._runLocked = locked
+        self._applyLock()
+
+    def setSliceReady(self, ready: bool) -> None:
+        """Whether a slice exists for these regions to belong to.
+
+        New slice is what makes Area 1 usable, and the greyed-out controls are
+        how the operator is told that it is the first step.
+        """
+        self._sliceReady = ready
+        self._applyLock()
+
+    def setRunStatus(self, status: str) -> None:
+        """The bound run's last reported status.
+
+        Only "paused" matters here, and only the *emitted* status will do.
+        Orchestrator._checkPause() runs at the top of the run loop, before the
+        refill check, so a Pause clicked during a survey does not stop that
+        survey -- the producer goes on imaging tiles and reading regions for as
+        long as it takes, and the loop parks at the next iteration. But
+        sigStatus("paused") is emitted from inside _checkPause, immediately
+        before it blocks, so while that status is current the worker is parked
+        there and cannot be inside a refill. That is what makes editing safe.
+        """
+        self._runStatus = status
+        self._applyLock()
+
+    def _editable(self) -> bool:
+        if not self._sliceReady:
+            return False
+        return not self._runLocked or self._runStatus == "paused"
+
+    def _applyLock(self) -> None:
+        editable = self._editable()
+        self.addRegionBtn.setEnabled(editable)
+        self.shapeCombo.setEnabled(editable)
+        self._applyDrawShape()
+        for roi in self._rois:
+            self._applyRoiLock(roi)
+
+    def _applyRoiLock(self, roi: pg.ROI) -> None:
+        """Make one ROI match the current gate.
+
+        Every affordance, not just the drag: leaving the handles live would let
+        a locked region be resized, and leaving `removable` on would let it be
+        deleted from the context menu.
+        """
+        editable = self._editable()
+        roi.translatable = editable
+        roi.resizable = editable
+        roi.removable = editable
+        for handle in roi.getHandles():
+            handle.setVisible(editable)
+```
+
+Change `_applyDrawShape` so a locked panel pans instead of drawing:
+
+```python
+    def _applyDrawShape(self, *_args) -> None:
+        self.view.setDrawShape(self.regionShape() if self._editable() else None)
+```
+
+And apply the lock to each ROI as it is attached, in `_attachRoi`, after `self.view.addItem(roi)`:
+
+```python
+        self._applyRoiLock(roi)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/ -q`
+
+Expected: PASS, once two earlier test files are updated — a panel with no slice being inert is the intended behaviour, so the tests written before the gate existed have to declare a slice:
+
+- `test_region_panel.py`: `test_the_add_region_button_asks_its_owner` needs `panel.setSliceReady(True)` before the click.
+- `test_region_drawing.py`: `test_a_drawn_region_reaches_the_panel` needs `panel.setSliceReady(True)` before it draws, or `_drawShape` is `None` and nothing is drawn.
+
+The `_DrawingViewBox` tests in that file construct the view box directly and are unaffected.
+
+- [ ] **Step 5: Prove both sides of the gate bite (mutation)**
+
+Mutation A — drop the paused exception: `return not self._runLocked`.
+Run: `... -m pytest acq4/modules/Autopatch/tests/test_region_panel.py -k paused -v` → expect FAIL in `test_a_paused_run_unlocks_editing`.
+
+Mutation B — widen it to any non-running status: `return not self._runLocked or self._runStatus != "running"`.
+Run: `... -m pytest acq4/modules/Autopatch/tests/test_region_panel.py -k surveying -v` → expect FAIL in `test_surveying_locks_editing_even_though_pause_was_pressed`.
+
+**Record the failing line number for each.** Revert both and re-run green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/modules/Autopatch/region_panel.py acq4/modules/Autopatch/tests/test_region_panel.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'MSG'
+feat: allow region edits only when the run is parked
+
+Editing needs a slice, and during a run it needs the emitted "paused"
+status -- the point at which the worker is provably not reading regions.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+MSG
+```
+
+---
+
+### Task 6: Pinned frames from the Camera module
+
+**Files:**
+- Modify: `acq4/util/imaging/imaging_ctrl.py` (`addPinnedFrame` ~line 274, `removePinnedFrame` ~line 286)
+- Create: `acq4/modules/Autopatch/region_mirrors.py`
+- Test: `acq4/modules/Autopatch/tests/test_region_mirrors.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `ImagingCtrl.sigPinnedFramesChanged` — `Qt.Signal()`, emitted by `addPinnedFrame` and `removePinnedFrame`.
+  - `PinnedFrameMirror(view)` with `bind(imagingCtrl)`, `unbind()`, `refresh()`, and `items` (the mirrored `pg.ImageItem`s, in the order drawn).
+
+**Why a copy and not the same item:** a `pg.ImageItem` belongs to exactly one `QGraphicsScene`. "Pinned frames display in both places" therefore cannot mean the same object in two views — the mirror builds its own item per pinned frame from the same image array and the same global transform.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `acq4/modules/Autopatch/tests/test_region_mirrors.py`:
+
+```python
+"""Tests for Area 1's two one-way mirrors: the Camera module's pinned frames
+coming in, and region outlines going out."""
+
+import gc
+import weakref
+
+import numpy as np
+import pyqtgraph as pg
+import pytest
+
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+class FakeImagingCtrl(Qt.QObject):
+    """Stands in for the Camera module's ImagingCtrl: a list of pinned image
+    items and the signal that says it changed."""
+
+    sigPinnedFramesChanged = Qt.Signal()
+
+    def __init__(self):
+        super().__init__()
+        self.pinnedFrames = []
+
+    def pin(self, item):
+        item.setZValue(-10000 + len(self.pinnedFrames))
+        self.pinnedFrames.append(item)
+        self.sigPinnedFramesChanged.emit()
+
+    def unpin(self, item):
+        self.pinnedFrames.remove(item)
+        self.sigPinnedFramesChanged.emit()
+
+
+def makeFrameItem(value, x, y):
+    # Asymmetric image on purpose: a transposed copy of a square array is
+    # indistinguishable from the original.
+    item = pg.ImageItem(np.full((4, 7), value, dtype=float))
+    transform = Qt.QTransform()
+    transform.translate(x, y)
+    transform.scale(1e-6, 2e-6)
+    item.setTransform(transform)
+    return item
+
+
+def makeMirror():
+    from acq4.modules.Autopatch.region_mirrors import PinnedFrameMirror
+
+    view = pg.ViewBox()
+    return PinnedFrameMirror(view), view
+
+
+def test_binding_shows_the_frames_already_pinned(qapp):
+    # The operator pins frames before opening Autopatch as often as after.
+    source = FakeImagingCtrl()
+    source.pin(makeFrameItem(1.0, 1e-3, 2e-3))
+    mirror, _view = makeMirror()
+
+    mirror.bind(source)
+
+    assert len(mirror.items) == 1
+
+
+def test_a_frame_pinned_later_appears(qapp):
+    source = FakeImagingCtrl()
+    mirror, _view = makeMirror()
+    mirror.bind(source)
+
+    source.pin(makeFrameItem(1.0, 1e-3, 2e-3))
+
+    assert len(mirror.items) == 1
+
+
+def test_a_frame_unpinned_disappears(qapp):
+    source = FakeImagingCtrl()
+    item = makeFrameItem(1.0, 1e-3, 2e-3)
+    source.pin(item)
+    mirror, _view = makeMirror()
+    mirror.bind(source)
+
+    source.unpin(item)
+
+    assert mirror.items == []
+
+
+def test_the_mirrored_item_carries_the_same_pixels_and_placement(qapp):
+    # A mirror that showed the right image in the wrong place would have the
+    # operator draw regions over tissue that is somewhere else.
+    source = FakeImagingCtrl()
+    original = makeFrameItem(3.0, 1e-3, 2e-3)
+    source.pin(original)
+    mirror, _view = makeMirror()
+    mirror.bind(source)
+
+    copy = mirror.items[0]
+    assert np.array_equal(copy.image, original.image)
+    assert copy.transform() == original.transform()
+    assert copy.zValue() == original.zValue()
+
+
+def test_the_mirrored_item_is_a_distinct_object_in_this_view(qapp):
+    # An ImageItem lives in exactly one scene, so re-adding the Camera module's
+    # own item would take it out of the Camera module's view.
+    source = FakeImagingCtrl()
+    original = makeFrameItem(3.0, 1e-3, 2e-3)
+    source.pin(original)
+    mirror, view = makeMirror()
+    mirror.bind(source)
+
+    assert mirror.items[0] is not original
+    assert mirror.items[0] in view.addedItems
+
+
+def test_unbinding_clears_the_view_and_stops_listening(qapp):
+    source = FakeImagingCtrl()
+    source.pin(makeFrameItem(1.0, 1e-3, 2e-3))
+    mirror, _view = makeMirror()
+    mirror.bind(source)
+
+    mirror.unbind()
+    source.pin(makeFrameItem(2.0, 3e-3, 4e-3))
+
+    assert mirror.items == []
+
+
+def test_unbinding_releases_the_source(qapp):
+    # A connection outliving its owner is this module's most-repeated defect:
+    # a mirror still listening after teardown draws into a dead view.
+    source = FakeImagingCtrl()
+    mirror, _view = makeMirror()
+    mirror.bind(source)
+    ref = weakref.ref(source)
+
+    mirror.unbind()
+    del source
+    gc.disable()
+    try:
+        assert ref() is None
+    finally:
+        gc.enable()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_region_mirrors.py -v`
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'acq4.modules.Autopatch.region_mirrors'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `acq4/util/imaging/imaging_ctrl.py`, add to the signal block at the top of `ImagingCtrl`:
+
+```python
+    sigPinnedFramesChanged = Qt.Signal()  # a frame was pinned or unpinned
+```
+
+Emit it as the last statement of `addPinnedFrame` and of `removePinnedFrame`:
+
+```python
+        self.sigPinnedFramesChanged.emit()
+```
+
+Create `acq4/modules/Autopatch/region_mirrors.py`:
+
+```python
+"""The two one-way mirrors either side of Area 1's view: the Camera module's
+pinned frames coming in, and read-only region outlines going out."""
+
+from __future__ import annotations
+
+import pyqtgraph as pg
+
+from acq4.util import Qt
+
+
+class PinnedFrameMirror:
+    """Shows the Camera module's pinned frames in another view.
+
+    A pg.ImageItem belongs to exactly one QGraphicsScene, so displaying the
+    pinned frames in both places cannot mean showing the same objects twice --
+    adding the Camera module's own items here would take them out of the Camera
+    module's view. This builds its own item per pinned frame instead, from the
+    same image array and the same global transform.
+
+    Display only: it holds no region state and nothing depends on it existing.
+    """
+
+    def __init__(self, view):
+        self._view = view
+        self._source = None
+        self.items: list[pg.ImageItem] = []
+
+    def bind(self, imagingCtrl) -> None:
+        """Mirror `imagingCtrl`'s pinned frames, replacing any current binding.
+
+        Draws what is already pinned rather than waiting for the next change:
+        pinning frames before opening this window is as ordinary as after.
+        """
+        self.unbind()
+        self._source = imagingCtrl
+        imagingCtrl.sigPinnedFramesChanged.connect(self.refresh)
+        self.refresh()
+
+    def unbind(self) -> None:
+        """Stop mirroring and take the copies out of the view."""
+        if self._source is not None:
+            Qt.disconnect(self._source.sigPinnedFramesChanged, self.refresh)
+            self._source = None
+        self._clearItems()
+
+    def refresh(self) -> None:
+        """Rebuild the mirrored items from the source's current set.
+
+        Rebuilding wholesale rather than diffing: the set is a handful of frames
+        changed by operator clicks, and a diff would be state to keep correct
+        for no measurable gain.
+        """
+        self._clearItems()
+        if self._source is None:
+            return
+        for original in self._source.pinnedFrames:
+            copy = pg.ImageItem(original.image)
+            copy.setTransform(original.transform())
+            copy.setZValue(original.zValue())
+            self._view.addItem(copy)
+            self.items.append(copy)
+
+    def _clearItems(self) -> None:
+        for item in self.items:
+            self._view.removeItem(item)
+        self.items = []
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_region_mirrors.py acq4/util -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Prove the release test bites (mutation)**
+
+Temporarily remove the `Qt.disconnect(...)` line from `unbind`.
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_region_mirrors.py -k releases -v`
+
+Expected: FAIL at `assert ref() is None`. **Record the failing line number.** Revert and re-run green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/util/imaging/imaging_ctrl.py acq4/modules/Autopatch/region_mirrors.py acq4/modules/Autopatch/tests/test_region_mirrors.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'MSG'
+feat: mirror the Camera module's pinned frames into another view
+
+ImagingCtrl announces pins and unpins, and PinnedFrameMirror redraws its own
+copies -- an ImageItem belongs to only one scene.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+MSG
+```
+
+---
+
+### Task 7: Region outlines in the Camera window
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/region_mirrors.py`
+- Test: `acq4/modules/Autopatch/tests/test_region_mirrors.py`
+
+**Interfaces:**
+- Consumes: `SearchRegion` subclasses; `REGION_PEN` from Task 2.
+- Produces: `CameraMirror(cameraWindowGetter)` with `setEnabled(bool)`, `setRegions(regions)`, `clear()`, and `items` (the `QGraphicsPathItem`s currently in the Camera window).
+
+`cameraWindowGetter` is a zero-argument callable returning the Camera window or `None`. A missing Camera module is ordinary, not an error: the checkbox is a display preference.
+
+**On using `QPainterPath` here:** P2c-1 replaced `QPainterPath.intersects()` with closed-form geometry because Qt's path clipper has absolute tolerances that misreport tiles at SI-metre magnitudes. That finding is about *deciding overlap*. Drawing an outline asks Qt no questions, so a path is the right tool here — and this comment exists so a later reader does not think the two contradict.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `acq4/modules/Autopatch/tests/test_region_mirrors.py`:
+
+```python
+from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
+
+RECT = RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+ELLIPSE = EllipseRegion(3.0e-3, 1.0e-3, 3.6e-3, 1.2e-3)
+TRIANGLE = PolygonRegion(((1.0e-3, 2.0e-3), (1.4e-3, 2.02e-3), (1.1e-3, 2.1e-3)))
+
+
+class FakeCameraWindow:
+    """Stands in for the Camera module's window: the addItem/removeItem pair
+    Autopatch reaches it through."""
+
+    def __init__(self):
+        self.items = []
+
+    def addItem(self, item, pos=(0, 0), scale=(1, 1), z=None, **kwds):
+        self.items.append(item)
+        if z is not None:
+            item.setZValue(z)
+
+    def removeItem(self, item):
+        self.items.remove(item)
+
+
+def makeCameraMirror(window):
+    from acq4.modules.Autopatch.region_mirrors import CameraMirror
+
+    return CameraMirror(lambda: window)
+
+
+def test_disabled_by_default_nothing_reaches_the_camera(qapp):
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+
+    mirror.setRegions([RECT, ELLIPSE])
+
+    assert window.items == []
+
+
+def test_enabling_draws_the_regions_already_set(qapp):
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setRegions([RECT, ELLIPSE])
+
+    mirror.setEnabled(True)
+
+    assert len(window.items) == 2
+
+
+def test_regions_set_while_enabled_are_drawn(qapp):
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+
+    mirror.setRegions([RECT, ELLIPSE, TRIANGLE])
+
+    assert len(window.items) == 3
+
+
+def test_disabling_takes_them_out_again(qapp):
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+    mirror.setRegions([RECT])
+
+    mirror.setEnabled(False)
+
+    assert window.items == []
+
+
+def test_the_outlines_cannot_be_grabbed(qapp):
+    # Autopatch is the only place a region is edited. A mirrored outline that
+    # accepted a mouse press would be a second, silent editing surface.
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+    mirror.setRegions([RECT])
+
+    assert window.items[0].acceptedMouseButtons() == Qt.Qt.NoButton
+
+
+@pytest.mark.parametrize(
+    "region,expected",
+    [(RECT, (1.0e-3, 2.0e-3, 0.4e-3, 0.1e-3)), (ELLIPSE, (3.0e-3, 1.0e-3, 0.6e-3, 0.2e-3))],
+)
+def test_an_outline_lands_on_its_regions_bounds(qapp, region, expected):
+    # Asymmetric bounds on both shapes: a square outline cannot catch a width
+    # and height that have been swapped.
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+    mirror.setRegions([region])
+
+    rect = window.items[0].path().boundingRect()
+    assert (rect.x(), rect.y(), rect.width(), rect.height()) == pytest.approx(expected)
+
+
+def test_a_polygon_outline_has_a_vertex_per_vertex(qapp):
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+    mirror.setRegions([TRIANGLE])
+
+    path = window.items[0].path()
+    drawn = {(path.elementAt(i).x, path.elementAt(i).y) for i in range(path.elementCount())}
+    for vertex in TRIANGLE.vertices:
+        assert any(
+            abs(x - vertex[0]) < 1e-12 and abs(y - vertex[1]) < 1e-12 for x, y in drawn
+        )
+
+
+def test_no_camera_window_is_not_an_error(qapp):
+    # A rig with the Camera module unloaded is ordinary; the checkbox is a
+    # display preference, not a requirement.
+    from acq4.modules.Autopatch.region_mirrors import CameraMirror
+
+    mirror = CameraMirror(lambda: None)
+    mirror.setEnabled(True)
+    mirror.setRegions([RECT])
+
+    assert mirror.items == []
+
+
+def test_clear_removes_everything_it_put_there(qapp):
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+    mirror.setRegions([RECT, ELLIPSE])
+
+    mirror.clear()
+
+    assert window.items == []
+    assert mirror.items == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_region_mirrors.py -k camera -v`
+
+Expected: FAIL — `ImportError: cannot import name 'CameraMirror'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Append to `acq4/modules/Autopatch/region_mirrors.py`:
+
+```python
+from acq4.experiment.search_region import EllipseRegion, PolygonRegion
+
+from .region_panel import REGION_PEN
+
+# Above the camera frame image so an outline is visible over tissue, below the
+# pipette target and its arrows at z=5000 so those stay on top -- the same band
+# the AutomationDebug survey ROI sits in.
+_MIRROR_Z = 4000
+
+
+def _pathForRegion(region) -> Qt.QPainterPath:
+    """The outline of `region`, in global metres.
+
+    A QPainterPath is the right tool for drawing an outline even though P2c-1
+    removed QPainterPath from the *overlap* test: that finding is about asking
+    Qt to decide whether a rect and a shape intersect, where its clipper's
+    absolute tolerances misreport tiles at SI-metre magnitudes. Drawing asks Qt
+    no such question.
+    """
+    path = Qt.QPainterPath()
+    if isinstance(region, PolygonRegion):
+        first = region.vertices[0]
+        path.moveTo(first[0], first[1])
+        for x, y in region.vertices[1:]:
+            path.lineTo(x, y)
+        path.closeSubpath()
+        return path
+    x0, y0, x1, y1 = region.bounds()
+    rect = Qt.QRectF(x0, y0, x1 - x0, y1 - y0)
+    if isinstance(region, EllipseRegion):
+        path.addEllipse(rect)
+    else:
+        path.addRect(rect)
+    return path
+
+
+class CameraMirror:
+    """Draws read-only outlines of Autopatch's regions in the Camera window.
+
+    Outlines are QGraphicsPathItems, not ROIs, and that is what makes them
+    read-only structurally rather than by policy: there is no handle to grab and
+    no second copy of a region's state to reconcile. Autopatch stays the only
+    place a region is edited.
+
+    Holds no region state of its own -- it is told what to draw. A Camera module
+    that is not loaded is ordinary, not an error: this is a display preference.
+    """
+
+    def __init__(self, cameraWindowGetter):
+        self._cameraWindow = cameraWindowGetter
+        self._enabled = False
+        self._regions = []
+        self.items = []
+
+    def setEnabled(self, enabled: bool) -> None:
+        self._enabled = enabled
+        self._redraw()
+
+    def setRegions(self, regions) -> None:
+        self._regions = list(regions)
+        self._redraw()
+
+    def clear(self) -> None:
+        """Take every outline out of the Camera window.
+
+        Separate from setEnabled(False) because teardown has to remove them
+        without changing what the operator asked for.
+        """
+        window = self._cameraWindow()
+        for item in self.items:
+            if window is not None:
+                window.removeItem(item)
+        self.items = []
+
+    def _redraw(self) -> None:
+        self.clear()
+        if not self._enabled:
+            return
+        window = self._cameraWindow()
+        if window is None:
+            return
+        for region in self._regions:
+            item = Qt.QGraphicsPathItem(_pathForRegion(region))
+            item.setPen(REGION_PEN)
+            item.setAcceptedMouseButtons(Qt.Qt.NoButton)
+            window.addItem(item, z=_MIRROR_Z)
+            self.items.append(item)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/ -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/modules/Autopatch/region_mirrors.py acq4/modules/Autopatch/tests/test_region_mirrors.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'MSG'
+feat: show Autopatch's regions in the Camera window
+
+Read-only path outlines, so Autopatch stays the only place a region can be
+edited and there is no second copy of its state to reconcile.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+MSG
+```
+
+---
+
+### Task 8: Mount Area 1 in the window
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/Autopatch.py`
+- Modify: `acq4/modules/Autopatch/search_panel.py`
+- Test: `acq4/modules/Autopatch/tests/test_window_integration.py`
+- Test: `acq4/modules/Autopatch/tests/test_search_panel.py`
+
+**Interfaces:**
+- Consumes: `RegionPanel` (Tasks 3–5), `PinnedFrameMirror` (Task 6), `CameraMirror` (Task 7), `Slice.setRegions` (Task 1).
+- Produces: `AutopatchWindow.regionPanel`, `AutopatchWindow._onRegionsEdited(regions)`, `AutopatchWindow._cameraWindow()`.
+
+**This task owns every call site of the controls it moves.** Derived from `git grep`, not from memory — a breaking API change whose signature-owning task does not own all its callers leaves a red tree at an intermediate commit, which is what happened in P2c-1.
+
+`SearchPanel` loses: `sigAddRegionRequested` (line 32), `shapeCombo` (95–102), `addRegionBtn` (104–109), the `"Region shape"` form row (118), the `addRegionBtn` layout add (123), the `addRegionBtn.clicked` connection (136), `regionShape()` (179–181), and both entries in `_applyLock` (241–242).
+
+`test_search_panel.py` loses the cases at lines 214–216, 242–243, 269, 276–277 and 287–288 — every assertion about `addRegionBtn`, `shapeCombo`, `regionShape`, or `sigAddRegionRequested`. Their coverage now lives in `test_region_panel.py`.
+
+`test_window_integration.py` needs three edits, and the ~20 `win.addRegionHere()` calls are unaffected because that method keeps its name and behaviour:
+
+- `test_add_region_here_builds_the_shape_area_2_selects` (~line 688) — rename to `..._the_shape_area_1_selects`, retarget to `win.regionPanel.shapeCombo`, and drop its now-false opening comment ("Until Area 1 can draw ROIs, this selector is the only way to seed a non-rectangular region").
+- `test_area_2_is_locked_until_a_slice_exists` (~line 1417) — it asserts on `win.searchPanel.addRegionBtn`, which no longer exists. Point it at a control Area 2 still owns (`win.searchPanel.nearDepthSpin`), and add the Area 1 equivalent from the new tests below.
+- `test_new_slice_reports_a_missing_storage_directory_in_area_2` (~line 1402) — leave it alone here; Task 9 rewrites it.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `acq4/modules/Autopatch/tests/test_window_integration.py`, following that file's existing fixture conventions for building a window with a fake camera:
+
+These use the `win` fixture that file already defines (`_makeWindow(tmp_path)` — a window with a loaded no-op protocol, a camera-backed selector, and a manager over a real temporary directory):
+
+```python
+def test_a_new_slice_leaves_area_1_empty_and_live(win):
+    # A Slice is fresh tissue with no regions, and Area 1 has to say so: an
+    # outline left from the last slice is a coordinate the operator might trust.
+    win.addRegionHere()
+    assert win.regionPanel.regions()
+
+    win.newSlice()
+
+    assert win.regionPanel.regions() == []
+    assert win.regionPanel.addRegionBtn.isEnabled()
+
+
+def test_seeding_a_region_draws_it_in_area_1(win):
+    win.addRegionHere()
+
+    assert len(win.regionPanel.regions()) == 1
+    assert win.regionPanel.regions() == win.slice.regions
+
+
+def test_add_region_here_seeds_a_polygon_when_area_1_asks_for_one(win):
+    # PolygonRegion has had no control able to produce it since P2c-1.
+    from acq4.experiment.search_region import PolygonRegion
+
+    win.newSlice()
+    win.regionPanel.shapeCombo.setCurrentIndex(
+        win.regionPanel.shapeCombo.findData("polygon")
+    )
+
+    win.addRegionHere()
+
+    region = win.slice.regions[0]
+    assert isinstance(region, PolygonRegion)
+    # Four corners of the same 3x3-field box the other two shapes get, so the
+    # button places a region of a known size whichever shape is selected.
+    assert len(region.vertices) == 4
+    assert len(win.slice.tileGrid()) > 1
+
+
+def test_editing_a_region_in_area_1_reaches_the_slice(win):
+    win.newSlice()
+    edited = RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+
+    win.regionPanel.sigRegionsChanged.emit([edited])
+
+    assert win.slice.regions == [edited]
+
+
+def test_editing_a_region_refreshes_the_survey_readout(win):
+    # The readout counts tiles over the regions, so an edit that did not refresh
+    # it would go on reporting the survey's size for a region that is gone.
+    win.newSlice()
+    win.addRegionHere()
+    before = win.searchPanel.surveyLabel.text()
+
+    win.regionPanel.sigRegionsChanged.emit(
+        [RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)]
+    )
+
+    assert win.searchPanel.surveyLabel.text() != before
+
+
+def test_a_region_edit_with_no_slice_is_ignored(win):
+    # Area 1's controls are gated on a slice existing, but a signal is not a
+    # permission check, and a traceback on the GUI thread is not a second line
+    # of defence.
+    assert win.slice is None
+
+    win.regionPanel.sigRegionsChanged.emit([])
+
+    assert win.slice is None
+
+
+def test_area_1_is_locked_until_a_slice_exists(win):
+    assert not win.regionPanel.addRegionBtn.isEnabled()
+
+    win.newSlice()
+
+    assert win.regionPanel.addRegionBtn.isEnabled()
+
+
+def test_a_running_run_locks_area_1(win):
+    win.newSlice()
+
+    win.statusPanel.sigInteractionLocked.emit(True)
+    win.statusPanel.sigStatusChanged.emit("running")
+
+    assert not win.regionPanel.addRegionBtn.isEnabled()
+
+
+def test_a_paused_run_unlocks_area_1(win):
+    # The other side of the gate, wired through the same two window-level
+    # connections rather than by calling the panel directly.
+    win.newSlice()
+    win.statusPanel.sigInteractionLocked.emit(True)
+    win.statusPanel.sigStatusChanged.emit("running")
+
+    win.statusPanel.sigStatusChanged.emit("paused")
+
+    assert win.regionPanel.addRegionBtn.isEnabled()
+
+
+def test_the_mirror_checkbox_drives_the_camera_mirror(win):
+    win.newSlice()
+    win.addRegionHere()
+
+    win.regionPanel.mirrorCheck.setChecked(True)
+
+    assert win._cameraMirror._enabled
+    assert win._cameraMirror._regions == win.slice.regions
+
+
+def test_teardown_takes_the_mirrored_outlines_out_of_the_camera_window(win):
+    # A camera window has to be supplied for this to test anything: _FakeManager
+    # has no Camera module, so _cameraWindow() returns None and the mirror holds
+    # nothing whether or not teardown clears it. Asserting an empty list against
+    # a mirror that was never able to draw is asserting a default.
+    drawn = []
+    fakeCameraWindow = SimpleNamespace(
+        addItem=lambda item, **kwds: drawn.append(item),
+        removeItem=drawn.remove,
+    )
+    win._cameraMirror._cameraWindow = lambda: fakeCameraWindow
+    win.newSlice()
+    win.addRegionHere()
+    win.regionPanel.mirrorCheck.setChecked(True)
+    assert drawn, "nothing was mirrored, so teardown has nothing to prove"
+
+    win.teardown()
+
+    assert drawn == []
+```
+
+The pinned-frame mirror's teardown is proven in Task 6 (`test_unbinding_releases_the_source`), where a source exists to release; there is no imaging control behind `_FakeManager` for it to have bound here.
+
+`RectRegion` is already imported at the top of that file. There is no Camera module behind `_FakeManager`, so `_cameraWindow()` returns `None` and the Camera mirror's `items` stay empty in these tests — which is why the mirror's drawing is tested against a fake window in Task 7 and only its *wiring* is tested here.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py -k "area_1 or mirror or seeds" -v`
+
+Expected: FAIL — `AttributeError: 'AutopatchWindow' object has no attribute 'regionPanel'`.
+
+- [ ] **Step 3: Strip the moved controls out of `SearchPanel`**
+
+Apply every deletion listed in the Interfaces block above to `acq4/modules/Autopatch/search_panel.py`, and update its module docstring to drop "region seeding":
+
+```python
+"""SearchPanel: Area 2's cell-finding config -- the search constraints that
+parameterise a cell producer, and a survey progress readout."""
+```
+
+Delete the corresponding cases from `test_search_panel.py`.
+
+- [ ] **Step 4: Write the window integration**
+
+In `acq4/modules/Autopatch/Autopatch.py`:
+
+Imports:
+
+```python
+from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
+
+from .region_mirrors import CameraMirror, PinnedFrameMirror
+from .region_panel import RegionPanel
+```
+
+In `__init__`, replace the Area 1 block (the comment and `newSliceBtn` block) with:
+
+```python
+        self.newSliceBtn = Qt.QPushButton("New slice")
+        self.newSliceBtn.setToolTip(
+            "Discard the current slice -- its regions, coverage, and queued "
+            "cells -- and start a fresh one for newly mounted tissue."
+        )
+        self.regionPanel = RegionPanel()
+        self.area1Box.layout().addWidget(self.newSliceBtn)
+        self.area1Box.layout().addWidget(self.regionPanel)
+
+        self._pinnedFrameMirror = PinnedFrameMirror(self.regionPanel.view)
+        self._cameraMirror = CameraMirror(self._cameraWindow)
+```
+
+Replace the left-column layout so Area 1 can be dragged large — a region spans a slice, and a fixed-height box makes drawing one an exercise in patience:
+
+```python
+        leftCol = Qt.QSplitter(Qt.Qt.Vertical)
+        leftCol.addWidget(self.area1Box)
+        leftCol.addWidget(self.area2Box)
+        # Area 1 is the view; Area 2 is four spin boxes and a readout.
+        leftCol.setStretchFactor(0, 3)
+        leftCol.setStretchFactor(1, 1)
+
+        rightCol = Qt.QVBoxLayout()
+        rightCol.addWidget(self.area3Box)
+        rightCol.addWidget(self.area4Box)
+        rightCol.addWidget(self.area5Box)
+        rightColWidget = Qt.QWidget()
+        rightColWidget.setLayout(rightCol)
+
+        outer = Qt.QHBoxLayout()
+        outer.addWidget(leftCol, 2)
+        outer.addWidget(rightColWidget, 1)
+        self.setLayout(outer)
+```
+
+Wiring, beside the existing connections:
+
+```python
+        self.regionPanel.sigAddRegionRequested.connect(self.addRegionHere)
+        self.regionPanel.sigRegionsChanged.connect(self._onRegionsEdited)
+        self.regionPanel.mirrorCheck.toggled.connect(self._cameraMirror.setEnabled)
+        self.statusPanel.sigInteractionLocked.connect(
+            self.regionPanel.setInteractionLocked
+        )
+        self.statusPanel.sigStatusChanged.connect(self.regionPanel.setRunStatus)
+```
+
+Delete the old `self.searchPanel.sigAddRegionRequested.connect(self.addRegionHere)` line.
+
+Add the new methods:
+
+```python
+    def _cameraWindow(self):
+        """The Camera module's window, or None if there is not one.
+
+        Not having one is ordinary -- a rig with the module unloaded, or a
+        headless test -- and both mirrors treat it as nothing to do rather than
+        as a failure.
+        """
+        if self.manager is None:
+            return None
+        try:
+            return self.manager.getModule("Camera").window()
+        except Exception:
+            return None
+
+    def _onRegionsEdited(self, regions) -> None:
+        """Take Area 1's edited region list as the slice's regions.
+
+        A wholesale swap, which is what makes this safe to do while a producer
+        may be reading regions on the worker thread (see Slice.setRegions).
+
+        A signal is not a permission check: Area 1's controls are gated on a
+        slice existing, but arriving here without one must not raise on the GUI
+        thread.
+        """
+        if self.slice is None:
+            return
+        self.slice.setRegions(regions)
+        self._cameraMirror.setRegions(regions)
+        self._refreshSurveyStats()
+```
+
+In `_startSlice`, after `self.searchPanel.setSliceReady(True)`:
+
+```python
+        self.regionPanel.setSliceReady(True)
+        # A fresh Slice has no regions, and an outline left from the last one is
+        # a coordinate on tissue that may no longer be there.
+        self.regionPanel.setRegions([])
+        self._cameraMirror.setRegions([])
+        self._bindPinnedFrames(camera)
+```
+
+and add:
+
+```python
+    def _bindPinnedFrames(self, camera) -> None:
+        """Mirror `camera`'s pinned frames into Area 1's view.
+
+        Bound here rather than at construction because this is the first point
+        at which a camera is known to be selected, and both routes into a slice
+        pass through it.
+        """
+        window = self._cameraWindow()
+        if window is None:
+            return
+        try:
+            imagingCtrl = window.getInterfaceForDevice(camera.name()).imagingCtrl
+        except (KeyError, AttributeError):
+            return
+        self._pinnedFrameMirror.bind(imagingCtrl)
+```
+
+In `addRegionHere`, replace the `regionClass` selection and the `addRegion` call:
+
+```python
+        shape = self.regionPanel.regionShape()
+        x0, y0, x1, y1 = cx - w / 2, cy - h / 2, cx + w / 2, cy + h / 2
+        if shape == "polygon":
+            # The same box, as a polygon: the button places a region of a known
+            # size, and the shape selector says what kind. A four-vertex seed is
+            # also the readiest thing to reshape into the outline actually
+            # wanted, which is the point of choosing polygon at all.
+            region = PolygonRegion(((x0, y0), (x1, y0), (x1, y1), (x0, y1)))
+        else:
+            regionClass = EllipseRegion if shape == "ellipse" else RectRegion
+            region = regionClass(x0, y0, x1, y1)
+        self.slice.addRegion(region)
+        self.regionPanel.setRegions(self.slice.regions)
+        self._cameraMirror.setRegions(self.slice.regions)
+        self._refreshSurveyStats()
+```
+
+In `newSlice`, after `self.cellPanel.clearCells()`:
+
+```python
+        self.regionPanel.setRegions([])
+        self._cameraMirror.setRegions([])
+```
+
+In `teardown`, before the existing orchestrator release:
+
+```python
+        self._pinnedFrameMirror.unbind()
+        self._cameraMirror.clear()
+```
+
+- [ ] **Step 5: Run the whole suite**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/ acq4/experiment/tests/ -q`
+
+Expected: PASS, no failures, no warnings. If anything in `test_window_integration.py` or `test_teardown.py` still references `searchPanel.shapeCombo` or `searchPanel.addRegionBtn`, fix it here — this task owns those call sites.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/modules/Autopatch/Autopatch.py acq4/modules/Autopatch/search_panel.py acq4/modules/Autopatch/tests/
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'MSG'
+feat!: give Area 1 the region view and its controls
+
+The shape selector and "Add region here" move from Area 2 to Area 1, where
+the regions they make are now drawn, edited, and mirrored.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+MSG
+```
+
+---
+
+### Task 9: New slice's instruction band
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/status_panel.py`
+- Modify: `acq4/modules/Autopatch/Autopatch.py` (`newSlice`'s `except HelpfulException`)
+- Test: `acq4/modules/Autopatch/tests/test_status_panel.py`
+- Test: `acq4/modules/Autopatch/tests/test_window_integration.py`
+
+**Interfaces:**
+- Consumes: `StatusPanel._updateErrorBand`, `AutopatchWindow.newSlice`.
+- Produces: `StatusPanel.setInstruction(text: str)`, `StatusPanel.clearInstruction()`, `StatusPanel.instruction() -> str`.
+
+**Why:** `newSlice()` currently reports `create_data_dir`'s `HelpfulException` — in practice `"Storage directory has not been set."`, the likeliest first-use failure of the button — through `searchPanel.setError()`, with a comment saying Area 3's band does not exist yet. It does. An instruction is not a `RunErrorRecord`: it gets no traceback, no Copy, and no Show-in-log, because there is nothing in the log to show.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `acq4/modules/Autopatch/tests/test_status_panel.py`:
+
+That file builds its records with a local `_record(exc_type="RuntimeError", message="boom", cell_repr="'c1'")` helper (~line 415), and imports `StatusPanel` **inside each test function** rather than at module level. Follow that convention — open each test below with `from acq4.modules.Autopatch.status_panel import StatusPanel`.
+
+```python
+def test_an_instruction_shows_in_the_band(qapp):
+    panel = StatusPanel()
+
+    panel.setInstruction("Storage directory has not been set.")
+
+    assert panel.instructionLabel.isVisible()
+    assert panel.instructionLabel.text() == "Storage directory has not been set."
+
+
+def test_an_instruction_offers_no_log_link(qapp):
+    # Show in log narrows the log to a run's records. An instruction is
+    # guidance about a click that never started a run, so there is nothing
+    # there to show and a button that led nowhere would be worse than none.
+    panel = StatusPanel()
+
+    panel.setInstruction("Storage directory has not been set.")
+
+    assert not panel.showInLogBtn.isVisible()
+
+
+def test_clearing_an_instruction_empties_the_band(qapp):
+    panel = StatusPanel()
+    panel.setInstruction("Storage directory has not been set.")
+
+    panel.clearInstruction()
+
+    assert panel.instruction() == ""
+    assert not panel.instructionLabel.isVisible()
+
+
+def test_a_run_error_still_wins_the_band(qapp):
+    # A failure that halted a run is about tissue and a pipette in it; guidance
+    # about a button is not. The error is the more urgent of the two and must
+    # not be displaced by a stale instruction.
+    panel = StatusPanel()
+    record = _record()
+    panel.setInstruction("Storage directory has not been set.")
+
+    panel._onRunError(record)
+
+    assert record.exc_message in panel.instructionLabel.text()
+    assert panel.showInLogBtn.isVisible()
+
+
+def test_the_instruction_comes_back_once_the_error_clears(qapp):
+    # The band holds two independent things. Whatever the instruction asked for
+    # has not been done in the meantime, so it is held rather than overwritten.
+    panel = StatusPanel()
+    panel.setInstruction("Storage directory has not been set.")
+    panel._onRunError(_record())
+
+    panel.clearError()
+
+    assert panel.instructionLabel.text() == "Storage directory has not been set."
+    assert not panel.showInLogBtn.isVisible()
+```
+
+In `test_window_integration.py`, rewrite the existing
+`test_new_slice_reports_a_missing_storage_directory_in_area_2` (~line 1402) — it asserts the message lands in Area 2's error label, which is the behaviour this task moves:
+
+```python
+def test_new_slice_reports_a_missing_storage_directory_as_an_instruction(win):
+    # The likeliest first use of New slice is by an operator who has not chosen
+    # a storage directory. They get an instruction in Area 3, and Area 2's error
+    # line -- which is about the search constraints -- stays out of it.
+    from acq4.util.HelpfulException import HelpfulException
+
+    def boom(*a, **k):
+        raise HelpfulException("Storage directory has not been set.")
+
+    win.manager.getCurrentDir = boom
+    win.newSlice()
+
+    assert "Storage directory" in win.statusPanel.instruction()
+    assert "Storage directory" not in win.searchPanel.errorLabel.text()
+
+
+def test_a_successful_new_slice_retracts_the_instruction(win):
+    # The instruction says what to do next; once it has been done it is a lie.
+    from acq4.util.HelpfulException import HelpfulException
+
+    def boom(*a, **k):
+        raise HelpfulException("Storage directory has not been set.")
+
+    original = win.manager.getCurrentDir
+    win.manager.getCurrentDir = boom
+    win.newSlice()
+    assert win.statusPanel.instruction() != ""
+
+    win.manager.getCurrentDir = original
+    win.newSlice()
+
+    assert win.statusPanel.instruction() == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_status_panel.py -k instruction -v`
+
+Expected: FAIL — `AttributeError: 'StatusPanel' object has no attribute 'setInstruction'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `StatusPanel.__init__`, beside `self._lastError`:
+
+```python
+        # Operator guidance about a control, as opposed to a failure that halted
+        # a run. Held separately from _lastError so neither erases the other:
+        # they have different writers, and neither can see the other's
+        # condition.
+        self._instruction = ""
+```
+
+Add:
+
+```python
+    def setInstruction(self, text: str) -> None:
+        """Show operator guidance in the band -- what to do, not what broke.
+
+        For a control that could not proceed, `AutopatchWindow.newSlice()` with
+        no storage directory chosen being the case this exists for. An
+        instruction is deliberately not a RunErrorRecord: no traceback, no Copy,
+        and no Show in log, because no run happened and there is nothing in the
+        log to show.
+        """
+        self._instruction = text
+        self._updateErrorBand()
+
+    def clearInstruction(self) -> None:
+        self._instruction = ""
+        self._updateErrorBand()
+
+    def instruction(self) -> str:
+        """The guidance currently showing, or an empty string."""
+        return self._instruction
+```
+
+Rewrite `_updateErrorBand`:
+
+```python
+    def _updateErrorBand(self) -> None:
+        """Render whichever of the two the band is carrying, the error first.
+
+        A failure that halted a run is about tissue and a pipette in it;
+        guidance about a button is not. The instruction is still held and comes
+        back once the error is cleared, since whatever it asked for has not been
+        done in the meantime.
+        """
+        record = self._lastError
+        if record is not None:
+            self.instructionLabel.setText(f"{record.exc_type}: {record.exc_message}")
+        else:
+            self.instructionLabel.setText(self._instruction)
+        showing = record is not None or bool(self._instruction)
+        self.instructionLabel.setVisible(showing)
+        self.showInLogBtn.setVisible(record is not None)
+```
+
+In `Autopatch.py`'s `newSlice`, replace the `except HelpfulException` body:
+
+```python
+        except HelpfulException as exc:
+            # Guidance, not a failure report: the operator has not chosen a
+            # storage directory, and Area 3's band is where instructions go.
+            # Narrowed to HelpfulException so a genuine programming error (a
+            # missing manager, say) propagates instead of being reported as
+            # storage guidance.
+            self.statusPanel.setInstruction(str(exc))
+            return
+```
+
+and clear it on the success path, immediately after `self.statusPanel.clearError()`:
+
+```python
+        self.statusPanel.clearInstruction()
+```
+
+- [ ] **Step 4: Run the whole suite**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/ acq4/experiment/tests/ -q`
+
+Expected: PASS.
+
+- [ ] **Step 5: Prove the precedence test bites (mutation)**
+
+Temporarily reverse the precedence in `_updateErrorBand` so the instruction wins when both are set.
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_status_panel.py -k wins -v`
+
+Expected: FAIL in `test_a_run_error_still_wins_the_band`. **Record the failing line number.** Revert and re-run green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/modules/Autopatch/status_panel.py acq4/modules/Autopatch/Autopatch.py acq4/modules/Autopatch/tests/
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'MSG'
+feat: instruct the operator when New slice has nowhere to write
+
+A storage directory that was never chosen is guidance, so it lands in Area
+3's band without a traceback or a log link.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+MSG
+```
+
+---
+
+## Final verification
+
+- [ ] Run the full repo suite: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4 -q`. Expected: green, with the Autopatch and experiment counts above their pre-branch numbers (677 in the touched suites, 1127 repo-wide as of `00c75e269`). No skips, no new warnings.
+- [ ] `git log --format='%an %s' _reviewed..HEAD` — every commit authored `Martin Chase (claude)`, and `git log --format=%B _reviewed..HEAD | grep -c "Generated with"` equals the commit count.
+- [ ] Grep the new tests for vacuous assertions: `git grep -n "is False\|== \[\]\|is None" -- 'acq4/modules/Autopatch/tests/test_region*'`. For each, name what primed the state. An assertion whose expected value equals the default is vacuous by construction — six of these were caught on one earlier branch.
+- [ ] Live smoke test, which the headless suite structurally cannot reach:
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python bin/acq4 --config /home/martin/src/acq4/acq4/config/mock/default.cfg -m Autopatch
+```
+
+  Check: New slice enables Area 1; drag out a rectangle, an ellipse, and a polygon and confirm each is tiled by the survey readout; drag and resize one; right-click Remove; tick Mirror to Camera and confirm outlines appear in the Camera window and cannot be grabbed there; pin a frame in the Camera module and confirm it appears in Area 1; start a run and confirm Area 1 locks, pause it and confirm it unlocks; close the window and confirm exit code 0 with no segfault.

--- a/docs/superpowers/plans/2026-08-10-autopatch-area1-region-graphics.md
+++ b/docs/superpowers/plans/2026-08-10-autopatch-area1-region-graphics.md
@@ -149,7 +149,7 @@ Add `SearchRegion` to the existing `search_region` import at the top of the file
 
 - [ ] **Step 2: Run test to verify it fails**
 
-Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -k "mid_scan or takes_effect or copies_so" -v`
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -k "does_not_drop or takes_effect or copies_so or leaves_coverage" -v`
 
 Expected: FAIL — `AttributeError: 'Slice' object has no attribute 'setRegions'`.
 
@@ -213,7 +213,9 @@ Temporarily change `setRegions` to mutate in place:
         self._regions[:] = list(regions)
 ```
 
-Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -k mid_scan -v`
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_slice.py -k does_not_drop -v`
+
+(`-k mid_scan` selects nothing: "mid_scan" appears only in the helper class name, not in any test function's name.)
 
 Expected: FAIL at the `assert laterTiles` line. **Record the file and line number of the failure in your report** — a mutation that fails at a different line has proven something else. Then revert the mutation and re-run to confirm green.
 
@@ -603,12 +605,19 @@ def test_dragging_a_region_reports_the_whole_list(qapp):
     panel.sigRegionsChanged.connect(seen.append)
 
     roi = panel._rois[0]
-    roi.setPos((2.0e-3, 5.0e-3))
+    # finish=False: setPos's own default (finish=True) already emits
+    # sigRegionChangeFinished, which is what a real drag never does mid-gesture
+    # (pg.MouseDragHandler always moves with finish=False and fires the signal
+    # exactly once, from _moveFinished, on release) -- so the explicit emit
+    # below is what stands in for that release.
+    roi.setPos((2.0e-3, 5.0e-3), finish=False)
     roi.sigRegionChangeFinished.emit(roi)
 
     assert len(seen) == 1
     moved, untouched = seen[0]
-    assert moved == RectRegion(2.0e-3, 5.0e-3, 2.4e-3, 5.1e-3)
+    # approx, not ==: the ROI's corners survive a subtract-then-re-add at SI
+    # magnitudes, so 1.0e-3 + 1.4e-3 - 1.0e-3 is not bit-identical to 1.4e-3.
+    assert moved.bounds() == pytest.approx((2.0e-3, 5.0e-3, 2.4e-3, 5.1e-3))
     assert untouched == OTHER
 
 

--- a/docs/superpowers/plans/2026-08-10-autopatch-area1-region-graphics.md
+++ b/docs/superpowers/plans/2026-08-10-autopatch-area1-region-graphics.md
@@ -2,11 +2,15 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Give the Autopatch module an Area 1 view where the operator sees the Camera module's pinned frames, draws and edits search regions over them in three shapes, and optionally mirrors those regions into the Camera window.
+**Goal:** Give the Autopatch module an Area 1 view where the operator sees the Camera module's pinned frames, seeds and edits search regions over them in three shapes, and optionally mirrors those regions into the Camera window.
+
+**Take pyqtgraph's tools as they come.** Region creation follows the pattern acq4's own Camera module already uses (`ROIPlotter._addRectROI`/`_addEllipseROI`/`_addPolygonROI`, `CameraWindow.py:509`): a shape control seeds an ROI at a known size and position, and the operator drags, resizes, and reshapes it with pyqtgraph's stock handles. `pg.PolyLineROI` already inserts a vertex where an edge is clicked (`segmentClicked`) and removes handles individually, so outlining a cortical layer needs no code of ours. pyqtgraph offers no drag-out-a-new-ROI gesture and neither does acq4; do not build one. The single deliberate departure is documented in Task 2.
 
 **Architecture:** A new `RegionPanel` owns a `pg.GraphicsView`/`pg.ViewBox` in global metres and renders a list of `SearchRegion` objects as pyqtgraph ROIs, emitting the whole list back on any edit. `AutopatchWindow` is the only thing that knows about both the panel and the `Slice`, and pushes edits into `Slice.setRegions()` — a wholesale list swap, because the cell producer reads regions on the worker thread. Two one-way mirrors (Camera pinned frames in, region outlines out) are display-only objects with no state of their own.
 
-**Tech Stack:** Python 3.12, PyQt via `acq4.util.Qt`, pyqtgraph (local checkout at `/home/martin/src/acq4/pyqtgraph`), pytest.
+**Tech Stack:** Python 3.12, PyQt via `acq4.util.Qt`, pyqtgraph, pytest.
+
+> **Which pyqtgraph runs:** the `acq4-gl` environment imports pyqtgraph from `site-packages`, *not* from the checkout at `/home/martin/src/acq4/pyqtgraph`. Read the checkout for source if you like, but verify behaviour against the interpreter.
 
 **Spec:** `docs/superpowers/specs/2026-08-10-autopatch-area1-region-graphics-design.md`
 
@@ -27,11 +31,10 @@
 
 | path | responsibility |
 |---|---|
-| `acq4/modules/Autopatch/region_panel.py` | `RegionPanel` widget, the shape↔ROI adapters, and `_DrawingViewBox`. |
+| `acq4/modules/Autopatch/region_panel.py` | `RegionPanel` widget and the shape↔ROI adapters. |
 | `acq4/modules/Autopatch/region_mirrors.py` | `PinnedFrameMirror` (Camera→Autopatch) and `CameraMirror` (Autopatch→Camera). Display only, no region state. |
 | `acq4/modules/Autopatch/tests/test_region_adapters.py` | Shape↔ROI round-trips. |
 | `acq4/modules/Autopatch/tests/test_region_panel.py` | Panel rendering, edit signals, gating. |
-| `acq4/modules/Autopatch/tests/test_region_drawing.py` | The draw state machine. |
 | `acq4/modules/Autopatch/tests/test_region_mirrors.py` | Both mirrors, including teardown. |
 
 **Modified:**
@@ -241,11 +244,11 @@ MSG
 - Consumes: `acq4.experiment.search_region.{SearchRegion, RectRegion, EllipseRegion, PolygonRegion}`.
 - Produces:
   - `roiForRegion(region: SearchRegion) -> pg.ROI`
-  - `regionForRoi(roi: pg.ROI) -> SearchRegion`
+  - `regionForRoi(roi: pg.ROI) -> SearchRegion | None` — `None` when the ROI has been dragged into a shape that is not a region
   - `REGION_PEN` — the pen every region ROI draws with.
   - `_AxisAlignedEllipseROI(pg.EllipseROI)`
 
-**Why the ellipse subclass:** `pg.EllipseROI._addHandles` adds a **rotate** handle. `EllipseRegion` is an ellipse inscribed in an axis-aligned box, so a rotated ROI maps back to a region that silently ignores the rotation — the operator would draw one thing and survey another.
+**Why the ellipse subclass — the one place a stock tool is inadequate.** `pg.EllipseROI._addHandles` adds a **rotate** handle. `EllipseRegion` is an ellipse inscribed in an axis-aligned box, so a rotated ROI maps back to a region with the rotation silently dropped: the operator outlines one patch of tissue and the survey tiles another. `ROIPlotter._addEllipseROI` uses the stock class quite correctly, because it only reads the pixels under the ROI and a rotation changes which pixels those are. Here the ROI has to survive a round trip through a shape that cannot express rotation, so the handle has to go. Everything else — `pg.RectROI`, `pg.PolyLineROI`, their handles, their `removable=True` context menu, the `ViewBox`'s pan and zoom — is used exactly as shipped.
 
 - [ ] **Step 1: Write the failing test**
 
@@ -329,6 +332,44 @@ def test_a_roi_dragged_past_its_own_origin_still_makes_a_region(qapp):
     assert regionForRoi(roi) == RECT
 
 
+@pytest.mark.parametrize("size", [(0.0, 0.1e-3), (0.4e-3, 0.0), (0.0, 0.0)])
+def test_an_roi_squashed_flat_reports_no_region(qapp, size):
+    # A pg.RectROI can be dragged to zero extent, and SearchRegion raises on
+    # that. Raising here would surface as a traceback on the GUI thread from
+    # inside a signal handler, mid-drag. One case per axis: a check that only
+    # looks at width passes a test that only squashes height.
+    from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
+
+    roi = roiForRegion(RECT)
+    roi.setSize(size)
+
+    assert regionForRoi(roi) is None
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        # Three vertices on a line: a bounding box with no extent in one axis.
+        [[1.0e-3, 2.0e-3], [1.2e-3, 2.0e-3], [1.4e-3, 2.0e-3]],
+        # Two vertices left after the operator removes handles from a triangle.
+        [[1.0e-3, 2.0e-3], [1.4e-3, 2.02e-3]],
+    ],
+)
+def test_a_polygon_with_no_area_reports_no_region(qapp, points):
+    # The polygon equivalents of a squashed box. Built by construction rather
+    # than by calling roi.setPoints() on a triangle: setPoints() reaches
+    # clearPoints() -> removeHandle() -> removeSegment(), which calls
+    # self.scene().removeItem() and raises AttributeError on an ROI that is not
+    # in a scene. Constructing is the path with no such requirement.
+    import pyqtgraph as pg
+
+    from acq4.modules.Autopatch.region_panel import regionForRoi
+
+    roi = pg.PolyLineROI(points, closed=True)
+
+    assert regionForRoi(roi) is None
+
+
 def test_a_moved_polygon_reports_its_vertices_in_global_coordinates(qapp):
     # A PolyLineROI holds its vertices in ROI-local coordinates, so dragging the
     # body moves the shape without touching them. Reading them raw would put the
@@ -404,25 +445,35 @@ def roiForRegion(region: SearchRegion) -> pg.ROI:
     )
 
 
-def regionForRoi(roi: pg.ROI) -> SearchRegion:
-    """The region `roi` currently describes, in global metres.
+def regionForRoi(roi: pg.ROI) -> SearchRegion | None:
+    """The region `roi` currently describes, or None if it does not describe one.
+
+    An ROI can be dragged flat, and its handles can be dragged collinear;
+    SearchRegion rejects both, since a region with no extent has no tiles. This
+    is reached from a Qt signal while the operator is mid-drag, so it reports
+    the failure by returning None rather than by raising a traceback out of a
+    slot -- the same choice `SearchPanel.constraints()` makes, and for the same
+    reason.
 
     Corner normalization is left to `_BoxRegion.__post_init__`, which already
     orders its corners -- an ROI resized past its own origin reports a negative
     size, and both paths through that hazard should agree by construction rather
     than by two implementations happening to match.
     """
-    if isinstance(roi, pg.PolyLineROI):
-        vertices = []
-        for _, localPos in roi.getLocalHandlePositions():
-            globalPos = roi.mapToParent(localPos)
-            vertices.append((globalPos.x(), globalPos.y()))
-        return PolygonRegion(tuple(vertices))
-    pos = roi.pos()
-    size = roi.size()
-    x0, y0 = pos.x(), pos.y()
-    regionClass = EllipseRegion if isinstance(roi, pg.EllipseROI) else RectRegion
-    return regionClass(x0, y0, x0 + size.x(), y0 + size.y())
+    try:
+        if isinstance(roi, pg.PolyLineROI):
+            vertices = []
+            for _, localPos in roi.getLocalHandlePositions():
+                globalPos = roi.mapToParent(localPos)
+                vertices.append((globalPos.x(), globalPos.y()))
+            return PolygonRegion(tuple(vertices))
+        pos = roi.pos()
+        size = roi.size()
+        x0, y0 = pos.x(), pos.y()
+        regionClass = EllipseRegion if isinstance(roi, pg.EllipseROI) else RectRegion
+        return regionClass(x0, y0, x0 + size.x(), y0 + size.y())
+    except ValueError:
+        return None
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
@@ -585,6 +636,59 @@ def test_a_removed_roi_leaves_the_view(qapp):
     assert roi.scene() is None
 
 
+def test_adding_a_polygon_vertex_reaches_the_reported_region(qapp):
+    # Reshaping a polygon is pyqtgraph's own segmentClicked inserting a handle
+    # where an edge was clicked -- the mechanism that makes outlining a cortical
+    # layer possible without any drawing code of ours. Pinned here because the
+    # panel depends on it: a handle added this way has to arrive in the region
+    # the panel reports, in global coordinates.
+    #
+    # segments[0] is the *closing* edge (last vertex back to first), not the
+    # first one, so the new vertex lands between the triangle's third and first
+    # points. Membership rather than a position is asserted for that reason --
+    # pyqtgraph's ordering is its own business as long as handle order,
+    # getState()['points'], and shape() agree, which they do.
+    triangle = PolygonRegion(
+        ((1.0e-3, 2.0e-3), (1.4e-3, 2.02e-3), (1.1e-3, 2.1e-3))
+    )
+    panel = makePanel()
+    panel.setRegions([triangle])
+    roi = panel._rois[0]
+
+    roi.segmentClicked(roi.segments[0], pos=Qt.QPointF(1.2e-3, 2.01e-3))
+
+    reported = panel.regions()[0]
+    assert len(reported.vertices) == 4
+    assert (1.2e-3, 2.01e-3) in [
+        (pytest.approx(x), pytest.approx(y)) for x, y in reported.vertices
+    ]
+
+
+def test_an_roi_squashed_flat_stays_on_screen_but_is_not_reported(qapp):
+    # Removing it would delete the operator's work mid-drag; reporting it would
+    # hand the slice a region with no tiles. It stays visible and uncounted.
+    panel = makePanel()
+    panel.setRegions([RECT, OTHER])
+
+    panel._rois[0].setSize((0.0, 0.1e-3))
+
+    assert len(panel._rois) == 2
+    assert panel.regions() == [OTHER]
+
+
+def test_fit_to_regions_ignores_a_squashed_roi(qapp):
+    # regions() drops it, so fitToRegions must read through regions() rather
+    # than the ROI list, or it frames a bounding box it cannot compute.
+    panel = makePanel()
+    panel.setRegions([RECT])
+    panel._rois[0].setSize((0.0, 0.0))
+    before = panel.view.viewRange()
+
+    panel.fitToRegions()
+
+    assert panel.view.viewRange() == before
+
+
 def test_the_shape_selector_offers_all_three_shapes(qapp):
     # PolygonRegion has been implemented and tested since P2c-1 with no control
     # able to produce one; a cortical layer is the reason regions became shapes.
@@ -688,10 +792,7 @@ class RegionPanel(Qt.QWidget):
             ("Polygon", "polygon"),
         ):
             self.shapeCombo.addItem(label, key)
-        self.shapeCombo.setToolTip(
-            "The shape drawn by dragging in the view, and the shape "
-            '"Add region here" seeds.'
-        )
+        self.shapeCombo.setToolTip('The shape "Add region here" seeds.')
 
         self.addRegionBtn = Qt.QPushButton("Add region here")
         self.addRegionBtn.setToolTip(
@@ -722,8 +823,13 @@ class RegionPanel(Qt.QWidget):
 
     # ---- regions ----
     def regions(self) -> list[SearchRegion]:
-        """The regions currently drawn, in the order they were added."""
-        return [regionForRoi(roi) for roi in self._rois]
+        """The regions currently drawn, in the order they were added.
+
+        An ROI the operator has squashed flat describes no region, and is left
+        out rather than reported or raised over: it stays on screen to be pulled
+        back into shape, and contributes no tiles until it is.
+        """
+        return [r for r in (regionForRoi(roi) for roi in self._rois) if r is not None]
 
     def setRegions(self, regions) -> None:
         """Draw `regions`, replacing whatever is drawn now.
@@ -771,9 +877,9 @@ class RegionPanel(Qt.QWidget):
         how a view ends up at a scale the operator cannot recover from, and the
         button is live before anything has been drawn.
         """
-        if not self._rois:
+        bounds = [region.bounds() for region in self.regions()]
+        if not bounds:
             return
-        bounds = [regionForRoi(roi).bounds() for roi in self._rois]
         x0 = min(b[0] for b in bounds)
         y0 = min(b[1] for b in bounds)
         x1 = max(b[2] for b in bounds)
@@ -816,364 +922,14 @@ MSG
 
 ---
 
-### Task 4: Drawing regions with the mouse
-
-**Files:**
-- Modify: `acq4/modules/Autopatch/region_panel.py`
-- Test: `acq4/modules/Autopatch/tests/test_region_drawing.py`
-
-**Interfaces:**
-- Consumes: `RegionPanel`, `regionShape()`, `_attachRoi`, `roiForRegion` from Tasks 2–3.
-- Produces:
-  - `_DrawingViewBox(pg.ViewBox)` with `sigRegionDrawn(object)` (a `SearchRegion`), `setDrawShape(shape: str | None)`, and the four plain entry points `beginDraw(pt)`, `dragDraw(pt)`, `endDraw(pt)`, `addVertex(pt)`, `closePolygon()` — all taking `(x, y)` tuples in global metres.
-  - `RegionPanel.view` becomes a `_DrawingViewBox`.
-
-**Why plain entry points:** the Qt handlers (`mouseDragEvent`, `mouseClickEvent`) do one thing — map the event's scene position into view coordinates and call one of these. All the state and all the geometry live behind methods a test can call directly with metre coordinates, so the drawing rules are covered without synthesising Qt mouse events. This is the same injected-seam split that made `tile_detector` testable.
-
-- [ ] **Step 1: Write the failing test**
-
-Create `acq4/modules/Autopatch/tests/test_region_drawing.py`:
-
-```python
-"""Tests for drawing a region with the mouse: the drag and click state machine
-behind Area 1's view, driven directly in global coordinates."""
-
-import pytest
-
-from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
-from acq4.util import Qt
-
-
-@pytest.fixture(scope="module")
-def qapp():
-    return Qt.QApplication.instance() or Qt.QApplication([])
-
-
-def makeBox(shape):
-    from acq4.modules.Autopatch.region_panel import _DrawingViewBox
-
-    box = _DrawingViewBox()
-    box.setDrawShape(shape)
-    return box
-
-
-def drawn(box):
-    seen = []
-    box.sigRegionDrawn.connect(seen.append)
-    return seen
-
-
-def test_dragging_out_a_rectangle_reports_one(qapp):
-    box = makeBox("rect")
-    seen = drawn(box)
-
-    box.beginDraw((1.0e-3, 2.0e-3))
-    box.dragDraw((1.2e-3, 2.05e-3))
-    box.endDraw((1.4e-3, 2.1e-3))
-
-    assert seen == [RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)]
-
-
-def test_dragging_out_an_ellipse_reports_one(qapp):
-    box = makeBox("ellipse")
-    seen = drawn(box)
-
-    box.beginDraw((1.0e-3, 2.0e-3))
-    box.endDraw((1.4e-3, 2.1e-3))
-
-    assert seen == [EllipseRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)]
-
-
-def test_a_drag_that_ends_where_it_started_reports_nothing(qapp):
-    # A region needs extent in both axes -- SearchRegion raises without it --
-    # and a stray click in the view is the ordinary way to produce this. It has
-    # to be dropped here, silently: nothing in this panel may raise on the GUI
-    # thread.
-    box = makeBox("rect")
-    seen = drawn(box)
-
-    box.beginDraw((1.0e-3, 2.0e-3))
-    box.endDraw((1.0e-3, 2.0e-3))
-
-    assert seen == []
-
-
-def test_a_drag_with_no_height_reports_nothing(qapp):
-    # Zero extent in either axis alone is still not a region. Tested per axis:
-    # a check that only looks at width passes a test that only drags a point.
-    box = makeBox("rect")
-    seen = drawn(box)
-
-    box.beginDraw((1.0e-3, 2.0e-3))
-    box.endDraw((1.4e-3, 2.0e-3))
-
-    assert seen == []
-
-
-def test_a_drag_with_no_width_reports_nothing(qapp):
-    box = makeBox("rect")
-    seen = drawn(box)
-
-    box.beginDraw((1.0e-3, 2.0e-3))
-    box.endDraw((1.0e-3, 2.1e-3))
-
-    assert seen == []
-
-
-def test_a_backwards_drag_still_reports_the_box_drawn(qapp):
-    # Dragging up and to the left is as ordinary as down and to the right.
-    box = makeBox("rect")
-    seen = drawn(box)
-
-    box.beginDraw((1.4e-3, 2.1e-3))
-    box.endDraw((1.0e-3, 2.0e-3))
-
-    assert seen == [RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)]
-
-
-def test_clicking_three_vertices_and_closing_reports_a_polygon(qapp):
-    box = makeBox("polygon")
-    seen = drawn(box)
-
-    box.addVertex((1.0e-3, 2.0e-3))
-    box.addVertex((1.4e-3, 2.02e-3))
-    box.addVertex((1.1e-3, 2.1e-3))
-    box.closePolygon()
-
-    assert seen == [
-        PolygonRegion(((1.0e-3, 2.0e-3), (1.4e-3, 2.02e-3), (1.1e-3, 2.1e-3)))
-    ]
-
-
-def test_closing_a_polygon_with_two_vertices_reports_nothing(qapp):
-    box = makeBox("polygon")
-    seen = drawn(box)
-
-    box.addVertex((1.0e-3, 2.0e-3))
-    box.addVertex((1.4e-3, 2.02e-3))
-    box.closePolygon()
-
-    assert seen == []
-
-
-def test_closing_a_polygon_clears_it_for_the_next_one(qapp):
-    # Vertices carried over would splice two regions the operator drew
-    # separately into one shape spanning both.
-    box = makeBox("polygon")
-    seen = drawn(box)
-
-    for pt in ((1.0e-3, 2.0e-3), (1.4e-3, 2.02e-3), (1.1e-3, 2.1e-3)):
-        box.addVertex(pt)
-    box.closePolygon()
-    for pt in ((3.0e-3, 1.0e-3), (3.6e-3, 1.02e-3), (3.2e-3, 1.2e-3)):
-        box.addVertex(pt)
-    box.closePolygon()
-
-    assert len(seen) == 2
-    assert seen[1].vertices == (
-        (3.0e-3, 1.0e-3),
-        (3.6e-3, 1.02e-3),
-        (3.2e-3, 1.2e-3),
-    )
-
-
-def test_with_no_shape_set_dragging_reports_nothing(qapp):
-    # No draw shape is the panel locked, or a slice that does not exist yet.
-    # The drag has to fall through to the ViewBox so the view still pans.
-    box = makeBox(None)
-    seen = drawn(box)
-
-    box.beginDraw((1.0e-3, 2.0e-3))
-    box.endDraw((1.4e-3, 2.1e-3))
-
-    assert seen == []
-
-
-def test_a_drawn_region_reaches_the_panel(qapp):
-    from acq4.modules.Autopatch.region_panel import RegionPanel
-
-    panel = RegionPanel()
-    panel.shapeCombo.setCurrentIndex(panel.shapeCombo.findData("rect"))
-    seen = []
-    panel.sigRegionsChanged.connect(seen.append)
-
-    panel.view.beginDraw((1.0e-3, 2.0e-3))
-    panel.view.endDraw((1.4e-3, 2.1e-3))
-
-    assert seen == [[RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)]]
-    assert len(panel._rois) == 1
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_region_drawing.py -v`
-
-Expected: FAIL — `ImportError: cannot import name '_DrawingViewBox'`.
-
-- [ ] **Step 3: Write minimal implementation**
-
-Insert `_DrawingViewBox` into `acq4/modules/Autopatch/region_panel.py`, above `RegionPanel`:
-
-```python
-class _DrawingViewBox(pg.ViewBox):
-    """The Area 1 view box, in the two modes a region view needs.
-
-    With no draw shape set it is an ordinary ViewBox: drags pan, wheels zoom.
-    With one set, a drag lays out a rectangle or ellipse and clicks lay out a
-    polygon's vertices.
-
-    The Qt handlers do exactly one thing -- map an event's scene position into
-    view coordinates and call one of the plain entry points below. Every rule
-    about what counts as a region lives behind those methods, so the drawing
-    logic is exercised in global metres without synthesising mouse events.
-    """
-
-    sigRegionDrawn = Qt.Signal(object)  # SearchRegion
-
-    def __init__(self, *args, **kwds):
-        super().__init__(*args, **kwds)
-        self._drawShape = None
-        self._dragStart = None
-        self._vertices: list[tuple[float, float]] = []
-
-    def setDrawShape(self, shape) -> None:
-        """Draw `shape` ("rect"/"ellipse"/"polygon") on drag, or None to pan.
-
-        Switching shape abandons a polygon in progress: its half-drawn vertices
-        belong to the shape the operator was drawing, not the next one.
-        """
-        self._drawShape = shape
-        self._dragStart = None
-        self._vertices = []
-
-    # ---- entry points ----
-    def beginDraw(self, pt) -> None:
-        self._dragStart = (pt[0], pt[1])
-
-    def dragDraw(self, pt) -> None:
-        """Called for each intermediate position of a drag.
-
-        Nothing is reported mid-drag: a drag in progress is not a decision.
-        """
-
-    def endDraw(self, pt) -> None:
-        start, self._dragStart = self._dragStart, None
-        if self._drawShape not in ("rect", "ellipse") or start is None:
-            return
-        x0, y0 = start
-        x1, y1 = pt[0], pt[1]
-        if x0 == x1 or y0 == y1:
-            # A region needs extent in both axes. A stray click in the view is
-            # the ordinary way to produce this, so it is dropped rather than
-            # raised: nothing here may raise on the GUI thread.
-            return
-        regionClass = EllipseRegion if self._drawShape == "ellipse" else RectRegion
-        # The corners arrive in whatever order they were dragged; _BoxRegion
-        # orders them.
-        self.sigRegionDrawn.emit(regionClass(x0, y0, x1, y1))
-
-    def addVertex(self, pt) -> None:
-        if self._drawShape != "polygon":
-            return
-        self._vertices.append((pt[0], pt[1]))
-
-    def closePolygon(self) -> None:
-        """Close the polygon under construction and report it, if it is one.
-
-        The vertices are cleared either way: carried over, they would splice the
-        abandoned shape onto the next one the operator draws.
-        """
-        vertices, self._vertices = self._vertices, []
-        if self._drawShape != "polygon" or len(vertices) < 3:
-            return
-        xs = [x for x, _ in vertices]
-        ys = [y for _, y in vertices]
-        if min(xs) == max(xs) or min(ys) == max(ys):
-            return
-        self.sigRegionDrawn.emit(PolygonRegion(tuple(vertices)))
-
-    # ---- Qt handlers ----
-    def mouseDragEvent(self, ev, axis=None):
-        if self._drawShape not in ("rect", "ellipse"):
-            super().mouseDragEvent(ev, axis=axis)
-            return
-        ev.accept()
-        pt = self.mapSceneToView(ev.scenePos())
-        if ev.isStart():
-            self.beginDraw((pt.x(), pt.y()))
-        elif ev.isFinish():
-            self.endDraw((pt.x(), pt.y()))
-        else:
-            self.dragDraw((pt.x(), pt.y()))
-
-    def mouseClickEvent(self, ev):
-        if self._drawShape != "polygon":
-            super().mouseClickEvent(ev)
-            return
-        ev.accept()
-        pt = self.mapSceneToView(ev.scenePos())
-        if ev.double():
-            self.closePolygon()
-        else:
-            self.addVertex((pt.x(), pt.y()))
-```
-
-In `RegionPanel.__init__`, build the drawing view box and wire it:
-
-```python
-        self.view = _DrawingViewBox()
-```
-
-and, after the other connections:
-
-```python
-        self.view.sigRegionDrawn.connect(self._onRegionDrawn)
-        self.shapeCombo.currentIndexChanged.connect(self._applyDrawShape)
-        self._applyDrawShape()
-```
-
-Add the two methods to `RegionPanel`:
-
-```python
-    def _onRegionDrawn(self, region) -> None:
-        self._attachRoi(roiForRegion(region))
-        self.sigRegionsChanged.emit(self.regions())
-
-    def _applyDrawShape(self, *_args) -> None:
-        self.view.setDrawShape(self.regionShape())
-```
-
-- [ ] **Step 4: Run tests to verify they pass**
-
-Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/ -q`
-
-Expected: PASS, no failures.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git rev-parse --show-toplevel && git branch --show-current
-git add acq4/modules/Autopatch/region_panel.py acq4/modules/Autopatch/tests/test_region_drawing.py
-git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'MSG'
-feat: draw regions with the mouse in Area 1
-
-Drag lays out a rectangle or ellipse, clicks lay out a polygon's vertices,
-and a shape with no extent in both axes is dropped rather than raised.
-
-🤖 Generated with [Claude Code](https://claude.ai/code)
-MSG
-```
-
----
-
-### Task 5: The editing gate
+### Task 4: The editing gate
 
 **Files:**
 - Modify: `acq4/modules/Autopatch/region_panel.py`
 - Test: `acq4/modules/Autopatch/tests/test_region_panel.py`
 
 **Interfaces:**
-- Consumes: `RegionPanel` from Tasks 3–4.
+- Consumes: `RegionPanel` from Task 3.
 - Produces:
   - `RegionPanel.setInteractionLocked(locked: bool)`
   - `RegionPanel.setSliceReady(ready: bool)`
@@ -1197,7 +953,6 @@ def test_a_panel_with_no_slice_cannot_be_drawn_on(qapp):
 
     assert not panel.addRegionBtn.isEnabled()
     assert not panel.shapeCombo.isEnabled()
-    assert panel.view._drawShape is None
 
 
 def test_a_slice_makes_the_controls_live(qapp):
@@ -1206,7 +961,6 @@ def test_a_slice_makes_the_controls_live(qapp):
 
     assert panel.addRegionBtn.isEnabled()
     assert panel.shapeCombo.isEnabled()
-    assert panel.view._drawShape == "rect"
 
 
 def test_a_running_run_locks_editing(qapp):
@@ -1218,7 +972,6 @@ def test_a_running_run_locks_editing(qapp):
     panel.setRunStatus("running")
 
     assert not panel.addRegionBtn.isEnabled()
-    assert panel.view._drawShape is None
     assert not panel._rois[0].translatable
     assert not panel._rois[0].resizable
     assert not panel._rois[0].removable
@@ -1236,7 +989,6 @@ def test_a_paused_run_unlocks_editing(qapp):
     panel.setRunStatus("paused")
 
     assert panel.addRegionBtn.isEnabled()
-    assert panel.view._drawShape == "rect"
     assert panel._rois[0].translatable
     assert panel._rois[0].resizable
     assert panel._rois[0].removable
@@ -1253,7 +1005,6 @@ def test_surveying_locks_editing_even_though_pause_was_pressed(qapp):
     panel.setRunStatus("surveying")
 
     assert not panel.addRegionBtn.isEnabled()
-    assert panel.view._drawShape is None
 
 
 def test_resuming_from_paused_locks_editing_again(qapp):
@@ -1313,7 +1064,7 @@ In `RegionPanel.__init__`, before the connections:
         self._runStatus = None
 ```
 
-and call `self._applyLock()` at the end of `__init__` instead of `self._applyDrawShape()`.
+and call `self._applyLock()` at the end of `__init__`, after the connections.
 
 Add to `RegionPanel`:
 
@@ -1360,7 +1111,6 @@ Add to `RegionPanel`:
         editable = self._editable()
         self.addRegionBtn.setEnabled(editable)
         self.shapeCombo.setEnabled(editable)
-        self._applyDrawShape()
         for roi in self._rois:
             self._applyRoiLock(roi)
 
@@ -1379,12 +1129,7 @@ Add to `RegionPanel`:
             handle.setVisible(editable)
 ```
 
-Change `_applyDrawShape` so a locked panel pans instead of drawing:
-
-```python
-    def _applyDrawShape(self, *_args) -> None:
-        self.view.setDrawShape(self.regionShape() if self._editable() else None)
-```
+Panning and zooming stay live in every state: the `ViewBox` is untouched by the gate, because looking at what is being surveyed is not editing it.
 
 And apply the lock to each ROI as it is attached, in `_attachRoi`, after `self.view.addItem(roi)`:
 
@@ -1396,12 +1141,7 @@ And apply the lock to each ROI as it is attached, in `_attachRoi`, after `self.v
 
 Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/ -q`
 
-Expected: PASS, once two earlier test files are updated — a panel with no slice being inert is the intended behaviour, so the tests written before the gate existed have to declare a slice:
-
-- `test_region_panel.py`: `test_the_add_region_button_asks_its_owner` needs `panel.setSliceReady(True)` before the click.
-- `test_region_drawing.py`: `test_a_drawn_region_reaches_the_panel` needs `panel.setSliceReady(True)` before it draws, or `_drawShape` is `None` and nothing is drawn.
-
-The `_DrawingViewBox` tests in that file construct the view box directly and are unaffected.
+Expected: PASS, once one earlier test is updated — a panel with no slice being inert is the intended behaviour, so `test_the_add_region_button_asks_its_owner` (Task 3) needs `panel.setSliceReady(True)` before the click. The rest of Task 3's tests drive `setRegions()` and `_rois` directly and are unaffected, since rendering is never gated.
 
 - [ ] **Step 5: Prove both sides of the gate bite (mutation)**
 
@@ -1430,7 +1170,7 @@ MSG
 
 ---
 
-### Task 6: Pinned frames from the Camera module
+### Task 5: Pinned frames from the Camera module
 
 **Files:**
 - Modify: `acq4/util/imaging/imaging_ctrl.py` (`addPinnedFrame` ~line 274, `removePinnedFrame` ~line 286)
@@ -1718,7 +1458,7 @@ MSG
 
 ---
 
-### Task 7: Region outlines in the Camera window
+### Task 6: Region outlines in the Camera window
 
 **Files:**
 - Modify: `acq4/modules/Autopatch/region_mirrors.py`
@@ -1994,7 +1734,7 @@ MSG
 
 ---
 
-### Task 8: Mount Area 1 in the window
+### Task 7: Mount Area 1 in the window
 
 **Files:**
 - Modify: `acq4/modules/Autopatch/Autopatch.py`
@@ -2003,7 +1743,7 @@ MSG
 - Test: `acq4/modules/Autopatch/tests/test_search_panel.py`
 
 **Interfaces:**
-- Consumes: `RegionPanel` (Tasks 3–5), `PinnedFrameMirror` (Task 6), `CameraMirror` (Task 7), `Slice.setRegions` (Task 1).
+- Consumes: `RegionPanel` (Tasks 3–4), `PinnedFrameMirror` (Task 5), `CameraMirror` (Task 6), `Slice.setRegions` (Task 1).
 - Produces: `AutopatchWindow.regionPanel`, `AutopatchWindow._onRegionsEdited(regions)`, `AutopatchWindow._cameraWindow()`.
 
 **This task owns every call site of the controls it moves.** Derived from `git grep`, not from memory — a breaking API change whose signature-owning task does not own all its callers leaves a red tree at an intermediate commit, which is what happened in P2c-1.
@@ -2366,7 +2106,7 @@ MSG
 
 ---
 
-### Task 9: New slice's instruction band
+### Task 8: New slice's instruction band
 
 **Files:**
 - Modify: `acq4/modules/Autopatch/status_panel.py`
@@ -2606,4 +2346,4 @@ MSG
 /home/martin/.miniforge3/envs/acq4-gl/bin/python bin/acq4 --config /home/martin/src/acq4/acq4/config/mock/default.cfg -m Autopatch
 ```
 
-  Check: New slice enables Area 1; drag out a rectangle, an ellipse, and a polygon and confirm each is tiled by the survey readout; drag and resize one; right-click Remove; tick Mirror to Camera and confirm outlines appear in the Camera window and cannot be grabbed there; pin a frame in the Camera module and confirm it appears in Area 1; start a run and confirm Area 1 locks, pause it and confirm it unlocks; close the window and confirm exit code 0 with no segfault.
+  Check: New slice enables Area 1; seed a rectangle, an ellipse, and a polygon with "Add region here" and confirm each is tiled by the survey readout; drag and resize one; click a polygon edge to add a vertex and drag it, then confirm the survey retiles to the new outline; check that an ellipse offers no rotate handle; right-click Remove; tick Mirror to Camera and confirm outlines appear in the Camera window and cannot be grabbed there; pin a frame in the Camera module and confirm it appears in Area 1; start a run and confirm Area 1 locks, pause it and confirm it unlocks; close the window and confirm exit code 0 with no segfault.

--- a/docs/superpowers/specs/2026-08-10-autopatch-area1-region-graphics-design.md
+++ b/docs/superpowers/specs/2026-08-10-autopatch-area1-region-graphics-design.md
@@ -101,23 +101,36 @@ Three hazards the adapters own:
   returns `None` there rather than letting `SearchRegion`'s validation raise; see
   §8.
 
-### 3.2.1 The one stock tool that is not adequate
+### 3.2.1 Rotation, and the pivot it turns on
 
-No region can express a rotation: `RectRegion` and `EllipseRegion` are
-axis-aligned boxes, and `PolygonRegion`'s vertices are read back through the
-ROI's own transform. A rotated ROI therefore maps back to a region with the
-rotation silently dropped — the operator outlines one patch of tissue and the
-survey tiles another. The Camera module's `ROIPlotter._addEllipseROI` uses the
-stock class quite correctly, because it only reads the pixels under the ROI and
-a rotation changes which pixels those are; here the shape has to survive a round
-trip through a representation that cannot express rotation.
+Tissue is not axis-aligned, so regions rotate. `RectRegion` and `EllipseRegion`
+carry an `angle` alongside their box; `PolygonRegion` needs no such field,
+because its vertices are read back through `roi.mapToParent`, which already
+includes the ROI's transform, so a turn arrives baked into the coordinates.
+Every ROI is built `rotatable=True` and the stock `pg.EllipseROI` is used as it
+ships, rotate handle and all.
 
-So **every** ROI is built `rotatable=False`. The flag, not the handle, is what
-matters: `pg.MouseDragHandler` enters rotate mode on an Alt-modified drag of the
-ROI *body*, with no handle involved, and consults the flag alone. `pg.EllipseROI`
-additionally ships a rotate handle; that is replaced with a second scale handle,
-because a handle the operator can grab that then does nothing is a control that
-lies. Nothing else about any ROI is modified.
+The pivot is the load-bearing detail, and it was measured rather than chosen.
+`pg.ROI.setAngle` records **degrees** and, given no explicit centre, turns the
+ROI about its **local origin** — which is exactly what `ROI.pos()` reports, and
+which it leaves untouched. So a region's angle is degrees counter-clockwise
+about its `(x0, y0)` corner, and `regionForRoi` reads `pos()` and `size()` back
+with the same arithmetic the axis-aligned case always used. That is what makes
+`regionForRoi(roiForRegion(r)) == r` exact rather than approximate.
+
+A centre pivot was tried first and rejected on measurement: recovering a corner
+from a centre costs a halving and its inverse, which over 2000 sampled regions
+failed to return the original float about half the time — including at zero
+angle, where it would have shifted regions nobody rotated. Radians were rejected
+for the same reason: `math.degrees(math.radians(30.0)) != 30.0`.
+
+Two consequences elsewhere. `bounds()` is now the axis-aligned extent of the
+*turned* shape, while the new `box()` is the unrotated box the operator sized;
+anything that draws or rebuilds a shape wants `box()`, and only the tiler wants
+`bounds()`. And the editing gate now includes `rotatable`, because rotation is a
+fourth way to change the tissue a survey is about to image — `pg.MouseDragHandler`
+enters rotate mode on an Alt-modified drag of the ROI *body*, with no handle
+involved, so hiding the handles does not reach it.
 
 ### 3.3 `PinnedFrameMirror` — Camera to Autopatch
 

--- a/docs/superpowers/specs/2026-08-10-autopatch-area1-region-graphics-design.md
+++ b/docs/superpowers/specs/2026-08-10-autopatch-area1-region-graphics-design.md
@@ -103,14 +103,21 @@ Three hazards the adapters own:
 
 ### 3.2.1 The one stock tool that is not adequate
 
-`pg.EllipseROI` ships a **rotate** handle. `EllipseRegion` is the ellipse
-inscribed in an axis-aligned box, so a rotated ROI maps back to a region with
-the rotation silently dropped — the operator outlines one patch of tissue and
-the survey tiles another. The Camera module's `ROIPlotter._addEllipseROI` uses
-the stock class quite correctly, because it only reads the pixels under the ROI
-and a rotation changes which pixels those are; here the shape has to survive a
-round trip through a representation that cannot express rotation. So the handle
-is dropped, and nothing else about any ROI is modified.
+No region can express a rotation: `RectRegion` and `EllipseRegion` are
+axis-aligned boxes, and `PolygonRegion`'s vertices are read back through the
+ROI's own transform. A rotated ROI therefore maps back to a region with the
+rotation silently dropped — the operator outlines one patch of tissue and the
+survey tiles another. The Camera module's `ROIPlotter._addEllipseROI` uses the
+stock class quite correctly, because it only reads the pixels under the ROI and
+a rotation changes which pixels those are; here the shape has to survive a round
+trip through a representation that cannot express rotation.
+
+So **every** ROI is built `rotatable=False`. The flag, not the handle, is what
+matters: `pg.MouseDragHandler` enters rotate mode on an Alt-modified drag of the
+ROI *body*, with no handle involved, and consults the flag alone. `pg.EllipseROI`
+additionally ships a rotate handle; that is replaced with a second scale handle,
+because a handle the operator can grab that then does nothing is a control that
+lies. Nothing else about any ROI is modified.
 
 ### 3.3 `PinnedFrameMirror` — Camera to Autopatch
 
@@ -179,6 +186,12 @@ operator having clicked Pause, and the distinction is load-bearing:
 So the status is a real guarantee where the click is not. `_processCell`'s retry
 loop calls `_checkPause()` too, and the same reasoning holds: blocked there is
 still not inside a refill.
+
+Disabling editing means every surface, not only the body drag: the seed
+controls, `translatable`/`resizable`/`removable`, the handles, and — for a
+polygon — the per-edge child items, each of which takes a left click and inserts
+a vertex there. `AutopatchWindow` also drops any region edit that reaches it
+while the gate is closed, because a signal is not a permission check.
 
 The atomic swap in §5 is not made redundant by this gate. An edit committed as
 the operator presses Resume is still concurrent, and belt-and-braces here costs
@@ -251,7 +264,10 @@ operator drags a spin box through invalid values:
 - No camera: the existing SearchPanel message stands.
 - No slice: drawing controls greyed, matching Area 2's `setSliceReady`.
 - Degenerate geometry — an ROI squashed to zero extent in either axis, a polygon
-  whose handles have been dragged collinear. `SearchRegion` raises on these, and
+  whose handles have been dragged onto a horizontal or vertical line. What
+  `SearchRegion` validates is the axis-aligned bounding box, so a polygon
+  flattened onto a *diagonal* is accepted and tiles along that line.
+  `SearchRegion` raises on the degenerate box, and
   an ROI can be dragged there, so `regionForRoi` returns `None` rather than
   propagating: the ROI stays on screen for the operator to pull back out, and
   contributes no tiles while it is degenerate. This follows

--- a/docs/superpowers/specs/2026-08-10-autopatch-area1-region-graphics-design.md
+++ b/docs/superpowers/specs/2026-08-10-autopatch-area1-region-graphics-design.md
@@ -28,8 +28,8 @@ This phase makes regions visible, drawable, and editable.
 
 - An Area 1 view: `pg.GraphicsView` + aspect-locked `pg.ViewBox` in global metres.
 - Pinned frames from the Camera module mirrored into that view (display only).
-- Drawing, moving, resizing, and deleting regions — rectangle, ellipse, and
-  closed polygon.
+- Seeding, moving, resizing, reshaping, and deleting regions — rectangle,
+  ellipse, and closed polygon.
 - The shape selector and "Add region here", moved out of Area 2 into Area 1.
 - A **mirror to Camera** checkbox putting read-only region outlines in the
   Camera window.
@@ -60,7 +60,7 @@ Owns the view and every control that makes or changes a region:
   `"ellipse"`, `"polygon"`), not display text, following the precedent
   `SearchPanel.regionShape()` set.
 - "Add region here" — the existing one-click 3×3-field seed, unchanged in
-  behaviour, relocated.
+  behaviour, relocated, and now producing a visible ROI in all three shapes.
 - "Mirror to Camera" checkbox.
 - "Fit to regions" — autorange the view over the regions and pinned frames.
 
@@ -85,13 +85,32 @@ Pure functions in the same module, no Qt state of their own:
 
 `roiForRegion(region) -> pg.ROI` and `regionForRoi(roi) -> SearchRegion`.
 
-Two hazards the adapters own:
+The ROIs are pyqtgraph's own, used as shipped: their handles resize them, their
+`removable=True` context menu deletes them, and `PolyLineROI.segmentClicked`
+inserts a vertex where an edge is clicked while individual handles can be
+removed. Reshaping a region to follow a cortical layer therefore costs no code.
+
+Three hazards the adapters own:
 
 - **An ROI dragged past its own origin reports a negative size.**
   `AutomationDebug`'s `SurveyRegion._bounds` documents this already.
   `regionForRoi` normalises so `x0 <= x1` and `y0 <= y1` before constructing.
 - **A polygon ROI carries its vertices in local coordinates.** They are mapped
   through the ROI's transform to global metres before `PolygonRegion` sees them.
+- **An ROI can be dragged to a shape that is not a region.** `regionForRoi`
+  returns `None` there rather than letting `SearchRegion`'s validation raise; see
+  §8.
+
+### 3.2.1 The one stock tool that is not adequate
+
+`pg.EllipseROI` ships a **rotate** handle. `EllipseRegion` is the ellipse
+inscribed in an axis-aligned box, so a rotated ROI maps back to a region with
+the rotation silently dropped — the operator outlines one patch of tissue and
+the survey tiles another. The Camera module's `ROIPlotter._addEllipseROI` uses
+the stock class quite correctly, because it only reads the pixels under the ROI
+and a rotation changes which pixels those are; here the shape has to survive a
+round trip through a representation that cannot express rotation. So the handle
+is dropped, and nothing else about any ROI is modified.
 
 ### 3.3 `PinnedFrameMirror` — Camera to Autopatch
 
@@ -167,13 +186,24 @@ three lines.
 
 ## 6. Interaction
 
-**Creating.** Choose a shape, then drag in the view. Rectangle and ellipse are
-press-drag-release. Polygon is click-per-vertex, double-click to close; fewer
-than three vertices discards.
+**Creating: seed, then shape.** Choose a shape and press "Add region here"; an
+ROI of that shape appears covering roughly 3×3 fields around the camera centre,
+and the operator drags it into place. This is the pattern acq4 already uses for
+adding an ROI to a camera-style view — `ROIPlotter._addRectROI`,
+`_addEllipseROI`, and `_addPolygonROI` in `modules/Camera/CameraWindow.py` each
+seed a default-sized ROI at the view centre and leave shaping to the operator.
+
+Drag-to-draw was considered and rejected on evidence: pyqtgraph offers no
+drag-out-a-new-ROI gesture (`ViewBox.RectMode`'s rubber band is a zoom tool, and
+there is no ROI-creation helper anywhere in the package), and no other acq4
+module has one. Building it would mean custom `mouseDragEvent`/`mouseClickEvent`
+handling to invent an idiom that exists nowhere else in the application.
 
 **Editing.** Every region is a live ROI: drag the body to move, handles to
-resize or reshape, and `removable=True` for pyqtgraph's own right-click Remove.
-Any of these rebuilds the region list and hands the whole list to the window.
+resize, `PolyLineROI`'s segment click to insert a vertex and its handle menu to
+remove one, and `removable=True` for pyqtgraph's own right-click Remove. All of
+it is stock behaviour. Any of these rebuilds the region list and hands the whole
+list to the window.
 
 **Deleting leaves coverage alone.** `Slice._covered` is a flat record of tile
 centres already imaged, and it is deliberately not pruned when a region goes
@@ -186,7 +216,10 @@ progress is not a decision, and `tileGrid()` is O(tiles) per call.
 
 **Seeding.** "Add region here" behaves exactly as it does today, including
 creating a slice on demand when none exists — the path that deliberately creates
-no directory (§7 Area 1). Drawing does the same.
+no directory (§7 Area 1). With Polygon selected it seeds the four corners of the
+same box, so the button places a region of a known size whichever shape is
+chosen, and a four-vertex seed is the readiest thing to reshape into the outline
+actually wanted.
 
 **Sizing.** The Area 1 view must be usable at slice scale, which the current
 fixed two-column `QVBoxLayout` will not give it. The left column becomes a
@@ -217,8 +250,14 @@ operator drags a spin box through invalid values:
 
 - No camera: the existing SearchPanel message stands.
 - No slice: drawing controls greyed, matching Area 2's `setSliceReady`.
-- Zero-area drag, polygon under three vertices: discarded silently. The operator
-  gets no region, which is what they drew.
+- Degenerate geometry — an ROI squashed to zero extent in either axis, a polygon
+  whose handles have been dragged collinear. `SearchRegion` raises on these, and
+  an ROI can be dragged there, so `regionForRoi` returns `None` rather than
+  propagating: the ROI stays on screen for the operator to pull back out, and
+  contributes no tiles while it is degenerate. This follows
+  `SearchPanel.constraints()`, which returns `None` for the same reason — an
+  operator dragging a control through invalid intermediate values must not get a
+  traceback.
 - Camera window absent or closed while mirroring: the mirror becomes a no-op.
 
 ## 9. Testing

--- a/docs/superpowers/specs/2026-08-10-autopatch-area1-region-graphics-design.md
+++ b/docs/superpowers/specs/2026-08-10-autopatch-area1-region-graphics-design.md
@@ -1,0 +1,252 @@
+# Autopatch P2c-3a — Area 1 region graphics
+
+Design for the first slice of Area 1: a global-coordinate view inside the
+Autopatch window that shows the Camera module's pinned frames, lets the operator
+draw and edit search regions over them, and optionally mirrors those regions into
+the Camera window as read-only outlines.
+
+Parent design: `autopatch-orchestration-design.md` §7 Area 1, §9, §10 (P2c).
+
+---
+
+## 1. Why this exists
+
+Regions today are created blind. `SearchPanel`'s "Add region here" seeds a shape
+of roughly 3×3 fields of view around the camera's current centre
+(`AutopatchWindow.addRegionHere`), and nothing in the interface ever draws it.
+The operator cannot see where the region sits, cannot tell whether it covers the
+tissue they mean to search, and cannot change it once made. P2c-1 generalised
+regions from rectangles to shapes precisely so a cortical layer or an undamaged
+corner could be searched — and `PolygonRegion` remains unreachable from the
+interface, because no control can produce one.
+
+This phase makes regions visible, drawable, and editable.
+
+## 2. Scope
+
+**In:**
+
+- An Area 1 view: `pg.GraphicsView` + aspect-locked `pg.ViewBox` in global metres.
+- Pinned frames from the Camera module mirrored into that view (display only).
+- Drawing, moving, resizing, and deleting regions — rectangle, ellipse, and
+  closed polygon.
+- The shape selector and "Add region here", moved out of Area 2 into Area 1.
+- A **mirror to Camera** checkbox putting read-only region outlines in the
+  Camera window.
+- `Slice.setRegions()` — a wholesale swap replacing in-place mutation.
+- Moving `newSlice()`'s `HelpfulException` message from Area 2's error line to a
+  new instruction band in Area 3.
+
+**Out, deliberately:**
+
+- The progress heatmap, and the cross-repo `acq4_automation.Cell` expansion it
+  forces (§10's "or an explicit decision not to" is still undecided).
+- The pinned-frames *workflow* — clear-to-start, operator instructions, and
+  waiting until a fresh set is pinned. Only display lands here.
+- Slice disk persistence via `DirHandle.setInfo()`.
+- Live camera video in the Area 1 view.
+- Editable ROIs in the Camera window. The mirror is one-way.
+
+## 3. Components
+
+### 3.1 `acq4/modules/Autopatch/region_panel.py` — `RegionPanel`
+
+Owns the view and every control that makes or changes a region:
+
+- `pg.GraphicsView` with a `pg.ViewBox`, `setAspectLocked(True)` and autorange
+  off — the same construction `CameraWindow.__init__` uses, deliberately a
+  *separate* view rather than the Camera module's own.
+- A shape selector: Rectangle, Ellipse, Polygon. Item **data** (`"rect"`,
+  `"ellipse"`, `"polygon"`), not display text, following the precedent
+  `SearchPanel.regionShape()` set.
+- "Add region here" — the existing one-click 3×3-field seed, unchanged in
+  behaviour, relocated.
+- "Mirror to Camera" checkbox.
+- "Fit to regions" — autorange the view over the regions and pinned frames.
+
+Emits `sigRegionsChanged(list)` carrying the complete region list after any
+edit, and `sigAddRegionRequested()` for the seed button (the panel does not know
+where the camera is; its owner does).
+
+The panel does not import `Slice` and holds no reference to one. It renders a
+list of regions and reports a list of regions; `AutopatchWindow` is what binds
+that to the current slice. This is what keeps it testable without a slice, a
+camera, or an orchestrator.
+
+### 3.2 Shape ↔ ROI adapters
+
+Pure functions in the same module, no Qt state of their own:
+
+| region | ROI |
+|---|---|
+| `RectRegion` | `pg.RectROI` |
+| `EllipseRegion` | `pg.EllipseROI` |
+| `PolygonRegion` | `pg.PolyLineROI(closed=True)` |
+
+`roiForRegion(region) -> pg.ROI` and `regionForRoi(roi) -> SearchRegion`.
+
+Two hazards the adapters own:
+
+- **An ROI dragged past its own origin reports a negative size.**
+  `AutomationDebug`'s `SurveyRegion._bounds` documents this already.
+  `regionForRoi` normalises so `x0 <= x1` and `y0 <= y1` before constructing.
+- **A polygon ROI carries its vertices in local coordinates.** They are mapped
+  through the ROI's transform to global metres before `PolygonRegion` sees them.
+
+### 3.3 `PinnedFrameMirror` — Camera to Autopatch
+
+A `pg.ImageItem` belongs to exactly one `QGraphicsScene`, so "pinned frames
+display in both places" (§7) cannot mean the same object in two views. The
+mirror builds its own `ImageItem` per pinned frame from the same image array and
+the same global `QTransform`, preserving relative z-order, and rebuilds when the
+Camera module's set changes.
+
+### 3.4 `CameraMirror` — Autopatch to Camera
+
+One read-only `QGraphicsPathItem` per region, added through
+`cameraWindow.addItem(item, z=...)` with `setAcceptedMouseButtons(Qt.Qt.NoButton)`
+(the idiom acq4 already uses, e.g. `analysis/atlas/AuditoryCortex/CortexROI.py`).
+A path item rather than an ROI is what makes it read-only structurally rather
+than by policy: there is no handle to grab and no second copy of the region's
+state to reconcile.
+
+Absence of a Camera window is normal, not an error — the checkbox is a display
+preference, and unchecking it or closing the Camera window removes the items.
+
+## 4. The one shared-file change
+
+`ImagingCtrl.pinnedFrames` is a plain list mutated by `addPinnedFrame` and
+`removePinnedFrame` with no notification of any kind
+(`acq4/util/imaging/imaging_ctrl.py`). Mirroring requires knowing when it
+changes, so `ImagingCtrl` gains an additive `sigPinnedFramesChanged` emitted from
+both mutators. The Camera module is unaffected. Polling is the only alternative,
+and for a set that changes on operator clicks it is the wrong mechanism.
+
+## 5. Authority, and the threading rule
+
+`Slice` remains authoritative for regions. `RegionPanel` is a view over them.
+
+`Slice` gains `setRegions(regions)`, which **rebinds** `self._regions` to a new
+list rather than mutating the existing one. `addRegion` keeps its signature and
+is reimplemented on top of the swap. Readers — `tileGrid()`, `forceRescan()` —
+snapshot `self._regions` into a local before iterating.
+
+This matters because `CellProducer` reaches `slice.nextTile()` -> `tileGrid()` on
+the **worker thread** while ROI edits arrive on the **GUI thread**, and
+`tileGrid()` iterates `self._regions` directly. Appending to a list under
+iteration is undefined in exactly the way that produces an intermittent, unloggable
+wrong answer. The swap makes a reader see either the whole old list or the whole
+new one, which is the same "make it one step" discipline `Orchestrator._refillQueue`
+already applies to the producer reference.
+
+### 5.1 When editing is allowed
+
+Region editing is enabled when:
+
+    not runLocked or status == "paused"
+
+`runLocked` is `StatusPanel.sigInteractionLocked`, already wired to Areas 2, 4,
+and 5. The paused exception is keyed on the **emitted status**, never on the
+operator having clicked Pause, and the distinction is load-bearing:
+
+- `_checkPause()` runs at the *top* of `_runLoopBody`, before `_shouldRefill()`.
+  Clicking Pause during a survey therefore does not stop the survey — the
+  producer goes on imaging tiles for seconds to minutes, reading regions the
+  whole time, and the loop only parks at the next iteration.
+- But `sigStatus("paused")` is emitted from *inside* `_checkPause`, immediately
+  before `_pauseEvent.wait()`. While that status is current the worker is
+  blocked there and provably cannot be inside `_refillQueue`.
+
+So the status is a real guarantee where the click is not. `_processCell`'s retry
+loop calls `_checkPause()` too, and the same reasoning holds: blocked there is
+still not inside a refill.
+
+The atomic swap in §5 is not made redundant by this gate. An edit committed as
+the operator presses Resume is still concurrent, and belt-and-braces here costs
+three lines.
+
+## 6. Interaction
+
+**Creating.** Choose a shape, then drag in the view. Rectangle and ellipse are
+press-drag-release. Polygon is click-per-vertex, double-click to close; fewer
+than three vertices discards.
+
+**Editing.** Every region is a live ROI: drag the body to move, handles to
+resize or reshape, and `removable=True` for pyqtgraph's own right-click Remove.
+Any of these rebuilds the region list and hands the whole list to the window.
+
+**Deleting leaves coverage alone.** `Slice._covered` is a flat record of tile
+centres already imaged, and it is deliberately not pruned when a region goes
+away: tiles that no longer fall in any region simply stop being planned, and a
+region redrawn over ground already surveyed should still count as surveyed.
+That is the same reasoning that makes coverage shared across producers (§6b).
+
+**Committing.** On `sigRegionChangeFinished`, not on every mouse move. A drag in
+progress is not a decision, and `tileGrid()` is O(tiles) per call.
+
+**Seeding.** "Add region here" behaves exactly as it does today, including
+creating a slice on demand when none exists — the path that deliberately creates
+no directory (§7 Area 1). Drawing does the same.
+
+**Sizing.** The Area 1 view must be usable at slice scale, which the current
+fixed two-column `QVBoxLayout` will not give it. The left column becomes a
+vertical `QSplitter` so Area 1 can be dragged large, the outer layout gives the
+left column the greater stretch, the view takes an expanding size policy with a
+sensible minimum, and "Fit to regions" exists so recovering a sane viewport is
+one click. The `ViewBox` supplies mouse zoom and pan for free.
+
+## 7. New slice, and the instruction band
+
+`newSlice()` currently reports `create_data_dir`'s `HelpfulException` — in
+practice "Storage directory has not been set." — through
+`searchPanel.setError()`, with a comment saying Area 3's band does not exist yet.
+It does now.
+
+`StatusPanel` gains `setInstruction(text)` / `clearInstruction()`, rendering in
+the existing band. An instruction is not a `RunErrorRecord`: no traceback, no
+Copy, no Show in log. It is cleared by the next successful New slice.
+
+A new slice clears the panel's regions along with everything else, because the
+new `Slice` has none.
+
+## 8. Errors and degenerate input
+
+Nothing in this panel raises on the GUI thread. Following the precedent of
+`SearchPanel.constraints()` returning `None` rather than throwing while an
+operator drags a spin box through invalid values:
+
+- No camera: the existing SearchPanel message stands.
+- No slice: drawing controls greyed, matching Area 2's `setSliceReady`.
+- Zero-area drag, polygon under three vertices: discarded silently. The operator
+  gets no region, which is what they drew.
+- Camera window absent or closed while mirroring: the mirror becomes a no-op.
+
+## 9. Testing
+
+- **Adapter round-trips, headless**, with **asymmetric fixtures**. P2c-1's
+  swapped `rx`/`ry` mutant survived all 324 experiment tests because every
+  ellipse fixture used a square bounding box. Every shape test here uses
+  distinct width and height, and at real SI magnitudes.
+- **Negative-size and past-origin drags** get their own cases.
+- **The edit gate gets a test per side** — locked while running, editable while
+  paused. P2b established that a one-sided test on a two-sided invariant passes
+  happily while the other side is broken.
+- **The atomic swap gets a mutation proof**: restore in-place `append`, and the
+  concurrent-iteration test must fail. Record the failing line number, not just
+  that it failed.
+- **Mirror lifetime**: `sigPinnedFramesChanged` and the Camera items must be
+  disconnected and removed on `teardown()`, proven with the weakref/`gc.disable`
+  pattern already in `tests/test_teardown.py`. Connections outliving their owner
+  is this module's most-repeated defect.
+- Panel tests follow `tests/test_search_panel.py`; `SearchPanel`'s tests lose
+  their `regionShape` coverage to `RegionPanel`'s.
+
+## 10. Open, and deferred on purpose
+
+- **The heatmap's cross-repo dependency** is untouched here and still needs an
+  owner decision.
+- **Drawing in a panel may prove cramped.** The mitigations in §6 are layout
+  ones. If they are not enough in practice, the fallback is moving drawing into
+  the Camera window — which is why the Camera mirror is a display concern with
+  no state of its own, and why `RegionPanel` renders a region list rather than
+  owning a slice. Neither decision has to be revisited to make that move.


### PR DESCRIPTION
Builds **Area 1** of the Autopatch module: a global-coordinate view showing the Camera module's pinned frames, over which the operator seeds and shapes the search regions that drive the cell-finding survey.

Until now regions were created blind — `SearchPanel`'s "Add region here" seeded a 3×3-field box at the camera centre and nothing ever drew it. You could not see where a region was, whether it covered the tissue you meant to search, or change it afterwards. P2c-1 generalised regions from rectangles to shapes precisely so a cortical layer or an undamaged corner could be outlined, and `PolygonRegion` has been unreachable from the interface ever since.

Design: `docs/superpowers/specs/2026-08-10-autopatch-area1-region-graphics-design.md`
Plan: `docs/superpowers/plans/2026-08-10-autopatch-area1-region-graphics.md`

## What changed

- **`RegionPanel`** (`modules/Autopatch/region_panel.py`) — an aspect-locked `ViewBox` in global metres, the shape selector, "Add region here", "Fit to regions", and the mirror checkbox. Renders a region list and reports a region list; it holds no `Slice`.
- **Shape ↔ ROI adapters** — `RectRegion`↔`RectROI`, `EllipseRegion`↔a de-rotated `EllipseROI`, `PolygonRegion`↔`PolyLineROI`. `regionForRoi` returns `None` for an ROI dragged into a shape that is not a region, rather than raising out of a Qt slot.
- **Two one-way mirrors** (`region_mirrors.py`) — the Camera module's pinned frames into Area 1, and read-only region outlines back into the Camera window. `ImagingCtrl` gains an additive `sigPinnedFramesChanged`.
- **`Slice.setRegions()`** — a wholesale list swap replacing in-place mutation.
- **An editing gate** — regions are editable only when a slice exists and the run is not live, or is reporting `"paused"`.
- **`StatusPanel.setInstruction()`** — New slice's "Storage directory has not been set." now lands in Area 3 as guidance rather than in Area 2's constraint error line.

**Breaking:** the shape selector and "Add region here" move from Area 2 to Area 1. `SearchPanel` loses `shapeCombo`, `addRegionBtn`, `sigAddRegionRequested`, and `regionShape()`; every call site moved in the same commit.

## Design notes a reviewer should know

**Regions are seeded, then shaped — there is no drag-to-draw.** pyqtgraph offers no drag-out-a-new-ROI gesture (`ViewBox.RectMode`'s rubber band is a zoom tool), and neither does acq4: `ROIPlotter._addRectROI`/`_addEllipseROI`/`_addPolygonROI` in `modules/Camera/CameraWindow.py` seed a default-sized ROI and leave shaping to the operator. `PolyLineROI.segmentClicked` already inserts a vertex where an edge is clicked. Building a custom gesture would have invented an idiom existing nowhere else in the application.

**Editing keys off the emitted `"paused"` status, never off the Pause click.** `Orchestrator._checkPause()` runs at the top of `_runLoopBody`, *before* `_shouldRefill()`, so a Pause pressed during a survey does not stop that survey — the producer keeps imaging tiles and reading regions for seconds to minutes. But `sigStatus("paused")` is emitted from *inside* `_checkPause`, immediately before it blocks, so while that status is current the worker provably cannot be in a refill. `"surveying"` stays locked. `Slice.setRegions`' swap is the belt to that braces.

**An `ImageItem` belongs to one scene**, so mirroring pinned frames means building our own items from the same array and transform — not re-adding the Camera module's, which would take them out of the Camera module's view.

## Measured pyqtgraph behaviour worth carrying forward

Each of these broke a draft and was confirmed against the interpreter, not inferred:

- `ViewBox.addItem` **raises** an item's z to `view.zValue()+1` when lower — setting z before adding collapses a mosaic's stacking (−10000 → −99). Add first, set z after.
- Dropping `EllipseROI`'s rotate *handle* is not enough: `ROI.__init__` defaults `rotatable=True` and `MouseDragHandler` enters rotate mode on an **Alt-modified body drag** with no handle involved. All three ROIs now pass `rotatable=False`. A rotated ROI read through `pos()`/`size()` handed the slice a box displaced by roughly half a field of view.
- `PolyLineROI`'s editing surface is its child `_PolyLineSegment` items, each with its own `setAcceptedMouseButtons(LeftButton)` — so a lock over `translatable`/`resizable`/`removable` does **not** lock a polygon. The gate now gates the segments too.
- `Manager.getModule` **loads** an unopened module, so the camera-window getter checks `manager.listModules()` first. Otherwise "Add region here" would start the Camera module.
- `setAngle()` honours no flag, so a rotation gate cannot be tested through it; the test replays the drag through `MouseDragHandler`.
- PyQt5 holds bound-method slots weakly, and `ViewBox.setRange` preserves the current span for a zero-extent range.

## Testing

1239 passed + 1 pre-existing xfail, repo-wide, up from 1127 at branch point. Output pristine. Every task carried a mutation proof recording the line the failure landed on.

Two findings from that discipline are worth flagging: a mandated "remove the disconnect" mutation **did not fail**, because a nearby `= None` already broke the cycle refcounting can see — neither delivered test actually proved the disconnect, so it now asserts Qt's own `receivers(signal)` goes 1 → 0. And the ellipse fixtures are asymmetric throughout, since a square fixture cannot catch a swapped `rx`/`ry`.

## Not done

- **The live GUI smoke test has not been run.** It needs a human at a screen: regions drawn over real tissue, the Camera mirror, a run locking Area 1 and a pause unlocking it. Nothing here is verified against the rig.
- Still open for Area 1: the progress heatmap and the cross-repo `acq4_automation.Cell` expansion it forces, the pinned-frames *workflow* (clear-to-start, instruct, wait), and slice disk persistence via `DirHandle.setInfo()`.
- Unrelated and pre-existing: `acq4/devices/Stage/tests/test_mockstage_move.py` aborts the process ~15/20 when run alone (11/20 at this branch's merge base). Filed separately; untouched here.

🤖 Generated with [Claude Code](https://claude.ai/code)
