### PR TITLE
Keep the throughline attached to log records and moves

### DIFF
--- a/acq4/devices/DoverStage/doverstage.py
+++ b/acq4/devices/DoverStage/doverstage.py
@@ -128,15 +128,18 @@ class DoverMoveFuture(MoveFuture):
 
     def _future_finished(self, req_fut):
         # External producer: the driver request's completion callback completes
-        # this promise. Honor a stop already requested on this future.
-        if self.is_stopped:
-            return
-        error = req_fut.error._get_value()
-        if error is not None:
-            excInfo = req_fut.exc_info._get_value()
-            if excInfo is not None and excInfo[1] is not None:
-                self.fail(excInfo[1])
+        # this promise. Honor a stop already requested on this future. The callback
+        # fires on a driver thread with no context of its own, so run under this
+        # move's throughline to keep completion attached to the requesting operation.
+        with self.throughlineContext():
+            if self.is_stopped:
+                return
+            error = req_fut.error._get_value()
+            if error is not None:
+                excInfo = req_fut.exc_info._get_value()
+                if excInfo is not None and excInfo[1] is not None:
+                    self.fail(excInfo[1])
+                else:
+                    self.fail(RuntimeError(str(error)))
             else:
-                self.fail(RuntimeError(str(error)))
-        else:
-            self.resolve(None)
+                self.resolve(None)

--- a/acq4/devices/MicroManagerStage/mmstage.py
+++ b/acq4/devices/MicroManagerStage/mmstage.py
@@ -311,13 +311,17 @@ class MicroManagerMoveFuture(MoveFuture):
         # Advance this move toward completion. Called by the device MonitorThread
         # each tick while the move is in flight: resolve on arrival, fail on a
         # missed target. Idempotent and race-safe (guards + atomic completion).
-        if self.is_stopped or self.is_done:
-            return
-        status = self._getStatus()
-        if status == 1:
-            self.resolve(None)
-        elif status == -1:
-            self.fail(RuntimeError(self._errorMsg or "Move did not complete."))
+        # Runs under this move's throughline: the lifetime monitor thread has no
+        # context of its own, so without it the move's completion (and any finish
+        # callback it fires) would be orphaned from the requesting operation.
+        with self.throughlineContext():
+            if self.is_stopped or self.is_done:
+                return
+            status = self._getStatus()
+            if status == 1:
+                self.resolve(None)
+            elif status == -1:
+                self.fail(RuntimeError(self._errorMsg or "Move did not complete."))
 
     def _getStatus(self):
         # check status of move unless we already know it is complete.

--- a/acq4/devices/MockStage.py
+++ b/acq4/devices/MockStage.py
@@ -205,16 +205,21 @@ class MockMoveFuture(MoveFuture):
         self.dev.stageThread.setTarget(self, pos, speed)
 
     def mockFinish(self):
-        if not self.is_done:
-            self.resolve(None)
+        # Completed from the stage's lifetime monitor thread, which has no context of
+        # its own; run under this move's throughline so finish callbacks and anything
+        # logged on the way out stay attached to the requesting operation.
+        with self.throughlineContext():
+            if not self.is_done:
+                self.resolve(None)
 
     def mockInterrupt(self):
         # A cooperative stop is completed with Stopped by stop(); don't overwrite
         # that with a RuntimeError, or callers suppressing Stopped see a spurious
         # error. Only a non-stop interruption (e.g. a superseding move) fails.
-        if self.is_stopped:
-            return
-        self.fail(RuntimeError('Move interrupted'))
+        with self.throughlineContext():
+            if self.is_stopped:
+                return
+            self.fail(RuntimeError('Move interrupted'))
 
 
 class MockStageThread(Thread):

--- a/acq4/devices/NewScaleMPM.py
+++ b/acq4/devices/NewScaleMPM.py
@@ -140,15 +140,19 @@ class NewScaleMoveFuture(MoveFuture):
         # per axis via isMoving(); resolve once no axis is still moving (mirrors
         # the driver's own wait(), but checks all three axes). Previously this
         # future was never completed.
-        if self.is_stopped or self.is_done:
-            return
-        with self.dev.lock:
-            moving = False
-            for ax in ('x', 'y', 'z'):
-                self.dev.dev.selectAxis(ax)
-                if self.dev.dev.isMoving():
-                    moving = True
-                    break
-        if not moving:
-            self.resolve(None)
+        # Runs under this move's throughline: the monitor thread has no context of
+        # its own, so completion would otherwise be orphaned from the requesting
+        # operation.
+        with self.throughlineContext():
+            if self.is_stopped or self.is_done:
+                return
+            with self.dev.lock:
+                moving = False
+                for ax in ('x', 'y', 'z'):
+                    self.dev.dev.selectAxis(ax)
+                    if self.dev.dev.isMoving():
+                        moving = True
+                        break
+            if not moving:
+                self.resolve(None)
 

--- a/acq4/devices/PatchPipette/statemanager.py
+++ b/acq4/devices/PatchPipette/statemanager.py
@@ -1,3 +1,4 @@
+import contextlib
 import inspect
 from collections import OrderedDict
 from typing import Optional
@@ -7,12 +8,26 @@ from docstring_parser import parse
 from acq4 import getManager
 from acq4.logging_config import get_logger
 from acq4.util import Qt
-from acq4.util.task import Stopped
+from acq4.util.task import Stopped, throughline
 from pyqtgraph import disconnect
 from pyqtgraph.parametertree import Parameter
 from . import states
 
 logger = get_logger(__name__)
