### PR TITLE
feat(autopatch): the pinned-frames workflow, and the Camera module as a precondition

### DIFF
--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -422,9 +422,6 @@ class AutopatchWindow(Qt.QWidget):
             camera.globalCenterPosition("roi")[:2], (fov[0] * 10, fov[1] * 10)
         )
         self._bindPinnedFrames(camera)
-        # Re-resolved per slice for the same reason the mirror is: the operator
-        # may have changed the selected camera since the last one.
-        self._referenceImagery.rebind()
         # There is a camera now, so retract the message above if it is up.
         self.searchPanel.setError("")
         return True
@@ -473,6 +470,12 @@ class AutopatchWindow(Qt.QWidget):
         exists for. A manager present with no Camera window behind it is not
         among these -- _cameraWindow() raises rather than answering that with
         silence, and that raise is deliberately left to propagate here too.
+
+        The `window is None` check below is not what makes the headless case
+        quiet, though: `None.getInterfaceForDevice(...)` would raise
+        AttributeError, which the except clause converts to None regardless.
+        It is kept only because spelling the headless case out here is
+        clearer than leaving it to fall through that catch.
         """
         window = self._cameraWindow()
         if window is None:

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -234,13 +234,17 @@ class AutopatchWindow(Qt.QWidget):
 
     @staticmethod
     def _cameraModuleWindow(manager):
-        """The Camera module's window under `manager`.
+        """The Camera module's window under `manager`, or None with no manager.
 
-        Raises rather than answering None: the Autopatch module opens the
-        Camera module at startup (see Autopatch.__init__), so a missing one
-        means it was closed underneath a running session. Degrading quietly
-        would leave Area 1 blank while the operator went on drawing regions
-        over nothing and the survey went on imaging tiles they could not see.
+        None only for the manager-less case: headless (module=None) is a
+        documented mode of this window (see AutopatchWindow.__init__ and
+        test_a_headless_window_with_no_manager_still_starts_a_slice), not a
+        degraded state for this getter to paper over. With a manager present,
+        there is no such case left: the Autopatch module opens the Camera
+        module at startup (see Autopatch.__init__), so seeing it missing or
+        windowless here means it was closed underneath a running session, and
+        raising is what surfaces that to the operator instead of leaving
+        Area 1 blank while regions keep getting drawn over nothing.
 
         HelpfulException rather than RuntimeError because this is acq4's
         operator-facing error type -- the same one create_data_dir raises for
@@ -252,9 +256,7 @@ class AutopatchWindow(Qt.QWidget):
         where it is constructed.
         """
         if manager is None:
-            raise HelpfulException(
-                "Autopatch needs a Manager to find the Camera module."
-            )
+            return None
         if "Camera" not in manager.listModules():
             raise HelpfulException(
                 "The Camera module is not open. Autopatch opens it at startup "
@@ -266,7 +268,7 @@ class AutopatchWindow(Qt.QWidget):
         return window
 
     def _cameraWindow(self):
-        """The Camera module's window."""
+        """The Camera module's window, or None with no manager (headless)."""
         return self._cameraModuleWindow(self.manager)
 
     def _onMirrorToggled(self, enabled: bool) -> None:
@@ -327,6 +329,17 @@ class AutopatchWindow(Qt.QWidget):
         _startSlice()'s job alone, called only once directory creation has
         already succeeded.
 
+        The Camera module precondition is checked here too, rather than left
+        for _bindPinnedFrames() to discover partway through _startSlice():
+        by then self.slice is already replaced and, via newSlice(), a Slice
+        data directory has already been created and made current -- see that
+        method's own docstring on why the camera/constraints check runs
+        before create_data_dir() at all. An operator missing the Camera
+        module gets the same treatment as one with no camera selected: a
+        message on SearchPanel's error line, reported before anything is
+        committed, rather than a raise discovered once it is too late to
+        back out of.
+
         A torn-down window can never start one again. teardown() waits on the
         orchestrator with the Qt event loop still pumping (see
         _stopAndReleaseOrchestrator), so New slice and Add region here stay
@@ -340,6 +353,11 @@ class AutopatchWindow(Qt.QWidget):
         camera = self.cameraSelector.getSelectedObj()
         if camera is None:
             self.searchPanel.setError("Select a camera before starting a slice.")
+            return False
+        try:
+            self._cameraWindow()
+        except HelpfulException as exc:
+            self.searchPanel.setError(str(exc))
             return False
         if self.searchPanel.constraints() is None:
             return False
@@ -403,17 +421,18 @@ class AutopatchWindow(Qt.QWidget):
         drawn over it.
 
         A manager-less window (module=None -- headless, or a test with no
-        Manager to stand in for) has nothing to bind to, and that is
-        ordinary. With a manager, though, there is no such case left to
-        return quietly out of: the Camera module is this module's own
-        precondition, so a manager present with no Camera window behind it
-        reaches here only because it closed underneath a running session,
-        and _cameraWindow() raises rather than answering that with silence.
+        Manager to stand in for) is the only case _cameraWindow() answers
+        with None; there is nothing to bind to there, and that is ordinary.
+        With a manager, though, there is no such case left to return quietly
+        out of: the Camera module is this module's own precondition, so a
+        manager present with no Camera window behind it reaches here only
+        because it closed underneath a running session, and _cameraWindow()
+        raises rather than answering that with silence.
         """
         self._pinnedFrameMirror.unbind()
-        if self.manager is None:
-            return
         window = self._cameraWindow()
+        if window is None:
+            return
         try:
             imagingCtrl = window.getInterfaceForDevice(camera.name()).imagingCtrl
         except (KeyError, AttributeError):
@@ -950,13 +969,27 @@ class Autopatch(Module):
             Autopatch._instance.ui.activateWindow()
             Qt.QTimer.singleShot(0, self.quit)
             return
-        Autopatch._instance = self
         # Before the window, which assumes it: Area 1 mirrors the Camera
-        # module's pinned frames and puts region outlines back into its view,
-        # and getModule() loads a module that is not already open. Making it
-        # this module's responsibility is what lets every consumer downstream
-        # treat a missing Camera module as an error rather than a case.
-        manager.getModule("Camera")
+        # module's pinned frames and puts region outlines back into its view.
+        # getModule() loads a module that is not already open, but
+        # Manager.loadDefinedModule only logs an error and returns None when
+        # "Camera" is not in this rig's configuration at all -- proceeding
+        # past that silently would open this window anyway and leave the
+        # operator to find out much later, from a message telling them to
+        # reopen a module that was never openable to begin with.
+        cameraModule = manager.getModule("Camera")
+        if cameraModule is None:
+            raise HelpfulException(
+                "Autopatch requires a Camera module, but none is configured "
+                "for this rig. Add one to the configuration and try again."
+            )
+        # Set only once Camera is confirmed, not before: a raise out of
+        # getModule() above (Camera's own constructor failing) must not
+        # leave this pointing at a module with no `.ui` -- every later
+        # attempt to open Autopatch would hit
+        # Autopatch._instance.ui.raise_() -> AttributeError, permanently,
+        # for the life of the app.
+        Autopatch._instance = self
         self.ui = AutopatchWindow(self)
         manager.declareInterface(name, ["autopatchModule"], self)
         self.ui.show()

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -172,9 +172,6 @@ class AutopatchWindow(Qt.QWidget):
         # on the orchestrator's worker thread and must not read a selector.
         self._cachedCamera = None
         self._cachedScope = None
-        # Whether Area 3's instruction band is currently carrying a message this
-        # window's Area 1 handlers put there -- see _setRegionInstruction().
-        self._regionInstruction = False
         self._tornDown = False
         self.protocolPanel.sigProtocolLoaded.connect(self._onProtocolLoaded)
         # Area 4 (the protocol picker/Reload) must not be usable while a
@@ -190,15 +187,6 @@ class AutopatchWindow(Qt.QWidget):
         self.regionPanel.sigAddRegionRequested.connect(self.addRegionHere)
         self.regionPanel.sigRegionsChanged.connect(self._onRegionsEdited)
         self.regionPanel.mirrorCheck.toggled.connect(self._onMirrorToggled)
-        if self.manager is not None:
-            # Both Area 1 mirrors resolve the Camera module through
-            # _cameraModuleWindow, which reports None while that module is not
-            # open -- so a mirror armed before the operator opens it binds to
-            # nothing. Manager announces every module load and quit here, which
-            # is the one event that can change that answer. Disconnected in
-            # teardown(); a window built with no module (the headless/test mode)
-            # has no manager to listen to.
-            self.manager.sigModulesChanged.connect(self._onModulesChanged)
         self.searchPanel.sigConstraintsChanged.connect(self._onConstraintsChanged)
         self.statusPanel.sigInteractionLocked.connect(
             self.searchPanel.setInteractionLocked
@@ -275,45 +263,8 @@ class AutopatchWindow(Qt.QWidget):
         return self._cameraModuleWindow(self.manager)
 
     def _onMirrorToggled(self, enabled: bool) -> None:
-        """Turn the outline mirror on or off, saying so if there is nowhere to
-        draw.
-
-        A tick with no Camera module open is otherwise a silent no-op: the
-        checkbox stays ticked, nothing appears anywhere, and nothing
-        distinguishes that from a mirror that is broken. The message is
-        accurate about what happens next -- _onModulesChanged() re-runs this
-        handler when a module is opened, so the outlines really do appear then.
-        """
+        """Turn the outline mirror on or off."""
         self._cameraMirror.setEnabled(enabled)
-        if enabled and self._cameraWindow() is None:
-            self._setRegionInstruction(
-                "Mirror to Camera: no Camera module is open. The outlines will "
-                "appear if one is opened."
-            )
-        else:
-            self._setRegionInstruction("")
-
-    def _onModulesChanged(self) -> None:
-        """Re-resolve Area 1's two mirrors against the modules now loaded.
-
-        Both of them find the Camera module once and keep the answer: the
-        outline mirror at the moment the checkbox is ticked, the pinned-frame
-        mirror at the moment a slice starts. Either can happen before the
-        Camera module is open, and Manager emits this whenever that changes.
-
-        Refuses once the window is torn down. teardown() waits on the
-        orchestrator with the Qt event loop still pumping, so a module loaded in
-        those seconds is announced while teardown is in progress, and re-binding
-        then would leave the Camera module holding a closed session's graphics.
-        """
-        if self._tornDown:
-            return
-        # Re-runs the checkbox's own handler, which redraws the outlines against
-        # whatever window there is now and raises or retracts its message.
-        self._onMirrorToggled(self.regionPanel.mirrorCheck.isChecked())
-        camera = self.cameraSelector.getSelectedObj()
-        if self.slice is not None and camera is not None:
-            self._bindPinnedFrames(camera)
 
     def _onRegionsEdited(self, regions) -> None:
         """Take Area 1's edited region list as the slice's regions.
@@ -354,21 +305,11 @@ class AutopatchWindow(Qt.QWidget):
         self._refreshSurveyStats()
 
     def _setRegionInstruction(self, text: str) -> None:
-        """Put Area 1's guidance in Area 3's band, or retract what it last put
-        there.
+        """Put Area 1's guidance in Area 3's band, or retract it.
 
         Area 1 has one guidance slot: a later message replaces an earlier one.
-        Whether this window is currently using that slot is tracked rather than
-        written straight through, because newSlice() writes into the same band
-        for its own reason -- an unchosen storage directory -- and clearing
-        Area 1's message must not erase guidance whose condition still holds.
         """
-        if text:
-            self._regionInstruction = True
-            self.statusPanel.setInstruction(text)
-        elif self._regionInstruction:
-            self._regionInstruction = False
-            self.statusPanel.clearInstruction()
+        self.statusPanel.setInstruction(text)
 
     def _canStartSlice(self) -> bool:
         """Whether a slice can be started right now, reporting the reason
@@ -505,11 +446,6 @@ class AutopatchWindow(Qt.QWidget):
             # Narrowed to HelpfulException so a genuine programming error (a
             # missing manager, say) propagates instead of being reported as
             # storage guidance.
-            #
-            # The band is this handler's now, not Area 1's, so a later region
-            # edit must not treat retracting its own message as licence to
-            # retract this one (see _setRegionInstruction).
-            self._regionInstruction = False
             self.statusPanel.setInstruction(str(exc))
             return
         if not self._startSlice(dirHandle=dirHandle):
@@ -522,7 +458,6 @@ class AutopatchWindow(Qt.QWidget):
         self.statusPanel.clearError()
         # Whichever handler filled the band, what it was about went with the
         # tissue just discarded.
-        self._regionInstruction = False
         self.statusPanel.clearInstruction()
         if self.orchestrator is not None:
             # Detached before the queue is cleared, not after: a refill still
@@ -974,16 +909,6 @@ class AutopatchWindow(Qt.QWidget):
             # this window: a raise while stopping the orchestrator would
             # otherwise leave the Camera module holding this session's outlines
             # and its imaging control still connected to a dead mirror.
-            #
-            # The manager goes first, and for the same reason the mirrors go
-            # last: the manager outlives this window, so a connection left on it
-            # would go on calling this window's handler at every later module
-            # load or quit, re-arming the mirrors the next two lines release.
-            # Dropping it here closes that off for good; anything announced
-            # during the wait above was already refused by _onModulesChanged's
-            # own torn-down check.
-            if self.manager is not None:
-                Qt.disconnect(self.manager.sigModulesChanged, self._onModulesChanged)
             self._pinnedFrameMirror.unbind()
             self._cameraMirror.clear()
             self._releaseCellPositionConnections()

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -500,10 +500,12 @@ class AutopatchWindow(Qt.QWidget):
         # that no longer exists once the operator has physically swapped in
         # new tissue.
         self.statusPanel.clearError()
-        # Whichever handler filled the band, what it was about went with the
-        # tissue just discarded. The storage slot alone: this is the condition
-        # New slice has just resolved, and the imagery slot is recomputed from
-        # state moments later by ReferenceImagery.
+        # Storage and region both, because what each was about went with the
+        # tissue just discarded: storage names a condition this click has now
+        # resolved, and region refused an edit to an outline that no longer
+        # exists. Imagery is deliberately left alone -- ReferenceImagery
+        # recomputes it from state moments later, and clearing it here would
+        # only race that.
         self.statusPanel.setInstruction("storage", "")
         self.statusPanel.setInstruction("region", "")
         if self.orchestrator is not None:

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -22,6 +22,7 @@ from .example_protocols import install_example_protocols
 from .progress_colors import ColorContext, brushesFor, legendFor
 from .progress_overlay import Marker, ProgressOverlay
 from .protocol_panel import ProtocolPanel
+from .reference_imagery import ReferenceImagery
 from .region_mirrors import CameraMirror, PinnedFrameMirror
 from .region_panel import RegionPanel
 from .search_panel import SearchPanel
@@ -117,6 +118,15 @@ class AutopatchWindow(Qt.QWidget):
         self.area1Box.layout().addWidget(self.regionPanel)
 
         self._pinnedFrameMirror = PinnedFrameMirror(self.regionPanel.view)
+        # parent=self so the clear prompt is owned by this window: a parentless
+        # QMessageBox centres on the primary screen rather than over Autopatch
+        # and can sit behind it with no taskbar entry of its own, which reads as
+        # a hung UI at the start of every slice. Every other QMessageBox in acq4
+        # passes a real widget.
+        self._referenceImagery = ReferenceImagery(self._imagingCtrl, parent=self)
+        self._referenceImagery.sigInstructionChanged.connect(
+            self._onImageryInstruction
+        )
         # The getter is closed over the manager alone, never over this window.
         # A bound self._cameraModuleWindow would give mirror -> window while
         # self._cameraMirror gives window -> mirror, and teardown() never drops
@@ -412,6 +422,9 @@ class AutopatchWindow(Qt.QWidget):
             camera.globalCenterPosition("roi")[:2], (fov[0] * 10, fov[1] * 10)
         )
         self._bindPinnedFrames(camera)
+        # Re-resolved per slice for the same reason the mirror is: the operator
+        # may have changed the selected camera since the last one.
+        self._referenceImagery.rebind()
         # There is a camera now, so retract the message above if it is up.
         self.searchPanel.setError("")
         return True
@@ -448,6 +461,30 @@ class AutopatchWindow(Qt.QWidget):
         except (KeyError, AttributeError):
             return
         self._pinnedFrameMirror.bind(imagingCtrl)
+
+    def _imagingCtrl(self):
+        """The selected camera's imaging control in the Camera module, or None.
+
+        Mirrors _bindPinnedFrames's own tolerance rather than raising for
+        either of its two ordinary cases: a manager-less (headless) window,
+        where _cameraWindow() itself already answers None, and a camera the
+        Camera module has no interface for, which is the same "switching
+        cameras" state _bindPinnedFrames's own KeyError/AttributeError catch
+        exists for. A manager present with no Camera window behind it is not
+        among these -- _cameraWindow() raises rather than answering that with
+        silence, and that raise is deliberately left to propagate here too.
+        """
+        window = self._cameraWindow()
+        if window is None:
+            return None
+        camera = self.cameraSelector.getSelectedObj()
+        try:
+            return window.getInterfaceForDevice(camera.name()).imagingCtrl
+        except (KeyError, AttributeError):
+            return None
+
+    def _onImageryInstruction(self, text: str) -> None:
+        self.statusPanel.setInstruction("imagery", text)
 
     def newSlice(self) -> None:
         """Start a fresh slice, discarding the current one and everything on it.
@@ -537,6 +574,12 @@ class AutopatchWindow(Qt.QWidget):
         # discarded Cell alive, and its sigPositionChanged connection live.
         self._progressOverlay.clear()
         self._releaseCellPositionConnections()
+        # Last, and deliberately: the prompt inside is modal, a modal dialog
+        # re-enters the Qt event loop, and every queued slot dispatches inside
+        # it -- including the sigCellFinished from the cell still in flight on
+        # the tissue this click just discarded, whose suppression assumes it
+        # lands outside a half-completed New slice.
+        self._referenceImagery.beginSlice()
 
     def addRegionHere(self) -> None:
         """Add a search region of roughly 3x3 fields of view around the camera center.
@@ -966,6 +1009,7 @@ class AutopatchWindow(Qt.QWidget):
             # otherwise leave the Camera module holding this session's outlines
             # and its imaging control still connected to a dead mirror.
             self._pinnedFrameMirror.unbind()
+            self._referenceImagery.release()
             self._cameraMirror.clear()
             self._releaseCellPositionConnections()
             self._progressOverlay.release()
@@ -973,6 +1017,13 @@ class AutopatchWindow(Qt.QWidget):
         self.cellPanel.unbindOrchestrator()
         self.cellPanel.clearCells()
         self.orchestrator = None
+        # Dropped for the same reason self.orchestrator is: _referenceImagery's
+        # getter is a bound method of this window and its sigInstructionChanged
+        # is connected to one of this window's own methods, so leaving the
+        # attribute in place would give window -> _referenceImagery -> window,
+        # a cycle only Python's cyclic GC could reclaim -- release() above only
+        # stops it listening to the pinned-frame source, not this half.
+        self._referenceImagery = None
 
     def closeEvent(self, event) -> None:
         self.teardown()

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -234,32 +234,39 @@ class AutopatchWindow(Qt.QWidget):
 
     @staticmethod
     def _cameraModuleWindow(manager):
-        """The Camera module's window under `manager`, or None if there is none.
+        """The Camera module's window under `manager`.
 
-        Not having one is ordinary -- a rig with the module unloaded, or a
-        headless test -- and both mirrors treat it as nothing to do rather than
-        as a failure.
+        Raises rather than answering None: the Autopatch module opens the
+        Camera module at startup (see Autopatch.__init__), so a missing one
+        means it was closed underneath a running session. Degrading quietly
+        would leave Area 1 blank while the operator went on drawing regions
+        over nothing and the survey went on imaging tiles they could not see.
 
-        Asked of the loaded modules rather than of Manager.getModule alone,
-        which loads a module that is not already open: this is reached from
-        every mirror redraw, including the one behind "Add region here", and a
-        button that adds a region must not also start the Camera module.
+        HelpfulException rather than RuntimeError because this is acq4's
+        operator-facing error type -- the same one create_data_dir raises for
+        an unset storage directory -- and it reaches the error dialog reading
+        as an instruction rather than as a crash.
 
-        Static, taking the manager as an argument, so that the Camera mirror can
-        be handed a getter that holds no reference to this window -- see where
-        it is constructed.
+        Static, taking the manager as an argument, so that the Camera mirror
+        can be handed a getter that holds no reference to this window -- see
+        where it is constructed.
         """
         if manager is None:
-            return None
-        try:
-            if "Camera" not in manager.listModules():
-                return None
-            return manager.getModule("Camera").window()
-        except Exception:
-            return None
+            raise HelpfulException(
+                "Autopatch needs a Manager to find the Camera module."
+            )
+        if "Camera" not in manager.listModules():
+            raise HelpfulException(
+                "The Camera module is not open. Autopatch opens it at startup "
+                "and needs it for reference imagery; reopen it and try again."
+            )
+        window = manager.getModule("Camera").window()
+        if window is None:
+            raise HelpfulException("The Camera module has no window.")
+        return window
 
     def _cameraWindow(self):
-        """The Camera module's window, or None if there is not one."""
+        """The Camera module's window."""
         return self._cameraModuleWindow(self.manager)
 
     def _onMirrorToggled(self, enabled: bool) -> None:
@@ -388,17 +395,25 @@ class AutopatchWindow(Qt.QWidget):
         at which a camera is known to be selected, and both routes into a slice
         pass through it.
 
-        Every path unbinds first, including the two that find nothing to bind
-        to. Switching from a camera the Camera module has an interface for to
-        one it does not -- or starting a slice after the Camera module has been
-        closed -- would otherwise leave Area 1 mirroring the previous camera's
-        frames: imagery of tissue that is no longer under the objective, with
-        regions being drawn over it.
+        Unbinds first regardless of what follows, including the headless case
+        below that finds nothing to bind to: switching from a camera the
+        Camera module has an interface for to one it does not would otherwise
+        leave Area 1 mirroring the previous camera's frames -- imagery of
+        tissue that is no longer under the objective, with regions being
+        drawn over it.
+
+        A manager-less window (module=None -- headless, or a test with no
+        Manager to stand in for) has nothing to bind to, and that is
+        ordinary. With a manager, though, there is no such case left to
+        return quietly out of: the Camera module is this module's own
+        precondition, so a manager present with no Camera window behind it
+        reaches here only because it closed underneath a running session,
+        and _cameraWindow() raises rather than answering that with silence.
         """
         self._pinnedFrameMirror.unbind()
-        window = self._cameraWindow()
-        if window is None:
+        if self.manager is None:
             return
+        window = self._cameraWindow()
         try:
             imagingCtrl = window.getInterfaceForDevice(camera.name()).imagingCtrl
         except (KeyError, AttributeError):
@@ -936,6 +951,12 @@ class Autopatch(Module):
             Qt.QTimer.singleShot(0, self.quit)
             return
         Autopatch._instance = self
+        # Before the window, which assumes it: Area 1 mirrors the Camera
+        # module's pinned frames and puts region outlines back into its view,
+        # and getModule() loads a module that is not already open. Making it
+        # this module's responsibility is what lets every consumer downstream
+        # treat a missing Camera module as an error rather than a case.
+        manager.getModule("Camera")
         self.ui = AutopatchWindow(self)
         manager.declareInterface(name, ["autopatchModule"], self)
         self.ui.show()

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -121,8 +121,8 @@ class AutopatchWindow(Qt.QWidget):
         # parent=self so the clear prompt is owned by this window: a parentless
         # QMessageBox centres on the primary screen rather than over Autopatch
         # and can sit behind it with no taskbar entry of its own, which reads as
-        # a hung UI at the start of every slice. Every other QMessageBox in acq4
-        # passes a real widget.
+        # a hung UI at the start of every slice. Every other QMessageBox.question/
+        # warning/critical call in acq4 passes a real widget as parent, too.
         self._referenceImagery = ReferenceImagery(self._imagingCtrl, parent=self)
         self._referenceImagery.sigInstructionChanged.connect(
             self._onImageryInstruction
@@ -1017,12 +1017,18 @@ class AutopatchWindow(Qt.QWidget):
         self.cellPanel.unbindOrchestrator()
         self.cellPanel.clearCells()
         self.orchestrator = None
-        # Dropped for the same reason self.orchestrator is: _referenceImagery's
-        # getter is a bound method of this window and its sigInstructionChanged
-        # is connected to one of this window's own methods, so leaving the
-        # attribute in place would give window -> _referenceImagery -> window,
-        # a cycle only Python's cyclic GC could reclaim -- release() above only
-        # stops it listening to the pinned-frame source, not this half.
+        # Dropped for the same reason self.orchestrator is: _referenceImagery
+        # holds two references back to this window -- self._getter (the bound
+        # method self._imagingCtrl) and self._parent (this window, from
+        # parent=self above, also closed over by the default _prompt's
+        # functools.partial) -- so leaving the attribute in place would give
+        # window -> _referenceImagery -> window, a cycle only Python's cyclic
+        # GC could reclaim. sigInstructionChanged being connected to one of
+        # this window's own methods contributes nothing to that cycle: PyQt
+        # holds only a weak reference to a QObject receiver's bound method, so
+        # that connection alone cannot keep either object alive. release()
+        # above only stops it listening to the pinned-frame source, not this
+        # half.
         self._referenceImagery = None
 
     def closeEvent(self, event) -> None:

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -576,9 +576,12 @@ class AutopatchWindow(Qt.QWidget):
         self._releaseCellPositionConnections()
         # Last, and deliberately: the prompt inside is modal, a modal dialog
         # re-enters the Qt event loop, and every queued slot dispatches inside
-        # it -- including the sigCellFinished from the cell still in flight on
-        # the tissue this click just discarded, whose suppression assumes it
-        # lands outside a half-completed New slice.
+        # it. No intermediate state of this method -- a half-cleared band, a
+        # detached producer, cells already gone from Area 5 but still in the
+        # orchestrator's queue -- may ever be observable from that nested
+        # loop, so everything above has to be finished before this call opens
+        # it. test_the_clear_prompt_opens_only_after_the_wipe pins exactly
+        # that.
         self._referenceImagery.beginSlice()
 
     def addRegionHere(self) -> None:

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -328,7 +328,7 @@ class AutopatchWindow(Qt.QWidget):
 
         Area 1 has one guidance slot: a later message replaces an earlier one.
         """
-        self.statusPanel.setInstruction(text)
+        self.statusPanel.setInstruction("region", text)
 
     def _canStartSlice(self) -> bool:
         """Whether a slice can be started right now, reporting the reason
@@ -490,7 +490,7 @@ class AutopatchWindow(Qt.QWidget):
             # Narrowed to HelpfulException so a genuine programming error (a
             # missing manager, say) propagates instead of being reported as
             # storage guidance.
-            self.statusPanel.setInstruction(str(exc))
+            self.statusPanel.setInstruction("storage", str(exc))
             return
         if not self._startSlice(dirHandle=dirHandle):
             return
@@ -501,8 +501,11 @@ class AutopatchWindow(Qt.QWidget):
         # new tissue.
         self.statusPanel.clearError()
         # Whichever handler filled the band, what it was about went with the
-        # tissue just discarded.
-        self.statusPanel.clearInstruction()
+        # tissue just discarded. The storage slot alone: this is the condition
+        # New slice has just resolved, and the imagery slot is recomputed from
+        # state moments later by ReferenceImagery.
+        self.statusPanel.setInstruction("storage", "")
+        self.statusPanel.setInstruction("region", "")
         if self.orchestrator is not None:
             # Detached before the queue is cleared, not after: a refill still
             # in flight on the worker thread reads the producer and enqueues

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -236,15 +236,18 @@ class AutopatchWindow(Qt.QWidget):
     def _cameraModuleWindow(manager):
         """The Camera module's window under `manager`, or None with no manager.
 
