### PR TITLE
Name each leg of the minirig scope unwind

### DIFF
--- a/acq4/motion/minirig_v1.py
+++ b/acq4/motion/minirig_v1.py
@@ -131,14 +131,16 @@ class MinirigV1MotionPlanner(DefaultMotionPlanner):
         if pip_name not in self._scope_context:
             return None
         scope, forward_path, _pip, _site = self._scope_context.pop(pip_name)
-        # forward_path = [original, up, park]; the return path is a full reversal, so park is
-        # re-commanded first.  This makes the unwind independent of where the scope actually is:
-        # if something moved it away from park, going to park (at park height) before descending
-        # keeps it clear of the objective, whereas heading straight for `up` would cut a diagonal
-        # from an unknown position.
-        return_waypoints = list(reversed(forward_path))
+        original_pos, up_pos, park_pos = forward_path
+        # The return path is a full reversal, so park is re-commanded first.  This makes the
+        # unwind independent of where the scope actually is: if something moved it away from
+        # park, going to park (at park height) before descending keeps it clear of the
+        # objective, whereas heading straight for `up` would cut a diagonal from an unknown
+        # position.
         scope_steps = [
-            AtomicMove(scope, wp, "fast", "scope return") for wp in return_waypoints
+            AtomicMove(scope, park_pos, "fast", "scope back to park position"),
+            AtomicMove(scope, up_pos, "fast", "scope lateral over original position"),
+            AtomicMove(scope, original_pos, "fast", "scope down to original position"),
         ]
         return SequentialGroup(scope_steps, "scope unwind")
 


### PR DESCRIPTION
## What

`MinirigV1MotionPlanner._scope_unwind_group()` built its three scope moves in a loop over `reversed(forward_path)`, giving every one of them the same explanation string: `"scope return"`. Now each move is written out with a name that says what it does:

- `scope back to park position`
- `scope lateral over original position`
- `scope down to original position`

## Why

Plan displays and logs showed three identical `"scope return"` entries, so there was no way to tell which leg of the unwind was executing (or which one stalled).

## Notes for review

- No behavior change: the same three waypoints are commanded in the same order. The `reversed()` indirection is gone because the moves are now spelled out, and the comment explaining *why* park is re-commanded first is preserved.
- `acq4/motion/tests/test_minirig_v1_planner.py` passes (19/19). No test asserted on the old string; the existing tests check device ordering, which is unchanged.

🤖 Generated with [Claude Code](https://claude.ai/code)