+
+
+@contextlib.contextmanager
+def stateJobContext():
+    """Build a state job as a top-level operation, outside any current throughline.
+
+    A state transition creates the next state's job from within the outgoing state's
+    finish handling, and a task captures its context at construction. Without this,
+    each state's throughline nests inside its predecessor's and the chain grows by one
+    name per transition, forever. States are siblings, not children -- the same reason
+    their jobs are created with detach=True.
+    """
+    with throughline.restore(()):
+        yield
 
 
 class PatchPipetteStateManager(Qt.QObject):
@@ -187,6 +202,10 @@ class PatchPipetteStateManager(Qt.QObject):
         return self.configureState(state, configOverride=config)
 
     def configureState(self, state, allowReset=True, configOverride=None):
+        with throughline(name=f"{self.dev.name()} -> state {state!r}"):
+            return self._configureState(state, allowReset=allowReset, configOverride=configOverride)
+
+    def _configureState(self, state, allowReset=True, configOverride=None):
         oldJob = self.currentJob
         fallback = None
         if oldJob is not None:
@@ -200,7 +219,8 @@ class PatchPipetteStateManager(Qt.QObject):
                 config.update(configOverride)
 
             self.logger.debug(f"Configuring next state {state} with config: {config}")
-            job = stateHandler(self.dev, config)
+            with stateJobContext():
+                job = stateHandler(self.dev, config)
         except Exception:
             raise
         else:

--- a/acq4/devices/PatchPipette/states/nucleus_collect.py
+++ b/acq4/devices/PatchPipette/states/nucleus_collect.py
@@ -87,5 +87,8 @@ class NucleusCollectState(PatchPipetteState):
         with log_and_ignore_exception(Exception, "Error resetting pipette position after collection"):
             if self.startPos is not None:
                 pip = self.dev.pipetteDevice
-                pip.dm.move(MoveSpec(pip, self.startPos, speed='fast')).wait(timeout=60)
+                pip.dm.move(
+                    MoveSpec(pip, self.startPos, speed='fast'),
+                    name=f"return {pip.name()} to pre-collection position",
+                ).wait(timeout=60)
         super()._cleanup()

--- a/acq4/devices/PatchPipette/tests/test_state_throughline.py
+++ b/acq4/devices/PatchPipette/tests/test_state_throughline.py
@@ -1,0 +1,30 @@
+"""Each patch state's throughline names that state, not the whole history of states.
+
+A state's job is constructed from inside the outgoing state's finish handling, so the
+task inherits the outgoing state's context. Left alone, states accumulate: by the tenth
+transition every log line carries all ten state names.
+"""
+from __future__ import annotations
+
+from gentletask import task_chain, throughline
+
+from acq4.util.task import QtFriendlyTask
+
+
+def test_state_job_does_not_inherit_the_outgoing_state_chain(qtbot):
+    """A state job built while an outgoing state is current is named only for itself."""
+    from acq4.devices.PatchPipette.statemanager import stateJobContext
+
+    seen = []
+    with throughline(name="State bath for PatchPipette1"):
+        with stateJobContext():
+            job = QtFriendlyTask(
+                lambda: seen.append(task_chain()),
+                name="State clean for PatchPipette1",
+                detach=True,
+                start=False,
+            )
+        job.start()
+        job.wait(timeout=5)
+
+    assert seen == [("State clean for PatchPipette1",)]