-        None only for the manager-less case: headless (module=None) is a
-        documented mode of this window (see AutopatchWindow.__init__ and
-        test_a_headless_window_with_no_manager_still_starts_a_slice), not a
-        degraded state for this getter to paper over. With a manager present,
-        there is no such case left: the Autopatch module opens the Camera
-        module at startup (see Autopatch.__init__), so seeing it missing or
-        windowless here means it was closed underneath a running session, and
-        raising is what surfaces that to the operator instead of leaving
-        Area 1 blank while regions keep getting drawn over nothing.
+        None only for the manager-less case: headless (module=None) is a mode
+        this window's constructor supports by design -- `module` defaults to
+        None, and the manager-is-None branch there only requires an explicit
+        `protocolDir` in its place (see AutopatchWindow.__init__) -- and
+        test_a_headless_window_with_no_manager_still_starts_a_slice asserts it
+        keeps working, not a degraded state for this getter to paper over.
+        With a manager present, there is no such case left: the Autopatch
+        module opens the Camera module at startup (see Autopatch.__init__), so
+        seeing it missing or windowless here means it was closed underneath a
+        running session, and raising is what surfaces that to the operator
+        instead of leaving Area 1 blank while regions keep getting drawn over
+        nothing.
 
         HelpfulException rather than RuntimeError because this is acq4's
         operator-facing error type -- the same one create_data_dir raises for
@@ -310,8 +313,15 @@ class AutopatchWindow(Qt.QWidget):
             self.regionPanel.setRegions(self.slice.regions)
             return
         self._setRegionInstruction("")
-        self._cameraMirror.setRegions(regions)
+        # Survey stats refreshed before the mirror is touched: the mirror's
+        # setRegions() can raise out of a closed Camera module (see
+        # CameraMirror._redraw()), and by this point self.slice.setRegions()
+        # above has already committed the edit. Area 2's readout must reflect
+        # that committed edit even if the raise below skips everything after
+        # it -- an operator judging feasibility from a stale tile count is the
+        # failure mode this ordering rules out.
         self._refreshSurveyStats()
+        self._cameraMirror.setRegions(regions)
 
     def _setRegionInstruction(self, text: str) -> None:
         """Put Area 1's guidance in Area 3's band, or retract it.
@@ -567,8 +577,15 @@ class AutopatchWindow(Qt.QWidget):
             self._setRegionInstruction(str(exc))
             return
         self.regionPanel.setRegions(self.slice.regions)
-        self._cameraMirror.setRegions(self.slice.regions)
+        # Survey stats refreshed before the mirror is touched: the mirror's
+        # setRegions() can raise out of a closed Camera module (see
+        # CameraMirror._redraw()), and by this point slice.addRegion() and
+        # regionPanel.setRegions() above have already committed the edit.
+        # Area 2's readout must reflect that committed edit even if the raise
+        # below skips everything after it -- an operator judging feasibility
+        # from a stale tile count is the failure mode this ordering rules out.
         self._refreshSurveyStats()
+        self._cameraMirror.setRegions(self.slice.regions)
 
     @staticmethod
     def _cameraFov(camera) -> tuple[float, float]:

--- a/acq4/modules/Autopatch/reference_imagery.py
+++ b/acq4/modules/Autopatch/reference_imagery.py
@@ -16,7 +16,7 @@ _CLEAR_PROMPT = (
 
 
 def _askToClear(text: str, parent=None) -> bool:
-    """Default prompt: a Yes/Cancel dialog asking to clear the pinned frames.
+    """Default prompt: an Ok/Cancel dialog asking to clear the pinned frames.
 
     Its title and two-paragraph body are specific to a slice starting, not a
     copy of ImagingCtrl's own Clear button confirmation -- only the button set

--- a/acq4/modules/Autopatch/reference_imagery.py
+++ b/acq4/modules/Autopatch/reference_imagery.py
@@ -90,14 +90,15 @@ class ReferenceImagery(Qt.QObject):
         self.rebind()
         self._sliceActive = True
         self._refresh()
-        if (
-            self._source is not None
-            and self._source.pinnedFrames
-            and self._prompt(_CLEAR_PROMPT)
-        ):
+        # Bound to a local before the prompt: the prompt is modal and re-enters
+        # the Qt event loop, and release() (teardown, dispatched from inside
+        # that loop) sets self._source to None. Reading self._source again
+        # after the prompt would risk calling clearPinnedFrames() on None.
+        source = self._source
+        if source is not None and source.pinnedFrames and self._prompt(_CLEAR_PROMPT):
             # Emits sigPinnedFramesChanged, so the recompute below is
             # belt-and-braces rather than the only path.
-            self._source.clearPinnedFrames()
+            source.clearPinnedFrames()
         self._refresh()
 
     def rebind(self) -> None:

--- a/acq4/modules/Autopatch/reference_imagery.py
+++ b/acq4/modules/Autopatch/reference_imagery.py
@@ -1,0 +1,120 @@
+"""ReferenceImagery: the pinned-frames workflow that opens a slice -- clear the
+previous slice's frames, then ask the operator to pin a fresh set."""
+from __future__ import annotations
+
+from acq4.util import Qt
+
+PIN_FRAMES_INSTRUCTION = (
+    "Pin reference frames of this slice in the Camera module."
+)
+
+_CLEAR_PROMPT = (
+    "Clear the pinned frames from the previous slice?\n\n"
+    "They are imagery of tissue that is no longer under the objective, and "
+    "regions for this slice will be drawn over them."
+)
+
+
+def _askToClear(text: str) -> bool:
+    """Default prompt: the same confirmation ImagingCtrl uses for its own
+    Clear button, so clearing frames asks the same way wherever it starts."""
+    answer = Qt.QMessageBox.question(
+        None, "Clear pinned frames?", text,
+        Qt.QMessageBox.Ok | Qt.QMessageBox.Cancel,
+    )
+    return answer == Qt.QMessageBox.Ok
+
+
+class ReferenceImagery(Qt.QObject):
+    """Sequences the Camera module's pinned frames into the start of a slice.
+
+    A QObject, unlike the plain PinnedFrameMirror/CameraMirror classes beside
+    it, because something listens to it: Area 3's band re-renders whenever the
+    pinned set changes.
+
+    The wait for a fresh set is advisory. Nothing here disables a control or
+    blocks a run -- the band says what to do and the operator decides.
+    """
+
+    # The instruction this component wants shown, or "". Carries the text so a
+    # listener need not call back to ask.
+    sigInstructionChanged = Qt.Signal(str)
+
+    def __init__(self, imagingCtrlGetter, prompt=None):
+        super().__init__()
+        self._getter = imagingCtrlGetter
+        self._prompt = prompt if prompt is not None else _askToClear
+        self._source = None
+        self._instruction = ""
+        # No slice yet, and the instruction is about a slice that has none of
+        # its own imagery -- not about the window having just opened.
+        self._sliceActive = False
+
+    def beginSlice(self) -> None:
+        """New slice's entry point: bind, offer to clear, then recompute.
+
+        Whatever the getter raises propagates. A Camera module closed after
+        startup is an error rather than a state to degrade into, and the
+        operator sees acq4's error dialog -- deliberately unlike the storage
+        slot beside it in the band, which is caught and rendered as guidance
+        because an unset storage directory is a thing not yet done.
+        """
+        self._sliceActive = True
+        self.rebind()
+        if self._source.pinnedFrames and self._prompt(_CLEAR_PROMPT):
+            # Emits sigPinnedFramesChanged, so the recompute below is
+            # belt-and-braces rather than the only path.
+            self._source.clearPinnedFrames()
+        self._refresh()
+
+    def rebind(self) -> None:
+        """Re-resolve the imaging control and move the subscription to it.
+
+        Re-resolved per slice because the operator may have changed the
+        selected camera since the last one.
+        """
+        self._disconnect()
+        self._source = self._getter()
+        self._source.sigPinnedFramesChanged.connect(self._refresh)
+        self._refresh()
+
+    def instruction(self) -> str:
+        """The guidance this component wants shown, or ""."""
+        return self._instruction
+
+    def release(self) -> None:
+        """Stop listening. Teardown's call.
+
+        Tolerant of a source Qt has already destroyed, exactly as
+        PinnedFrameMirror.unbind() is: Qt.disconnect swallows a dead
+        connection's RuntimeError, but the signal is read off the source
+        before it can be handed over, and that read raises through a wrapper
+        whose C++ object is gone. A raise here would abandon the rest of
+        AutopatchWindow.teardown().
+        """
+        self._disconnect()
+        self._sliceActive = False
+
+    def _disconnect(self) -> None:
+        source, self._source = self._source, None
+        if source is not None:
+            try:
+                Qt.disconnect(source.sigPinnedFramesChanged, self._refresh)
+            except RuntimeError:
+                pass
+
+    def _refresh(self) -> None:
+        """Recompute the instruction from current state, announcing a change.
+
+        A pure function of state rather than of the event that got us here, so
+        pinning the first frame and unpinning the last both fall out without
+        either being handled: the band shows the instruction exactly while a
+        slice has no reference imagery.
+        """
+        text = ""
+        if self._sliceActive and self._source is not None:
+            if not self._source.pinnedFrames:
+                text = PIN_FRAMES_INSTRUCTION
+        if text != self._instruction:
+            self._instruction = text
+            self.sigInstructionChanged.emit(text)

--- a/acq4/modules/Autopatch/reference_imagery.py
+++ b/acq4/modules/Autopatch/reference_imagery.py
@@ -15,11 +15,16 @@ _CLEAR_PROMPT = (
 )
 
 
-def _askToClear(text: str) -> bool:
-    """Default prompt: the same confirmation ImagingCtrl uses for its own
-    Clear button, so clearing frames asks the same way wherever it starts."""
+def _askToClear(text: str, parent=None) -> bool:
+    """Default prompt: a Yes/Cancel dialog asking to clear the pinned frames.
+
+    Its title and two-paragraph body are specific to a slice starting, not a
+    copy of ImagingCtrl's own Clear button confirmation -- only the button set
+    (Ok/Cancel) matches. `parent` places the dialog over the calling window
+    instead of centring it on the primary screen with no owner.
+    """
     answer = Qt.QMessageBox.question(
-        None, "Clear pinned frames?", text,
+        parent, "Clear pinned frames?", text,
         Qt.QMessageBox.Ok | Qt.QMessageBox.Cancel,
     )
     return answer == Qt.QMessageBox.Ok
@@ -40,10 +45,18 @@ class ReferenceImagery(Qt.QObject):
     # listener need not call back to ask.
     sigInstructionChanged = Qt.Signal(str)
 
-    def __init__(self, imagingCtrlGetter, prompt=None):
+    def __init__(self, imagingCtrlGetter, prompt=None, parent=None):
         super().__init__()
         self._getter = imagingCtrlGetter
-        self._prompt = prompt if prompt is not None else _askToClear
+        # Owner window for the default clear-prompt dialog, so it stays over
+        # the calling window on a multi-monitor rig instead of centring on
+        # the primary screen with no taskbar entry of its own. Unused when a
+        # caller supplies its own `prompt`.
+        self._parent = parent
+        if prompt is not None:
+            self._prompt = prompt
+        else:
+            self._prompt = lambda text: _askToClear(text, self._parent)
         self._source = None
         self._instruction = ""
         # No slice yet, and the instruction is about a slice that has none of
@@ -53,14 +66,15 @@ class ReferenceImagery(Qt.QObject):
     def beginSlice(self) -> None:
         """New slice's entry point: bind, offer to clear, then recompute.
 
-        Whatever the getter raises propagates. A Camera module closed after
-        startup is an error rather than a state to degrade into, and the
-        operator sees acq4's error dialog -- deliberately unlike the storage
-        slot beside it in the band, which is caught and rendered as guidance
-        because an unset storage directory is a thing not yet done.
+        Whatever the getter raises propagates rather than being caught here.
+        A Camera module closed after startup is an error rather than a state
+        to degrade into. `_sliceActive` is only set once `rebind()` has
+        returned successfully, so a raised getter leaves this component as if
+        no slice had begun rather than stuck active with no source.
         """
-        self._sliceActive = True
         self.rebind()
+        self._sliceActive = True
+        self._refresh()
         if self._source.pinnedFrames and self._prompt(_CLEAR_PROMPT):
             # Emits sigPinnedFramesChanged, so the recompute below is
             # belt-and-braces rather than the only path.
@@ -92,8 +106,9 @@ class ReferenceImagery(Qt.QObject):
         whose C++ object is gone. A raise here would abandon the rest of
         AutopatchWindow.teardown().
         """
-        self._disconnect()
         self._sliceActive = False
+        self._disconnect()
+        self._refresh()
 
     def _disconnect(self) -> None:
         source, self._source = self._source, None

--- a/acq4/modules/Autopatch/reference_imagery.py
+++ b/acq4/modules/Autopatch/reference_imagery.py
@@ -2,6 +2,8 @@
 previous slice's frames, then ask the operator to pin a fresh set."""
 from __future__ import annotations
 
+import functools
+
 from acq4.util import Qt
 
 PIN_FRAMES_INSTRUCTION = (
@@ -56,7 +58,13 @@ class ReferenceImagery(Qt.QObject):
         if prompt is not None:
             self._prompt = prompt
         else:
-            self._prompt = lambda text: _askToClear(text, self._parent)
+            # functools.partial closing over the `parent` argument, not
+            # `self._parent`: a lambda reading self._parent would close over
+            # self, making a QObject that references itself -- a cycle
+            # reclaimable only by the cyclic collector, exactly the shape
+            # AutopatchWindow.teardown() exists to avoid for everything else
+            # it owns.
+            self._prompt = functools.partial(_askToClear, parent=parent)
         self._source = None
         self._instruction = ""
         # No slice yet, and the instruction is about a slice that has none of
@@ -71,11 +79,22 @@ class ReferenceImagery(Qt.QObject):
         to degrade into. `_sliceActive` is only set once `rebind()` has
         returned successfully, so a raised getter leaves this component as if
         no slice had begun rather than stuck active with no source.
+
+        A getter answering None outright (rather than raising) is not that
+        case, though, and is not a slice to skip either: a headless window or
+        a camera the Camera module has no interface for are both ordinary --
+        see _imagingCtrl's own docstring -- so the offer to clear is simply
+        skipped rather than raised through, exactly as _refresh() already
+        treats a None source as "nothing to show" rather than an error.
         """
         self.rebind()
         self._sliceActive = True
         self._refresh()
-        if self._source.pinnedFrames and self._prompt(_CLEAR_PROMPT):
+        if (
+            self._source is not None
+            and self._source.pinnedFrames
+            and self._prompt(_CLEAR_PROMPT)
+        ):
             # Emits sigPinnedFramesChanged, so the recompute below is
             # belt-and-braces rather than the only path.
             self._source.clearPinnedFrames()
@@ -86,10 +105,17 @@ class ReferenceImagery(Qt.QObject):
 
         Re-resolved per slice because the operator may have changed the
         selected camera since the last one.
+
+        Tolerant of the getter answering None: a headless window and a
+        camera the Camera module has no interface for are both ordinary
+        (see _imagingCtrl's own docstring), and there is nothing to
+        subscribe to in either case -- exactly the state _refresh() and
+        _disconnect() already treat a None source as, not an error.
         """
         self._disconnect()
         self._source = self._getter()
-        self._source.sigPinnedFramesChanged.connect(self._refresh)
+        if self._source is not None:
+            self._source.sigPinnedFramesChanged.connect(self._refresh)
         self._refresh()
 
     def instruction(self) -> str:

--- a/acq4/modules/Autopatch/region_mirrors.py
+++ b/acq4/modules/Autopatch/region_mirrors.py
@@ -7,7 +7,6 @@ import pyqtgraph as pg
 
 from acq4.experiment.search_region import EllipseRegion, PolygonRegion
 from acq4.util import Qt
-from acq4.util.HelpfulException import HelpfulException
 
 from .region_panel import REGION_PEN
 
@@ -149,8 +148,11 @@ class CameraMirror:
     no second copy of a region's state to reconcile. Autopatch stays the only
     place a region is edited.
 
-    Holds no region state of its own -- it is told what to draw. A Camera module
-    that is not loaded is ordinary, not an error: this is a display preference.
+    Holds no region state of its own -- it is told what to draw. A missing
+    Camera module is ordinary only for clear(), which teardown() depends on
+    never raising (see _windowOrNone()); redrawing what the operator asked
+    to see mirrored is not, and propagates the getter's raise instead of
+    silently doing nothing.
     """
 
     def __init__(self, cameraWindowGetter):
@@ -183,7 +185,11 @@ class CameraMirror:
         self.clear()
         if not self._enabled:
             return
-        window = self._windowOrNone()
+        # Not _windowOrNone(): a ticked "Mirror to Camera" that silently does
+        # nothing because the Camera module closed is worse than the raise
+        # reaching the operator. clear() above already took the stale items
+        # out regardless, so a raise here does not leave outlines stranded.
+        window = self._cameraWindow()
         if window is None:
             return
         for region in self._regions:
@@ -196,16 +202,23 @@ class CameraMirror:
     def _windowOrNone(self):
         """The Camera window, or None if there is not one.
 
-        The getter (AutopatchWindow._cameraModuleWindow) raises rather than
-        answering None everywhere else, since a missing Camera module is an
-        operator-facing error there. Here it stays what the class docstring
-        above says it always was: no manager (a headless window), no Camera
-        module, or one closed since this window opened are all ordinary --
-        this mirror is a display preference, not a dependency -- so any of
-        those is folded back into the None this class already knows how to do
-        nothing with.
+        Used by clear() only -- not by _redraw(), which calls the getter
+        directly and lets a raise propagate. clear() cannot afford to raise:
+        it runs inside AutopatchWindow.teardown()'s `finally` block, ahead of
+        _releaseCellPositionConnections() and _progressOverlay.release() (see
+        that docstring), and a raise there would skip both -- the same
+        exit-crash hazard PinnedFrameMirror.unbind's own docstring exists to
+        prevent.
+
+        Catches bare Exception, not just HelpfulException: Manager.loadModule
+        reserves a module's name in `self.modules` (so listModules() already
+        reports it) before the module class is constructed, leaving a None
+        placeholder there until construction finishes (see Manager.py). A
+        getModule() call landing in that window hands back that None, and
+        `.window()` on it raises AttributeError, not HelpfulException -- which
+        must not escape teardown's `finally` either.
         """
         try:
             return self._cameraWindow()
-        except HelpfulException:
+        except Exception:
             return None

--- a/acq4/modules/Autopatch/region_mirrors.py
+++ b/acq4/modules/Autopatch/region_mirrors.py
@@ -7,6 +7,7 @@ import pyqtgraph as pg
 
 from acq4.experiment.search_region import EllipseRegion, PolygonRegion
 from acq4.util import Qt
+from acq4.util.HelpfulException import HelpfulException
 
 from .region_panel import REGION_PEN
 
@@ -172,7 +173,7 @@ class CameraMirror:
         Separate from setEnabled(False) because teardown has to remove them
         without changing what the operator asked for.
         """
-        window = self._cameraWindow()
+        window = self._windowOrNone()
         for item in self.items:
             if window is not None:
                 window.removeItem(item)
@@ -182,7 +183,7 @@ class CameraMirror:
         self.clear()
         if not self._enabled:
             return
-        window = self._cameraWindow()
+        window = self._windowOrNone()
         if window is None:
             return
         for region in self._regions:
@@ -191,3 +192,20 @@ class CameraMirror:
             item.setAcceptedMouseButtons(Qt.Qt.NoButton)
             window.addItem(item, z=_MIRROR_Z)
             self.items.append(item)
+
+    def _windowOrNone(self):
+        """The Camera window, or None if there is not one.
+
+        The getter (AutopatchWindow._cameraModuleWindow) raises rather than
+        answering None everywhere else, since a missing Camera module is an
+        operator-facing error there. Here it stays what the class docstring
+        above says it always was: no manager (a headless window), no Camera
+        module, or one closed since this window opened are all ordinary --
+        this mirror is a display preference, not a dependency -- so any of
+        those is folded back into the None this class already knows how to do
+        nothing with.
+        """
+        try:
+            return self._cameraWindow()
+        except HelpfulException:
+            return None

--- a/acq4/modules/Autopatch/status_panel.py
+++ b/acq4/modules/Autopatch/status_panel.py
@@ -6,6 +6,18 @@ from acq4.util import Qt
 
 from .error_display import showInLog
 
+# Area 3's band carries one instruction at a time, but three independent
+# writers can each have something to say: an unchosen storage directory, a
+# region edit refused for being too large, and a slice with no reference
+# imagery pinned. They are not mutually exclusive -- newSlice() can fail at
+# create_data_dir with the previous slice still installed -- so each holds its
+# own slot and the first non-empty one in this order renders.
+#
+# storage first: New slice could not complete at all. region next: a refused
+# edit answers something the operator did a moment ago. imagery last: a
+# standing condition that will still hold once they have read the other two.
+INSTRUCTION_SOURCES = ("storage", "region", "imagery")
+
 
 class StatusPanel(Qt.QWidget):
     # Emitted whenever the bound orchestrator's status changes, True while a
@@ -41,7 +53,7 @@ class StatusPanel(Qt.QWidget):
         # a run. Held separately from _lastError so neither erases the other:
         # they have different writers, and neither can see the other's
         # condition.
-        self._instruction = ""
+        self._instructions = {source: "" for source in INSTRUCTION_SOURCES}
 
         self.startBtn = Qt.QPushButton("Start")
         self.stopBtn = Qt.QPushButton("Stop")
@@ -192,25 +204,31 @@ class StatusPanel(Qt.QWidget):
         self._lastError = None
         self._updateErrorBand()
 
-    def setInstruction(self, text: str) -> None:
+    def setInstruction(self, source: str, text: str) -> None:
         """Show operator guidance in the band -- what to do, not what broke.
 
-        For a control that could not proceed, `AutopatchWindow.newSlice()` with
-        no storage directory chosen being the case this exists for. An
-        instruction is deliberately not a RunErrorRecord: no traceback, no Copy,
-        and no Show in log, because no run happened and there is nothing in the
-        log to show.
-        """
-        self._instruction = text
-        self._updateErrorBand()
+        `text` of "" retracts this source's message and only this source's:
+        the writers cannot see each other's conditions, so one deciding the
+        band is now empty would be speaking for the other two.
 
-    def clearInstruction(self) -> None:
-        self._instruction = ""
+        An instruction is deliberately not a RunErrorRecord: no traceback, no
+        Copy, and no Show in log, because no run happened and there is nothing
+        in the log to show.
+        """
+        if source not in self._instructions:
+            raise ValueError(
+                f"{source!r} is not an instruction source; "
+                f"expected one of {INSTRUCTION_SOURCES}"
+            )
+        self._instructions[source] = text
         self._updateErrorBand()
 
     def instruction(self) -> str:
         """The guidance currently showing, or an empty string."""
-        return self._instruction
+        for source in INSTRUCTION_SOURCES:
+            if self._instructions[source]:
+                return self._instructions[source]
+        return ""
 
     def _updateErrorBand(self) -> None:
         """Render whichever of the two the band is carrying, the error first.
