### PR TITLE
fix: join MockStage monitor thread on quit and guard superseded arrivals

### DIFF
--- a/acq4/devices/MockStage.py
+++ b/acq4/devices/MockStage.py
@@ -252,7 +252,11 @@ class MockStageThread(Thread):
     def quit(self):
         with self.lock:
             self._quit = True
-            
+        # Join before returning: a QThread destroyed while its thread is still
+        # running aborts the process.
+        if not self.wait(10000):
+            raise TimeoutError("Timed out waiting for MockStageThread to exit")
+
     def setTarget(self, future, target, speed):
         """Begin moving toward a target position.
         """
@@ -286,6 +290,7 @@ class MockStageThread(Thread):
                 speed = self.speed
                 velocity = self.velocity
                 pos = self.pos
+                move = self.currentMove
 
             dt = now - lastUpdate
             lastUpdate = now
@@ -298,9 +303,18 @@ class MockStageThread(Thread):
                 stepDist = speed * dt
                 if stepDist >= dist:
                     self._setPosition(target)
-                    self.stop()
-                    # race condition here if we finish the move before stopping
-                    self.currentMove.mockFinish()
+                    with self.lock:
+                        # Retire this move only if it is still the current one. A
+                        # move submitted while we were stepping must keep its
+                        # target and must not be resolved at this move's position.
+                        superseded = self.currentMove is not move
+                        if not superseded:
+                            self.target = None
+                            self.speed = None
+                            self.velocity = None
+                            self.currentMove = None
+                    if not superseded and move is not None:
+                        move.mockFinish()
                 else:
                     unit = dif / dist
                     step = unit * stepDist

--- a/acq4/devices/Stage/tests/test_mockstage_move.py
+++ b/acq4/devices/Stage/tests/test_mockstage_move.py
@@ -6,11 +6,13 @@ arrival and fails it on interrupt, with no per-move polling thread. These tests
 lock in that contract (a move returns a future the monitor resolves on arrival
 and fails on abort), which every Stage subclass adopting the pattern must meet.
 """
+import threading
+
 import numpy as np
 import pytest
 from unittest.mock import MagicMock, patch
 
-from acq4.devices.MockStage import MockStage
+from acq4.devices.MockStage import MockStage, MockStageThread
 
 
 @pytest.fixture
@@ -53,3 +55,44 @@ def test_abort_fails_move_in_flight(stage):
     with pytest.raises(RuntimeError):
         fut.wait(timeout=5)
     assert fut.is_done
+
+
+def test_quit_joins_monitor_thread(stage):
+    # quit() must not return while the monitor is still running: a live QThread
+    # whose Python wrapper is later garbage-collected aborts the process with
+    # "QThread: Destroyed while thread is still running".
+    stage.quit()
+    assert not stage.stageThread.isRunning()
+
+
+def test_arrival_does_not_resolve_a_superseding_move(qtbot):
+    # A move submitted while the monitor is retiring an earlier arrival must keep
+    # its target and must not be resolved at the earlier move's position.
+    thread = MockStageThread()
+    first = MagicMock()
+    second = MagicMock()
+    superseded = threading.Event()
+    resolvedAt = []
+
+    second.mockFinish.side_effect = lambda: resolvedAt.append(thread.getPosition()[:3])
+
+    setPosition = thread._setPosition
+
+    def supersedeOnArrival(pos):
+        # Land the second move in the window between the monitor deciding the
+        # first has arrived and it clearing/resolving that move.
+        setPosition(pos)
+        if not superseded.is_set():
+            thread.setTarget(second, np.array([100e-6, 0.0, 0.0]), 1e-3)
+            superseded.set()
+
+    thread._setPosition = supersedeOnArrival
+    thread.setTarget(first, np.zeros(3), 1e-3)
+    thread.start()
+    try:
+        qtbot.waitUntil(superseded.is_set, timeout=2000)
+        qtbot.waitUntil(lambda: bool(resolvedAt), timeout=2000)
+    finally:
+        thread.quit()
+
+    np.testing.assert_allclose(resolvedAt[0], [100e-6, 0, 0], atol=1e-6)


### PR DESCRIPTION
`acq4/devices/Stage/tests/test_mockstage_move.py` aborted the Python process (SIGABRT, not a pytest failure) in 15/20 runs on its own, and intermittently failed `test_move_resolves_on_arrival` in the repo-wide suite (~1 in 10). Both causes are pre-existing `MockStage` bugs — the new test file just exercised them in isolation. An aborting process masks whatever else that file would have reported.

## Bug A — the SIGABRT

`MockStageThread.quit()` set `self._quit = True` and returned. `run()` only checks that flag at the top of its loop, after a `time.sleep(30ms)` at the bottom, so `MockStage.quit()` (and fixture teardown) returned with the thread still running. Moments later pytest's `unraisableexception` plugin ran `gc_collect_harder`, the Python wrapper was collected, and the C++ `QThread` destructor called `qFatal`:

```
QThread: Destroyed while thread is still running
Fatal Python error: Aborted
  ...
  File ".../acq4/devices/MockStage.py", line 311 in run
  Current thread ...: Garbage-collecting
```

`quit()` now joins with a bounded `wait(10000)`, matching the `Camera.quit()` convention.

## Bug B — the flaky assertion

`run()` read `target`/`speed`/`pos` under the lock but performed arrival handling *outside* it, re-reading `self.currentMove` unlocked. A `setTarget()` landing in that window had its target wiped by `self.stop()` and its future resolved by the *old* move's completion. `MockStage.__init__` issues a zero-distance move that arrives on the monitor's very first iteration — exactly when a move requested right after construction lands. Failure signature: future resolved successfully, but

```
ACTUAL: array([0, 0, 0])
DESIRED: array([0.0001, 0., 0.])
```

Arrival now retires the move under a single lock hold and skips it entirely if a newer move superseded it. This is the race the old `# race condition here if we finish the move before stopping` comment flagged; the comment is removed as no longer true.

## Tests

Two tests added to `test_mockstage_move.py`, written failing first:

- `test_quit_joins_monitor_thread` — deterministic.
- `test_arrival_does_not_resolve_a_superseding_move` — injects the second move from inside `_setPosition` so it lands in the race window by construction rather than by luck.

## Verification

- 25/25 clean runs of `pytest acq4/devices/Stage/tests/test_mockstage_move.py -q` (was 15/20 aborting)
- 3x `pytest acq4 -q` -> 1131 passed, 1 xfailed each

🧙 Built with [WOZCODE](https://wozcode.com)