--- a/acq4/devices/Pipette/calibration.py
+++ b/acq4/devices/Pipette/calibration.py
@@ -233,7 +233,10 @@ def findNewPipette(pipette: Pipette, imager: Camera, scopeDevice, searchSpeed=0.
         pipY /= np.linalg.norm(pipY)
         searchPos1 = center + pipVector * 1e-3 + pipY * 1e-3
         searchPos2 = center + pipVector * 1e-3 - pipY * 1e-3
-        getManager().move(MoveSpec(pipette, searchPos1, speed='fast')).wait()
+        getManager().move(
+            MoveSpec(pipette, searchPos1, speed='fast'),
+            name=f"move {pipette.name()} to tip-detection search position",
+        ).wait()
 
         # collect background images, analyze noise
         with imager.ensureRunning():

--- a/acq4/devices/Pipette/pipette.py
+++ b/acq4/devices/Pipette/pipette.py
@@ -222,7 +222,10 @@ class Pipette(Device, OptomechDevice):
             saved_pos = self.loadPosition(position)
             if saved_pos is None:
                 raise ValueError(f"Unknown pipette move position {position!r}")
-            future = self.dm.move(MoveSpec(self, np.asarray(saved_pos, dtype=float), speed=speed))
+            future = self.dm.move(
+                MoveSpec(self, np.asarray(saved_pos, dtype=float), speed=speed),
+                name=f"move {self.name()} to {position}",
+            )
 
         if raiseErrors is not False:
             raise_errors(
@@ -534,7 +537,10 @@ class Pipette(Device, OptomechDevice):
         Always routes through the global motion planner so that any
         post-interaction cleanup steps are included when needed.
         """
-        return self.dm.move(MoveSpec(self, self.homePosition(), speed=speed))
+        return self.dm.move(
+            MoveSpec(self, self.homePosition(), speed=speed),
+            name=f"move {self.name()} to home",
+        )
 
     def homePosition(self) -> ndarray[Any, dtype[Any]]:
         manipulator = self.parentDevice()
@@ -566,16 +572,23 @@ class Pipette(Device, OptomechDevice):
         return self.dm.move(
             MoveSpec(scope, scope_pos, speed=speed),
             MoveSpec(self, target, speed=speed),
+            name=f"move {self.name()} to search",
         )
 
     def goApproach(self, speed, **kwds):
         """Move the tip to approach depth above the target, aligned along the pipette axis."""
         approach_pos = self.positionAtDepth(self.approachDepth(), start=self.targetPosition())
-        return self.dm.move(MoveSpec(self, approach_pos, speed=speed))
+        return self.dm.move(
+            MoveSpec(self, approach_pos, speed=speed),
+            name=f"move {self.name()} to approach",
+        )
 
     def goTarget(self, speed, **kwds):
         """Move the tip to the current target position."""
-        return self.dm.move(MoveSpec(self, self.targetPosition(), speed=speed))
+        return self.dm.move(
+            MoveSpec(self, self.targetPosition(), speed=speed),
+            name=f"move {self.name()} to target",
+        )
 
     @asynch
     def goAboveTarget(self, speed, **kwds):
@@ -596,8 +609,12 @@ class Pipette(Device, OptomechDevice):
         self.dm.move(
             MoveSpec(self, hysteresis_wp, speed=speed),
             MoveSpec(scope, above_target, speed=speed),
+            name=f"move {self.name()} to hysteresis waypoint above target",
         ).wait()
-        self.dm.move(MoveSpec(self, above_target, speed=speed)).wait()
+        self.dm.move(
+            MoveSpec(self, above_target, speed=speed),
+            name=f"move {self.name()} to above target",
+        ).wait()
 
     def _movePath(self, path, name=None) -> MovePathFuture:
         """

--- a/acq4/devices/Pipette/tests/test_named_moves.py
+++ b/acq4/devices/Pipette/tests/test_named_moves.py
@@ -1,0 +1,50 @@
+"""Pipette moves name themselves, so the throughline says where the tip was going.
+
+Pipette.goHome() and friends hand a motion plan to the manager; the name they pass is
+what reaches the planner's throughline frame and every move underneath it. Without a
+name the log shows an anonymous move with no hint of its destination.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from acq4.devices.Pipette import Pipette
+
+
+class _RecordingManager:
+    """Stands in for the Manager, capturing the name each motion plan is given."""
+
+    def __init__(self):
+        self.calls = []
+
+    def move(self, *specs, name: str = ""):
+        self.calls.append(name)
+        return MagicMock()
+
+
+@pytest.fixture
+def pipette(monkeypatch):
+    pip = Pipette.__new__(Pipette)
+    pip.dm = _RecordingManager()
+    return pip
+
+
+def test_go_home_names_its_move(pipette, monkeypatch):
+    monkeypatch.setattr(Pipette, "homePosition", lambda self: np.zeros(3))
+    monkeypatch.setattr(Pipette, "name", lambda self: "Pipette1")
+
+    pipette.goHome(speed="fast")
+
+    assert pipette.dm.calls == ["move Pipette1 to home"]
+
+
+def test_go_target_names_its_move(pipette, monkeypatch):
+    monkeypatch.setattr(Pipette, "targetPosition", lambda self: np.zeros(3))
+    monkeypatch.setattr(Pipette, "name", lambda self: "Pipette1")
+
+    pipette.goTarget(speed="fast")
+
+    assert pipette.dm.calls == ["move Pipette1 to target"]

--- a/acq4/devices/Scientifica/scientifica.py
+++ b/acq4/devices/Scientifica/scientifica.py
@@ -288,11 +288,13 @@ class ScientificaMoveFuture(MoveFuture):
 
         if speed < dev.minimumSpeed:
             # device _can't_ move this slow; we need to break the move into steps
-            self.stepwiseThread = threading.Thread(target=self._stepwiseMove, daemon=True, name=name)
             self.doStepwise = True
             currentPos = dev.getPosition()
             targetPos = [currentPos[i] if pos[i] is None else pos[i] for i in range(len(pos))]
             super().__init__(dev, targetPos, speed, name=name)
+            # Built after super().__init__, which is what captures the requesting
+            # throughline that producerThread restores on the monitor thread.
+            self.stepwiseThread = self.producerThread(self._stepwiseMove, name=name)
             self.stepwiseThread.start()
         else:
             self._moveReq = dev.driver.moveTo(np.array(pos), speed / 1e-6, name=name, **kwds)

--- a/acq4/devices/Sensapex.py
+++ b/acq4/devices/Sensapex.py
@@ -286,20 +286,20 @@ class SensapexMoveFuture(MoveFuture):
         if self.speed >= 1e-6:
             if self.dev.nAxes == 4:
                 # we have to break up the movement because D is always separate from Z
-                self._monitorThread = threading.Thread(
-                    target=self._4AxisMove, daemon=True, name=f"{name} sensapex 4-axis move"
+                self._monitorThread = self.producerThread(
+                    self._4AxisMove, name=f"{name} sensapex 4-axis move"
                 )
             else:
                 self._moveReq = self.dev.dev.goto_pos(
                     pos, self.speed * 1e6, simultaneous=linear, linear=linear, max_attempts=self.max_attempts
                 )
-                self._monitorThread = threading.Thread(
-                    target=self._watchForFinish, daemon=True, name=f"{name} sensapex monitor"
+                self._monitorThread = self.producerThread(
+                    self._watchForFinish, name=f"{name} sensapex monitor"
                 )
         else:
             # uMp has trouble with very slow speeds, so we do this manually by looping over small steps
-            self._monitorThread = threading.Thread(
-                target=self._stepwiseMove, daemon=True, name=f"{name} sensapex stepwise move"
+            self._monitorThread = self.producerThread(
+                self._stepwiseMove, name=f"{name} sensapex stepwise move"
             )
         self._monitorThread.start()
 

--- a/acq4/devices/Stage/Stage.py
+++ b/acq4/devices/Stage/Stage.py
@@ -24,7 +24,7 @@ from ...util.geometry import (
     load_transform,
     minimum_displacement_inverse_kinematics,
 )
-from ...util.task import ManualQtFriendlyTask, Stopped, FutureButton
+from ...util.task import ManualQtFriendlyTask, Stopped, FutureButton, throughline
 
 
 class Stage(Device, OptomechDevice):
@@ -645,7 +645,7 @@ class Stage(Device, OptomechDevice):
         homePos = self.homePosition()
         if homePos is None:
             raise RuntimeError(f"No home position set for {self.name()}")
-        return self.dm.move(MoveSpec(self, homePos, speed=speed))
+        return self.dm.move(MoveSpec(self, homePos, speed=speed), name=f"move {self.name()} to home")
 
     def setHomePosition(self):
         """Set the home position in global coordinates."""
@@ -723,12 +723,42 @@ class MoveFuture(ManualQtFriendlyTask):
         if name is None:
             name = f"{dev.name()} move"
         ManualQtFriendlyTask.__init__(self, name=name)
+        # A ManualTask has no body, so it never enters task_context and never puts its
+        # own name on the throughline; and the producer threads that drive it are raw
+        # threads, which start with an empty context. Capture the requesting context
+        # here (plus this move's name) so producers can re-establish it via
+        # throughlineContext() and everything logged during the move stays attached to
+        # the operation that asked for it.
+        self._throughlineFrames = throughline.frames() + ({"name": name},)
         self.startTime = ptime.time()
         self.dev = dev
         self.speed = speed
         self.targetPos = np.asarray(pos)
         self.startPos = np.asarray(dev.getPosition())
         self._isStopCallable = CallOnce()
+
+    def throughlineContext(self):
+        """Re-establish the throughline this move was requested under.
+
+        Producer threads (a per-move monitor, or a stage's lifetime monitor thread
+        handling this move) wrap the work that drives this move in this, so their log
+        records carry the requesting operation's chain and this move's name.
+        """
+        return throughline.restore(self._throughlineFrames)
+
+    def producerThread(self, target, name) -> threading.Thread:
+        """Return an unstarted daemon thread running *target* under this move's throughline.
+
+        The preferred way for a device subclass to spawn a per-move monitor thread:
+        a raw thread would start with an empty context and orphan everything it logs
+        from the operation that requested the move.
+        """
+
+        def run():
+            with self.throughlineContext():
+                target()
+
+        return threading.Thread(target=run, daemon=True, name=name)
 
     def percentDone(self):
         """Return the percent of the move that has completed.
@@ -803,7 +833,7 @@ class MovePathFuture(MoveFuture):
                     f"Cannot move {dev.name()} to path step {i}/{len(self.path)}: {step}"
                 ) from exc
 
-        self._moveThread = threading.Thread(target=self._movePath, name=f'{dev.name()} : {name}')
+        self._moveThread = self.producerThread(self._movePath, name=f'{dev.name()} : {name}')
         self._moveThread.start()
 
     def percentDone(self):
@@ -828,13 +858,15 @@ class MovePathFuture(MoveFuture):
     def _movePath(self):
         # Producer thread for this externally-completed promise. It is a raw
         # thread (not a gentletask task), so it honors our stop by polling
-        # self.is_stopped rather than using check_stop().
+        # self.is_stopped rather than using check_stop(). It runs under this path's
+        # throughline (see producerThread), which also puts each step's move under
+        # this path, since the step futures are constructed on this thread.
         try:
             for i, step in enumerate(self.path):
                 step = step.copy()
                 explanation = step.pop('explanation', 'unnamed')
                 fut = self.dev.move(
-                    **step, name=f'{self.name} step {i+1}/{len(self.path)}: {explanation}'
+                    **step, name=f'{self._name} step {i+1}/{len(self.path)}: {explanation}'
                 )
                 fut._pathStep = i
                 self._currentFuture = fut
@@ -878,7 +910,7 @@ class MovePathFuture(MoveFuture):
             step['position'] = fwdPath[i]['position']
             step['explanation'] = f"undo {step.get('explanation')}"
             revPath.append(step)
-        return self.dev.movePath(revPath, name=f"undo {self.name}")
+        return self.dev.movePath(revPath, name=f"undo {self._name}")
 
 
 class StageInterface(Qt.QWidget):

--- a/acq4/devices/Stage/tests/test_move_throughline.py
+++ b/acq4/devices/Stage/tests/test_move_throughline.py
@@ -1,0 +1,104 @@
+"""A move carries its caller's throughline, plus its own name, into the thread that drives it.
+
+Move completion is driven by raw producer threads (per-move monitors, or a stage's
+lifetime monitor thread), which start with an empty context; without an explicit
+restore, everything logged while a move runs is orphaned from the operation that
+asked for the move.
+"""
+import threading
+
+import pytest
+from gentletask import task_chain, throughline
+from unittest.mock import MagicMock, patch
+
+from acq4.devices.MockStage import MockStage
+
+
+@pytest.fixture
+def stage(qtbot):
+    class MockDM:
+        def __init__(self):
+            self.sigAbortAll = MagicMock()
+
+        def declareInterface(self, name, interfaces, obj):
+            pass
+
+        def getDevice(self, name):
+            return None
+
+        def readConfigFile(self, fn):
+            return {}
+
+    mock_dm = MockDM()
+    config = {'driver': 'MockStage', 'nAxes': 3}
+    with patch("acq4.Manager.Manager.single") as single:
+        single.return_value = mock_dm
+        dev = MockStage(mock_dm, config, "MockMoveStage")
+        yield dev
+        dev.quit()
+
+
+def test_move_restores_callers_throughline_in_another_thread(stage):
+    """A producer thread entering the move's context sees caller chain + move name."""
+    with throughline(name="clean state"):
+        fut = stage._move([100e-6, 0, 0], 1e-3, False, name="move to clean well")
+
+    seen = []
+
+    def producer():
+        with fut.throughlineContext():
+            seen.append(task_chain())
+
+    thread = threading.Thread(target=producer)
+    thread.start()
+    thread.join(timeout=5)
+
+    assert seen == [("clean state", "move to clean well")]
+
+
+def test_producer_thread_runs_under_the_move_throughline(stage):
+    """producerThread() gives device drivers a monitor thread with the context restored."""
+    with throughline(name="clean state"):
+        fut = stage._move([100e-6, 0, 0], 1e-3, False, name="move to clean well")
+
+    seen = []
+    thread = fut.producerThread(lambda: seen.append(task_chain()), name="fake monitor")
+    thread.start()
+    thread.join(timeout=5)
+
+    assert thread.daemon
+    assert seen == [("clean state", "move to clean well")]
+
+
+def test_path_move_steps_nest_under_the_path_throughline(stage):
+    """Each step of a path move carries the caller's chain, the path, and the step."""
+    with throughline(name="clean state"):
+        fut = stage.movePath(
+            [
+                {'position': [100e-6, 0, 0], 'speed': 1e-3, 'explanation': 'into the well'},
+                {'position': [0, 0, 0], 'speed': 1e-3, 'explanation': 'back out'},
+            ],
+            name="clean path",
+        )
+
+    chains = []
+    fut.add_finish_callback(lambda result, exc: chains.append(task_chain()))
+    fut.wait(timeout=10)
+
+    assert chains == [("clean state", "clean path")]
+
+
+def test_move_is_completed_under_the_move_throughline(stage):
+    """The thread that actually completes the move runs under the move's throughline.
+
+    Finish callbacks fire on the completing thread, so they observe the context the
+    monitor thread was running under when it resolved the move.
+    """
+    chains = []
+    with throughline(name="clean state"):
+        fut = stage._move([1e-3, 0, 0], 1e-3, False, name="move to clean well")
+    fut.add_finish_callback(lambda result, exc: chains.append(task_chain()))
+
+    fut.wait(timeout=10)
+
+    assert chains == [("clean state", "move to clean well")]

--- a/acq4/devices/Stage/tests/test_move_throughline.py
+++ b/acq4/devices/Stage/tests/test_move_throughline.py
@@ -82,9 +82,15 @@ def test_path_move_steps_nest_under_the_path_throughline(stage):
         )
 
     chains = []