@@ -221,12 +239,12 @@ class StatusPanel(Qt.QWidget):
         done in the meantime.
         """
         record = self._lastError
+        showing = self.instruction()
         if record is not None:
             self.instructionLabel.setText(f"{record.exc_type}: {record.exc_message}")
         else:
-            self.instructionLabel.setText(self._instruction)
-        showing = record is not None or bool(self._instruction)
-        self.instructionLabel.setVisible(showing)
+            self.instructionLabel.setText(showing)
+        self.instructionLabel.setVisible(record is not None or bool(showing))
         self.showInLogBtn.setVisible(record is not None)
 
     def _onShowInLogClicked(self) -> None:

--- a/acq4/modules/Autopatch/tests/test_module_init.py
+++ b/acq4/modules/Autopatch/tests/test_module_init.py
@@ -1,0 +1,89 @@
+"""Tests for Autopatch.__init__: it opens the Camera module before building
+the window, and refuses to open at all when no Camera module is configured."""
+import importlib
+
+import pytest
+
+from acq4.modules.Autopatch.Autopatch import Autopatch
+from acq4.util import Qt
+from acq4.util.HelpfulException import HelpfulException
+
+# Not `import acq4.modules.Autopatch.Autopatch as autopatch_module`: the
+# package's own __init__.py does `from .Autopatch import Autopatch`, which
+# rebinds the package's `Autopatch` attribute to the class -- so `import a.b.c
+# as x` (attribute lookup through the package) would hand back the class, not
+# the module namespace `AutopatchWindow` actually lives in.
+autopatch_module = importlib.import_module("acq4.modules.Autopatch.Autopatch")
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+class _FakeManager:
+    """The minimum Module.__init__ needs (declareInterface) plus getModule,
+    for exercising Autopatch.__init__ in isolation -- no real Manager, no
+    AutopatchWindow, no config file on disk."""
+
+    def __init__(self, cameraModule):
+        self._cameraModule = cameraModule
+
+    def declareInterface(self, name, interfaces, obj):
+        pass
+
+    def getModule(self, name):
+        assert name == "Camera"
+        return self._cameraModule
+
+
+@pytest.fixture(autouse=True)
+def _resetInstance():
+    # Autopatch._instance is a class attribute shared across every instance;
+    # a value left behind by one test's construction (successful or not)
+    # would otherwise leak into the next.
+    Autopatch._instance = None
+    yield
+    Autopatch._instance = None
+
+
+def test_camera_is_opened_before_the_window_is_built(qapp, monkeypatch):
+    order = []
+    manager = _FakeManager(cameraModule=object())
+    realGetModule = manager.getModule
+
+    def getModule(name):
+        order.append("getModule")
+        return realGetModule(name)
+
+    monkeypatch.setattr(manager, "getModule", getModule)
+
+    class _FakeWindow:
+        def __init__(self, module):
+            order.append("window")
+
+        def show(self):
+            pass
+
+    monkeypatch.setattr(autopatch_module, "AutopatchWindow", _FakeWindow)
+
+    Autopatch(manager, "Autopatch", {})
+
+    assert order == ["getModule", "window"]
+
+
+def test_init_refuses_when_camera_is_not_configured(qapp):
+    # Manager.loadDefinedModule (see Manager.py) only logs an error and
+    # returns None, rather than raising, when "Camera" is not in the rig's
+    # configuration at all -- the case that reaches here as
+    # manager.getModule("Camera") answering None.
+    manager = _FakeManager(cameraModule=None)
+
+    with pytest.raises(HelpfulException, match="Camera"):
+        Autopatch(manager, "Autopatch", {})
+
+    # Set only once Camera is confirmed present: a refusal here must not
+    # leave _instance pointing at a half-built module with no .ui, or every
+    # later attempt to open Autopatch would hit
+    # Autopatch._instance.ui.raise_() -> AttributeError, permanently.
+    assert Autopatch._instance is None

--- a/acq4/modules/Autopatch/tests/test_reference_imagery.py
+++ b/acq4/modules/Autopatch/tests/test_reference_imagery.py
@@ -1,0 +1,175 @@
+"""Tests for ReferenceImagery: the pinned-frames workflow that starts a slice."""
+from __future__ import annotations
+
+import pytest
+
+from acq4.util import Qt
+from acq4.util.HelpfulException import HelpfulException
+
+
+class _FakeImagingCtrl(Qt.QObject):
+    """Stands in for the Camera module's ImagingCtrl.
+
+    clearPinnedFrames() genuinely empties the list and emits, because the real
+    one does (via removePinnedFrame): a fake that skipped either would hide a
+    missing recompute in the code under test.
+    """
+
+    sigPinnedFramesChanged = Qt.Signal()
+
+    def __init__(self, frames=()):
+        super().__init__()
+        self.pinnedFrames = list(frames)
+
+    def clearPinnedFrames(self):
+        self.pinnedFrames = []
+        self.sigPinnedFramesChanged.emit()
+
+    def pin(self, frame="frame"):
+        self.pinnedFrames.append(frame)
+        self.sigPinnedFramesChanged.emit()
+
+    def unpinAll(self):
+        self.pinnedFrames = []
+        self.sigPinnedFramesChanged.emit()
+
+
+def _imagery(source, answer=True):
+    from acq4.modules.Autopatch.reference_imagery import ReferenceImagery
+
+    asked = []
+
+    def prompt(text):
+        asked.append(text)
+        return answer
+
+    return ReferenceImagery(lambda: source, prompt=prompt), asked
+
+
+def test_nothing_pinned_means_no_prompt(qapp):
+    source = _FakeImagingCtrl()
+    imagery, asked = _imagery(source)
+
+    imagery.beginSlice()
+
+    assert asked == []
+
+
+def test_a_yes_clears_the_pinned_frames(qapp):
+    source = _FakeImagingCtrl(["a", "b"])
+    imagery, asked = _imagery(source, answer=True)
+
+    imagery.beginSlice()
+
+    assert len(asked) == 1
+    assert source.pinnedFrames == []
+
+
+def test_a_no_leaves_the_pinned_frames(qapp):
+    source = _FakeImagingCtrl(["a", "b"])
+    imagery, asked = _imagery(source, answer=False)
+
+    imagery.beginSlice()
+
+    assert len(asked) == 1
+    assert source.pinnedFrames == ["a", "b"]
+
+
+def test_an_empty_slice_asks_for_frames(qapp):
+    from acq4.modules.Autopatch.reference_imagery import PIN_FRAMES_INSTRUCTION
+
+    source = _FakeImagingCtrl()
+    imagery, _ = _imagery(source)
+
+    imagery.beginSlice()
+
+    assert imagery.instruction() == PIN_FRAMES_INSTRUCTION
+
+
+def test_there_is_no_instruction_before_a_slice(qapp):
+    source = _FakeImagingCtrl()
+    imagery, _ = _imagery(source)
+
+    assert imagery.instruction() == ""
+
+
+def test_pinning_a_frame_retracts_the_instruction(qapp):
+    source = _FakeImagingCtrl()
+    imagery, _ = _imagery(source)
+    imagery.beginSlice()
+
+    source.pin()
+
+    assert imagery.instruction() == ""
+
+
+def test_unpinning_the_last_frame_brings_it_back(qapp):
+    from acq4.modules.Autopatch.reference_imagery import PIN_FRAMES_INSTRUCTION
+
+    source = _FakeImagingCtrl(["a"])
+    imagery, _ = _imagery(source, answer=False)
+    imagery.beginSlice()
+    assert imagery.instruction() == ""
+
+    source.unpinAll()
+
+    assert imagery.instruction() == PIN_FRAMES_INSTRUCTION
+
+
+def test_the_signal_carries_only_real_changes(qapp):
+    source = _FakeImagingCtrl(["a"])
+    imagery, _ = _imagery(source, answer=False)
+    imagery.beginSlice()
+    seen = []
+    imagery.sigInstructionChanged.connect(seen.append)
+
+    source.pin("b")
+
+    assert seen == []
+
+
+def test_the_signal_reports_the_new_text(qapp):
+    from acq4.modules.Autopatch.reference_imagery import PIN_FRAMES_INSTRUCTION
+
+    source = _FakeImagingCtrl(["a"])
+    imagery, _ = _imagery(source, answer=False)
+    imagery.beginSlice()
+    seen = []
+    imagery.sigInstructionChanged.connect(seen.append)
+
+    source.unpinAll()
+
+    assert seen == [PIN_FRAMES_INSTRUCTION]
+
+
+def test_a_closed_camera_module_propagates(qapp):
+    from acq4.modules.Autopatch.reference_imagery import ReferenceImagery
+
+    def getter():
+        raise HelpfulException("The Camera module is not open.")
+
+    imagery = ReferenceImagery(getter, prompt=lambda text: True)
+
+    with pytest.raises(HelpfulException, match="Camera"):
+        imagery.beginSlice()
+
+
+def test_release_disconnects_from_the_source(qapp):
+    source = _FakeImagingCtrl()
+    imagery, _ = _imagery(source)
+    imagery.beginSlice()
+    assert source.receivers(source.sigPinnedFramesChanged) == 1
+
+    imagery.release()
+
+    assert source.receivers(source.sigPinnedFramesChanged) == 0
+
+
+def test_rebinding_does_not_stack_connections(qapp):
+    source = _FakeImagingCtrl()
+    imagery, _ = _imagery(source)
+
+    imagery.rebind()
+    imagery.rebind()
+
+    assert source.receivers(source.sigPinnedFramesChanged) == 1

--- a/acq4/modules/Autopatch/tests/test_reference_imagery.py
+++ b/acq4/modules/Autopatch/tests/test_reference_imagery.py
@@ -13,6 +13,14 @@ class _FakeImagingCtrl(Qt.QObject):
     clearPinnedFrames() genuinely empties the list and emits, because the real
     one does (via removePinnedFrame): a fake that skipped either would hide a
     missing recompute in the code under test.
+
+    Two things it does not reproduce from the real removePinnedFrame-based
+    clearPinnedFrames (acq4/util/imaging/imaging_ctrl.py): it emits
+    sigPinnedFramesChanged once for the whole clear rather than once per
+    removed frame, and it rebinds self.pinnedFrames to a new empty list
+    rather than mutating the existing list in place with .remove(). Nothing
+    in ReferenceImagery depends on emission count or on the list identity
+    surviving a clear, so neither divergence is exercised by these tests.
     """
 
     sigPinnedFramesChanged = Qt.Signal()
@@ -87,8 +95,45 @@ def test_an_empty_slice_asks_for_frames(qapp):
 
 
 def test_there_is_no_instruction_before_a_slice(qapp):
+    # Bound to a source with nothing pinned -- if a slice were considered
+    # active here, this would show PIN_FRAMES_INSTRUCTION. rebind() alone
+    # does not begin a slice, so no instruction should appear.
     source = _FakeImagingCtrl()
     imagery, _ = _imagery(source)
+
+    imagery.rebind()
+
+    assert imagery.instruction() == ""
+
+
+def test_release_ends_the_slice(qapp):
+    # A later bare rebind() (a camera-change handler, say) must not publish
+    # the pin-frames instruction as though a new slice had begun.
+    from acq4.modules.Autopatch.reference_imagery import PIN_FRAMES_INSTRUCTION
+
+    source = _FakeImagingCtrl()
+    imagery, _ = _imagery(source)
+    imagery.beginSlice()
+    assert imagery.instruction() == PIN_FRAMES_INSTRUCTION
+
+    imagery.release()
+    imagery.rebind()
+
+    assert imagery.instruction() == ""
+
+
+def test_rebind_recomputes_for_the_new_source(qapp):
+    from acq4.modules.Autopatch.reference_imagery import PIN_FRAMES_INSTRUCTION, ReferenceImagery
+
+    sources = {"current": _FakeImagingCtrl()}
+    imagery = ReferenceImagery(lambda: sources["current"], prompt=lambda text: True)
+    imagery.beginSlice()
+    assert imagery.instruction() == PIN_FRAMES_INSTRUCTION
+
+    # The operator switches the selected camera mid-slice; the new one
+    # already has frames pinned.
+    sources["current"] = _FakeImagingCtrl(["a"])
+    imagery.rebind()
 
     assert imagery.instruction() == ""
 

--- a/acq4/modules/Autopatch/tests/test_region_mirrors.py
+++ b/acq4/modules/Autopatch/tests/test_region_mirrors.py
@@ -369,8 +369,11 @@ def test_the_outline_keeps_its_assigned_z_value(qapp):
 
 
 def test_no_camera_window_is_not_an_error(qapp):
-    # A rig with the Camera module unloaded is ordinary; the checkbox is a
-    # display preference, not a requirement.
+    # CameraMirror(lambda: None) stands for the headless (manager-less) case
+    # only: that is the one case _cameraModuleWindow answers with None rather
+    # than raising (see Autopatch._cameraModuleWindow). An actually unloaded
+    # or closed Camera module raises instead, and _redraw() lets that
+    # propagate rather than swallowing it here.
     from acq4.modules.Autopatch.region_mirrors import CameraMirror
 
     mirror = CameraMirror(lambda: None)
@@ -389,6 +392,51 @@ def test_clear_removes_everything_it_put_there(qapp):
     mirror.clear()
 
     assert window.items == []
+    assert mirror.items == []
+
+
+def test_redraw_propagates_a_raising_getter(qapp):
+    # The owner's decision: a ticked "Mirror to Camera" that silently does
+    # nothing because the Camera module closed is worse than the raise
+    # reaching the operator (see CameraMirror._redraw()). Reverting _redraw()
+    # to call _windowOrNone() instead of the getter directly (region_mirrors.py,
+    # in _redraw()) is one of the two mutations the reviewer found the whole
+    # suite stayed green under.
+    from acq4.modules.Autopatch.region_mirrors import CameraMirror
+    from acq4.util.HelpfulException import HelpfulException
+
+    def boom():
+        raise HelpfulException("The Camera module is not open.")
+
+    mirror = CameraMirror(boom)
+
+    with pytest.raises(HelpfulException):
+        mirror.setEnabled(True)
+
+
+def test_clear_swallows_a_raising_getter(qapp):
+    # The other half of the same decision: clear() runs inside
+    # AutopatchWindow.teardown()'s `finally` block, ahead of
+    # _releaseCellPositionConnections() and _progressOverlay.release() -- a
+    # raise here would skip both. Reverting clear() to call the getter
+    # directly instead of _windowOrNone() (region_mirrors.py, in clear()) is
+    # the other of the two mutations the reviewer found the whole suite
+    # stayed green under.
+    from acq4.util.HelpfulException import HelpfulException
+
+    window = FakeCameraWindow()
+    mirror = makeCameraMirror(window)
+    mirror.setEnabled(True)
+    mirror.setRegions([RECT])
+    assert mirror.items, "nothing was drawn, so clear() has nothing to prove"
+
+    def boom():
+        raise HelpfulException("The Camera module is not open.")
+
+    mirror._cameraWindow = boom
+
+    mirror.clear()  # must not raise
+
     assert mirror.items == []
 
 

--- a/acq4/modules/Autopatch/tests/test_status_panel.py
+++ b/acq4/modules/Autopatch/tests/test_status_panel.py
@@ -539,7 +539,7 @@ def test_an_instruction_shows_in_the_band(qapp):
 
     panel = StatusPanel()
 
-    panel.setInstruction("Storage directory has not been set.")
+    panel.setInstruction("storage", "Storage directory has not been set.")
 
     assert panel.instructionLabel.isVisibleTo(panel)
     assert panel.instructionLabel.text() == "Storage directory has not been set."
@@ -553,7 +553,7 @@ def test_an_instruction_offers_no_log_link(qapp):
 
     panel = StatusPanel()
 
-    panel.setInstruction("Storage directory has not been set.")
+    panel.setInstruction("storage", "Storage directory has not been set.")
 
     assert not panel.showInLogBtn.isVisibleTo(panel)
 
@@ -562,9 +562,9 @@ def test_clearing_an_instruction_empties_the_band(qapp):
     from acq4.modules.Autopatch.status_panel import StatusPanel
 
     panel = StatusPanel()
-    panel.setInstruction("Storage directory has not been set.")
+    panel.setInstruction("storage", "Storage directory has not been set.")
 
-    panel.clearInstruction()
+    panel.setInstruction("storage", "")
 
     assert panel.instruction() == ""
     assert not panel.instructionLabel.isVisibleTo(panel)
@@ -578,7 +578,7 @@ def test_a_run_error_still_wins_the_band(qapp):
 
     panel = StatusPanel()
     record = _record()
-    panel.setInstruction("Storage directory has not been set.")
+    panel.setInstruction("storage", "Storage directory has not been set.")
 
     panel._onRunError(record)
 
@@ -592,10 +592,59 @@ def test_the_instruction_comes_back_once_the_error_clears(qapp):
     from acq4.modules.Autopatch.status_panel import StatusPanel
 
     panel = StatusPanel()
-    panel.setInstruction("Storage directory has not been set.")
+    panel.setInstruction("storage", "Storage directory has not been set.")
     panel._onRunError(_record())
 
     panel.clearError()
 
     assert panel.instructionLabel.text() == "Storage directory has not been set."
     assert not panel.showInLogBtn.isVisibleTo(panel)
+
+
+def test_a_higher_priority_source_wins_the_band(qapp):
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+
+    panel.setInstruction("imagery", "Pin reference frames.")
+    panel.setInstruction("storage", "Storage directory has not been set.")
+
+    assert panel.instruction() == "Storage directory has not been set."
+
+
+def test_clearing_one_source_does_not_erase_another(qapp):
+    # The property the whole change exists for. newSlice() can fail at
+    # create_data_dir with the previous slice still installed, so the storage
+    # message and the imagery instruction can want the band at the same time,
+    # and whichever cleared last must not take the other down with it.
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+    panel.setInstruction("imagery", "Pin reference frames.")
+    panel.setInstruction("storage", "Storage directory has not been set.")
+
+    panel.setInstruction("storage", "")
+
+    assert panel.instruction() == "Pin reference frames."
+
+
+def test_a_lower_priority_source_does_not_displace_a_higher_one(qapp):
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+    panel.setInstruction("storage", "Storage directory has not been set.")
+
+    panel.setInstruction("imagery", "Pin reference frames.")
+
+    assert panel.instruction() == "Storage directory has not been set."
+
+
+def test_an_unknown_source_is_a_programming_error(qapp):
+    # A typo'd source would otherwise write into a slot nothing ever renders,
+    # failing silently and looking exactly like a band that was not updated.
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+
+    with pytest.raises(ValueError, match="pinned"):
+        panel.setInstruction("pinned", "Pin reference frames.")

--- a/acq4/modules/Autopatch/tests/test_teardown.py
+++ b/acq4/modules/Autopatch/tests/test_teardown.py
@@ -494,7 +494,11 @@ def test_teardown_releases_the_reference_imagery(qapp, tmp_path):
 
     win.newSlice()
     source = win.manager.pinnedFrameSource
-    assert source.receivers(source.sigPinnedFramesChanged) > 0
+    # Two, not merely nonzero: PinnedFrameMirror and ReferenceImagery both
+    # subscribe to this signal, so pinning the precondition to just one of
+    # them (> 0) would still be satisfied by PinnedFrameMirror alone even if
+    # ReferenceImagery.rebind() never subscribed at all.
+    assert source.receivers(source.sigPinnedFramesChanged) == 2
 
     win.teardown()
 

--- a/acq4/modules/Autopatch/tests/test_teardown.py
+++ b/acq4/modules/Autopatch/tests/test_teardown.py
@@ -463,3 +463,41 @@ def test_teardown_releases_the_progress_overlay(qapp, tmp_path):
     assert scatter not in win.regionPanel.view.addedItems
 
     win.close()
+
+
+def test_teardown_releases_the_reference_imagery(qapp, tmp_path):
+    """ReferenceImagery.rebind() subscribes to the Camera module's
+    ImagingCtrl, same as PinnedFrameMirror does -- a live connection there
+    would go on recomputing Area 3's imagery instruction for a torn-down
+    window. The manager and camera stand-ins come from test_window_integration
+    for the same reason test_teardown_frees_the_slice_producer_and_cells_by_
+    refcounting above borrows them: newSlice() needs a real camera and a real
+    pinned-frame source to reach ReferenceImagery.beginSlice() at all.
+    """
+    from types import SimpleNamespace
+
+    import acq4.util.DataManager as dm
+    from acq4.modules.Autopatch.Autopatch import AutopatchWindow
+
+    from .test_window_integration import _FakeCameraWithDevice, _FakeManager
+
+    _write_protocol(tmp_path, "demo.py", _NOOP_PROTOCOL)
+    storageRoot = dm.getDirHandle(str(tmp_path / "storage"), create=True)
+
+    win = AutopatchWindow(
+        module=SimpleNamespace(manager=_FakeManager(storageRoot)),
+        protocolDir=str(tmp_path),
+        pipetteSelector=_FakePipetteSelector(target=(1e-3, 2e-3, 3e-3)),
+        cameraSelector=_FakeCameraWithDevice(),
+    )
+    win.protocolPanel.fileCombo.setCurrentText("demo")
+
+    win.newSlice()
+    source = win.manager.pinnedFrameSource
+    assert source.receivers(source.sigPinnedFramesChanged) > 0
+
+    win.teardown()
+
+    assert source.receivers(source.sigPinnedFramesChanged) == 0
+
+    win.close()

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -4,6 +4,8 @@ import importlib
 import os
 from types import SimpleNamespace
 
+import numpy as np
+import pyqtgraph as pg
 import pytest
 from coorx import Point
 
@@ -18,6 +20,7 @@ from acq4.modules.Autopatch.progress_colors import (
     healthBrushes,
     successBrushes,
 )
+from acq4.modules.Autopatch.reference_imagery import PIN_FRAMES_INSTRUCTION
 from acq4.util import Qt
 from acq4.util.HelpfulException import HelpfulException
 from acq4_automation.feature_tracking.cell import Cell
@@ -158,13 +161,24 @@ class _FakeCameraWithDevice(Qt.QWidget):
 
 class _FakePinnedFrameSource(Qt.QObject):
     """Stands in for the Camera module's ImagingCtrl: the pinned-frame list and
-    the signal Area 1 mirrors it through."""
+    the signal Area 1 mirrors it through.
+
+    clearPinnedFrames() genuinely empties the list and emits, because the real
+    one does (via removePinnedFrame) -- ReferenceImagery.beginSlice() calls it
+    when the operator agrees to clear a previous slice's frames, and a fake
+    that only recorded the call rather than emptying the list would hide a
+    missing recompute in the code under test.
+    """
 
     sigPinnedFramesChanged = Qt.Signal()
 
     def __init__(self):
         super().__init__()
         self.pinnedFrames = []
+
+    def clearPinnedFrames(self):
+        self.pinnedFrames = []
+        self.sigPinnedFramesChanged.emit()
 
 
 # The one folder type newSlice() asks create_data_dir for. A real Manager's
@@ -888,7 +902,12 @@ def test_new_slice_clears_area_3s_error_band(qapp, tmp_path):
         win.newSlice()
 
         assert win.statusPanel.lastError() is None
-        assert not win.statusPanel.instructionLabel.isVisibleTo(win.statusPanel)
+        # The band is not empty -- the default fake pins no frames, so
+        # newSlice() leaves the imagery instruction showing -- but that text
+        # is proof the error slot itself is empty, not merely that the whole
+        # band is.
+        assert win.statusPanel.instructionLabel.isVisibleTo(win.statusPanel)
+        assert win.statusPanel.instruction() == PIN_FRAMES_INSTRUCTION
     finally:
         win.teardown()
 
@@ -1535,7 +1554,9 @@ def test_a_successful_new_slice_retracts_the_instruction(win):
     win.manager.getCurrentDir = original
     win.newSlice()
 
-    assert win.statusPanel.instruction() == ""
+    # storage outranks imagery, so the imagery instruction showing is proof the
+    # storage slot is empty -- not merely that the band is.
+    assert win.statusPanel.instruction() == PIN_FRAMES_INSTRUCTION
 
 
 def test_add_region_here_does_not_create_a_directory(win):
@@ -1869,13 +1890,29 @@ def _withPinnedFrameSource(win, hasInterface=True):
     return source
 
 
+def _makePinnedFrame():
+    """A minimal stand-in for a real pinned frame.
+
+    win's own PinnedFrameMirror is bound to the same fake pinned-frame source
+    these tests mutate, so a "pinned frame" has to be something
+    PinnedFrameMirror.refresh() can actually mirror (pg.ImageItem.image/
+    transform()/getLevels()/lut/zValue()) -- a plain string satisfies
+    ReferenceImagery's own tests (test_reference_imagery.py), which have no
+    such mirror in the loop, but raises AttributeError here.
+    """
+    return pg.ImageItem(np.zeros((2, 2)))
+
+
 def test_starting_a_slice_mirrors_the_cameras_pinned_frames(win):
     source = _withPinnedFrameSource(win)
 
     win.newSlice()
 
     assert win._pinnedFrameMirror._source is source
-    assert source.receivers(source.sigPinnedFramesChanged) == 1
+    # Two, not one: ReferenceImagery.rebind() subscribes to the same signal
+    # PinnedFrameMirror does, so a slice with a working camera leaves both
+    # listening on the one source.
+    assert source.receivers(source.sigPinnedFramesChanged) == 2
 
 
 def test_teardown_stops_mirroring_the_cameras_pinned_frames(win):
@@ -1885,7 +1922,8 @@ def test_teardown_stops_mirroring_the_cameras_pinned_frames(win):
     # calling a torn-down window's mirror -- and keep the window reachable.
     source = _withPinnedFrameSource(win)
     win.newSlice()
-    assert source.receivers(source.sigPinnedFramesChanged) == 1
+    # Two: PinnedFrameMirror and ReferenceImagery both subscribed.
+    assert source.receivers(source.sigPinnedFramesChanged) == 2
 
     win.teardown()
 
@@ -1926,6 +1964,72 @@ def test_a_closed_camera_window_stops_the_previous_mirror(win):
 
     assert win._pinnedFrameMirror._source is None
     assert first.receivers(first.sigPinnedFramesChanged) == 0
+
+
+def test_new_slice_offers_to_clear_the_pinned_frames(win, monkeypatch):
+    old = _makePinnedFrame()
+    win.manager.pinnedFrameSource.pinnedFrames = [old]
+    asked = []
+    monkeypatch.setattr(
+        win._referenceImagery, "_prompt", lambda text: asked.append(text) or True
+    )
+
+    win.newSlice()
+
+    assert len(asked) == 1
+    assert win.manager.pinnedFrameSource.pinnedFrames == []
+
+
+def test_declining_leaves_the_pinned_frames(win, monkeypatch):
+    old = _makePinnedFrame()
+    win.manager.pinnedFrameSource.pinnedFrames = [old]
+    monkeypatch.setattr(win._referenceImagery, "_prompt", lambda text: False)
+
+    win.newSlice()
+
+    assert win.manager.pinnedFrameSource.pinnedFrames == [old]
+
+
+def test_a_slice_with_no_imagery_asks_for_frames(win, monkeypatch):
+    monkeypatch.setattr(win._referenceImagery, "_prompt", lambda text: True)
+
+    win.newSlice()
+
+    assert win.statusPanel.instruction() == PIN_FRAMES_INSTRUCTION
+
+
+def test_pinning_a_frame_clears_the_band(win, monkeypatch):
+    monkeypatch.setattr(win._referenceImagery, "_prompt", lambda text: True)
+    win.newSlice()
+
+    win.manager.pinnedFrameSource.pinnedFrames.append(_makePinnedFrame())
+    win.manager.pinnedFrameSource.sigPinnedFramesChanged.emit()
+
+    assert win.statusPanel.instruction() == ""
+
+
+def test_a_storage_failure_outranks_the_imagery_instruction(win, monkeypatch):
+    # Both slots filled at once, which is reachable because create_data_dir can
+    # fail with the previous slice still installed.
+    monkeypatch.setattr(win._referenceImagery, "_prompt", lambda text: True)
+    win.newSlice()
+    assert win.statusPanel.instruction() == PIN_FRAMES_INSTRUCTION
+
+    def boom(*a, **k):
+        raise HelpfulException("Storage directory has not been set.")
+
+    # Not a monkeypatch.setattr("acq4.modules.Autopatch.Autopatch.create_data_dir", ...)
+    # string patch: acq4/modules/Autopatch/__init__.py does
+    # `from .Autopatch import Autopatch`, so that dotted path resolves to the
+    # re-exported Module subclass rather than the Autopatch.py module, and
+    # pytest's import-path resolution fails looking for create_data_dir as a
+    # class attribute. Failing manager.getCurrentDir() is what create_data_dir
+    # itself calls unguarded, and is the same route the other storage-failure
+    # tests in this file use.
+    monkeypatch.setattr(win.manager, "getCurrentDir", boom)
+    win.newSlice()
+
+    assert "Storage directory" in win.statusPanel.instruction()
 
 
 class _ReentrantOrchestrator:
@@ -2176,7 +2280,9 @@ def test_the_next_good_edit_retracts_the_refusal(win):
 
     win.regionPanel.sigRegionsChanged.emit([RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)])
 
-    assert win.statusPanel.instruction() == ""
+    # region outranks imagery: the imagery instruction showing proves the
+    # refusal was retracted.
+    assert win.statusPanel.instruction() == PIN_FRAMES_INSTRUCTION
     assert len(win.slice.regions) == 1
 
 

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -904,8 +904,10 @@ def test_new_slice_clears_area_3s_error_band(qapp, tmp_path):
         assert win.statusPanel.lastError() is None
         # The band is not empty -- the default fake pins no frames, so
         # newSlice() leaves the imagery instruction showing -- but that text
-        # is proof the error slot itself is empty, not merely that the whole
-        # band is.
+        # is proof the storage and region slots are both empty, not the error
+        # slot: instruction() only ever reads _instructions, never _lastError,
+        # so it cannot speak to the error slot either way. The assertion just
+        # above (lastError() is None) is what proves that one.
         assert win.statusPanel.instructionLabel.isVisibleTo(win.statusPanel)
         assert win.statusPanel.instruction() == PIN_FRAMES_INSTRUCTION
     finally:
@@ -2001,11 +2003,38 @@ def test_a_slice_with_no_imagery_asks_for_frames(win, monkeypatch):
 def test_pinning_a_frame_clears_the_band(win, monkeypatch):
     monkeypatch.setattr(win._referenceImagery, "_prompt", lambda text: True)
     win.newSlice()
+    assert win.statusPanel.instruction() == PIN_FRAMES_INSTRUCTION
 
     win.manager.pinnedFrameSource.pinnedFrames.append(_makePinnedFrame())
     win.manager.pinnedFrameSource.sigPinnedFramesChanged.emit()
 
     assert win.statusPanel.instruction() == ""
+
+
+def test_the_clear_prompt_opens_only_after_the_wipe(win, monkeypatch):
+    """beginSlice() runs last in newSlice(), after the cell queue and Area 5's
+    list are wiped, because its prompt is modal: a modal dialog re-enters the
+    Qt event loop, and every queued slot dispatches inside it. By the time
+    anything modal can open, the wipe must already be complete -- so whatever
+    dispatches inside that re-entered loop sees a finished transaction rather
+    than a half-done one, instead of observing the previous slice's queued
+    cell still sitting in Area 5's list.
+    """
+    win.newSlice()
+    cell = _makeCell()
+    win.cellPanel.addCell(cell)
+    win.orchestrator.enqueue(cell)
+    win.manager.pinnedFrameSource.pinnedFrames = [_makePinnedFrame()]
+    seen = {}
+
+    def prompt(text):
+        seen["rows"] = win.cellPanel.cellList.count()
+        return True
+
+    monkeypatch.setattr(win._referenceImagery, "_prompt", prompt)
+    win.newSlice()
+
+    assert seen == {"rows": 0}
 
 
 def test_a_storage_failure_outranks_the_imagery_instruction(win, monkeypatch):

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -2109,27 +2109,6 @@ def test_the_next_good_edit_retracts_the_refusal(win):
     assert len(win.slice.regions) == 1
 
 
-def test_a_refused_edit_does_not_erase_the_storage_instruction(win):
-    """Area 3's band has two Area 1 writers with different conditions, and
-    neither can see the other's. A region edit retracting its own refusal must
-    not also retract newSlice()'s "choose a storage directory", which is still
-    just as true as it was."""
-    from acq4.util.HelpfulException import HelpfulException
-
-    win.addRegionHere()  # a slice, without going through create_data_dir
-
-    def boom(*a, **k):
-        raise HelpfulException("Storage directory has not been set.")
-
-    win.manager.getCurrentDir = boom
-    win.newSlice()
-    assert "Storage directory" in win.statusPanel.instruction()
-
-    win.regionPanel.sigRegionsChanged.emit([RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)])
-
-    assert "Storage directory" in win.statusPanel.instruction()
-
-
 def test_add_region_here_reports_a_refusal_rather_than_raising(win):
     """"Add region here" seeds 3x3 fields, which is nine tiles whatever the
     field of view, so it cannot trip the cap as it stands. The refusal is