-    fut.add_finish_callback(lambda result, exc: chains.append(task_chain()))
-    fut.wait(timeout=10)
+    fired = threading.Event()
 
+    def record(result, exc):
+        chains.append(task_chain())
+        fired.set()
+
+    fut.add_finish_callback(record)
+
+    assert fired.wait(timeout=10)
     assert chains == [("clean state", "clean path")]
 
 
@@ -95,10 +101,20 @@ def test_move_is_completed_under_the_move_throughline(stage):
     monitor thread was running under when it resolved the move.
     """
     chains = []
+    fired = threading.Event()
+
+    def record(result, exc):
+        chains.append(task_chain())
+        fired.set()
+
     with throughline(name="clean state"):
         fut = stage._move([1e-3, 0, 0], 1e-3, False, name="move to clean well")
-    fut.add_finish_callback(lambda result, exc: chains.append(task_chain()))
+        # Registered inside the context and immediately after the move starts: a
+        # callback added after completion would fire inline on this thread instead of
+        # on the thread that completed the move.
+        fut.add_finish_callback(record)
 
-    fut.wait(timeout=10)
-
+    # Wait on the callback, not on the future: _finish wakes waiters before it runs
+    # finish callbacks, so wait() can return before `record` has been called.
+    assert fired.wait(timeout=10)
     assert chains == [("clean state", "move to clean well")]

--- a/acq4/devices/SutterMPC200/SutterMPC200.py
+++ b/acq4/devices/SutterMPC200/SutterMPC200.py
@@ -332,13 +332,17 @@ class MPC200MoveFuture(MoveFuture):
         # Advance this move toward completion. Called by the shared MonitorThread
         # each tick while the move is in flight: resolve on arrival, fail on a
         # move error. Idempotent and race-safe (guards + atomic completion).
-        if self.is_stopped or self.is_done:
-            return
-        start, status = self._getStatus()
-        if isinstance(status, Exception):
-            self.fail(status)
-        elif status is True:
-            self.resolve(None)
+        # Runs under this move's throughline: the shared monitor thread has no
+        # context of its own, so completion would otherwise be orphaned from the
+        # requesting operation.
+        with self.throughlineContext():
+            if self.is_stopped or self.is_done:
+                return
+            start, status = self._getStatus()
+            if isinstance(status, Exception):
+                self.fail(status)
+            elif status is True:
+                self.resolve(None)
 
     def percentDone(self):
         """Return an estimate of the percent of move completed based on the