@@ -2197,122 +2176,14 @@ def test_add_region_here_without_a_slice_frames_area_1_too(win):
         win.teardown()
 
 
-def _cameraModuleAppears(win, cameraWindow=None):
-    """Have `win`'s manager start reporting a loaded Camera module, and announce
-    it the way Manager.loadModule() does.
-
-    Returns the window that module hands out, and the list of items drawn into
-    it, so a caller can see what the outline mirror put there."""
-    drawn = []
-    if cameraWindow is None:
-        cameraWindow = SimpleNamespace(
-            addItem=lambda item, **kwds: drawn.append(item),
-            removeItem=drawn.remove,
-        )
-    win.manager.listModules = lambda: ["Camera"]
-    win.manager.getModule = lambda name: SimpleNamespace(window=lambda: cameraWindow)
-    win.manager.sigModulesChanged.emit()
-    return cameraWindow, drawn
-
-
-def test_outlines_appear_when_the_camera_module_is_opened_after_the_tick(win):
-    """Both mirrors resolved the Camera module once, at a moment that can
-    precede the module being open, and nothing retried. On the rig this showed
-    up as a ticked "Mirror to Camera" that drew nothing until some later region
-    edit happened to redraw it."""
-    # No Camera module open yet, so the tick below resolves against nothing --
-    # the condition this test is about, distinct from the default fake's.
-    win.manager.listModules = lambda: ["Data Manager"]
-    win.newSlice()
-    win.addRegionHere()
-
-    win.regionPanel.mirrorCheck.setChecked(True)
-    _cameraWindow, drawn = _cameraModuleAppears(win)
-
-    assert len(drawn) == len(win.slice.regions) == 1
-
-
 def test_no_outlines_appear_when_the_checkbox_is_not_ticked(win):
-    # The other side: a module change is not a reason to start mirroring
-    # something the operator never asked to mirror.
+    # A region is not a reason to start mirroring something the operator never
+    # asked to mirror.
     win.newSlice()
+
     win.addRegionHere()
 
-    _cameraWindow, drawn = _cameraModuleAppears(win)
-
-    assert drawn == []
-
-
-def test_pinned_frames_bind_when_the_camera_module_is_opened_after_the_slice(win):
-    """_bindPinnedFrames runs only from _startSlice, so a Camera module opened
-    afterwards was never picked up: on the rig, PinnedFrameMirror._source was
-    None with a frame already pinned and waiting."""
-    # No Camera module open yet, so newSlice() below has nothing to bind to --
-    # the condition this test is about, distinct from the default fake's.
-    win.manager.listModules = lambda: ["Data Manager"]
-    win.newSlice()
-    assert win._pinnedFrameMirror._source is None
-
-    source = _withPinnedFrameSource(win)
-    win.manager.sigModulesChanged.emit()
-
-    assert win._pinnedFrameMirror._source is source
-    assert source.receivers(source.sigPinnedFramesChanged) == 1
-
-
-def test_a_camera_module_opening_with_no_slice_binds_nothing(win):
-    # Nothing is being drawn over yet, and _startSlice binds on its own way
-    # through -- so there is nothing here to retry.
-    source = _withPinnedFrameSource(win)
-
-    win.manager.sigModulesChanged.emit()
-
-    assert win._pinnedFrameMirror._source is None
-    assert source.receivers(source.sigPinnedFramesChanged) == 0
-
-
-def test_a_camera_module_quitting_releases_the_pinned_frame_mirror(win):
-    # sigModulesChanged is also how a module going away is announced, and a
-    # mirror left bound to a dead Camera module would go on showing imagery of
-    # tissue nobody is looking at.
-    source = _withPinnedFrameSource(win)
-    win.newSlice()
-    assert win._pinnedFrameMirror._source is source
-
-    win._cameraWindow = lambda: None
-    win.manager.sigModulesChanged.emit()
-
-    assert win._pinnedFrameMirror._source is None
-    assert source.receivers(source.sigPinnedFramesChanged) == 0
-
-
-def test_teardown_stops_listening_for_module_changes(win):
-    # The manager outlives this window by a long way, so a connection left on it
-    # would go on calling a torn-down window's handler at every later module
-    # load or quit -- re-arming the mirrors teardown had just released.
-    assert win.manager.receivers(win.manager.sigModulesChanged) == 1
-
-    win.teardown()
-
-    assert win.manager.receivers(win.manager.sigModulesChanged) == 0
-
-
-def test_a_module_change_during_teardowns_wait_cannot_re_arm_the_mirrors(win):
-    # teardown() waits on the orchestrator with the Qt event loop still pumping,
-    # so a Camera module loading in those seconds is announced while teardown is
-    # in progress -- and must not bind this closing session's mirrors to it.
-    source = _withPinnedFrameSource(win)
-    win.newSlice()
-    win.regionPanel.mirrorCheck.setChecked(True)
-    win._pinnedFrameMirror.unbind()
-    win.statusPanel.unbindOrchestrator()
-    win.cellPanel.unbindOrchestrator()
-    win.orchestrator = _ReentrantOrchestrator(win.manager.sigModulesChanged.emit)
-
-    win.teardown()
-
-    assert win._pinnedFrameMirror._source is None
-    assert source.receivers(source.sigPinnedFramesChanged) == 0
+    assert win.manager.drawn == []
 
 
 def test_a_headless_window_with_no_manager_still_starts_a_slice(qapp, tmp_path):
@@ -2334,39 +2205,15 @@ def test_a_headless_window_with_no_manager_still_starts_a_slice(qapp, tmp_path):
         win.teardown()
 
 
-def test_ticking_the_mirror_with_no_camera_module_open_says_so(win):
-    # Otherwise the tick is a silent no-op: the checkbox stays ticked and
-    # nothing appears anywhere, with no way to tell that from a broken mirror.
-    win.newSlice()
-
-    win.regionPanel.mirrorCheck.setChecked(True)
-
-    assert "Camera" in win.statusPanel.instruction()
-
-
-def test_the_message_goes_once_a_camera_module_is_open(win):
+def test_unticking_the_mirror_takes_the_outlines_down(win):
     win.newSlice()
     win.addRegionHere()
     win.regionPanel.mirrorCheck.setChecked(True)
-    assert win.statusPanel.instruction() != ""
-
-    _cameraModuleAppears(win)
-
-    assert win.statusPanel.instruction() == ""
-
-
-def test_unticking_the_mirror_retracts_the_message(win):
-    # No Camera module open yet, so the tick below raises the message this
-    # test is about unticking -- the condition this test is about, distinct
-    # from the default fake's.
-    win.manager.listModules = lambda: ["Data Manager"]
-    win.newSlice()
-    win.regionPanel.mirrorCheck.setChecked(True)
-    assert win.statusPanel.instruction() != ""
+    assert win.manager.drawn != []
 
     win.regionPanel.mirrorCheck.setChecked(False)
 
-    assert win.statusPanel.instruction() == ""
+    assert win.manager.drawn == []
 
 
 def test_a_seeded_cell_gets_a_marker(qapp, win):

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -689,6 +689,32 @@ def test_a_started_slice_retracts_the_no_camera_message(qapp, tmp_path):
     assert win.searchPanel.errorLabel.text() == ""
 
 
+def test_new_slice_reports_rather_than_raising_when_the_camera_module_is_closed(
+    qapp, tmp_path
+):
+    # The owner's second precondition, alongside "clear() swallows,
+    # _redraw() propagates": Autopatch.__init__ opens the Camera module at
+    # startup, so a manager present with it missing or windowless means it
+    # closed underneath a running session, and _cameraModuleWindow raises
+    # rather than answering None (see its docstring). _canStartSlice()'s
+    # try/except around that call is what keeps this raise from escaping into
+    # New slice's click handler -- reporting it through SearchPanel exactly
+    # as it already does for "no camera selected" -- and deleting that
+    # try/except is one of the two mutations the reviewer found the whole
+    # suite stayed green under.
+    win = _makeWindow(tmp_path)
+
+    def boom():
+        raise HelpfulException("The Camera module is not open.")
+
+    win._cameraWindow = boom
+
+    win.newSlice()
+
+    assert win.slice is None
+    assert "Camera module" in win.searchPanel.errorLabel.text()
+
+
 def test_new_slice_with_invalid_constraints_creates_nothing_and_keeps_the_old_slice(
     qapp, tmp_path
 ):
@@ -1698,6 +1724,33 @@ def test_editing_a_region_refreshes_the_survey_readout(win):
     assert win.searchPanel.surveyLabel.text() != before
 
 
+def test_a_region_edit_refreshes_survey_stats_even_when_the_mirror_raises(win):
+    # self.slice.setRegions() inside _onRegionsEdited has already committed the
+    # edit by the time _cameraMirror.setRegions() runs; a Camera module closed
+    # underneath a running session makes that mirror call raise
+    # (CameraMirror._redraw() propagates it rather than swallowing it). If the
+    # survey refresh ran after the mirror call instead of before, this raise
+    # would skip it, and Area 2 would go on advertising the previous edit's
+    # tile count -- the operator's only feasibility readout -- for a region
+    # that has already changed underneath it, with nothing but a log entry to
+    # say so.
+    win.newSlice()
+    win.addRegionHere()
+    before = win.searchPanel.surveyLabel.text()
+
+    def boom(_regions):
+        raise HelpfulException("The Camera module is not open.")
+
+    win._cameraMirror.setRegions = boom
+    edited = RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)
+
+    with pytest.raises(HelpfulException):
+        win._onRegionsEdited([edited])
+
+    assert win.slice.regions == [edited]
+    assert win.searchPanel.surveyLabel.text() != before
+
+
 def test_a_region_edit_with_no_slice_is_ignored(win):
     # Area 1's controls are gated on a slice existing, but a signal is not a
     # permission check, and a traceback on the GUI thread is not a second line
@@ -1856,8 +1909,14 @@ def test_a_camera_with_no_imaging_control_stops_the_previous_mirror(win):
 
 
 def test_a_closed_camera_window_stops_the_previous_mirror(win):
-    # The same hazard by the other route: the Camera module has been closed
-    # since the last slice was started.
+    # The same hazard by the other route: forcing the getter itself to answer
+    # None, standing in for the manager-less (headless) case
+    # _cameraModuleWindow documents -- not a closed Camera module, which now
+    # raises instead and never reaches here, because _canStartSlice() refuses
+    # the slice before _startSlice() calls _bindPinnedFrames() at all. What
+    # this still proves: _bindPinnedFrames() unbinds the previous source
+    # unconditionally, even when the getter it calls next answers None rather
+    # than a window.
     first = _withPinnedFrameSource(win)
     win.newSlice()
     assert win._pinnedFrameMirror._source is first
@@ -2140,6 +2199,29 @@ def test_add_region_here_reports_a_refusal_rather_than_raising(win):
 
     assert "999999" in win.statusPanel.instruction()
     assert win.regionPanel.regions() == []
+
+
+def test_add_region_here_refreshes_survey_stats_even_when_the_mirror_raises(win):
+    # slice.addRegion() and regionPanel.setRegions() above have already
+    # committed the seeded region by the time _cameraMirror.setRegions() runs;
+    # a Camera module closed underneath a running session makes that mirror
+    # call raise (CameraMirror._redraw() propagates it rather than swallowing
+    # it). If the survey refresh ran after the mirror call instead of before,
+    # this raise would skip it, and Area 2 would go on reporting "no region"
+    # for a slice that this button just gave nine tiles -- the operator's only
+    # feasibility readout, silently stale until the next successful edit.
+    win.newSlice()
+
+    def boom(_regions):
+        raise HelpfulException("The Camera module is not open.")
+
+    win._cameraMirror.setRegions = boom
+
+    with pytest.raises(HelpfulException):
+        win.addRegionHere()
+
+    assert len(win.slice.regions) == 1
+    assert win.searchPanel.surveyLabel.text() != "no region"
 
 
 def test_starting_a_slice_frames_area_1_on_the_camera(win):

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -2180,6 +2180,27 @@ def test_the_next_good_edit_retracts_the_refusal(win):
     assert len(win.slice.regions) == 1
 
 
+def test_a_refused_edit_does_not_erase_the_storage_instruction(win):
+    """Area 3's band has two Area 1 writers with different conditions, and
+    neither can see the other's. A region edit retracting its own refusal must
+    not also retract newSlice()'s "choose a storage directory", which is still
+    just as true as it was."""
+    from acq4.util.HelpfulException import HelpfulException
+
+    win.addRegionHere()  # a slice, without going through create_data_dir
+
+    def boom(*a, **k):
+        raise HelpfulException("Storage directory has not been set.")
+
+    win.manager.getCurrentDir = boom
+    win.newSlice()
+    assert "Storage directory" in win.statusPanel.instruction()
+
+    win.regionPanel.sigRegionsChanged.emit([RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)])
+
+    assert "Storage directory" in win.statusPanel.instruction()
+
+
 def test_add_region_here_reports_a_refusal_rather_than_raising(win):
     """"Add region here" seeds 3x3 fields, which is nine tiles whatever the
     field of view, so it cannot trip the cap as it stands. The refusal is

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -155,6 +155,16 @@ class _FakeCameraWithDevice(Qt.QWidget):
         return self.camera
 
 
+class _FakePinnedFrameSource(Qt.QObject):
+    """Stands in for the Camera module's ImagingCtrl."""
+
+    sigPinnedFramesChanged = Qt.Signal()
+
+    def __init__(self):
+        super().__init__()
+        self.pinnedFrames = []
+
+
 # The one folder type newSlice() asks create_data_dir for. A real Manager's
 # config carries many more, but this window only ever creates a "Slice".
 _FOLDER_TYPES = {"Slice": {"name": "Slice_%Y%m%d_%H%M%S", "experimentalUnit": False}}
@@ -165,6 +175,10 @@ class _FakeManager(Qt.QObject):
     create_data_dir's mkdir/setInfo calls land on an actual directory, the way
     they would through the real Manager AutopatchWindow otherwise gets from
     its module.
+
+    Offers a Camera module by default, because the Autopatch module opens one
+    at startup and everything in Area 1 is written to assume it. A fake that
+    reported none would stand for a state production rules out.
 
     A QObject carrying sigModulesChanged, because the real Manager is one and
     emits that signal whenever a module is loaded or quits -- which is how
@@ -177,6 +191,23 @@ class _FakeManager(Qt.QObject):
     def __init__(self, root_dir):
         super().__init__()
         self._current_dir = root_dir
+        self.drawn = []
+        self.pinnedFrameSource = _FakePinnedFrameSource()
+        self.cameraWindow = SimpleNamespace(
+            getInterfaceForDevice=lambda name: SimpleNamespace(
+                imagingCtrl=self.pinnedFrameSource
+            ),
+            addItem=lambda item, **kwds: self.drawn.append(item),
+            removeItem=self.drawn.remove,
+        )
+
+    def listModules(self):
+        return ["Camera", "Data Manager"]
+
+    def getModule(self, name):
+        if name != "Camera":
+            raise KeyError(name)
+        return SimpleNamespace(window=lambda: self.cameraWindow)
 
     def getCurrentDir(self):
         return self._current_dir
@@ -1768,17 +1799,6 @@ def test_a_region_edit_while_paused_still_reaches_the_slice(win):
     assert win.slice.regions == [edited]
 
 
-class _FakePinnedFrameSource(Qt.QObject):
-    """Stands in for the Camera module's ImagingCtrl: the pinned-frame list and
-    the signal Area 1 mirrors it through."""
-
-    sigPinnedFramesChanged = Qt.Signal()
-
-    def __init__(self):
-        super().__init__()
-        self.pinnedFrames = []
-
-
 def _withPinnedFrameSource(win, hasInterface=True):
     """Point `win` at a Camera window offering one imaging control, and return
     the control it would bind to."""
@@ -2009,6 +2029,16 @@ def test_the_camera_window_getter_does_not_load_the_camera_module(win):
     assert loaded == []
 
 
+def test_the_default_fake_manager_offers_a_camera_module(win):
+    # Production guarantees a Camera module: the Autopatch module opens one at
+    # startup. A fake that reports none does not reproduce production, and the
+    # None-returning path it stands for is deleted in this branch.
+    window = win._cameraWindow()
+
+    assert window is not None
+    assert window.getInterfaceForDevice("cam").imagingCtrl is not None
+
+
 # 200 x 150 fields of the fake camera's 12 x 8 um ROI: 30,000 tiles, past the
 # 20,000-tile cap. Asymmetric in both axes and at a realistic stage coordinate,
 # so a guard that read one axis twice would be caught.
@@ -2189,6 +2219,9 @@ def test_outlines_appear_when_the_camera_module_is_opened_after_the_tick(win):
     precede the module being open, and nothing retried. On the rig this showed
     up as a ticked "Mirror to Camera" that drew nothing until some later region
     edit happened to redraw it."""
+    # No Camera module open yet, so the tick below resolves against nothing --
+    # the condition this test is about, distinct from the default fake's.
+    win.manager.listModules = lambda: ["Data Manager"]
     win.newSlice()
     win.addRegionHere()
 
@@ -2213,6 +2246,9 @@ def test_pinned_frames_bind_when_the_camera_module_is_opened_after_the_slice(win
     """_bindPinnedFrames runs only from _startSlice, so a Camera module opened
     afterwards was never picked up: on the rig, PinnedFrameMirror._source was
     None with a frame already pinned and waiting."""
+    # No Camera module open yet, so newSlice() below has nothing to bind to --
+    # the condition this test is about, distinct from the default fake's.
+    win.manager.listModules = lambda: ["Data Manager"]
     win.newSlice()
     assert win._pinnedFrameMirror._source is None
 
@@ -2319,6 +2355,10 @@ def test_the_message_goes_once_a_camera_module_is_open(win):
 
 
 def test_unticking_the_mirror_retracts_the_message(win):
+    # No Camera module open yet, so the tick below raises the message this
+    # test is about unticking -- the condition this test is about, distinct
+    # from the default fake's.
+    win.manager.listModules = lambda: ["Data Manager"]
     win.newSlice()
     win.regionPanel.mirrorCheck.setChecked(True)
     assert win.statusPanel.instruction() != ""

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -181,10 +181,9 @@ class _FakeManager(Qt.QObject):
     at startup and everything in Area 1 is written to assume it. A fake that
     reported none would stand for a state production rules out.
 
-    A QObject carrying sigModulesChanged, because the real Manager is one and
-    emits that signal whenever a module is loaded or quits -- which is how
-    Area 1's two mirrors find a Camera module that was not open when they were
-    first resolved.
+    A QObject carrying sigModulesChanged, because the real Manager is one.
+    Nothing in Autopatch listens to that signal, so the fake's implementation
+    is inert; it exists to match the interface of the thing it stands in for.
     """
 
     sigModulesChanged = Qt.Signal()

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -2281,8 +2281,10 @@ def test_no_outlines_appear_when_the_checkbox_is_not_ticked(win):
 
 
 def test_a_headless_window_with_no_manager_still_starts_a_slice(qapp, tmp_path):
-    # module=None is the constructor's documented headless mode: there is no
-    # manager to listen to, and that must not be an error.
+    # module=None is a mode the constructor supports by design -- the parameter
+    # defaults to None (see AutopatchWindow.__init__'s signature; it carries no
+    # docstring saying so) -- and with no manager there is nothing to listen to,
+    # which must not be an error.
     from acq4.modules.Autopatch.Autopatch import AutopatchWindow
 
     _write_protocol(tmp_path, "demo.py", _NOOP_PROTOCOL)

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -2011,18 +2011,32 @@ def test_the_camera_window_getter_finds_a_loaded_camera_module(win):
     assert win._cameraWindow() is cameraWindow
 
 
-def test_the_camera_window_getter_raises_when_the_module_is_closed(win):
-    # The Autopatch module opens the Camera module at startup. One closed
-    # afterwards is an error, not a state to degrade into -- a blank Area 1
-    # with regions being drawn over nothing is worse than a raise.
-    win.manager.listModules = lambda: ["Data Manager"]
+def test_the_camera_window_getter_raises_when_the_module_is_closed(win, monkeypatch):
+    # The Autopatch module opens the Camera module at startup. A module
+    # closed afterwards is an error, not a state to degrade into -- a blank
+    # Area 1 with regions being drawn over nothing is worse than a raise.
+    loaded = []
+
+    def getModule(name):
+        loaded.append(name)
+        return SimpleNamespace(window=SimpleNamespace)
+
+    monkeypatch.setattr(win.manager, "listModules", lambda: ["Data Manager"])
+    monkeypatch.setattr(win.manager, "getModule", getModule)
 
     with pytest.raises(HelpfulException, match="Camera"):
         win._cameraWindow()
 
+    # Manager.getModule loads a module that is not already open, and this
+    # getter is called on every mirror redraw -- including from "Add region
+    # here". A button that adds a region must not also start the Camera
+    # module: listModules() is checked first, so a module reported closed is
+    # never handed to getModule() at all.
+    assert loaded == []
 
-def test_the_camera_window_getter_raises_when_the_module_has_no_window(win):
-    win.manager.getModule = lambda name: SimpleNamespace(window=lambda: None)
+
+def test_the_camera_window_getter_raises_when_the_module_has_no_window(win, monkeypatch):
+    monkeypatch.setattr(win.manager, "getModule", lambda name: SimpleNamespace(window=lambda: None))
 
     with pytest.raises(HelpfulException, match="Camera"):
         win._cameraWindow()

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -19,6 +19,7 @@ from acq4.modules.Autopatch.progress_colors import (
     successBrushes,
 )
 from acq4.util import Qt
+from acq4.util.HelpfulException import HelpfulException
 from acq4_automation.feature_tracking.cell import Cell
 
 
@@ -2010,23 +2011,21 @@ def test_the_camera_window_getter_finds_a_loaded_camera_module(win):
     assert win._cameraWindow() is cameraWindow
 
 
-def test_the_camera_window_getter_does_not_load_the_camera_module(win):
-    # Manager.getModule loads a module that is not already open, and this getter
-    # is called on every mirror redraw -- including from "Add region here". A
-    # button that adds a region must not also start the Camera module, and the
-    # window it would hand back is a different instance from the one any
-    # already-drawn outline belongs to.
-    loaded = []
-
-    def getModule(name):
-        loaded.append(name)
-        return SimpleNamespace(window=SimpleNamespace)
-
+def test_the_camera_window_getter_raises_when_the_module_is_closed(win):
+    # The Autopatch module opens the Camera module at startup. One closed
+    # afterwards is an error, not a state to degrade into -- a blank Area 1
+    # with regions being drawn over nothing is worse than a raise.
     win.manager.listModules = lambda: ["Data Manager"]
-    win.manager.getModule = getModule
 
-    assert win._cameraWindow() is None
-    assert loaded == []
+    with pytest.raises(HelpfulException, match="Camera"):
+        win._cameraWindow()
+
+
+def test_the_camera_window_getter_raises_when_the_module_has_no_window(win):
+    win.manager.getModule = lambda name: SimpleNamespace(window=lambda: None)
+
+    with pytest.raises(HelpfulException, match="Camera"):
+        win._cameraWindow()
 
 
 def test_the_default_fake_manager_offers_a_camera_module(win):

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -717,16 +717,22 @@ def test_new_slice_reports_rather_than_raising_when_the_camera_module_is_closed(
     # try/except is one of the two mutations the reviewer found the whole
     # suite stayed green under.
     win = _makeWindow(tmp_path)
+    try:
+        win.newSlice()
+        first = win.slice
+        assert first is not None
 
-    def boom():
-        raise HelpfulException("The Camera module is not open.")
+        def boom():
+            raise HelpfulException("The Camera module is not open.")
 
-    win._cameraWindow = boom
+        win._cameraWindow = boom
 
-    win.newSlice()
+        win.newSlice()
 
-    assert win.slice is None
-    assert "Camera module" in win.searchPanel.errorLabel.text()
+        assert win.slice is first
+        assert "Camera module" in win.searchPanel.errorLabel.text()
+    finally:
+        win.teardown()
 
 
 def test_new_slice_with_invalid_constraints_creates_nothing_and_keeps_the_old_slice(

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -156,7 +156,8 @@ class _FakeCameraWithDevice(Qt.QWidget):
 
 
 class _FakePinnedFrameSource(Qt.QObject):
-    """Stands in for the Camera module's ImagingCtrl."""
+    """Stands in for the Camera module's ImagingCtrl: the pinned-frame list and
+    the signal Area 1 mirrors it through."""
 
     sigPinnedFramesChanged = Qt.Signal()
 
@@ -1748,10 +1749,10 @@ def test_the_mirror_checkbox_drives_the_camera_mirror(win):
 
 
 def test_teardown_takes_the_mirrored_outlines_out_of_the_camera_window(win):
-    # A camera window has to be supplied for this to test anything: _FakeManager
-    # has no Camera module, so _cameraWindow() returns None and the mirror holds
-    # nothing whether or not teardown clears it. Asserting an empty list against
-    # a mirror that was never able to draw is asserting a default.
+    # Patches _cameraMirror._cameraWindow directly instead of going through
+    # _FakeManager's own Camera window, so `drawn` is a recorder scoped to
+    # this test alone -- the same idiom the neighboring teardown/release
+    # tests use for the same reason.
     drawn = []
     fakeCameraWindow = SimpleNamespace(
         addItem=lambda item, **kwds: drawn.append(item),

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -2336,6 +2336,23 @@ def test_a_refused_edit_does_not_erase_the_storage_instruction(win):
     assert "Storage directory" in win.statusPanel.instruction()
 
 
+def test_a_new_slice_retracts_a_refused_edits_message(win):
+    """The opposite direction from test_a_refused_edit_does_not_erase_the_
+    storage_instruction: a region refusal names an outline on tissue that
+    newSlice() is about to discard, so newSlice() must retract it -- unlike
+    the storage instruction above, which survives a region edit because it
+    is still true."""
+    win.newSlice()
+    win.regionPanel.sigRegionsChanged.emit([_OVERSIZED_REGION])
+    assert win.statusPanel.instruction() != ""
+
+    win.newSlice()
+
+    # region outranks imagery: the imagery instruction showing proves the
+    # refusal was retracted, not merely outranked.
+    assert win.statusPanel.instruction() == PIN_FRAMES_INSTRUCTION
+
+
 def test_add_region_here_reports_a_refusal_rather_than_raising(win):
     """"Add region here" seeds 3x3 fields, which is nine tiles whatever the
     field of view, so it cannot trip the cap as it stands. The refusal is

--- a/docs/superpowers/plans/2026-08-14-autopatch-pinned-frames-workflow.md
+++ b/docs/superpowers/plans/2026-08-14-autopatch-pinned-frames-workflow.md
@@ -1229,7 +1229,12 @@ Expected: FAIL with `AttributeError: 'AutopatchWindow' object has no attribute '
 In `AutopatchWindow.__init__`, immediately after `self._pinnedFrameMirror = PinnedFrameMirror(self.regionPanel.view)` (~line 119):
 
 ```python
-        self._referenceImagery = ReferenceImagery(self._imagingCtrl)
+        # parent=self so the clear prompt is owned by this window: a parentless
+        # QMessageBox centres on the primary screen rather than over Autopatch
+        # and can sit behind it with no taskbar entry of its own, which reads as
+        # a hung UI at the start of every slice. Every other QMessageBox in acq4
+        # passes a real widget.
+        self._referenceImagery = ReferenceImagery(self._imagingCtrl, parent=self)
         self._referenceImagery.sigInstructionChanged.connect(
             self._onImageryInstruction
         )

--- a/docs/superpowers/plans/2026-08-14-autopatch-pinned-frames-workflow.md
+++ b/docs/superpowers/plans/2026-08-14-autopatch-pinned-frames-workflow.md
@@ -203,25 +203,16 @@ The "no Camera module is open" message and the whole `sigModulesChanged` apparat
 - Consumes: Task 1's `_FakeManager`.
 - Produces: `AutopatchWindow._setRegionInstruction(text: str) -> None`, now writing straight through with no ownership flag. `AutopatchWindow._onModulesChanged` no longer exists.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Delete the warning's tests and rewrite the third**
 
-Add to `acq4/modules/Autopatch/tests/test_window_integration.py`, replacing `test_ticking_the_mirror_with_no_camera_module_open_says_so` (~line 2299) in place:
+Delete both of these from `acq4/modules/Autopatch/tests/test_window_integration.py` outright — they test a message this task removes:
 
-```python
-def test_ticking_the_mirror_says_nothing(win):
-    # The Camera module is a precondition of the Autopatch module, not a
-    # possibility to warn about: it is opened at startup, and a closed one
-    # raises rather than degrading into a message.
-    win.newSlice()
+- `test_ticking_the_mirror_with_no_camera_module_open_says_so` (~line 2299)
+- `test_the_message_goes_once_a_camera_module_is_open` (~line 2309)
 
-    win.regionPanel.mirrorCheck.setChecked(True)
+**Do not replace them with a test asserting the message is gone.** `instruction() == ""` is the band's state before anything ever wrote to it, so such a test passes against code that never had the feature — the "asserting a default is asserting nothing" trap in the Global Constraints. Deleting a feature does not require a test that it stays deleted.
 
-    assert win.statusPanel.instruction() == ""
-```
-
-Delete `test_the_message_goes_once_a_camera_module_is_open` (~line 2309) outright — it asserts the retraction of a message that no longer exists.
-
-Keep `test_unticking_the_mirror_retracts_the_message` but rewrite it, since there is no longer a message to retract:
+Keep `test_unticking_the_mirror_retracts_the_message` but rewrite it, since there is no longer a message to retract — it now asserts something that can actually fail:
 
 ```python
 def test_unticking_the_mirror_takes_the_outlines_down(win):
@@ -235,13 +226,15 @@ def test_unticking_the_mirror_takes_the_outlines_down(win):
     assert win.manager.drawn == []
 ```
 
-- [ ] **Step 2: Run them and watch the first fail**
+- [ ] **Step 2: Run the rewritten test and watch it pass**
 
 ```bash
-/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py -k "ticking_the_mirror or unticking_the_mirror" -v
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py -k "unticking_the_mirror" -v
 ```
 
-Expected: `test_ticking_the_mirror_says_nothing` FAILS — with Task 1's fake the getter returns a window, so no message appears and it may already pass. **If it passes, that is expected and not a defect**: Task 1's fake removed the condition. Confirm the old behaviour is genuinely gone by temporarily pointing `win._cameraWindow = lambda: None` inside the test, watching it fail, and removing that line again. Record what you saw.
+Expected: PASS. It asserts outlines appear and then go, which Task 1's fake Camera window already makes reachable — this rewrite is not driving new behaviour, it is replacing an assertion about a deleted message with one about the mirror's actual job.
+
+Prove it can fail before moving on: temporarily comment out `self._cameraMirror.setEnabled(enabled)` in `_onMirrorToggled`, run it, **record the failing line number**, and restore.
 
 - [ ] **Step 3: Strip `_onMirrorToggled` to its job**
 
@@ -1255,22 +1248,56 @@ In `teardown()`'s `finally`, beside the other outward-reaching releases:
             self._cameraMirror.clear()
 ```
 
-- [ ] **Step 7: Run them and watch them pass**
+- [ ] **Step 7: Update the two tests this task changes the answer for**
+
+This task makes every successful `newSlice()` put `PIN_FRAMES_INSTRUCTION` in the band, because the default fake pins no frames. Two landed tests assert the band is *empty* after one, and they are this task's to own — the plan's rule is that the task changing a behaviour owns every site that reads it.
+
+Both become stronger, not weaker. `storage` and `region` both outrank `imagery`, so seeing the imagery text is proof the higher slot is empty — a better assertion than `== ""`, which could not tell an empty slot from an empty band.
+
+In `test_the_storage_message_goes_once_a_directory_is_chosen` (~line 1480), replace the final assertion:
+
+```python
+    win.manager.getCurrentDir = original
+    win.newSlice()
+
+    # storage outranks imagery, so the imagery instruction showing is proof the
+    # storage slot is empty -- not merely that the band is.
+    assert win.statusPanel.instruction() == PIN_FRAMES_INSTRUCTION
+```
+
+In `test_the_next_good_edit_retracts_the_refusal` (~line 2077), replace the first of the two final assertions the same way:
+
+```python
+    win.regionPanel.sigRegionsChanged.emit([RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)])
+
+    # region outranks imagery: the imagery instruction showing proves the
+    # refusal was retracted.
+    assert win.statusPanel.instruction() == PIN_FRAMES_INSTRUCTION
+    assert len(win.slice.regions) == 1
+```
+
+Add the import at the top of the test file:
+
+```python
+from acq4.modules.Autopatch.reference_imagery import PIN_FRAMES_INSTRUCTION
+```
+
+- [ ] **Step 8: Run them and watch them pass**
 
 ```bash
 /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/ -q
 ```
 
-Expected: all PASS.
+Expected: all PASS. If any *other* test asserts an empty band after `newSlice()`, it is the same case — fix it the same way and name it in the commit message. If more than these two turn up, stop and report; the plan expected exactly two.
 
-- [ ] **Step 8: Mutation proofs**
+- [ ] **Step 9: Mutation proofs**
 
 Two, restored between:
 
 1. Move `self._referenceImagery.beginSlice()` from the end of `newSlice()` to immediately after `if not self._startSlice(dirHandle=dirHandle): return`. Run the full Autopatch suite. **Record whether anything fails.** If nothing does, that is the finding to report: the ordering is a reasoned safeguard with no test able to distinguish it, and it should be recorded as such in the PR rather than presented as covered.
 2. Delete `self._referenceImagery.release()` from `teardown()`. Run `test_teardown_releases_the_reference_imagery`. Expected FAIL at the `receivers(...) == 0` assertion. **Record the line.**
 
-- [ ] **Step 9: Commit**
+- [ ] **Step 10: Commit**
 
 ```bash
 git rev-parse --show-toplevel && git branch --show-current
@@ -1342,6 +1369,8 @@ Base `_reviewed` on `origin/acq4`. The body must state plainly:
 
 **Type consistency.** `setInstruction(source, text)` is defined in Task 4 and called with `"region"`/`"storage"` there and `"imagery"` in Task 6. `INSTRUCTION_SOURCES` is the same tuple in both. `ReferenceImagery(imagingCtrlGetter, prompt=None)` is constructed in Task 6 exactly as defined in Task 5, with `_imagingCtrl` matching the `getter()` signature. `PIN_FRAMES_INSTRUCTION` is imported by name in Tasks 5 and 6. `_FakeManager.pinnedFrameSource` is produced in Task 1 and consumed in Task 6.
 
-**Two gaps this review found and fixed.** (1) Task 4 originally left `newSlice()`'s success path clearing only `storage`, stranding a `region` message from before the tissue was discarded — it now clears both. (2) Task 1's Step 7 originally said "fix any failing test"; it now names the three tests that must be left failing, because a task that deletes a test whose feature still exists cannot be reviewed on its own.
+**Gaps this review found and fixed.** (1) Task 4 originally left `newSlice()`'s success path clearing only `storage`, stranding a `region` message from before the tissue was discarded — it now clears both. (2) Task 1's Step 7 originally said "fix any failing test"; it now names the three tests that must be left failing, because a task that deletes a test whose feature still exists cannot be reviewed on its own.
+
+**Two more found in the pre-flight scan, after the plan was first committed.** (3) Task 6 changes what `instruction()` returns after every successful `newSlice()`, breaking two landed tests the plan never mentioned; Task 6 Step 7 now owns them, and the replacement assertions are stronger than the ones they replace — `storage` and `region` both outrank `imagery`, so the imagery text showing proves the higher slot is empty. (4) Task 2 originally mandated a test asserting `instruction() == ""`, which is the band's state before any feature existed; it is deleted rather than replaced.
 
 **One risk the plan cannot remove.** Task 6's prompt-last ordering may have no test that can distinguish it — its mutation step is written to treat that as a finding to report rather than a step to pass.

--- a/docs/superpowers/plans/2026-08-14-autopatch-pinned-frames-workflow.md
+++ b/docs/superpowers/plans/2026-08-14-autopatch-pinned-frames-workflow.md
@@ -1,0 +1,1347 @@
+# Autopatch pinned-frames workflow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Sequence the Camera module's pinned frames into the start of a slice — clear the old set behind a prompt, instruct the operator to pin a fresh one — and make the Camera module a precondition of the Autopatch module rather than a possibility every consumer checks for.
+
+**Architecture:** A new `ReferenceImagery` QObject beside the two Area 1 mirrors owns the pinned-frame workflow and publishes one instruction string. `StatusPanel`'s single instruction slot becomes three named, priority-ordered slots so its three writers cannot retract each other. The `Autopatch` module opens the Camera module at startup, and `_cameraWindow()` raises `HelpfulException` instead of returning `None`.
+
+**Tech Stack:** Python 3, PyQt5 via `acq4.util.Qt`, pyqtgraph, pytest.
+
+Spec: `docs/superpowers/specs/2026-08-14-autopatch-pinned-frames-workflow-design.md`
+
+## Global Constraints
+
+- **Python interpreter is `/home/martin/.miniforge3/envs/acq4-gl/bin/python`.** Not `acq4-torch`, which lacks gentletask 0.7.0.
+- **Verify you are in the right checkout before committing.** Run `git rev-parse --show-toplevel` and `git branch --show-current`. Expected toplevel: `/home/martin/src/acq4/acq4/.claude/worktrees/minirig-v1-move-names-cd821b`. Expected branch: `claude/autopatch-ui-work-45342d`. A previous implementer committed into the main checkout on the wrong branch; do not repeat it.
+- **Commit messages use the project footer.** Use a heredoc, never a single-line `-m`, so the footer survives:
+  ```
+  🤖 Generated with [Claude Code](https://claude.ai/code)
+  ```
+  and commit with `--author="Martin Chase (claude) <outofculture@gmail.com>"` and `-c user.email=outofculture@gmail.com`.
+- **Test output must be pristine.** No warnings introduced, no skips added.
+- **Mutation proof is mandatory for any test whose assertion is about absence** (`== ""`, `is None`, "not called", "still pinned", "unchanged"). Apply the defect, run the test, and **record the line number the failure occurred at**. A mutation that fails at a different line than the assertion has proven nothing. A mutation that does *not* fail is a finding: report it rather than moving on.
+- **Every comment's rationale is a claim.** Do not write a justification you have not verified. Six false comments were corrected on a previous branch in this module.
+- **Do not use `weakref` to prove a disconnect.** Assert Qt's own `receivers(signal)`. Twice a mandated "remove the disconnect" mutation passed because a nearby `= None` had already broken the cycle refcounting sees.
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+| --- | --- | --- |
+| `acq4/modules/Autopatch/tests/test_window_integration.py` | `_FakeManager` grows a Camera module, matching the guarantee production now makes | 1, 2, 3, 6 |
+| `acq4/modules/Autopatch/Autopatch.py` | Delete the mirror warning and modules-changed wiring; open Camera at startup; raise; wire `ReferenceImagery` | 2, 3, 4, 6 |
+| `acq4/modules/Autopatch/status_panel.py` | Named instruction slots | 4 |
+| `acq4/modules/Autopatch/tests/test_status_panel.py` | Slot priority and isolation | 4 |
+| `acq4/modules/Autopatch/reference_imagery.py` | **New.** The pinned-frames workflow: resolve, prompt-and-clear, publish an instruction | 5 |
+| `acq4/modules/Autopatch/tests/test_reference_imagery.py` | **New.** Headless unit tests against a fake ImagingCtrl | 5 |
+| `acq4/modules/Autopatch/tests/test_teardown.py` | `release()` reached from `teardown()` | 6 |
+
+---
+
+## Task 1: Make the fakes tell production's truth
+
+`_FakeManager` carries no `listModules`/`getModule`, so `_cameraModuleWindow`'s `except Exception: return None` is what 82 `newSlice()`-calling tests actually exercise. Task 3 deletes that fallback. This task makes the default fake supply a Camera module **first**, so the suite is green at every commit.
+
+This is the same defect class as P2b's `restore_depth` and `_FakeCamera`: a fake that reports a state production guarantees cannot happen.
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/tests/test_window_integration.py` (`_FakeManager`, ~line 162)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `_FakeManager.listModules() -> list[str]` returning `["Camera"]`; `_FakeManager.getModule(name) -> SimpleNamespace` with `.window()`; `_FakeManager.cameraWindow` — the fake Camera window, with `getInterfaceForDevice(name) -> SimpleNamespace(imagingCtrl=...)`, `addItem(item, **kwds)`, `removeItem(item)`, and `drawn: list`. `_FakeManager.pinnedFrameSource` — the `_FakePinnedFrameSource` its interface hands out.
+
+- [ ] **Step 1: Read the two existing helpers you are generalising**
+
+Read `_FakePinnedFrameSource` (~line 1770) and `_withPinnedFrameSource` (~line 1782) in `acq4/modules/Autopatch/tests/test_window_integration.py`. The new default must offer the same surface, so tests already calling `_withPinnedFrameSource(win)` keep working when it overrides the default.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `acq4/modules/Autopatch/tests/test_window_integration.py`, next to the other camera-window-getter tests (~line 2286):
+
+```python
+def test_the_default_fake_manager_offers_a_camera_module(win):
+    # Production guarantees a Camera module: the Autopatch module opens one at
+    # startup. A fake that reports none does not reproduce production, and the
+    # None-returning path it stands for is deleted in this branch.
+    window = win._cameraWindow()
+
+    assert window is not None
+    assert window.getInterfaceForDevice("cam").imagingCtrl is not None
+```
+
+- [ ] **Step 3: Run it and watch it fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py::test_the_default_fake_manager_offers_a_camera_module -v
+```
+
+Expected: FAIL — `assert None is not None`, because `_FakeManager` has no `listModules` and `_cameraModuleWindow` swallows the `AttributeError`.
+
+- [ ] **Step 4: Move `_FakePinnedFrameSource` above `_FakeManager`**
+
+`_FakeManager` is defined at ~line 162 and `_FakePinnedFrameSource` at ~line 1770. Python resolves the name at call time, not definition time, so this move is not strictly required — but the file reads top-down and a fake referenced by the manager belongs above it. Cut the class and paste it immediately above `_FAKE_FOLDER_TYPES`/`_FakeManager`:
+
+```python
+class _FakePinnedFrameSource(Qt.QObject):
+    """Stands in for the Camera module's ImagingCtrl."""
+
+    sigPinnedFramesChanged = Qt.Signal()
+
+    def __init__(self):
+        super().__init__()
+        self.pinnedFrames = []
+```
+
+- [ ] **Step 5: Give `_FakeManager` a Camera module**
+
+Replace `_FakeManager`'s docstring and `__init__`, and add the three methods. The existing `getCurrentDir`/`setCurrentDir`/`folderTypesConfig` are unchanged:
+
+```python
+class _FakeManager(Qt.QObject):
+    """Stands in for Manager: backed by a real DirHandle (on tmp_path) so
+    create_data_dir's mkdir/setInfo calls land on an actual directory, the way
+    they would through the real Manager AutopatchWindow otherwise gets from
+    its module.
+
+    Offers a Camera module by default, because the Autopatch module opens one
+    at startup and everything in Area 1 is written to assume it. A fake that
+    reported none would stand for a state production rules out.
+
+    A QObject because the real Manager is one. Nothing in Autopatch listens to
+    sigModulesChanged any more, but the real Manager still carries it.
+    """
+
+    sigModulesChanged = Qt.Signal()
+
+    def __init__(self, root_dir):
+        super().__init__()
+        self._current_dir = root_dir
+        self.drawn = []
+        self.pinnedFrameSource = _FakePinnedFrameSource()
+        self.cameraWindow = SimpleNamespace(
+            getInterfaceForDevice=lambda name: SimpleNamespace(
+                imagingCtrl=self.pinnedFrameSource
+            ),
+            addItem=lambda item, **kwds: self.drawn.append(item),
+            removeItem=self.drawn.remove,
+        )
+
+    def listModules(self):
+        return ["Camera", "Data Manager"]
+
+    def getModule(self, name):
+        if name != "Camera":
+            raise KeyError(name)
+        return SimpleNamespace(window=lambda: self.cameraWindow)
+
+    def getCurrentDir(self):
+        return self._current_dir
+
+    def setCurrentDir(self, d):
+        self._current_dir = d
+
+    def folderTypesConfig(self):
+        return _FOLDER_TYPES
+```
+
+- [ ] **Step 6: Run the new test**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py::test_the_default_fake_manager_offers_a_camera_module -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run the whole Autopatch suite and fix the fallout**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/ -q
+```
+
+Tests that previously ran with **no** Camera module now run with one. Expect failures in tests asserting nothing was mirrored or drawn. For each failure decide, and say which in the commit message:
+
+- A test whose *subject* is the absent Camera module (`test_ticking_the_mirror_with_no_camera_module_open_says_so`, `test_the_message_goes_once_a_camera_module_is_open`, `test_the_camera_window_getter_does_not_load_the_camera_module`) — **leave failing and note it**; Tasks 2 and 3 delete them. Do not delete them here; a task that deletes a test whose feature still exists is unreviewable.
+- Any other test — the fake changed under it, so **fix the test**, not the fake.
+
+If more than three tests outside that set fail, stop and report rather than patching broadly.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/modules/Autopatch/tests/test_window_integration.py
+git -c user.email=outofculture@gmail.com commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'EOF'
+test(autopatch): give the fake manager a Camera module
+
+Production guarantees one from startup, so a fake reporting none stands for
+a state that cannot happen -- and it is what the deleted None-returning
+getter path was actually exercising across 82 tests.
+
+Three tests about the absent-Camera-module case are left failing; they are
+deleted with the features they cover in the next two commits.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+```
+
+---
+
+## Task 2: Delete the mirror warning and the modules-changed wiring
+
+The "no Camera module is open" message and the whole `sigModulesChanged` apparatus exist to handle a Camera module arriving late. Task 3 makes that impossible. Delete them first, so Task 3 never has to reason about dead branches.
+
+`_setRegionInstruction` **survives** — `_onRegionsEdited` uses it for `RegionTooLarge`. Only `_regionInstruction`, the bool that arbitrated between it and `newSlice()`, goes; Task 4 replaces that arbitration with slots.
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/Autopatch.py` (`__init__` ~177 and ~193-201, `_onMirrorToggled` ~277, `_onModulesChanged` ~296, `_setRegionInstruction` ~356, `teardown` ~985)
+- Modify: `acq4/modules/Autopatch/tests/test_window_integration.py`
+
+**Interfaces:**
+- Consumes: Task 1's `_FakeManager`.
+- Produces: `AutopatchWindow._setRegionInstruction(text: str) -> None`, now writing straight through with no ownership flag. `AutopatchWindow._onModulesChanged` no longer exists.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `acq4/modules/Autopatch/tests/test_window_integration.py`, replacing `test_ticking_the_mirror_with_no_camera_module_open_says_so` (~line 2299) in place:
+
+```python
+def test_ticking_the_mirror_says_nothing(win):
+    # The Camera module is a precondition of the Autopatch module, not a
+    # possibility to warn about: it is opened at startup, and a closed one
+    # raises rather than degrading into a message.
+    win.newSlice()
+
+    win.regionPanel.mirrorCheck.setChecked(True)
+
+    assert win.statusPanel.instruction() == ""
+```
+
+Delete `test_the_message_goes_once_a_camera_module_is_open` (~line 2309) outright — it asserts the retraction of a message that no longer exists.
+
+Keep `test_unticking_the_mirror_retracts_the_message` but rewrite it, since there is no longer a message to retract:
+
+```python
+def test_unticking_the_mirror_takes_the_outlines_down(win):
+    win.newSlice()
+    win.addRegionHere()
+    win.regionPanel.mirrorCheck.setChecked(True)
+    assert win.manager.drawn != []
+
+    win.regionPanel.mirrorCheck.setChecked(False)
+
+    assert win.manager.drawn == []
+```
+
+- [ ] **Step 2: Run them and watch the first fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py -k "ticking_the_mirror or unticking_the_mirror" -v
+```
+
+Expected: `test_ticking_the_mirror_says_nothing` FAILS — with Task 1's fake the getter returns a window, so no message appears and it may already pass. **If it passes, that is expected and not a defect**: Task 1's fake removed the condition. Confirm the old behaviour is genuinely gone by temporarily pointing `win._cameraWindow = lambda: None` inside the test, watching it fail, and removing that line again. Record what you saw.
+
+- [ ] **Step 3: Strip `_onMirrorToggled` to its job**
+
+Replace `_onMirrorToggled` (~line 277) entirely:
+
+```python
+    def _onMirrorToggled(self, enabled: bool) -> None:
+        """Turn the outline mirror on or off."""
+        self._cameraMirror.setEnabled(enabled)
+```
+
+- [ ] **Step 4: Delete `_onModulesChanged` and its wiring**
+
+Delete the whole `_onModulesChanged` method (~line 296 through the line before `_onRegionsEdited`).
+
+In `__init__` (~line 193), delete these six lines including the comment:
+
+```python
+        if self.manager is not None:
+            # Both Area 1 mirrors resolve the Camera module through
+            # ... (comment continues)
+            self.manager.sigModulesChanged.connect(self._onModulesChanged)
+```
+
+In `teardown()` (~line 985), delete the disconnect and rewrite the comment above it, which explains an ordering that no longer has two sides:
+
+```python
+            # In a finally because these are the releases that reach *outside*
+            # this window: a raise while stopping the orchestrator would
+            # otherwise leave the Camera module holding this session's outlines
+            # and its imaging control still connected to a dead mirror.
+            self._pinnedFrameMirror.unbind()
+            self._cameraMirror.clear()
+            self._releaseCellPositionConnections()
+            self._progressOverlay.release()
+```
+
+- [ ] **Step 5: Drop the ownership flag**
+
+Delete `self._regionInstruction = False` from `__init__` (~line 177), and replace `_setRegionInstruction` (~line 356):
+
+```python
+    def _setRegionInstruction(self, text: str) -> None:
+        """Put Area 1's guidance in Area 3's band, or retract it.
+
+        Area 1 has one guidance slot: a later message replaces an earlier one.
+        """
+        self.statusPanel.setInstruction(text)
+```
+
+Note this is deliberately a half-step: it writes through to the single-slot band and would now clobber `newSlice()`'s storage message. Task 4 closes that, and no test between here and there covers the collision.
+
+- [ ] **Step 6: Delete the two remaining flag reads**
+
+Search for the flag and remove both assignments left in `newSlice()`:
+
+```bash
+grep -n "_regionInstruction" acq4/modules/Autopatch/Autopatch.py
+```
+
+Expected after editing: no matches. In `newSlice()` these two lines go (~512 and ~524), each with the comment above it that explains the flag:
+
+```python
+            self._regionInstruction = False
+```
+
+- [ ] **Step 7: Run the suite**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/ -q
+```
+
+Expected: all pass except `test_the_camera_window_getter_does_not_load_the_camera_module`, which Task 3 deletes.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/modules/Autopatch/Autopatch.py acq4/modules/Autopatch/tests/test_window_integration.py
+git -c user.email=outofculture@gmail.com commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'EOF'
+refactor(autopatch): drop the late-Camera-module apparatus
+
+The mirror's "no Camera module is open" warning, _onModulesChanged and its
+sigModulesChanged wiring all served a module arriving after the window. The
+Autopatch module now opens one at startup, so that cannot happen.
+
+_setRegionInstruction survives for its RegionTooLarge caller; only the
+_regionInstruction ownership bool goes, and named slots replace what it did.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+```
+
+---
+
+## Task 3: The Camera module is a precondition
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/Autopatch.py` (`_cameraModuleWindow` ~247, `Autopatch.__init__` ~1006)
+- Modify: `acq4/modules/Autopatch/tests/test_window_integration.py`
+
+**Interfaces:**
+- Consumes: Task 1's `_FakeManager`.
+- Produces: `AutopatchWindow._cameraModuleWindow(manager)` raises `HelpfulException` instead of returning `None`; `AutopatchWindow._cameraWindow()` likewise. Callers no longer check for `None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Replace `test_the_camera_window_getter_does_not_load_the_camera_module` (~line 2306) with:
+
+```python
+def test_the_camera_window_getter_raises_when_the_module_is_closed(win):
+    # The Autopatch module opens the Camera module at startup. One closed
+    # afterwards is an error, not a state to degrade into -- a blank Area 1
+    # with regions being drawn over nothing is worse than a raise.
+    win.manager.listModules = lambda: ["Data Manager"]
+
+    with pytest.raises(HelpfulException, match="Camera"):
+        win._cameraWindow()
+
+
+def test_the_camera_window_getter_raises_when_the_module_has_no_window(win):
+    win.manager.getModule = lambda name: SimpleNamespace(window=lambda: None)
+
+    with pytest.raises(HelpfulException, match="Camera"):
+        win._cameraWindow()
+```
+
+Add the import at the top of the file if absent:
+
+```python
+from acq4.util.HelpfulException import HelpfulException
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py -k "camera_window_getter" -v
+```
+
+Expected: both FAIL with `DID NOT RAISE`.
+
+- [ ] **Step 3: Make the getter raise**
+
+Replace `_cameraModuleWindow` (~line 247):
+
+```python
+    @staticmethod
+    def _cameraModuleWindow(manager):
+        """The Camera module's window under `manager`.
+
+        Raises rather than answering None: the Autopatch module opens the
+        Camera module at startup (see Autopatch.__init__), so a missing one
+        means it was closed underneath a running session. Degrading quietly
+        would leave Area 1 blank while the operator went on drawing regions
+        over nothing and the survey went on imaging tiles they could not see.
+
+        HelpfulException rather than RuntimeError because this is acq4's
+        operator-facing error type -- the same one create_data_dir raises for
+        an unset storage directory -- and it reaches the error dialog reading
+        as an instruction rather than as a crash.
+
+        Static, taking the manager as an argument, so that the Camera mirror
+        can be handed a getter that holds no reference to this window -- see
+        where it is constructed.
+        """
+        if manager is None:
+            raise HelpfulException(
+                "Autopatch needs a Manager to find the Camera module."
+            )
+        if "Camera" not in manager.listModules():
+            raise HelpfulException(
+                "The Camera module is not open. Autopatch opens it at startup "
+                "and needs it for reference imagery; reopen it and try again."
+            )
+        window = manager.getModule("Camera").window()
+        if window is None:
+            raise HelpfulException("The Camera module has no window.")
+        return window
+```
+
+- [ ] **Step 4: Run them and watch them pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py -k "camera_window_getter" -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Open the Camera module at startup**
+
+In `Autopatch.__init__` (~line 1006), open it before the window is built, so the window may assume it:
+
+```python
+    def __init__(self, manager, name, config):
+        Module.__init__(self, manager, name, config)
+        if Autopatch._instance is not None:
+            Autopatch._instance.ui.raise_()
+            Autopatch._instance.ui.activateWindow()
+            Qt.QTimer.singleShot(0, self.quit)
+            return
+        Autopatch._instance = self
+        # Before the window, which assumes it: Area 1 mirrors the Camera
+        # module's pinned frames and puts region outlines back into its view,
+        # and getModule() loads a module that is not already open. Making it
+        # this module's responsibility is what lets every consumer downstream
+        # treat a missing Camera module as an error rather than a case.
+        manager.getModule("Camera")
+        self.ui = AutopatchWindow(self)
+        manager.declareInterface(name, ["autopatchModule"], self)
+        self.ui.show()
+```
+
+- [ ] **Step 6: Mutation proof**
+
+Remove the `if "Camera" not in manager.listModules():` block from `_cameraModuleWindow`. Run:
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py::test_the_camera_window_getter_raises_when_the_module_is_closed -v
+```
+
+Expected: FAIL. **Record the line number of the failure** and confirm it is the `pytest.raises` line, not an incidental `KeyError` from the fake's `getModule`. Restore the block.
+
+- [ ] **Step 7: Run the suite**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/ -q
+```
+
+Expected: all pass. If a test fails because it constructs a window with `manager=None`, that window never calls the getter unless a mirror is used — fix the test by giving it a manager, not by restoring the `None` return.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/modules/Autopatch/Autopatch.py acq4/modules/Autopatch/tests/test_window_integration.py
+git -c user.email=outofculture@gmail.com commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'EOF'
+feat(autopatch): open the Camera module at startup and require it
+
+The Autopatch module opens Camera before building its window, so Area 1 can
+assume the imagery it mirrors exists. A module closed afterwards raises
+HelpfulException instead of leaving Area 1 blank while regions are drawn
+over nothing.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+```
+
+---
+
+## Task 4: Named instruction slots
+
+Three writers share Area 3's band: `storage` (`newSlice`), `region` (`_onRegionsEdited`'s `RegionTooLarge`), and — from Task 6 — `imagery`. They are not mutually exclusive: `create_data_dir` can fail with the previous slice still installed.
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/status_panel.py` (~line 41, ~195-230)
+- Modify: `acq4/modules/Autopatch/Autopatch.py` (`_setRegionInstruction`, `newSlice`)
+- Modify: `acq4/modules/Autopatch/tests/test_status_panel.py` (~535-600)
+
+**Interfaces:**
+- Consumes: Task 2's flag-free `_setRegionInstruction`.
+- Produces: `StatusPanel.setInstruction(source: str, text: str) -> None` — `""` clears that source only. `StatusPanel.instruction() -> str` unchanged: the text now showing. `StatusPanel.clearInstruction()` is **gone**. Valid sources are the module constant `INSTRUCTION_SOURCES = ("storage", "region", "imagery")`, highest priority first.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `acq4/modules/Autopatch/tests/test_status_panel.py`, after `test_the_instruction_comes_back_once_the_error_clears`:
+
+```python
+def test_a_higher_priority_source_wins_the_band(qapp):
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+
+    panel.setInstruction("imagery", "Pin reference frames.")
+    panel.setInstruction("storage", "Storage directory has not been set.")
+
+    assert panel.instruction() == "Storage directory has not been set."
+
+
+def test_clearing_one_source_does_not_erase_another(qapp):
+    # The property the whole change exists for. newSlice() can fail at
+    # create_data_dir with the previous slice still installed, so the storage
+    # message and the imagery instruction can want the band at the same time,
+    # and whichever cleared last must not take the other down with it.
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+    panel.setInstruction("imagery", "Pin reference frames.")
+    panel.setInstruction("storage", "Storage directory has not been set.")
+
+    panel.setInstruction("storage", "")
+
+    assert panel.instruction() == "Pin reference frames."
+
+
+def test_a_lower_priority_source_does_not_displace_a_higher_one(qapp):
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+    panel.setInstruction("storage", "Storage directory has not been set.")
+
+    panel.setInstruction("imagery", "Pin reference frames.")
+
+    assert panel.instruction() == "Storage directory has not been set."
+
+
+def test_an_unknown_source_is_a_programming_error(qapp):
+    # A typo'd source would otherwise write into a slot nothing ever renders,
+    # failing silently and looking exactly like a band that was not updated.
+    from acq4.modules.Autopatch.status_panel import StatusPanel
+
+    panel = StatusPanel()
+
+    with pytest.raises(ValueError, match="pinned"):
+        panel.setInstruction("pinned", "Pin reference frames.")
+```
+
+Add `import pytest` at the top of the file if absent.
+
+Then update the five existing instruction tests (~535-600) to the new signature: `panel.setInstruction("storage", "Storage directory has not been set.")`, and in `test_clearing_an_instruction_empties_the_band` replace `panel.clearInstruction()` with `panel.setInstruction("storage", "")`.
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_status_panel.py -v
+```
+
+Expected: the four new tests FAIL with `TypeError: setInstruction() takes 2 positional arguments but 3 were given`; the five updated ones fail the same way.
+
+- [ ] **Step 3: Add the slots**
+
+In `acq4/modules/Autopatch/status_panel.py`, add above `class StatusPanel`:
+
+```python
+# Area 3's band carries one instruction at a time, but three independent
+# writers can each have something to say: an unchosen storage directory, a
+# region edit refused for being too large, and a slice with no reference
+# imagery pinned. They are not mutually exclusive -- newSlice() can fail at
+# create_data_dir with the previous slice still installed -- so each holds its
+# own slot and the first non-empty one in this order renders.
+#
+# storage first: New slice could not complete at all. region next: a refused
+# edit answers something the operator did a moment ago. imagery last: a
+# standing condition that will still hold once they have read the other two.
+INSTRUCTION_SOURCES = ("storage", "region", "imagery")
+```
+
+Replace the `self._instruction = ""` line in `__init__` (~line 41), keeping the comment above it:
+
+```python
+        self._instructions = {source: "" for source in INSTRUCTION_SOURCES}
+```
+
+- [ ] **Step 4: Replace the three methods**
+
+Replace `setInstruction`, `clearInstruction` and `instruction` (~lines 195-213):
+
+```python
+    def setInstruction(self, source: str, text: str) -> None:
+        """Show operator guidance in the band -- what to do, not what broke.
+
+        `text` of "" retracts this source's message and only this source's:
+        the writers cannot see each other's conditions, so one deciding the
+        band is now empty would be speaking for the other two.
+
+        An instruction is deliberately not a RunErrorRecord: no traceback, no
+        Copy, and no Show in log, because no run happened and there is nothing
+        in the log to show.
+        """
+        if source not in self._instructions:
+            raise ValueError(
+                f"{source!r} is not an instruction source; "
+                f"expected one of {INSTRUCTION_SOURCES}"
+            )
+        self._instructions[source] = text
+        self._updateErrorBand()
+
+    def instruction(self) -> str:
+        """The guidance currently showing, or an empty string."""
+        for source in INSTRUCTION_SOURCES:
+            if self._instructions[source]:
+                return self._instructions[source]
+        return ""
+```
+
+Replace the two `self._instruction` reads in `_updateErrorBand` (~lines 227-228):
+
+```python
+        record = self._lastError
+        showing = self.instruction()
+        if record is not None:
+            self.instructionLabel.setText(f"{record.exc_type}: {record.exc_message}")
+        else:
+            self.instructionLabel.setText(showing)
+        self.instructionLabel.setVisible(record is not None or bool(showing))
+        self.showInLogBtn.setVisible(record is not None)
+```
+
+- [ ] **Step 5: Run the panel tests**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_status_panel.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Update the two window call sites**
+
+In `acq4/modules/Autopatch/Autopatch.py`, `_setRegionInstruction`:
+
+```python
+    def _setRegionInstruction(self, text: str) -> None:
+        """Put Area 1's guidance in Area 3's band, or retract it.
+
+        Area 1 has one guidance slot: a later message replaces an earlier one.
+        """
+        self.statusPanel.setInstruction("region", text)
+```
+
+In `newSlice()`, the storage handler (~line 513) — the comment above it referring to the deleted flag must go too:
+
+```python
+        except HelpfulException as exc:
+            # Guidance, not a failure report: the operator has not chosen a
+            # storage directory, and Area 3's band is where instructions go.
+            # Narrowed to HelpfulException so a genuine programming error (a
+            # missing manager, say) propagates instead of being reported as
+            # storage guidance.
+            self.statusPanel.setInstruction("storage", str(exc))
+            return
+```
+
+and the success path (~line 526), whose blanket `clearInstruction()` becomes a single-slot clear:
+
+```python
+        # Whichever handler filled the band, what it was about went with the
+        # tissue just discarded. The storage slot alone: this is the condition
+        # New slice has just resolved, and the imagery slot is recomputed from
+        # state moments later by ReferenceImagery.
+        self.statusPanel.setInstruction("storage", "")
+        self.statusPanel.setInstruction("region", "")
+```
+
+- [ ] **Step 7: Mutation proof**
+
+In `setInstruction`, replace `self._instructions[source] = text` with `self._instructions = {s: "" for s in INSTRUCTION_SOURCES}; self._instructions[source] = text` — the single-slot behaviour this task replaces. Run:
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_status_panel.py::test_clearing_one_source_does_not_erase_another -v
+```
+
+Expected: FAIL. **Record the failing line number** and confirm it is the final `assert`. Restore.
+
+- [ ] **Step 8: Run the suite and commit**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/ -q
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/modules/Autopatch/status_panel.py acq4/modules/Autopatch/Autopatch.py acq4/modules/Autopatch/tests/test_status_panel.py
+git -c user.email=outofculture@gmail.com commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'EOF'
+refactor(autopatch): give Area 3's band named instruction slots
+
+Three writers share one band and cannot see each other's conditions, so a
+writer clearing it was speaking for the others. Each now holds its own slot
+and the highest-priority non-empty one renders.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+```
+
+---
+
+## Task 5: `ReferenceImagery`
+
+Headless and unwired. Task 6 mounts it.
+
+**Files:**
+- Create: `acq4/modules/Autopatch/reference_imagery.py`
+- Create: `acq4/modules/Autopatch/tests/test_reference_imagery.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `ReferenceImagery(imagingCtrlGetter, prompt=None)` with `beginSlice() -> None`, `rebind() -> None`, `instruction() -> str`, `release() -> None`, and `sigInstructionChanged = Qt.Signal(str)` carrying the new text. Module constant `PIN_FRAMES_INSTRUCTION: str`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `acq4/modules/Autopatch/tests/test_reference_imagery.py`:
+
+```python
+"""Tests for ReferenceImagery: the pinned-frames workflow that starts a slice."""
+from __future__ import annotations
+
+import pytest
+
+from acq4.util import Qt
+from acq4.util.HelpfulException import HelpfulException
+
+
+class _FakeImagingCtrl(Qt.QObject):
+    """Stands in for the Camera module's ImagingCtrl.
+
+    clearPinnedFrames() genuinely empties the list and emits, because the real
+    one does (via removePinnedFrame): a fake that skipped either would hide a
+    missing recompute in the code under test.
+    """
+
+    sigPinnedFramesChanged = Qt.Signal()
+
+    def __init__(self, frames=()):
+        super().__init__()
+        self.pinnedFrames = list(frames)
+
+    def clearPinnedFrames(self):
+        self.pinnedFrames = []
+        self.sigPinnedFramesChanged.emit()
+
+    def pin(self, frame="frame"):
+        self.pinnedFrames.append(frame)
+        self.sigPinnedFramesChanged.emit()
+
+    def unpinAll(self):
+        self.pinnedFrames = []
+        self.sigPinnedFramesChanged.emit()
+
+
+def _imagery(source, answer=True):
+    from acq4.modules.Autopatch.reference_imagery import ReferenceImagery
+
+    asked = []
+
+    def prompt(text):
+        asked.append(text)
+        return answer
+
+    return ReferenceImagery(lambda: source, prompt=prompt), asked
+
+
+def test_nothing_pinned_means_no_prompt(qapp):
+    source = _FakeImagingCtrl()
+    imagery, asked = _imagery(source)
+
+    imagery.beginSlice()
+
+    assert asked == []
+
+
+def test_a_yes_clears_the_pinned_frames(qapp):
+    source = _FakeImagingCtrl(["a", "b"])
+    imagery, asked = _imagery(source, answer=True)
+
+    imagery.beginSlice()
+
+    assert len(asked) == 1
+    assert source.pinnedFrames == []
+
+
+def test_a_no_leaves_the_pinned_frames(qapp):
+    source = _FakeImagingCtrl(["a", "b"])
+    imagery, asked = _imagery(source, answer=False)
+
+    imagery.beginSlice()
+
+    assert len(asked) == 1
+    assert source.pinnedFrames == ["a", "b"]
+
+
+def test_an_empty_slice_asks_for_frames(qapp):
+    from acq4.modules.Autopatch.reference_imagery import PIN_FRAMES_INSTRUCTION
+
+    source = _FakeImagingCtrl()
+    imagery, _ = _imagery(source)
+
+    imagery.beginSlice()
+
+    assert imagery.instruction() == PIN_FRAMES_INSTRUCTION
+
+
+def test_there_is_no_instruction_before_a_slice(qapp):
+    source = _FakeImagingCtrl()
+    imagery, _ = _imagery(source)
+
+    assert imagery.instruction() == ""
+
+
+def test_pinning_a_frame_retracts_the_instruction(qapp):
+    source = _FakeImagingCtrl()
+    imagery, _ = _imagery(source)
+    imagery.beginSlice()
+
+    source.pin()
+
+    assert imagery.instruction() == ""
+
+
+def test_unpinning_the_last_frame_brings_it_back(qapp):
+    from acq4.modules.Autopatch.reference_imagery import PIN_FRAMES_INSTRUCTION
+
+    source = _FakeImagingCtrl(["a"])
+    imagery, _ = _imagery(source, answer=False)
+    imagery.beginSlice()
+    assert imagery.instruction() == ""
+
+    source.unpinAll()
+
+    assert imagery.instruction() == PIN_FRAMES_INSTRUCTION
+
+
+def test_the_signal_carries_only_real_changes(qapp):
+    source = _FakeImagingCtrl(["a"])
+    imagery, _ = _imagery(source, answer=False)
+    imagery.beginSlice()
+    seen = []
+    imagery.sigInstructionChanged.connect(seen.append)
+
+    source.pin("b")
+
+    assert seen == []
+
+
+def test_the_signal_reports_the_new_text(qapp):
+    from acq4.modules.Autopatch.reference_imagery import PIN_FRAMES_INSTRUCTION
+
+    source = _FakeImagingCtrl(["a"])
+    imagery, _ = _imagery(source, answer=False)
+    imagery.beginSlice()
+    seen = []
+    imagery.sigInstructionChanged.connect(seen.append)
+
+    source.unpinAll()
+
+    assert seen == [PIN_FRAMES_INSTRUCTION]
+
+
+def test_a_closed_camera_module_propagates(qapp):
+    from acq4.modules.Autopatch.reference_imagery import ReferenceImagery
+
+    def getter():
+        raise HelpfulException("The Camera module is not open.")
+
+    imagery = ReferenceImagery(getter, prompt=lambda text: True)
+
+    with pytest.raises(HelpfulException, match="Camera"):
+        imagery.beginSlice()
+
+
+def test_release_disconnects_from_the_source(qapp):
+    source = _FakeImagingCtrl()
+    imagery, _ = _imagery(source)
+    imagery.beginSlice()
+    assert source.receivers(source.sigPinnedFramesChanged) == 1
+
+    imagery.release()
+
+    assert source.receivers(source.sigPinnedFramesChanged) == 0
+
+
+def test_rebinding_does_not_stack_connections(qapp):
+    source = _FakeImagingCtrl()
+    imagery, _ = _imagery(source)
+
+    imagery.rebind()
+    imagery.rebind()
+
+    assert source.receivers(source.sigPinnedFramesChanged) == 1
+```
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_reference_imagery.py -v
+```
+
+Expected: every test FAILS at collection or import with `ModuleNotFoundError: acq4.modules.Autopatch.reference_imagery`.
+
+- [ ] **Step 3: Write the module**
+
+Create `acq4/modules/Autopatch/reference_imagery.py`:
+
+```python
+"""ReferenceImagery: the pinned-frames workflow that opens a slice -- clear the
+previous slice's frames, then ask the operator to pin a fresh set."""
+from __future__ import annotations
+
+from acq4.util import Qt
+
+PIN_FRAMES_INSTRUCTION = (
+    "Pin reference frames of this slice in the Camera module."
+)
+
+_CLEAR_PROMPT = (
+    "Clear the pinned frames from the previous slice?\n\n"
+    "They are imagery of tissue that is no longer under the objective, and "
+    "regions for this slice will be drawn over them."
+)
+
+
+def _askToClear(text: str) -> bool:
+    """Default prompt: the same confirmation ImagingCtrl uses for its own
+    Clear button, so clearing frames asks the same way wherever it starts."""
+    answer = Qt.QMessageBox.question(
+        None, "Clear pinned frames?", text,
+        Qt.QMessageBox.Ok | Qt.QMessageBox.Cancel,
+    )
+    return answer == Qt.QMessageBox.Ok
+
+
+class ReferenceImagery(Qt.QObject):
+    """Sequences the Camera module's pinned frames into the start of a slice.
+
+    A QObject, unlike the plain PinnedFrameMirror/CameraMirror classes beside
+    it, because something listens to it: Area 3's band re-renders whenever the
+    pinned set changes.
+
+    The wait for a fresh set is advisory. Nothing here disables a control or
+    blocks a run -- the band says what to do and the operator decides.
+    """
+
+    # The instruction this component wants shown, or "". Carries the text so a
+    # listener need not call back to ask.
+    sigInstructionChanged = Qt.Signal(str)
+
+    def __init__(self, imagingCtrlGetter, prompt=None):
+        super().__init__()
+        self._getter = imagingCtrlGetter
+        self._prompt = prompt if prompt is not None else _askToClear
+        self._source = None
+        self._instruction = ""
+        # No slice yet, and the instruction is about a slice that has none of
+        # its own imagery -- not about the window having just opened.
+        self._sliceActive = False
+
+    def beginSlice(self) -> None:
+        """New slice's entry point: bind, offer to clear, then recompute.
+
+        Whatever the getter raises propagates. A Camera module closed after
+        startup is an error rather than a state to degrade into, and the
+        operator sees acq4's error dialog -- deliberately unlike the storage
+        slot beside it in the band, which is caught and rendered as guidance
+        because an unset storage directory is a thing not yet done.
+        """
+        self._sliceActive = True
+        self.rebind()
+        if self._source.pinnedFrames and self._prompt(_CLEAR_PROMPT):
+            # Emits sigPinnedFramesChanged, so the recompute below is
+            # belt-and-braces rather than the only path.
+            self._source.clearPinnedFrames()
+        self._refresh()
+
+    def rebind(self) -> None:
+        """Re-resolve the imaging control and move the subscription to it.
+
+        Re-resolved per slice because the operator may have changed the
+        selected camera since the last one.
+        """
+        self._disconnect()
+        self._source = self._getter()
+        self._source.sigPinnedFramesChanged.connect(self._refresh)
+        self._refresh()
+
+    def instruction(self) -> str:
+        """The guidance this component wants shown, or ""."""
+        return self._instruction
+
+    def release(self) -> None:
+        """Stop listening. Teardown's call.
+
+        Tolerant of a source Qt has already destroyed, exactly as
+        PinnedFrameMirror.unbind() is: Qt.disconnect swallows a dead
+        connection's RuntimeError, but the signal is read off the source
+        before it can be handed over, and that read raises through a wrapper
+        whose C++ object is gone. A raise here would abandon the rest of
+        AutopatchWindow.teardown().
+        """
+        self._disconnect()
+        self._sliceActive = False
+
+    def _disconnect(self) -> None:
+        source, self._source = self._source, None
+        if source is not None:
+            try:
+                Qt.disconnect(source.sigPinnedFramesChanged, self._refresh)
+            except RuntimeError:
+                pass
+
+    def _refresh(self) -> None:
+        """Recompute the instruction from current state, announcing a change.
+
+        A pure function of state rather than of the event that got us here, so
+        pinning the first frame and unpinning the last both fall out without
+        either being handled: the band shows the instruction exactly while a
+        slice has no reference imagery.
+        """
+        text = ""
+        if self._sliceActive and self._source is not None:
+            if not self._source.pinnedFrames:
+                text = PIN_FRAMES_INSTRUCTION
+        if text != self._instruction:
+            self._instruction = text
+            self.sigInstructionChanged.emit(text)
+```
+
+- [ ] **Step 4: Run them and watch them pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_reference_imagery.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Mutation proofs**
+
+Three, each restored before the next:
+
+1. In `_refresh`, replace `if text != self._instruction:` with `if True:`. Run `test_the_signal_carries_only_real_changes`. Expected FAIL at its `assert seen == []`. **Record the line.**
+2. In `beginSlice`, drop the `self._source.pinnedFrames and` guard so it always prompts. Run `test_nothing_pinned_means_no_prompt`. Expected FAIL at `assert asked == []`. **Record the line.**
+3. In `_disconnect`, delete the `Qt.disconnect(...)` call, leaving the `source, self._source = self._source, None` line. Run `test_release_disconnects_from_the_source`. Expected FAIL at the `receivers(...) == 0` assertion. **Record the line.** This is the mutation that has silently passed twice before on this module when written with weakrefs; if it passes here, stop and report.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/modules/Autopatch/reference_imagery.py acq4/modules/Autopatch/tests/test_reference_imagery.py
+git -c user.email=outofculture@gmail.com commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'EOF'
+feat(autopatch): add the pinned-frames workflow
+
+ReferenceImagery offers to clear the previous slice's frames and publishes
+an instruction while a slice has no reference imagery. The instruction is a
+pure function of state, so pinning the first frame and unpinning the last
+need no handling of their own.
+
+Unwired; the window mounts it next.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+```
+
+---
+
+## Task 6: Mount it in the window
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/Autopatch.py` (`__init__`, `_startSlice`, `newSlice`, `teardown`)
+- Modify: `acq4/modules/Autopatch/tests/test_window_integration.py`
+- Modify: `acq4/modules/Autopatch/tests/test_teardown.py`
+
+**Interfaces:**
+- Consumes: Task 5's `ReferenceImagery`; Task 4's `setInstruction(source, text)`; Task 1's `_FakeManager.pinnedFrameSource`.
+- Produces: `AutopatchWindow._referenceImagery`; `AutopatchWindow._imagingCtrl()` returning the selected camera's `ImagingCtrl`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `acq4/modules/Autopatch/tests/test_window_integration.py`, near the other pinned-frame tests:
+
+```python
+def test_new_slice_offers_to_clear_the_pinned_frames(win, monkeypatch):
+    win.manager.pinnedFrameSource.pinnedFrames = ["old"]
+    asked = []
+    monkeypatch.setattr(
+        win._referenceImagery, "_prompt", lambda text: asked.append(text) or True
+    )
+
+    win.newSlice()
+
+    assert len(asked) == 1
+    assert win.manager.pinnedFrameSource.pinnedFrames == []
+
+
+def test_declining_leaves_the_pinned_frames(win, monkeypatch):
+    win.manager.pinnedFrameSource.pinnedFrames = ["old"]
+    monkeypatch.setattr(win._referenceImagery, "_prompt", lambda text: False)
+
+    win.newSlice()
+
+    assert win.manager.pinnedFrameSource.pinnedFrames == ["old"]
+
+
+def test_a_slice_with_no_imagery_asks_for_frames(win, monkeypatch):
+    from acq4.modules.Autopatch.reference_imagery import PIN_FRAMES_INSTRUCTION
+
+    monkeypatch.setattr(win._referenceImagery, "_prompt", lambda text: True)
+
+    win.newSlice()
+
+    assert win.statusPanel.instruction() == PIN_FRAMES_INSTRUCTION
+
+
+def test_pinning_a_frame_clears_the_band(win, monkeypatch):
+    monkeypatch.setattr(win._referenceImagery, "_prompt", lambda text: True)
+    win.newSlice()
+
+    win.manager.pinnedFrameSource.pinnedFrames.append("fresh")
+    win.manager.pinnedFrameSource.sigPinnedFramesChanged.emit()
+
+    assert win.statusPanel.instruction() == ""
+
+
+def test_a_storage_failure_outranks_the_imagery_instruction(win, monkeypatch):
+    # Both slots filled at once, which is reachable because create_data_dir can
+    # fail with the previous slice still installed.
+    from acq4.modules.Autopatch.reference_imagery import PIN_FRAMES_INSTRUCTION
+
+    monkeypatch.setattr(win._referenceImagery, "_prompt", lambda text: True)
+    win.newSlice()
+    assert win.statusPanel.instruction() == PIN_FRAMES_INSTRUCTION
+
+    def boom(manager, level):
+        raise HelpfulException("Storage directory has not been set.")
+
+    monkeypatch.setattr(
+        "acq4.modules.Autopatch.Autopatch.create_data_dir", boom
+    )
+    win.newSlice()
+
+    assert "Storage directory" in win.statusPanel.instruction()
+```
+
+Add to `acq4/modules/Autopatch/tests/test_teardown.py`:
+
+```python
+def test_teardown_releases_the_reference_imagery(win):
+    win.newSlice()
+    source = win.manager.pinnedFrameSource
+    assert source.receivers(source.sigPinnedFramesChanged) > 0
+
+    win.teardown()
+
+    assert source.receivers(source.sigPinnedFramesChanged) == 0
+```
+
+Read the top of `test_teardown.py` first and follow whatever window fixture it already uses; if it builds windows itself rather than via a `win` fixture, match that.
+
+- [ ] **Step 2: Run them and watch them fail**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py -k "pinned_frames or asks_for_frames or clears_the_band or outranks" acq4/modules/Autopatch/tests/test_teardown.py -v
+```
+
+Expected: FAIL with `AttributeError: 'AutopatchWindow' object has no attribute '_referenceImagery'`.
+
+- [ ] **Step 3: Construct it**
+
+In `AutopatchWindow.__init__`, immediately after `self._pinnedFrameMirror = PinnedFrameMirror(self.regionPanel.view)` (~line 119):
+
+```python
+        self._referenceImagery = ReferenceImagery(self._imagingCtrl)
+        self._referenceImagery.sigInstructionChanged.connect(
+            self._onImageryInstruction
+        )
+```
+
+Add the import beside the other panel imports:
+
+```python
+from .reference_imagery import ReferenceImagery
+```
+
+- [ ] **Step 4: Add the resolver and the band handler**
+
+Add both methods next to `_bindPinnedFrames`:
+
+```python
+    def _imagingCtrl(self):
+        """The selected camera's imaging control in the Camera module.
+
+        Raises rather than answering None, for the same reason _cameraWindow
+        does: a Camera module without an interface for the camera Autopatch is
+        driving cannot show the operator what they are outlining.
+        """
+        window = self._cameraWindow()
+        camera = self.cameraSelector.getSelectedObj()
+        try:
+            return window.getInterfaceForDevice(camera.name()).imagingCtrl
+        except (KeyError, AttributeError):
+            raise HelpfulException(
+                f"The Camera module has no imaging interface for "
+                f"{camera.name()!r}."
+            )
+
+    def _onImageryInstruction(self, text: str) -> None:
+        self.statusPanel.setInstruction("imagery", text)
+```
+
+- [ ] **Step 5: Rebind per slice, and begin last**
+
+In `_startSlice()`, beside the existing `self._bindPinnedFrames(camera)` (~line 438):
+
+```python
+        self._bindPinnedFrames(camera)
+        # Re-resolved per slice for the same reason the mirror is: the operator
+        # may have changed the selected camera since the last one.
+        self._referenceImagery.rebind()
+```
+
+At the very end of `newSlice()`, after `self._refreshSurveyStats()`:
+
+```python
+        # Last, and deliberately: the prompt inside is modal, a modal dialog
+        # re-enters the Qt event loop, and every queued slot dispatches inside
+        # it -- including the sigCellFinished from the cell still in flight on
+        # the tissue this click just discarded, whose suppression assumes it
+        # lands outside a half-completed New slice.
+        self._referenceImagery.beginSlice()
+```
+
+- [ ] **Step 6: Release in teardown**
+
+In `teardown()`'s `finally`, beside the other outward-reaching releases:
+
+```python
+            self._pinnedFrameMirror.unbind()
+            self._referenceImagery.release()
+            self._cameraMirror.clear()
+```
+
+- [ ] **Step 7: Run them and watch them pass**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/ -q
+```
+
+Expected: all PASS.
+
+- [ ] **Step 8: Mutation proofs**
+
+Two, restored between:
+
+1. Move `self._referenceImagery.beginSlice()` from the end of `newSlice()` to immediately after `if not self._startSlice(dirHandle=dirHandle): return`. Run the full Autopatch suite. **Record whether anything fails.** If nothing does, that is the finding to report: the ordering is a reasoned safeguard with no test able to distinguish it, and it should be recorded as such in the PR rather than presented as covered.
+2. Delete `self._referenceImagery.release()` from `teardown()`. Run `test_teardown_releases_the_reference_imagery`. Expected FAIL at the `receivers(...) == 0` assertion. **Record the line.**
+
+- [ ] **Step 9: Commit**
+
+```bash
+git rev-parse --show-toplevel && git branch --show-current
+git add acq4/modules/Autopatch/Autopatch.py acq4/modules/Autopatch/tests/
+git -c user.email=outofculture@gmail.com commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'EOF'
+feat(autopatch): run the pinned-frames workflow from New slice
+
+New slice offers to clear the previous slice's frames and Area 3's band asks
+for a fresh set until one is pinned. beginSlice() goes last in newSlice()
+because its prompt is modal and would otherwise re-enter the event loop
+mid-transaction.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+```
+
+---
+
+## Task 7: Whole-branch verification and the PR
+
+**Files:** none changed.
+
+- [ ] **Step 1: Autopatch and experiment suites**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/ acq4/experiment/ -q
+```
+
+Expected: all pass, output pristine. Record the count.
+
+- [ ] **Step 2: Whole repo**
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest -q
+```
+
+Expected: no new failures against the branch point. Known pre-existing and **not** to be fixed here: `acq4/devices/Stage/tests/test_mockstage_move.py` aborts the process intermittently when run alone.
+
+- [ ] **Step 3: Confirm the branch carries only this work**
+
+```bash
+git log --oneline fd8aff832..HEAD
+```
+
+Expected: the six task commits and nothing else. A commit from another session means the shared checkout leaked; the fix is a fresh branch off the last good commit, never a force-move.
+
+- [ ] **Step 4: Check no dead references survive**
+
+```bash
+grep -rn "_regionInstruction\|_onModulesChanged\|clearInstruction" acq4/
+```
+
+Expected: no matches.
+
+- [ ] **Step 5: Open the PR**
+
+Base `_reviewed` on `origin/acq4`. The body must state plainly:
+
+- **The live GUI smoke test has not been run**, and specifically that `manager.getModule("Camera")` from inside `Autopatch.__init__` re-enters `Manager`'s module loading and is **assumed, not verified**. If it misbehaves, the fallback is `AutopatchWindow`'s first `showEvent`.
+- That a rig whose Camera module is named something other than `"Camera"` now gets a `HelpfulException` where it previously got a blank Area 1.
+- Every mutation-proof result, **including the failing line numbers**, and any mutation that did not fail — particularly Task 6's ordering mutation, which may well not be detectable by any test.
+- The `_FakeManager` change and why it is the more honest fake.
+
+---
+
+## Self-Review
+
+**Spec coverage.** §1 advisory-only → no gating exists in any task. §1b → Tasks 2 (warning, `_onModulesChanged`) and 3 (startup open, raise). §2 `ReferenceImagery` and its two seams → Task 5. §3 New slice sequence and prompt-last → Task 6 Steps 5, 8. §4 slots, priority, the `region` writer, the single-slot clear on success → Task 4. §5 threading (nothing to do — single-threaded) and `release()` → Tasks 5, 6. §6 testing: honest fake → Task 5 Step 1; slot isolation → Task 4; window integration → Task 6; `_FakeManager` → Task 1; mutation discipline → Global Constraints and every task's proof step. §7 open items are out of scope by the spec's own statement.
+
+**Type consistency.** `setInstruction(source, text)` is defined in Task 4 and called with `"region"`/`"storage"` there and `"imagery"` in Task 6. `INSTRUCTION_SOURCES` is the same tuple in both. `ReferenceImagery(imagingCtrlGetter, prompt=None)` is constructed in Task 6 exactly as defined in Task 5, with `_imagingCtrl` matching the `getter()` signature. `PIN_FRAMES_INSTRUCTION` is imported by name in Tasks 5 and 6. `_FakeManager.pinnedFrameSource` is produced in Task 1 and consumed in Task 6.
+
+**Two gaps this review found and fixed.** (1) Task 4 originally left `newSlice()`'s success path clearing only `storage`, stranding a `region` message from before the tissue was discarded — it now clears both. (2) Task 1's Step 7 originally said "fix any failing test"; it now names the three tests that must be left failing, because a task that deletes a test whose feature still exists cannot be reviewed on its own.
+
+**One risk the plan cannot remove.** Task 6's prompt-last ordering may have no test that can distinguish it — its mutation step is written to treat that as a finding to report rather than a step to pass.

--- a/docs/superpowers/plans/2026-08-14-autopatch-pinned-frames-workflow.md
+++ b/docs/superpowers/plans/2026-08-14-autopatch-pinned-frames-workflow.md
@@ -203,12 +203,29 @@ The "no Camera module is open" message and the whole `sigModulesChanged` apparat
 - Consumes: Task 1's `_FakeManager`.
 - Produces: `AutopatchWindow._setRegionInstruction(text: str) -> None`, now writing straight through with no ownership flag. `AutopatchWindow._onModulesChanged` no longer exists.
 
-- [ ] **Step 1: Delete the warning's tests and rewrite the third**
+- [ ] **Step 1: Delete the tests of the deleted features, and rewrite the two that survive**
 
-Delete both of these from `acq4/modules/Autopatch/tests/test_window_integration.py` outright — they test a message this task removes:
+Delete these four from `acq4/modules/Autopatch/tests/test_window_integration.py` outright — each tests a feature this task removes. The first two cover the warning; the second two cover `_onModulesChanged` re-resolving a Camera module that arrives late, which cannot happen once the Autopatch module opens one at startup:
 
-- `test_ticking_the_mirror_with_no_camera_module_open_says_so` (~line 2299)
-- `test_the_message_goes_once_a_camera_module_is_open` (~line 2309)
+- `test_ticking_the_mirror_with_no_camera_module_open_says_so` (~line 2340)
+- `test_the_message_goes_once_a_camera_module_is_open` (~line 2348)
+- `test_outlines_appear_when_the_camera_module_is_opened_after_the_tick` (~line 2217)
+- `test_pinned_frames_bind_when_the_camera_module_is_opened_after_the_slice` (~line 2245)
+
+Then delete the `_cameraModuleAppears` helper (~line 2200) — with those two tests gone its remaining caller is `test_no_outlines_appear_when_the_checkbox_is_not_ticked`, which this step rewrites to stop using it. Confirm with `grep -n "_cameraModuleAppears" acq4/modules/Autopatch/tests/test_window_integration.py` returning nothing when you are done.
+
+Rewrite `test_no_outlines_appear_when_the_checkbox_is_not_ticked`, whose point survives — an unticked box mirrors nothing — but whose mechanism (announcing a module) does not:
+
+```python
+def test_no_outlines_appear_when_the_checkbox_is_not_ticked(win):
+    # A region is not a reason to start mirroring something the operator never
+    # asked to mirror.
+    win.newSlice()
+
+    win.addRegionHere()
+
+    assert win.manager.drawn == []
+```
 
 **Do not replace them with a test asserting the message is gone.** `instruction() == ""` is the band's state before anything ever wrote to it, so such a test passes against code that never had the feature — the "asserting a default is asserting nothing" trap in the Global Constraints. Deleting a feature does not require a test that it stays deleted.
 

--- a/docs/superpowers/plans/2026-08-14-autopatch-pinned-frames-workflow.md
+++ b/docs/superpowers/plans/2026-08-14-autopatch-pinned-frames-workflow.md
@@ -694,7 +694,41 @@ and the success path (~line 526), whose blanket `clearInstruction()` becomes a s
         self.statusPanel.setInstruction("region", "")
 ```
 
-- [ ] **Step 7: Mutation proof**
+- [ ] **Step 7: Restore the test Task 2 had to delete**
+
+Task 2 removed the `_regionInstruction` ownership bool, which broke `test_a_refused_edit_does_not_erase_the_storage_instruction` — a landed test covering exactly the property this task's slots restore. Task 2 deleted it rather than patch around a collision it was told not to fix. **Put it back verbatim**, in `acq4/modules/Autopatch/tests/test_window_integration.py`, next to the other refused-edit tests:
+
+```python
+def test_a_refused_edit_does_not_erase_the_storage_instruction(win):
+    """Area 3's band has two Area 1 writers with different conditions, and
+    neither can see the other's. A region edit retracting its own refusal must
+    not also retract newSlice()'s "choose a storage directory", which is still
+    just as true as it was."""
+    from acq4.util.HelpfulException import HelpfulException
+
+    win.addRegionHere()  # a slice, without going through create_data_dir
+
+    def boom(*a, **k):
+        raise HelpfulException("Storage directory has not been set.")
+
+    win.manager.getCurrentDir = boom
+    win.newSlice()
+    assert "Storage directory" in win.statusPanel.instruction()
+
+    win.regionPanel.sigRegionsChanged.emit([RectRegion(1.0e-3, 2.0e-3, 1.4e-3, 2.1e-3)])
+
+    assert "Storage directory" in win.statusPanel.instruction()
+```
+
+Run it:
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_window_integration.py::test_a_refused_edit_does_not_erase_the_storage_instruction -v
+```
+
+Expected: PASS, because `storage` outranks `region` and clearing the `region` slot no longer touches the `storage` one. If it fails, the slots are wrong — this test is the reason they exist.
+
+- [ ] **Step 8: Mutation proof**
 
 In `setInstruction`, replace `self._instructions[source] = text` with `self._instructions = {s: "" for s in INSTRUCTION_SOURCES}; self._instructions[source] = text` — the single-slot behaviour this task replaces. Run:
 
@@ -704,12 +738,12 @@ In `setInstruction`, replace `self._instructions[source] = text` with `self._ins
 
 Expected: FAIL. **Record the failing line number** and confirm it is the final `assert`. Restore.
 
-- [ ] **Step 8: Run the suite and commit**
+- [ ] **Step 9: Run the suite and commit**
 
 ```bash
 /home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/ -q
 git rev-parse --show-toplevel && git branch --show-current
-git add acq4/modules/Autopatch/status_panel.py acq4/modules/Autopatch/Autopatch.py acq4/modules/Autopatch/tests/test_status_panel.py
+git add acq4/modules/Autopatch/status_panel.py acq4/modules/Autopatch/Autopatch.py acq4/modules/Autopatch/tests/
 git -c user.email=outofculture@gmail.com commit --author="Martin Chase (claude) <outofculture@gmail.com>" -F - <<'EOF'
 refactor(autopatch): give Area 3's band named instruction slots
 

--- a/docs/superpowers/specs/2026-08-14-autopatch-pinned-frames-workflow-design.md
+++ b/docs/superpowers/specs/2026-08-14-autopatch-pinned-frames-workflow-design.md
@@ -1,0 +1,253 @@
+# Autopatch Area 1 — the pinned-frames workflow
+
+Design agreed 2026-08-14. The last unbuilt piece of Area 1: sequencing the
+Camera module's pinned frames into the start of a slice, so that the regions an
+operator draws are drawn over imagery of the tissue actually under the
+objective.
+
+## 1. What this builds, and what it does not
+
+The design doc's §7 Area 1 says imaging is manual in v1: reference imagery is
+the Camera module's pinned frames, and Autopatch "optionally **clears pinned
+frames** to start, gives the operator **clear instructions**, and **waits until
+a fresh set is pinned**."
+
+P2c-3a built the display half — `PinnedFrameMirror` shows those frames in Area
+1's view, bound at `_startSlice`. This builds the workflow half:
+
+- **Clearing** the previous slice's frames, behind a confirmation prompt.
+- **Instructing** the operator to pin a fresh set, in Area 3's band.
+- **Opening** the Camera module if it is not already open, so there is
+  somewhere to pin them.
+
+**The "wait" is advisory.** No control is disabled and no run is blocked.
+Nothing gates on reference imagery existing; the band says what to do and the
+operator decides. This was chosen over gating region drawing and over gating
+Start, both of which were on the table.
+
+Out of scope: slice disk persistence via `DirHandle.setInfo()`, the progress
+heatmap's remaining cross-repo work, and the live GUI smoke test — all still
+open, none of them this.
+
+## 2. `ReferenceImagery`
+
+New file `acq4/modules/Autopatch/reference_imagery.py`.
+
+```python
+ReferenceImagery(imagingCtrlGetter, moduleOpener, prompt=None)
+```
+
+A `QObject`, unlike the plain `PinnedFrameMirror`/`CameraMirror` classes beside
+it, because something listens to it: the band has to re-render when the pinned
+set changes. `ProgressOverlay` is a `QObject` for the same reason.
+
+### Surface
+
+| Member | Meaning |
+| --- | --- |
+| `beginSlice()` | New slice's entry point: open the module, resolve, prompt-and-clear, recompute. |
+| `rebind()` | Re-resolve the source, swap the subscription, recompute. |
+| `instruction() -> str` | The guidance this component wants shown; `""` for none. |
+| `sigInstructionChanged` | Emitted **only when `instruction()` changes value**. |
+| `release()` | Disconnect and forget the source. Teardown's call. |
+
+### The three injected seams
+
+Injection is what makes this headless-testable, the same choice P2b made for
+the tile detector.
+
+- **`imagingCtrlGetter() -> imagingCtrl | None`** resolves the Camera module's
+  `ImagingCtrl` for the selected camera, exactly as `_bindPinnedFrames` does
+  today (`window.getInterfaceForDevice(camera.name()).imagingCtrl`, with
+  `KeyError`/`AttributeError` meaning "none").
+- **`moduleOpener() -> None`** opens the Camera module. This is a deliberate
+  `manager.getModule("Camera")` — a *load*, not a lookup. It must **not** go
+  through `_cameraModuleWindow`, whose `listModules()` guard exists precisely so
+  that a mirror redraw (including the one behind "Add region here") cannot start
+  a module as a side effect. Two callers wanting opposite behaviour is why they
+  stay two code paths.
+- **`prompt(text) -> bool`** defaults to a `QMessageBox.question`, mirroring
+  `ImagingCtrl.clearPinnedFramesClicked`'s own confirmation. Injected so no
+  headless test can open a modal.
+
+### Why not extend `PinnedFrameMirror`
+
+It already binds the `ImagingCtrl` and knows the frame count, so the
+subscription is half-built there. But its docstring stakes out "display only:
+it holds no region state and nothing depends on it existing", and that property
+is what makes it safe to bind and unbind at will. A modal prompt and a workflow
+gate hanging off it would take that away. `ReferenceImagery` subscribes to
+`sigPinnedFramesChanged` independently instead; two subscribers to one signal
+costs nothing and keeps both classes single-purpose.
+
+## 3. The New slice sequence
+
+`beginSlice()` is called **last** in `AutopatchWindow.newSlice()` — after
+`_startSlice()`, after `cellPanel.clearCells()`, after the band clears, after
+the orchestrator detach/`clearQueue()`/`abandonCellInHand()`, and after
+`_refreshSurveyStats()`.
+
+**This ordering is load-bearing.** The prompt is modal; a modal dialog re-enters
+the Qt event loop; every queued slot dispatches inside it. That includes
+`_onModulesChanged` announcing the module we just opened, and any
+`sigCellFinished` queued from the cell still in flight on the discarded tissue.
+Running the prompt last means no half-completed New slice is ever observable
+from inside a nested event loop. This project has been bitten repeatedly by a
+queued signal landing mid-transaction; opening a nested loop in the middle of
+one invites the same class of defect.
+
+Inside `beginSlice()`, in order:
+
+1. `moduleOpener()`.
+2. `rebind()` — resolve the `ImagingCtrl`, subscribe to
+   `sigPinnedFramesChanged`.
+3. If the source resolved and its `pinnedFrames` is non-empty, `prompt(...)`;
+   on a Yes, `source.clearPinnedFrames()`.
+4. Recompute the instruction and emit if it changed.
+
+**Declining does not abort New slice.** The slice is already built by the time
+this runs; the prompt is about frames alone. **Zero pinned frames means no
+prompt at all** — there is nothing to confirm.
+
+`_tornDown` already blocks this path: `newSlice()` returns early from
+`_canStartSlice()`, so `beginSlice()` is never reached on a torn-down window.
+
+## 4. The instruction, and named slots in `StatusPanel`
+
+Area 3's band currently holds one instruction string, with a `_regionInstruction`
+bool on the window answering "may I retract what is up?". A third writer makes
+that a three-way ownership problem — the "state outliving what it belongs to"
+shape that has cost this project five review rounds elsewhere. Replace it with
+slots.
+
+```python
+StatusPanel.setInstruction(source: str, text: str)   # "" clears that slot only
+StatusPanel.instruction() -> str                     # unchanged meaning
+```
+
+Priority is a module-level constant; the first non-empty slot renders:
+
+| Rank | Source | Message | Why here |
+| --- | --- | --- | --- |
+| 1 | `storage` | `str(HelpfulException)` — "Storage directory has not been set." | New slice could not complete at all. |
+| 2 | `imagery` | "Pin reference frames of this slice in the Camera module." | The slice exists but has no reference imagery. |
+| 3 | `mirror` | "Mirror to Camera: no Camera module is open. The outlines will appear if one is opened." | A display preference. |
+
+A `RunErrorRecord` still outranks all three, unchanged: a failure that halted a
+run is about tissue and a pipette in it, and guidance about a button is not.
+
+`instruction()` keeps returning *the text now showing*, so the existing test
+reads are unaffected. The four production `setInstruction`/`clearInstruction`
+call sites and the `setInstruction` calls in `test_status_panel.py` take the
+source argument. `_regionInstruction` is deleted: it existed only to answer "may
+I retract this?", which slots answer structurally.
+
+**One deliberate behaviour change falls out of this.** `newSlice()`'s success
+path today calls `clearInstruction()`, wiping whatever the band held. Under
+slots it clears the `storage` slot alone — the one whose condition New slice
+has just resolved. The `mirror` slot survives, correctly: New slice does not
+change whether a Camera module is open, so retracting that message would have
+been a lie. In practice the message goes anyway, because `beginSlice()` opens
+the Camera module and `_onModulesChanged` re-runs the mirror handler.
+
+### What `imagery` says, and when
+
+State-driven, not event-driven. The slot's text is a pure function of the
+current state, recomputed on every `sigPinnedFramesChanged` and on every
+`rebind()`:
+
+- No slice → `""`.
+- Slice, source resolved, zero frames pinned → the pin-frames instruction.
+- Slice, source resolved, one or more frames pinned → `""`.
+- Slice, **no source resolved** → "Open the Camera module to pin reference
+  frames for this slice." Now the exception rather than the norm, since
+  `beginSlice()` opens it; this covers a rig with no Camera module configured,
+  a selected camera the Camera module has no interface for, and a `getModule`
+  that raised.
+
+Retracting on the first pin and returning if the operator unpins everything
+both fall out of this for free. Deriving the text from state rather than from
+an event also dodges the failure the error-surfacing branch measured, where a
+band gated on a transient status was shown and hidden inside one run.
+
+## 5. Threading and lifetime
+
+**Single-threaded.** `sigPinnedFramesChanged` is emitted on the GUI thread by
+operator clicks in the Camera module. No producer, orchestrator or worker
+thread touches any of this, and no cross-thread hazard applies.
+
+`release()` is called from `AutopatchWindow.teardown()` and must tolerate a
+source Qt has already destroyed. `Qt.disconnect` (which is `pg.disconnect`)
+swallows a dead connection's
+`RuntimeError`, but the signal is read off the source *before* it can be handed
+over, and that read raises through a wrapper whose C++ object is gone — the
+hazard `PinnedFrameMirror.unbind()` documents. A raise here would abandon the
+rest of `teardown()`, leaving every other panel wired to an orchestrator that
+has just been stopped.
+
+The window also calls `rebind()` wherever it already calls `_bindPinnedFrames`:
+`_startSlice()` and `_onModulesChanged()`. The latter is what makes the
+"no Camera module" instruction retract by itself when one is opened.
+
+## 6. Testing
+
+### `ReferenceImagery`, headless
+
+Against a fake `ImagingCtrl`: a `QObject` with `sigPinnedFramesChanged`, a
+`pinnedFrames` list, and a `clearPinnedFrames()` that **genuinely empties the
+list and emits**. An honest fake is not optional here — P2b's `restore_depth`
+and `_FakeCamera` defects both survived because the fake agreed with the code
+and neither matched the device. A `clearPinnedFrames()` that does not emit
+would hide a missing recompute.
+
+Fake opener records its calls; prompt stub is parameterised True/False.
+
+Cases: opener called on `beginSlice`; no prompt when nothing is pinned; prompt
+then clear on Yes; prompt then **frames still pinned** on No; instruction
+appears at zero frames and retracts on the first pin; instruction returns when
+the last frame is unpinned; the no-source text; `sigInstructionChanged` emitted
+only on an actual change; `release()` disconnects.
+
+### `StatusPanel` slots
+
+Priority order across all three sources, and — the property the change exists
+for — that setting or clearing one source does not disturb another's message.
+Errors still outrank instructions.
+
+### Window integration
+
+New slice opens the Camera module, prompts, and clears; declining leaves the
+frames; the instruction appears and retracts as frames are pinned and unpinned;
+`teardown()` releases.
+
+The release test asserts Qt's own `receivers(signal)` rather than a weakref.
+Twice now a mandated "remove the disconnect" mutation has passed because a
+nearby `= None` had already broken the cycle refcounting sees, so the weakref
+proof proved nothing.
+
+### Mutation discipline
+
+Every test whose assertion is about absence (`== ""`, `is None`, "not called",
+"still pinned") gets a mutation proof, and the proof must record **the line
+number the failure occurred at** — two mandated mutations on the
+error-surfacing branch were defective, one failing a step before its assertion
+and one not failing at all, and only reading the failure output caught either.
+
+## 7. Open, and deliberately deferred
+
+- **Still open for Area 1** after this: slice disk persistence via
+  `DirHandle.setInfo()`, and the progress heatmap's cross-repo
+  `acq4_automation.Cell` expansion.
+- **The live GUI smoke test still needs a human at a screen** — the prompt's
+  wording, the band's legibility, and whether opening the Camera module from
+  New slice feels helpful or intrusive on a real rig. P2c-3a and the progress
+  overlay both shipped unverified against the rig and this will too.
+- **"Fresh" is enforced only by the clear.** An operator who declines the
+  prompt keeps frames of the previous slice, and the instruction stays retracted
+  because frames are pinned. Nothing tracks which slice a frame was taken on.
+  Making that distinction real would mean stamping frames at pin time in the
+  Camera module, which is a change to shared code for a case the operator has
+  explicitly opted into.
+- **`"Camera"` stays hard-coded** as the module name, matching
+  `_cameraModuleWindow`. A rig that names its Camera module something else
+  already does not get the outline mirror either.

--- a/docs/superpowers/specs/2026-08-14-autopatch-pinned-frames-workflow-design.md
+++ b/docs/superpowers/specs/2026-08-14-autopatch-pinned-frames-workflow-design.md
@@ -17,8 +17,11 @@ P2c-3a built the display half — `PinnedFrameMirror` shows those frames in Area
 
 - **Clearing** the previous slice's frames, behind a confirmation prompt.
 - **Instructing** the operator to pin a fresh set, in Area 3's band.
-- **Opening** the Camera module if it is not already open, so there is
-  somewhere to pin them.
+
+And one simplification of landed code that this depends on:
+
+- **The Camera module is opened at startup**, by the `Autopatch` module itself,
+  and is thereafter assumed to exist.
 
 **The "wait" is advisory.** No control is disabled and no run is blocked.
 Nothing gates on reference imagery existing; the band says what to do and the
@@ -29,12 +32,45 @@ Out of scope: slice disk persistence via `DirHandle.setInfo()`, the progress
 heatmap's remaining cross-repo work, and the live GUI smoke test — all still
 open, none of them this.
 
+## 1b. The Camera module is a precondition, not a possibility
+
+Everything in Area 1 that touches imagery — both mirrors and now the reference
+workflow — was written to treat a closed Camera module as ordinary: resolve to
+`None`, do nothing, and in the mirror's case put a message in the band about it.
+That was three code paths and one operator-facing warning serving a state the
+rig is never meant to be in.
+
+**Instead: `Autopatch.__init__` opens the Camera module** — in the `Module`
+class, before `AutopatchWindow(self)` is constructed, so the window can assume
+it. A Camera module closed after startup is an error, not a state to degrade
+into, and `_cameraWindow()` raises `HelpfulException` when asked for a window
+that is not there. `HelpfulException` rather than `RuntimeError` because it is
+acq4's operator-facing error type — the same one `create_data_dir` raises for an
+unset storage directory — and it surfaces through acq4's existing error dialog
+rather than reading as a crash.
+
+Three things are deleted outright:
+
+- The **"Mirror to Camera: no Camera module is open"** instruction, and with it
+  `_setRegionInstruction` and the `_regionInstruction` bool.
+- **`_onModulesChanged`**, its `sigModulesChanged` connection and its teardown
+  disconnect. Its entire job was re-binding the mirrors when a Camera module
+  appeared later, which can no longer happen. It also carried a `_tornDown`
+  guard for a race it can no longer lose.
+- The `except Exception: return None` fallback in `_cameraModuleWindow`.
+
+**Verify before relying on it:** `manager.getModule("Camera")` called from
+inside another module's `__init__` re-enters `Manager`'s module loading. This is
+assumed to work and must be confirmed against a running app, not reasoned about.
+If it does not, the fallback is opening it from `AutopatchWindow`'s first
+`showEvent` instead.
+
 ## 2. `ReferenceImagery`
 
 New file `acq4/modules/Autopatch/reference_imagery.py`.
 
 ```python
-ReferenceImagery(imagingCtrlGetter, moduleOpener, prompt=None)
+ReferenceImagery(imagingCtrlGetter, prompt=None)
 ```
 
 A `QObject`, unlike the plain `PinnedFrameMirror`/`CameraMirror` classes beside
@@ -45,30 +81,33 @@ set changes. `ProgressOverlay` is a `QObject` for the same reason.
 
 | Member | Meaning |
 | --- | --- |
-| `beginSlice()` | New slice's entry point: open the module, resolve, prompt-and-clear, recompute. |
+| `beginSlice()` | New slice's entry point: resolve, prompt-and-clear, recompute. |
 | `rebind()` | Re-resolve the source, swap the subscription, recompute. |
 | `instruction() -> str` | The guidance this component wants shown; `""` for none. |
 | `sigInstructionChanged` | Emitted **only when `instruction()` changes value**. |
 | `release()` | Disconnect and forget the source. Teardown's call. |
 
-### The three injected seams
+### The two injected seams
 
 Injection is what makes this headless-testable, the same choice P2b made for
 the tile detector.
 
-- **`imagingCtrlGetter() -> imagingCtrl | None`** resolves the Camera module's
-  `ImagingCtrl` for the selected camera, exactly as `_bindPinnedFrames` does
-  today (`window.getInterfaceForDevice(camera.name()).imagingCtrl`, with
-  `KeyError`/`AttributeError` meaning "none").
-- **`moduleOpener() -> None`** opens the Camera module. This is a deliberate
-  `manager.getModule("Camera")` — a *load*, not a lookup. It must **not** go
-  through `_cameraModuleWindow`, whose `listModules()` guard exists precisely so
-  that a mirror redraw (including the one behind "Add region here") cannot start
-  a module as a side effect. Two callers wanting opposite behaviour is why they
-  stay two code paths.
+- **`imagingCtrlGetter() -> imagingCtrl`** resolves the Camera module's
+  `ImagingCtrl` for the selected camera, as `_bindPinnedFrames` does today
+  (`window.getInterfaceForDevice(camera.name()).imagingCtrl`). It no longer has
+  a "none" answer: a missing Camera window raises `HelpfulException` from
+  `_cameraWindow()`, and a Camera module with no interface for the selected
+  camera raises one too, naming the camera.
 - **`prompt(text) -> bool`** defaults to a `QMessageBox.question`, mirroring
   `ImagingCtrl.clearPinnedFramesClicked`'s own confirmation. Injected so no
   headless test can open a modal.
+
+**Nothing catches these raises.** `beginSlice()` lets them propagate out of
+`newSlice()` to acq4's error dialog, which is the agreed handling for a Camera
+module closed after startup. Note this is a different decision from the
+`storage` slot beside it, which *is* caught and rendered as guidance: an unset
+storage directory is a thing the operator has not done yet, while a closed
+Camera module is a thing that should not have happened.
 
 ### Why not extend `PinnedFrameMirror`
 
@@ -88,22 +127,23 @@ the orchestrator detach/`clearQueue()`/`abandonCellInHand()`, and after
 `_refreshSurveyStats()`.
 
 **This ordering is load-bearing.** The prompt is modal; a modal dialog re-enters
-the Qt event loop; every queued slot dispatches inside it. That includes
-`_onModulesChanged` announcing the module we just opened, and any
-`sigCellFinished` queued from the cell still in flight on the discarded tissue.
-Running the prompt last means no half-completed New slice is ever observable
-from inside a nested event loop. This project has been bitten repeatedly by a
-queued signal landing mid-transaction; opening a nested loop in the middle of
-one invites the same class of defect.
+the Qt event loop; every queued slot dispatches inside it — most consequentially
+the `sigCellFinished` queued from the cell still in flight on the tissue this
+click just discarded, whose whole suppression dance
+(`abandonCellInHand`, and the six review rounds behind it) assumes it lands
+outside a half-completed New slice. Running the prompt last means no
+intermediate state of `newSlice()` is ever observable from inside a nested
+event loop. This project has been bitten repeatedly by a queued signal landing
+mid-transaction; opening a nested loop in the middle of one invites the same
+class of defect.
 
 Inside `beginSlice()`, in order:
 
-1. `moduleOpener()`.
-2. `rebind()` — resolve the `ImagingCtrl`, subscribe to
+1. `rebind()` — resolve the `ImagingCtrl`, subscribe to
    `sigPinnedFramesChanged`.
-3. If the source resolved and its `pinnedFrames` is non-empty, `prompt(...)`;
-   on a Yes, `source.clearPinnedFrames()`.
-4. Recompute the instruction and emit if it changed.
+2. If `pinnedFrames` is non-empty, `prompt(...)`; on a Yes,
+   `source.clearPinnedFrames()`.
+3. Recompute the instruction and emit if it changed.
 
 **Declining does not abort New slice.** The slice is already built by the time
 this runs; the prompt is about frames alone. **Zero pinned frames means no
@@ -115,10 +155,15 @@ prompt at all** — there is nothing to confirm.
 ## 4. The instruction, and named slots in `StatusPanel`
 
 Area 3's band currently holds one instruction string, with a `_regionInstruction`
-bool on the window answering "may I retract what is up?". A third writer makes
-that a three-way ownership problem — the "state outliving what it belongs to"
-shape that has cost this project five review rounds elsewhere. Replace it with
-slots.
+bool on the window answering "may I retract what is up?". Replace it with slots.
+
+**Slots are still needed even though §1b deletes one of the writers.** With the
+mirror message gone the band has two: `storage` and `imagery`. They are not
+mutually exclusive. `newSlice()` can fail at `create_data_dir` **with the
+previous slice still installed** — so the storage message goes up while a slice
+exists whose frames may all have been unpinned, which is exactly when the
+imagery message wants the band too. A single string plus an ownership bool
+cannot hold both, and which one wins would depend on click order.
 
 ```python
 StatusPanel.setInstruction(source: str, text: str)   # "" clears that slot only
@@ -131,7 +176,6 @@ Priority is a module-level constant; the first non-empty slot renders:
 | --- | --- | --- | --- |
 | 1 | `storage` | `str(HelpfulException)` — "Storage directory has not been set." | New slice could not complete at all. |
 | 2 | `imagery` | "Pin reference frames of this slice in the Camera module." | The slice exists but has no reference imagery. |
-| 3 | `mirror` | "Mirror to Camera: no Camera module is open. The outlines will appear if one is opened." | A display preference. |
 
 A `RunErrorRecord` still outranks all three, unchanged: a failure that halted a
 run is about tissue and a pipette in it, and guidance about a button is not.
@@ -145,10 +189,9 @@ I retract this?", which slots answer structurally.
 **One deliberate behaviour change falls out of this.** `newSlice()`'s success
 path today calls `clearInstruction()`, wiping whatever the band held. Under
 slots it clears the `storage` slot alone — the one whose condition New slice
-has just resolved. The `mirror` slot survives, correctly: New slice does not
-change whether a Camera module is open, so retracting that message would have
-been a lie. In practice the message goes anyway, because `beginSlice()` opens
-the Camera module and `_onModulesChanged` re-runs the mirror handler.
+has just resolved — and leaves `imagery` to `ReferenceImagery`, which
+recomputes it from state moments later in `beginSlice()`. A blanket wipe would
+have raced that recompute for no reason.
 
 ### What `imagery` says, and when
 
@@ -157,13 +200,11 @@ current state, recomputed on every `sigPinnedFramesChanged` and on every
 `rebind()`:
 
 - No slice → `""`.
-- Slice, source resolved, zero frames pinned → the pin-frames instruction.
-- Slice, source resolved, one or more frames pinned → `""`.
-- Slice, **no source resolved** → "Open the Camera module to pin reference
-  frames for this slice." Now the exception rather than the norm, since
-  `beginSlice()` opens it; this covers a rig with no Camera module configured,
-  a selected camera the Camera module has no interface for, and a `getModule`
-  that raised.
+- Slice, zero frames pinned → the pin-frames instruction.
+- Slice, one or more frames pinned → `""`.
+
+There is no "no source" case: per §1b the Camera module is a precondition, and
+failing to resolve one raises rather than producing a third message.
 
 Retracting on the first pin and returning if the operator unpins everything
 both fall out of this for free. Deriving the text from state rather than from
@@ -185,9 +226,10 @@ hazard `PinnedFrameMirror.unbind()` documents. A raise here would abandon the
 rest of `teardown()`, leaving every other panel wired to an orchestrator that
 has just been stopped.
 
-The window also calls `rebind()` wherever it already calls `_bindPinnedFrames`:
-`_startSlice()` and `_onModulesChanged()`. The latter is what makes the
-"no Camera module" instruction retract by itself when one is opened.
+The window calls `rebind()` from `_startSlice()`, beside `_bindPinnedFrames` —
+the only remaining caller, now that `_onModulesChanged` is deleted. Both need
+re-resolving for the same reason: the operator may have changed the selected
+camera between slices.
 
 ## 6. Testing
 
@@ -200,25 +242,41 @@ and `_FakeCamera` defects both survived because the fake agreed with the code
 and neither matched the device. A `clearPinnedFrames()` that does not emit
 would hide a missing recompute.
 
-Fake opener records its calls; prompt stub is parameterised True/False.
+Prompt stub is parameterised True/False.
 
-Cases: opener called on `beginSlice`; no prompt when nothing is pinned; prompt
-then clear on Yes; prompt then **frames still pinned** on No; instruction
-appears at zero frames and retracts on the first pin; instruction returns when
-the last frame is unpinned; the no-source text; `sigInstructionChanged` emitted
-only on an actual change; `release()` disconnects.
+Cases: no prompt when nothing is pinned; prompt then clear on Yes; prompt then
+**frames still pinned** on No; instruction appears at zero frames and retracts
+on the first pin; instruction returns when the last frame is unpinned;
+`sigInstructionChanged` emitted only on an actual change; a getter that raises
+`HelpfulException` propagates out of `beginSlice()`; `release()` disconnects.
 
 ### `StatusPanel` slots
 
-Priority order across all three sources, and — the property the change exists
-for — that setting or clearing one source does not disturb another's message.
-Errors still outrank instructions.
+Priority order across both sources, and — the property the change exists for —
+that setting or clearing one source does not disturb another's message. The
+case that motivates it gets its own test: `storage` set while `imagery` is
+also non-empty, which is reachable because `create_data_dir` can fail with the
+previous slice still installed. Errors still outrank instructions.
 
 ### Window integration
 
-New slice opens the Camera module, prompts, and clears; declining leaves the
-frames; the instruction appears and retracts as frames are pinned and unpinned;
-`teardown()` releases.
+New slice prompts and clears; declining leaves the frames; the instruction
+appears and retracts as frames are pinned and unpinned; `teardown()` releases.
+
+**`_FakeManager` has to change, and this is the largest test cost of §1b.** It
+carries no `listModules`/`getModule` today — tests that need a Camera window
+monkeypatch them in, and everything else relies on `_cameraModuleWindow`'s
+`except Exception: return None`. With that fallback deleted, the default fake
+must supply a Camera module with a working `getInterfaceForDevice`. That is the
+more honest fake regardless: production now guarantees a Camera module, and a
+fake that reports none does not reproduce production — the same defect class as
+P2b's `restore_depth` and `_FakeCamera`.
+
+Its `sigModulesChanged` signal stays (harmless, and the real `Manager` has one)
+but nothing in Autopatch listens to it any more. The two tests asserting the
+"no Camera module is open" mirror warning are deleted with the warning; the
+test that asserts `_cameraModuleWindow` does **not** load an unopened module is
+deleted with the guard, and replaced by one asserting the raise.
 
 The release test asserts Qt's own `receivers(signal)` rather than a weakref.
 Twice now a mandated "remove the disconnect" mutation has passed because a
@@ -239,9 +297,10 @@ and one not failing at all, and only reading the failure output caught either.
   `DirHandle.setInfo()`, and the progress heatmap's cross-repo
   `acq4_automation.Cell` expansion.
 - **The live GUI smoke test still needs a human at a screen** — the prompt's
-  wording, the band's legibility, and whether opening the Camera module from
-  New slice feels helpful or intrusive on a real rig. P2c-3a and the progress
-  overlay both shipped unverified against the rig and this will too.
+  wording, the band's legibility, and above all whether `getModule("Camera")`
+  from inside `Autopatch.__init__` actually works (§1b). P2c-3a and the
+  progress overlay both shipped unverified against the rig and this will too,
+  but that one assumption is worth a deliberate check.
 - **"Fresh" is enforced only by the clear.** An operator who declines the
   prompt keeps frames of the previous slice, and the instruction stays retracted
   because frames are pinned. Nothing tracks which slice a frame was taken on.
@@ -250,4 +309,6 @@ and one not failing at all, and only reading the failure output caught either.
   explicitly opted into.
 - **`"Camera"` stays hard-coded** as the module name, matching
   `_cameraModuleWindow`. A rig that names its Camera module something else
-  already does not get the outline mirror either.
+  already does not get the outline mirror either — though under §1b that rig
+  now gets a `HelpfulException` where it previously got a blank Area 1, which
+  is arguably the better outcome and definitely the louder one.

--- a/docs/superpowers/specs/2026-08-14-autopatch-pinned-frames-workflow-design.md
+++ b/docs/superpowers/specs/2026-08-14-autopatch-pinned-frames-workflow-design.md
@@ -129,15 +129,14 @@ the orchestrator detach/`clearQueue()`/`abandonCellInHand()`, and after
 `_refreshSurveyStats()`.
 
 **This ordering is load-bearing.** The prompt is modal; a modal dialog re-enters
-the Qt event loop; every queued slot dispatches inside it — most consequentially
-the `sigCellFinished` queued from the cell still in flight on the tissue this
-click just discarded, whose whole suppression dance
-(`abandonCellInHand`, and the six review rounds behind it) assumes it lands
-outside a half-completed New slice. Running the prompt last means no
-intermediate state of `newSlice()` is ever observable from inside a nested
-event loop. This project has been bitten repeatedly by a queued signal landing
-mid-transaction; opening a nested loop in the middle of one invites the same
-class of defect.
+the Qt event loop; every queued slot dispatches inside it. Running the prompt
+last means no intermediate state of `newSlice()` -- a half-cleared band, a
+detached producer, cells already gone from Area 5 but still in the
+orchestrator's queue -- is ever observable from inside that nested loop.
+`test_the_clear_prompt_opens_only_after_the_wipe` pins exactly this: the wipe
+is complete before the prompt can open at all. This project has been bitten
+repeatedly by a queued signal landing mid-transaction; opening a nested loop
+in the middle of one invites the same class of defect.
 
 Inside `beginSlice()`, in order:
 
@@ -199,10 +198,11 @@ I retract this?", which slots answer structurally.
 
 **One deliberate behaviour change falls out of this.** `newSlice()`'s success
 path today calls `clearInstruction()`, wiping whatever the band held. Under
-slots it clears the `storage` slot alone — the one whose condition New slice
-has just resolved — and leaves `imagery` to `ReferenceImagery`, which
-recomputes it from state moments later in `beginSlice()`. A blanket wipe would
-have raced that recompute for no reason.
+slots it clears the `storage` and `region` slots — storage because New slice
+has just resolved that condition, region because a refusal it might be showing
+named an outline on tissue that is now gone — and leaves `imagery` to
+`ReferenceImagery`, which recomputes it from state moments later in
+`beginSlice()`. A blanket wipe would have raced that recompute for no reason.
 
 ### What `imagery` says, and when
 

--- a/docs/superpowers/specs/2026-08-14-autopatch-pinned-frames-workflow-design.md
+++ b/docs/superpowers/specs/2026-08-14-autopatch-pinned-frames-workflow-design.md
@@ -72,7 +72,7 @@ If it does not, the fallback is opening it from `AutopatchWindow`'s first
 New file `acq4/modules/Autopatch/reference_imagery.py`.
 
 ```python
-ReferenceImagery(imagingCtrlGetter, prompt=None)
+ReferenceImagery(imagingCtrlGetter, prompt=None, parent=None)
 ```
 
 A `QObject`, unlike the plain `PinnedFrameMirror`/`CameraMirror` classes beside
@@ -89,27 +89,45 @@ set changes. `ProgressOverlay` is a `QObject` for the same reason.
 | `sigInstructionChanged` | Emitted **only when `instruction()` changes value**. |
 | `release()` | Disconnect and forget the source. Teardown's call. |
 
-### The two injected seams
+### The injected seams
 
 Injection is what makes this headless-testable, the same choice P2b made for
 the tile detector.
 
-- **`imagingCtrlGetter() -> imagingCtrl`** resolves the Camera module's
-  `ImagingCtrl` for the selected camera, as `_bindPinnedFrames` does today
-  (`window.getInterfaceForDevice(camera.name()).imagingCtrl`). It no longer has
-  a "none" answer: a missing Camera window raises `HelpfulException` from
-  `_cameraWindow()`, and a Camera module with no interface for the selected
-  camera raises one too, naming the camera.
-- **`prompt(text) -> bool`** defaults to a `QMessageBox.question`, mirroring
-  `ImagingCtrl.clearPinnedFramesClicked`'s own confirmation. Injected so no
-  headless test can open a modal.
+- **`imagingCtrlGetter() -> imagingCtrl | None`** resolves the Camera module's
+  `ImagingCtrl` for the selected camera, as `_bindPinnedFrames` does
+  (`window.getInterfaceForDevice(camera.name()).imagingCtrl`).
+- **`prompt(text, parent) -> bool`** defaults to a `QMessageBox.question`.
+  Injected so no headless test can open a modal. **`parent` matters:** a
+  parentless `QMessageBox` centres on the primary screen rather than over the
+  Autopatch window and can sit behind it with no taskbar entry of its own,
+  which reads as a hung UI at the start of every slice. The window passes
+  itself.
 
-**Nothing catches these raises.** `beginSlice()` lets them propagate out of
-`newSlice()` to acq4's error dialog, which is the agreed handling for a Camera
-module closed after startup. Note this is a different decision from the
-`storage` slot beside it, which *is* caught and rendered as guidance: an unset
-storage directory is a thing the operator has not done yet, while a closed
-Camera module is a thing that should not have happened.
+**Three states, not two — corrected 2026-08-14 during implementation.** This
+section originally said the getter "no longer has a `None` answer" and that
+every failure raises. That was wrong, and building it that way reintroduced
+the very conflation §1b exists to remove: the first implementation reported a
+**headless** window as a missing-Camera-module error. The distinction that
+actually holds:
+
+| State | Answer | Why |
+| --- | --- | --- |
+| No Manager (headless) | `None` | A documented first-class mode, not a rig fault. |
+| Camera module open, no interface for the selected camera | `None` | The "switching cameras" state `_bindPinnedFrames` already tolerates. |
+| Manager present, Camera module absent | **raises** `HelpfulException` | §1b's precondition, violated. |
+
+Only the third raises, and `beginSlice()` lets it propagate out of `newSlice()`
+to acq4's error dialog. That is a different decision from the `storage` slot
+beside it, which *is* caught and rendered as guidance: an unset storage
+directory is a thing the operator has not done yet, while a closed Camera
+module is a thing that should not have happened.
+
+`ReferenceImagery` treats a `None` source as "nothing to show" throughout —
+`rebind()` subscribes to nothing, `beginSlice()` skips the offer to clear, and
+`_refresh()` computes an empty instruction. **Known gap:** an operator whose
+selected camera has no interface in the Camera module therefore gets silence
+rather than guidance. Nothing covers that combination today.
 
 ### Why not extend `PinnedFrameMirror`
 

--- a/docs/superpowers/specs/2026-08-14-autopatch-pinned-frames-workflow-design.md
+++ b/docs/superpowers/specs/2026-08-14-autopatch-pinned-frames-workflow-design.md
@@ -52,7 +52,9 @@ rather than reading as a crash.
 Three things are deleted outright:
 
 - The **"Mirror to Camera: no Camera module is open"** instruction, and with it
-  `_setRegionInstruction` and the `_regionInstruction` bool.
+  the `_regionInstruction` bool. `_setRegionInstruction` itself survives its
+  other caller — `_onRegionsEdited` puts a `RegionTooLarge` message in the same
+  band — and becomes a plain write to the `region` slot (§4).
 - **`_onModulesChanged`**, its `sigModulesChanged` connection and its teardown
   disconnect. Its entire job was re-binding the mirrors when a Camera module
   appeared later, which can no longer happen. It also carried a `_tornDown`
@@ -157,13 +159,17 @@ prompt at all** — there is nothing to confirm.
 Area 3's band currently holds one instruction string, with a `_regionInstruction`
 bool on the window answering "may I retract what is up?". Replace it with slots.
 
-**Slots are still needed even though §1b deletes one of the writers.** With the
-mirror message gone the band has two: `storage` and `imagery`. They are not
-mutually exclusive. `newSlice()` can fail at `create_data_dir` **with the
-previous slice still installed** — so the storage message goes up while a slice
-exists whose frames may all have been unpinned, which is exactly when the
-imagery message wants the band too. A single string plus an ownership bool
-cannot hold both, and which one wins would depend on click order.
+**Deleting the mirror warning does not drop the band to two writers.**
+`_setRegionInstruction` has a second caller: `_onRegionsEdited` puts a
+`RegionTooLarge` refusal in the same band. So after §1b the writers are
+`storage`, `region` and `imagery` — still three.
+
+They are not mutually exclusive, which is what makes a single string plus an
+ownership bool wrong. `newSlice()` can fail at `create_data_dir` **with the
+previous slice still installed**, so the storage message goes up while a slice
+exists whose frames may all have been unpinned — exactly when the imagery
+message wants the band too. A region refused for being too large is
+independent of both. Which message survives would depend on click order.
 
 ```python
 StatusPanel.setInstruction(source: str, text: str)   # "" clears that slot only
@@ -175,7 +181,12 @@ Priority is a module-level constant; the first non-empty slot renders:
 | Rank | Source | Message | Why here |
 | --- | --- | --- | --- |
 | 1 | `storage` | `str(HelpfulException)` — "Storage directory has not been set." | New slice could not complete at all. |
-| 2 | `imagery` | "Pin reference frames of this slice in the Camera module." | The slice exists but has no reference imagery. |
+| 2 | `region` | `str(RegionTooLarge)` | An edit the operator just made was refused outright. |
+| 3 | `imagery` | "Pin reference frames of this slice in the Camera module." | The slice exists but has no reference imagery. |
+
+`region` outranks `imagery` because a refused edit is a response to something
+the operator did a moment ago, while the imagery instruction is a standing
+condition that will still be true once they have read the refusal.
 
 A `RunErrorRecord` still outranks all three, unchanged: a failure that halted a
 run is about tissue and a pipette in it, and guidance about a button is not.
@@ -252,9 +263,9 @@ on the first pin; instruction returns when the last frame is unpinned;
 
 ### `StatusPanel` slots
 
-Priority order across both sources, and — the property the change exists for —
-that setting or clearing one source does not disturb another's message. The
-case that motivates it gets its own test: `storage` set while `imagery` is
+Priority order across all three sources, and — the property the change exists
+for — that setting or clearing one source does not disturb another's message.
+The case that motivates it gets its own test: `storage` set while `imagery` is
 also non-empty, which is reachable because `create_data_dir` can fail with the
 previous slice still installed. Errors still outrank instructions.
 


### PR DESCRIPTION
Area 1's last unbuilt piece: the Camera module's pinned frames get sequenced into the start of a slice, so the regions an operator draws are drawn over imagery of the tissue actually under the objective.

Spec: `docs/superpowers/specs/2026-08-14-autopatch-pinned-frames-workflow-design.md`
Plan: `docs/superpowers/plans/2026-08-14-autopatch-pinned-frames-workflow.md`

## What this does

**The pinned-frames workflow.** New slice offers to clear the previous slice's pinned frames — imagery of tissue no longer under the objective, which regions would otherwise be drawn over — and Area 3's band asks the operator to pin a fresh set until one is pinned. **The wait is advisory**: nothing is disabled, no run is blocked. New `acq4/modules/Autopatch/reference_imagery.py`.

**The Camera module becomes a precondition.** `Autopatch.__init__` opens it at startup and refuses to open when the rig has none configured. `_cameraWindow()` raises `HelpfulException` when it is absent, but answers `None` for a manager-less headless window. The "no Camera module is open" warning, `_onModulesChanged` and the `sigModulesChanged` wiring are deleted, along with nine tests covering them.

**Area 3's band gained named slots.** Three writers share it — `storage`, `region`, `imagery` — and cannot see each other's conditions, so `setInstruction(source, text)` gives each its own, highest-priority non-empty rendering. Replaces a single string plus an ownership bool. They are genuinely not mutually exclusive: `newSlice()` can fail at `create_data_dir` with the previous slice still installed.

## Verification

519 tests in `acq4/modules/Autopatch/`, 1585 repo-wide (from 1584), 24 xfailed, no failures, no warnings, no skips.

Seven tasks, each with a per-task review, plus a whole-branch review on the most capable model. That last pass earned its keep for the sixth time on this module — see below.

## Not done, and known gaps

- **The live GUI smoke test has not been run.** Most importantly, `manager.getModule("Camera")` from inside `Autopatch.__init__` re-enters `Manager`'s module loading. Static analysis says it is safe (`moduleLock` is recursive; `loadModule` deletes its placeholder if the constructor raises) but this needs a running app. If it misbehaves, the fallback is `AutopatchWindow`'s first `showEvent`.
- **`"Camera"` is matched as a literal module name.** A rig whose config names its camera module otherwise now cannot open Autopatch at all, where before it got a blank Area 1. Louder, and arguably better, but it is a behaviour change.
- **A Camera module quit no longer releases Area 1's mirrors.** Task 2 deleted that path assuming a missing Camera module was becoming impossible; Task 3 made it an *error* instead, which is not the same claim. Close the Camera module mid-session and both mirrors stay bound, drawing stale pinned frames until New slice (which now refuses) or teardown. Deliberately left — the fix means reinstating part of the apparatus this branch removes.
- **A camera with no interface in the Camera module gets silence.** `_imagingCtrl()` answers `None` for that case, so the band says nothing rather than offering guidance. Nothing covers the combination.
- **The modal widens two pre-existing race windows** (a queued `sigRunError` and `abandonCellInHand`'s documented uncovered ordering). Neither outcome is new — both would land the instant `newSlice()` returned — but the window is now as long as the operator takes to answer a dialog. Verified by probe; not caused by this branch.

## What the reviews caught, since the diff alone will not show it

- **The comment justifying the branch's central ordering decision was fiction.** `beginSlice()` goes last in `newSlice()` because its prompt is modal; the comment said this was to keep a queued `sigCellFinished` out of the re-entered event loop. Driving a real `Orchestrator` showed **zero** such emissions — `_reportFinished` suppresses it at source for an abandoned cell. The decision is right for the spec's other reason (no intermediate state of `newSlice()` observable from a nested loop) and is now pinned by `test_the_clear_prompt_opens_only_after_the_wipe`. The false mechanism is gone from both the code and the spec.
- **The first implementation reported a *headless* window as a missing-Camera-module error** — the exact conflation the precondition work exists to remove, arriving by a new route. Caught by a reviewer who reverted a file and re-ran rather than reading the diff for plausibility.
- **A propagating mirror raise left region edits half-done.** Probed: `surveyStats` went 442 → 6300 tiles while Area 2 never updated, so the readout an operator uses to judge feasibility was silently stale. Fixed by refreshing stats before the mirror can raise.
- **`ReferenceImagery`'s default prompt was a self-referencing closure** — a QObject holding a lambda closing over `self`, reclaimable only by cyclic GC, which is precisely the shape this module's deterministic teardown exists to prevent. Proven with `gc.disable()`; fixed with `functools.partial`.
- **Three vacuous tests and roughly a dozen false comments** were corrected across the branch, several introduced by a fix meant to correct another.
- **The plan claimed the prompt-last ordering might be untestable.** That was wrong: a reviewer wrote a test that fails when `beginSlice()` moves earlier, and it is now in the suite.

## A process note worth recording

A fix subagent committed into the **main checkout on the shared `_reviewed` branch** instead of the worktree — the failure this project has seen before. It was never pushed; `_reviewed` was restored with `git update-ref` to match `origin/_reviewed` and the fix re-applied here. The "verify toplevel and branch" instruction alone did not prevent it; later dispatches required pasting that output into the report.

🤖 Generated with [Claude Code](https://claude.ai/code)