--- a/acq4/devices/ThorlabsMFC1/MFC1.py
+++ b/acq4/devices/ThorlabsMFC1/MFC1.py
@@ -241,18 +241,22 @@ class MFC1MoveFuture(MoveFuture):
         # Advance this move toward completion. Called by the device MonitorThread
         # each tick while the move is in flight: resolve on arrival, fail on a
         # missed target. Idempotent and race-safe (guards + atomic completion).
-        if self.is_stopped or self.is_done:
-            return
-        stat = self._getStatus()['status']
-        if stat == 'interrupted':
-            # The driver only marks a move 'interrupted' when dev.stop() was
-            # called, which also completes this promise with Stopped via
-            # stop(); just let that path own completion.
-            return
-        elif stat == 'failed':
-            self.fail(RuntimeError(self.errorMessage()))
-        elif stat == 'done':
-            self.resolve(None)
+        # Runs under this move's throughline: the monitor thread has no context of
+        # its own, so completion would otherwise be orphaned from the requesting
+        # operation.
+        with self.throughlineContext():
+            if self.is_stopped or self.is_done:
+                return
+            stat = self._getStatus()['status']
+            if stat == 'interrupted':
+                # The driver only marks a move 'interrupted' when dev.stop() was
+                # called, which also completes this promise with Stopped via
+                # stop(); just let that path own completion.
+                return
+            elif stat == 'failed':
+                self.fail(RuntimeError(self.errorMessage()))
+            elif stat == 'done':
+                self.resolve(None)
 
     def percentDone(self):
         """Return an estimate of the percent of move completed based on the

--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -224,7 +224,7 @@ class Orchestrator(Qt.QObject):
     def start(self):
         """Launch the queue loop asynchronously; returns the launched task."""
         self._task = asynch_with_qt_signals(
-            self._runLoopBody, on_finish=self._onLoopFinished
+            self._runLoopBody, name="autopatch queue loop", on_finish=self._onLoopFinished
         )()
         return self._task
 

--- a/acq4/logging_config.py
+++ b/acq4/logging_config.py
@@ -14,6 +14,21 @@ log_server: LogServer | None = None
 log_handlers = []
 log_file_handler: logging.FileHandler | None = None
 
+# Tags every record with the gentletask throughline (the task-name chain) so the log
+# viewer, console, and file show what operation each line belongs to. Filters must be
+# attached to handlers rather than a logger: a filter on a logger only runs for records
+# logged directly to it, so records from child loggers (acq4.device.*, gentletask, ...)
+# would go untagged. One shared instance means every handler tags identically, and
+# add_throughline_filter() is the single place that puts it on a handler.
+throughline_filter = ThroughlineNameFilter()
+
+
+def add_throughline_filter(handler: logging.Handler) -> None:
+    """Attach the shared throughline filter to *handler*, at most once."""
+    if throughline_filter not in handler.filters:
+        handler.addFilter(throughline_filter)
+
+
 def __reload__(old):
     global log_server, log_handlers
     log_server = old.get('log_server', None)
@@ -149,15 +164,12 @@ def setup_logging(
         root_logger.addHandler(error_dialog.handler)
         log_handlers.append(error_dialog.handler)
 
-    # Tag every record with the gentletask throughline (the task-name chain) so the
-    # log viewer, console, and file show what operation each line belongs to.
-    # Attaching to the handlers (rather than a logger) ensures propagated
-    # child-logger records are tagged too; the filter mutates the record in place,
-    # and teleprox's LogSender copies the record __dict__ on to the viewer.
-    throughline_filter = ThroughlineNameFilter()
+    # Tag every record with the gentletask throughline (see add_throughline_filter).
+    # The filter mutates the record in place, and teleprox's LogSender copies the
+    # record __dict__ on to the viewer.
     for _logger in (root_logger, acq4_logger):
         for _handler in _logger.handlers:
-            _handler.addFilter(throughline_filter)
+            add_throughline_filter(_handler)
 
 
 def set_log_file(log_file: str | None, is_temp_file: bool = False) -> None:
@@ -199,6 +211,10 @@ def set_log_file(log_file: str | None, is_temp_file: bool = False) -> None:
         exc_info_as_array=True,
     )
     log_file_handler.setFormatter(json_formatter)
+    # This handler is rebuilt every time the log file changes, long after
+    # setup_logging ran, so it tags records itself instead of depending on an
+    # earlier handler in the chain having done it.
+    add_throughline_filter(log_file_handler)
     root_logger.addHandler(log_file_handler)
 
 

--- a/acq4/modules/MultiPatch/multipatch.py
+++ b/acq4/modules/MultiPatch/multipatch.py
@@ -16,7 +16,7 @@ from neuroanalysis.test_pulse_stack import H5BackedTestPulseStack
 from .mockPatch import MockPatch
 from .pipetteControl import PipetteControl
 from ...devices.PatchPipette.statemanager import PatchPipetteStateManager
-from ...util.task import MultiFuture, asynch, raise_errors, run_in_gui_thread
+from ...util.task import MultiFuture, asynch, raise_errors, run_in_gui_thread, throughline
 from ...util.json_encoder import ACQ4JSONEncoder
 
 Ui_MultiPatch = Qt.importTemplate('.multipatchTemplate')
@@ -257,14 +257,18 @@ class MultiPatchWindow(Qt.QWidget):
         ], name=f"Set pipettes state to {state}")
 
     def _moveHome(self):
-        futures = []
-        for pip in self.selectedPipettes():
-            speed = self.selectedSpeed(default='fast')
-            if isinstance(pip, PatchPipette):
-                pip.setState('out')
-                pip = pip.pipetteDevice
-            futures.append(pip.goHome(speed))
-        return MultiFuture(futures, name="Move pipettes home")
+        # This runs on the GUI thread, which carries no throughline of its own; the
+        # frame is what tells the log that these moves came from a button press, and
+        # each move's task nests under it.
+        with throughline(name="Move pipettes home"):
+            futures = []
+            for pip in self.selectedPipettes():
+                speed = self.selectedSpeed(default='fast')
+                if isinstance(pip, PatchPipette):
+                    pip.setState('out')
+                    pip = pip.pipetteDevice
+                futures.append(pip.goHome(speed))
+            return MultiFuture(futures, name="Move pipettes home")
 
     def _nucleusHome(self):
         return self._setAllSelectedPipettesToState('home with nucleus')
@@ -323,13 +327,14 @@ class MultiPatchWindow(Qt.QWidget):
         return self._setAllSelectedPipettesToState('refill')
 
     def _approach(self):
-        futures = []
-        for pip in self.selectedPipettes():
-            if isinstance(pip, PatchPipette):
-                futures.append(pip.setState('approach'))
-            else:
-                futures.append(pip.goApproach(self.selectedSpeed(default='fast')))
-        return MultiFuture(futures, name="Move pipettes to approach")
+        with throughline(name="Move pipettes to approach"):
+            futures = []
+            for pip in self.selectedPipettes():
+                if isinstance(pip, PatchPipette):
+                    futures.append(pip.setState('approach'))
+                else:
+                    futures.append(pip.goApproach(self.selectedSpeed(default='fast')))
+            return MultiFuture(futures, name="Move pipettes to approach")
 
     def _clean(self):
         return self._setAllSelectedPipettesToState('clean')
@@ -349,14 +354,15 @@ class MultiPatchWindow(Qt.QWidget):
         return default
 
     def moveSearch(self, distance):
-        speed = self.selectedSpeed(default='fast')
-        futures = []
-        for pip in self.selectedPipettes():
-            if isinstance(pip, PatchPipette):
-                pip.setState('bath')
-                pip = pip.pipetteDevice
-            futures.append(pip.goSearch(speed, distance=distance))
-        return MultiFuture(futures, name="Move pipettes to search")
+        with throughline(name="Move pipettes to search"):
+            speed = self.selectedSpeed(default='fast')
+            futures = []
+            for pip in self.selectedPipettes():
+                if isinstance(pip, PatchPipette):
+                    pip.setState('bath')
+                    pip = pip.pipetteDevice
+                futures.append(pip.goSearch(speed, distance=distance))
+            return MultiFuture(futures, name="Move pipettes to search")
 
     def setTipToggled(self, b):
         cammod = getManager().getModule('Camera')

--- a/acq4/motion/planner.py
+++ b/acq4/motion/planner.py
@@ -134,7 +134,10 @@ class MotionPlanner:
 def _move_device(device, position, speed, name, kwargs):
     """Call the appropriate movement primitive on a device."""
     if hasattr(device, "moveToGlobalNoPlanning"):
-        with throughline(name=f"moving {device} to '{name}'"):
+        # Name the device only. The plan step's own name reaches the throughline via the
+        # MoveFuture this creates, so repeating it here would say it twice; and when a
+        # step has no explanation, "moving X to ''" said nothing at all.
+        with throughline(name=f"moving {device.name()}"):
             device.logger.debug(f"Starting move to {position}")
             return device.moveToGlobalNoPlanning(position, speed, name=name, **kwargs)
     raise RuntimeError(f"Device {device!r} has no moveToGlobalNoPlanning method")

--- a/acq4/util/tests/test_logging_config.py
+++ b/acq4/util/tests/test_logging_config.py
@@ -1,8 +1,11 @@
-"""Tests for set_log_file migration behavior in acq4.logging_config."""
+"""Tests for set_log_file migration and throughline tagging in acq4.logging_config."""
+import contextlib
+import json
 import logging
 import os
 
 import pytest
+from gentletask import throughline
 
 import acq4.logging_config as lc
 
@@ -40,6 +43,41 @@ def test_temp_log_deleted_after_migration(tmp_path, clean_log_handler):
     assert not temp_log.exists()
     assert new_log.exists()
     assert b"hello from temp" in new_log.read_bytes()
+
+
+@contextlib.contextmanager
+def _at_level(logger, level):
+    """Temporarily force *logger* to *level* so DEBUG records are emitted."""
+    saved = logger.level
+    logger.setLevel(level)
+    try:
+        yield
+    finally:
+        logger.setLevel(saved)
+
+
+def _records_in(log_file):
+    return [json.loads(line) for line in log_file.read_text().splitlines() if line.strip()]
+
+
+def test_log_file_records_carry_the_throughline(tmp_path, clean_log_handler):
+    """Records written to a freshly-set log file are tagged with the active throughline.
+
+    The file handler is rebuilt whenever the log file changes (e.g. when Manager
+    switches from the temp log to the session's log.json), so it must carry the
+    throughline filter itself rather than relying on another handler to have
+    tagged the record on the way past.
+    """
+    log_file = tmp_path / "log.json"
+    lc.set_log_file(str(log_file))
+
+    logger = logging.getLogger("acq4")
+    with _at_level(logger, logging.DEBUG), throughline(name="cleaning pipette"):
+        logger.debug("scrubbing")
+
+    records = [r for r in _records_in(log_file) if r["message"] == "scrubbing"]
+    assert len(records) == 1
+    assert records[0]["throughline"] == ["cleaning pipette"]
 
 
 def test_non_temp_log_not_deleted(tmp_path, clean_log_handler):

--- a/acq4/util/tests/test_logwindow_throughline.py
+++ b/acq4/util/tests/test_logwindow_throughline.py
@@ -37,3 +37,31 @@ def test_task_column_falls_back_to_taskname(qapp):
     rec = _record(throughline=(), taskName="legacy-task")
     text = model._get_column_text(rec, LogColumns.TASK)
     assert text == "legacy-task"
+
+
+def test_qt_log_handler_applies_its_filters(qapp):
+    """The Qt handler feeding the log window runs its filters before delivering a record.
+
+    The Task column reads record.throughline, which the throughline filter attaches.
+    A handler that skips filters shows a blank Task column for every record it is the
+    first (or only) handler to see.
+    """
+    import logging
+
+    from gentletask import throughline
+    from teleprox.log.logviewer.viewer import QtLogHandler
+
+    from acq4.logging_config import add_throughline_filter
+
+    handler = QtLogHandler()
+    add_throughline_filter(handler)
+
+    delivered = []
+    handler.new_record.connect(delivered.append)
+
+    record = logging.LogRecord("acq4.probe", logging.DEBUG, __file__, 1, "hi", None, None)
+    with throughline(name="cleaning pipette"):
+        handler.handle(record)
+
+    assert len(delivered) == 1
+    assert delivered[0].throughline == ("cleaning pipette",)


### PR DESCRIPTION
## Why

Almost nothing in the log carried a throughline. In a real session log (`junk_data/2026.07.31_000/log.json`, 1179 records): **213 had no `throughline` attribute at all, 919 had an empty one, and 47 were populated.**

Most of it turned out to be plumbing, not missing context — records that *had* good context were losing it before they reached the file.

## What was wrong

**1. The JSON log handler had no throughline filter.** `setup_logging` attaches the filter to the handlers that exist at that moment, but `Manager` later calls `set_log_file()`, which builds a fresh `FileHandler` with no filters. After that swap a record was only tagged if an earlier root handler's filter mutated it in passing — and the only one that does is the console handler, at WARNING. Reproduced:

```
DEBUG   after switch  | throughline: <ABSENT>     <-- context existed, discarded
INFO    after switch  | throughline: <ABSENT>     <-- context existed, discarded
WARNING after switch  | throughline: ['PHASE-B']
```

That is why all 102 `_move_device` "Starting move to …" lines were untagged despite being emitted *inside* a `throughline(...)` block.

**2. `QtLogHandler.handle()` never ran its filters** (fixed in teleprox, see below), so the Log window's Task column only ever showed context another handler had already attached.

**3. Move names never reached the throughline.** `MoveFuture` is a `ManualTask` — no body, so it never enters `task_context` — and the producer threads that drive moves are raw `threading.Thread`s, which start with an empty context:

```
inline                       -> ('clean state',)
gentletask ThreadTask        -> ('clean state', 'pipette move to clean')
ManualTask producer thread   -> ()                 <-- MoveFuture's world
raw thread                   -> ()
```

**4. Patch states nested into their predecessors, forever.** A state's job is constructed inside the outgoing state's finish handling, and `ThreadTask` snapshots `copy_context()` at construction:

```
1 ('State 1',)
3 ('State 1', 'State 2', 'State 3')
5 ('State 1', 'State 2', 'State 3', 'State 4', 'State 5')
```

**5. Anonymous work.** `dm.move(...)` was called with no `name` from every `go*()` method, and unnamed tasks fall back to `fn.__qualname__` — which is why the best chains in the log literally read `Orchestrator._runLoopBody`.

## What changed

- `logging_config`: one shared filter instance applied via `add_throughline_filter()`, which `set_log_file()` now uses.
- `MoveFuture` captures the requesting context plus its own name, exposed as `throughlineContext()` and `producerThread()`; every stage driver's monitor adopts it (Sensapex, Scientifica, MicroManager, NewScale, MPC200, MFC1, Dover, MockStage, `MovePathFuture`).
- Patch state jobs are built under `stateJobContext()`, matching the `detach=True` that already makes states siblings.
- Named the pipette `go*()` destinations, the autopatch queue loop, the MultiPatch move buttons, and state transitions.

**Drive-by fix:** `MovePathFuture` used `self.name`, which the gentletask migration renamed to `_name` — path moves raised `AttributeError` on their first step. A new test caught it.

## Result

The chain you get for a Clean-state move, read back out of an actual log file:

```
'Starting move to [0.0001, 0, 0]' -> State clean for PatchPipette1 > interact with CleanWell > moving Manipulator1
'move finished'                   -> State clean for PatchPipette1 > interact with CleanWell > moving Manipulator1 > move Pipette1 to clean
```

The second line is emitted from the monitor thread and still carries the whole chain.

## Testing

New tests in `test_logging_config.py`, `test_logwindow_throughline.py`, `test_move_throughline.py`, `test_state_throughline.py`, `test_named_moves.py`. Full suite: 1342 passed, 1 xfailed, stable over three runs.

## Companion PR

Requires campagnola/teleprox#43 — `QtLogHandler.handle()` skipping `self.filter(record)`.

🧙 Built with [WOZCODE](https://wozcode.com)