### PR TITLE
feat(autopatch): Area 5's action details widgets

### DIFF
--- a/acq4/devices/PatchPipette/patchpipette.py
+++ b/acq4/devices/PatchPipette/patchpipette.py
@@ -88,7 +88,13 @@ class PatchPipette(Device):
         self.waitingForSwap = False
         self._accessWarning = (False, "")
         self._lastPos = None
-        self._emitTestPulseData = False
+        # Tokens held by whoever currently wants test_pulse events to carry the
+        # full PatchClampTestPulse object, not just its analysis. A set rather
+        # than a bool because independent recorders subscribe independently:
+        # with a bool, whichever one stopped last would silence the others.
+        # Holds tokens, never the subscribers themselves, so nothing here keeps
+        # a recorder alive.
+        self._fullTestPulseSubscribers = set()
         self.cell = None
         self.previousCells = []
 
@@ -425,12 +431,26 @@ class PatchPipette(Device):
     def _autoBiasChanged(self, clamp, enabled, target):
         self.emitNewEvent('auto_bias_change', {'enabled': enabled, 'target': target})
 
-    def emitFullTestPulseData(self, emit: bool):
-        self._emitTestPulseData = emit
+    def requestFullTestPulseData(self, token) -> None:
+        """Ask that test_pulse events carry the full PatchClampTestPulse object.
+
+        `token` identifies the subscriber and is what releaseFullTestPulseData()
+        takes back; any hashable will do. Idempotent per token.
+        """
+        self._fullTestPulseSubscribers.add(token)
+
+    def releaseFullTestPulseData(self, token) -> None:
+        """Withdraw `token`'s request. Full data keeps flowing while any other
+        subscriber holds one. Releasing an unknown token is a no-op, so a
+        recorder's idempotent stop() can call it freely."""
+        self._fullTestPulseSubscribers.discard(token)
+
+    def emitsFullTestPulseData(self) -> bool:
+        return bool(self._fullTestPulseSubscribers)
 
     def _testPulseFinished(self, clamp, result: PatchClampTestPulse):
         data = result.analysis
-        if self._emitTestPulseData:
+        if self._fullTestPulseSubscribers:
             data = {'full_test_pulse': result, **data}  # copy it so we don't modify the original
         self.emitNewEvent('test_pulse', data)
 

--- a/acq4/devices/PatchPipette/tests/test_full_test_pulse_subscription.py
+++ b/acq4/devices/PatchPipette/tests/test_full_test_pulse_subscription.py
@@ -1,0 +1,71 @@
+"""Tests for PatchPipette's full-test-pulse subscription: independent recorders
+must each be able to request the full test-pulse object without one's release
+silencing the other's."""
+import pytest
+
+from acq4.devices.PatchPipette.patchpipette import PatchPipette
+
+
+class _Pip:
+    """Exercises the subscription methods against a bare instance, without
+    standing up a real PatchPipette (which needs a Manager and devices)."""
+
+    requestFullTestPulseData = PatchPipette.requestFullTestPulseData
+    releaseFullTestPulseData = PatchPipette.releaseFullTestPulseData
+    emitsFullTestPulseData = PatchPipette.emitsFullTestPulseData
+
+    def __init__(self):
+        self._fullTestPulseSubscribers = set()
+
+
+def test_no_subscribers_means_no_full_data():
+    assert _Pip().emitsFullTestPulseData() is False
+
+
+def test_one_subscriber_turns_it_on():
+    pip = _Pip()
+    pip.requestFullTestPulseData("recorder-a")
+    assert pip.emitsFullTestPulseData() is True
+
+
+def test_releasing_the_only_subscriber_turns_it_off():
+    pip = _Pip()
+    token = object()
+    pip.requestFullTestPulseData(token)
+    pip.releaseFullTestPulseData(token)
+    assert pip.emitsFullTestPulseData() is False
+
+
+def test_one_recorder_releasing_does_not_silence_another():
+    # The whole reason this is a set and not a bool: Autopatch stopping its
+    # recorder must not switch off MultiPatch's full-test-pulse capture.
+    pip = _Pip()
+    autopatch, multipatch = object(), object()
+    pip.requestFullTestPulseData(autopatch)
+    pip.requestFullTestPulseData(multipatch)
+
+    pip.releaseFullTestPulseData(autopatch)
+
+    assert pip.emitsFullTestPulseData() is True
+
+
+def test_requesting_twice_with_one_token_is_idempotent():
+    pip = _Pip()
+    token = object()
+    pip.requestFullTestPulseData(token)
+    pip.requestFullTestPulseData(token)
+    pip.releaseFullTestPulseData(token)
+    assert pip.emitsFullTestPulseData() is False
+
+
+def test_releasing_an_unknown_token_is_harmless():
+    # stop() is idempotent, so it may release a token it already released.
+    pip = _Pip()
+    pip.releaseFullTestPulseData(object())
+    assert pip.emitsFullTestPulseData() is False
+
+
+def test_the_old_boolean_setter_is_gone():
+    # A bare setter is what let the last caller to stop win; leaving it in place
+    # would leave that footgun loaded.
+    assert not hasattr(PatchPipette, "emitFullTestPulseData")

--- a/acq4/experiment/actions/device.py
+++ b/acq4/experiment/actions/device.py
@@ -353,7 +353,6 @@ def run_task(ctx, store: bool = True, timeout: float = 0.0):
                 {
                     "traces": traces,
                     "sequence_dir": _sequenceDirName(taskrunner),
-                    "sweep_count": len(traces),
                     "decimation": decimation,
                     "units": units,
                 },

--- a/acq4/experiment/actions/device.py
+++ b/acq4/experiment/actions/device.py
@@ -327,9 +327,12 @@ def run_task(ctx, store: bool = True, timeout: float = 0.0):
             traces.append((times, values))
             decimation = max(decimation, factor)
 
-        # Queued by default, so sweeps arriving on the task thread do not touch
-        # this action's collection from there.
-        taskrunner.sigNewFrame.connect(onNewFrame)
+        # Connected on the GUI thread, where sigNewFrame is emitted: PyQt gives
+        # a plain callable slot the affinity of the thread that called
+        # connect(), and this action runs on a gentletask ThreadTask with no Qt
+        # event loop -- connecting from here directly would queue every frame to
+        # a thread that never pumps events, so no sweep would ever be collected.
+        run_in_gui_thread(taskrunner.sigNewFrame.connect, onNewFrame)
         action_entry.set_status("running task runner sequence")
         try:
             run_in_gui_thread(taskrunner.runSequence, store=store).wait(timeout=timeout)

--- a/acq4/experiment/actions/device.py
+++ b/acq4/experiment/actions/device.py
@@ -10,6 +10,8 @@ ctx.pipette is a PatchPipette; the underlying manipulator is ctx.pipette.pipette
 """
 from __future__ import annotations
 
+import numpy as np
+
 from acq4.util.imaging.sequencer import run_image_sequence
 from acq4.util.model_config import segmenter_path
 from acq4.util.task import run_in_gui_thread
@@ -116,12 +118,38 @@ def find_surface(ctx):
         return depth
 
 
+def _trackerStack(cell):
+    """The 3D stack a cell's tracker holds, oriented for display, or None.
+
+    Reads the same attribute chain AutomationDebug's cell stack view does, and
+    swaps rows/cols the same way so the stack displays in the same orientation
+    as the Camera module. Returns None rather than raising for a cell whose
+    tracker never exposed one: this feeds a display payload, and an action must
+    not fail on the orchestrator's worker thread over what the pane can show.
+    """
+    tracker = getattr(cell, "_tracker", None)
+    if tracker is None:
+        return None
+    try:
+        stack = tracker.motion_estimator.original_object_stack.data
+    except Exception:
+        return None
+    if stack is None:
+        return None
+    stack = np.asarray(stack)
+    if stack.ndim >= 2:
+        stack = np.swapaxes(stack, -2, -1)
+    return stack
+
+
 def cellfie(ctx, height: float = 30e-6, step: float = 1e-6) -> None:
     """Capture the cell "cellfie": focus on the target, save a z-stack into the
     current storage directory, and initialize the cell tracker's reference.
 
     The z-stack save mirrors ApproachState._maybeTakeACellfie; preset switching
     (e.g. GFP/brightfield) is protocol-specific and left to the caller.
+
+    Retains the tracker's cropped object stack as this action's Area 5 details.
     """
     with ctx.log_action("Cellfie") as action_entry:
         pip = ctx.pipette
@@ -160,8 +188,26 @@ def cellfie(ctx, height: float = 30e-6, step: float = 1e-6) -> None:
             # The tracker could not re-find this cell against its own reference
             # stacks, so the stacks are useless: the cell has drifted out of
             # reach or died. That is a question about the tissue, not about this
-            # action, and the window is what can answer it. Never returns.
+            # action, and the window is what can answer it. Never returns, so
+            # there is no stack to retain for the pane.
             ctx.tissue_moved(exc.reason or str(exc))
+        # Retained for Area 5: the cube around the cell, which is what an
+        # operator reads to judge a cellfie. The full acquired z-stack stays on
+        # disk in the cellfie/ directory saved above.
+        stack = _trackerStack(ctx.cell)
+        if stack is not None:
+            action_entry.set_details(
+                "image_stack",
+                {
+                    "stack": stack,
+                    "center_index": (
+                        stack.shape[0] // 2
+                        if stack.ndim >= 3 and stack.shape[0] > 1
+                        else None
+                    ),
+                    "title": "Cellfie",
+                },
+            )
 
 
 def load_preset(ctx, preset: str | None = None) -> None:

--- a/acq4/experiment/actions/device.py
+++ b/acq4/experiment/actions/device.py
@@ -263,7 +263,10 @@ def run_task(ctx, store: bool = True, timeout: float = 0.0):
 
     Finds the TaskRunner module whose docks include this pipette's clamp device
     and runs its loaded sequence to completion (mirroring
-    AutomationDebug.autopatch.Autopatcher._autopatchRunTaskRunner).
+    AutomationDebug.autopatch.Autopatcher._autopatchRunTaskRunner). Each sweep's
+    primary trace is collected, decimated to a plottable size, and retained --
+    together with the saved sequence directory -- as a "task_results" details
+    payload.
 
     TODO: opening the TaskRunner module and loading a specified protocol file are
     still the operator's responsibility; taking that over is deferred.
@@ -271,6 +274,15 @@ def run_task(ctx, store: bool = True, timeout: float = 0.0):
     with ctx.log_action("Task Runner Sequence") as action_entry:
         man = ctx.manager
         clampName = ctx.pipette.clampDevice.name()
+        try:
+            # 'primary' is a current recording only in voltage clamp; in IC or
+            # I=0 it is a membrane potential. Mirrors neuroanalysis
+            # TestPulse.plot_units, adjusted for getMode()'s upper-case values.
+            units = "A" if ctx.pipette.clampDevice.getMode() == "VC" else "V"
+        except Exception:
+            # This is a display label, not the sequence itself -- a clamp that
+            # cannot report its mode must not fail the action over it.
+            units = "A"
         taskrunner = None
         for modName in man.listInterfaces("taskRunnerModule"):
             mod = man.getModule(modName)
@@ -284,15 +296,15 @@ def run_task(ctx, store: bool = True, timeout: float = 0.0):
         info = taskrunner.sequenceInfo
         expected_duration = info["period"] * info["totalParams"]
         timeout = timeout or max(30, expected_duration * 20)
-        clampName = ctx.pipette.clampDevice.name()
         traces = []
         decimation = 1
+        failed_frames = 0
 
         def onNewFrame(frame):
             """Collect one sweep's clamp trace. Reads the result the way
             MultiClamp's own task GUI does: result['primary'] against
             result.xvals('Time')."""
-            nonlocal decimation
+            nonlocal decimation, failed_frames
             result = frame.get("result", {}).get(clampName)
             if result is None:
                 return
@@ -303,7 +315,10 @@ def run_task(ctx, store: bool = True, timeout: float = 0.0):
             except Exception:
                 # A device whose result is not shaped like a clamp recording is
                 # not a reason to fail the sequence; the data is saved on disk
-                # regardless of whether the pane can plot it.
+                # regardless of whether the pane can plot it. Counted rather
+                # than logged here so that a sequence of many failing sweeps
+                # produces one summary line, not one per frame.
+                failed_frames += 1
                 return
             traces.append((times, values))
             decimation = max(decimation, factor)
@@ -321,6 +336,11 @@ def run_task(ctx, store: bool = True, timeout: float = 0.0):
                     f"{action_entry.name}: plotting sweeps decimated {decimation}x; "
                     f"full data saved on disk"
                 )
+            if failed_frames:
+                ctx.log(
+                    f"{action_entry.name}: {failed_frames} sweep(s) could not be "
+                    f"read for plotting; full data saved on disk"
+                )
             action_entry.set_details(
                 "task_results",
                 {
@@ -328,6 +348,6 @@ def run_task(ctx, store: bool = True, timeout: float = 0.0):
                     "sequence_dir": _sequenceDirName(taskrunner),
                     "sweep_count": len(traces),
                     "decimation": decimation,
-                    "units": "A",
+                    "units": units,
                 },
             )

--- a/acq4/experiment/actions/device.py
+++ b/acq4/experiment/actions/device.py
@@ -12,11 +12,18 @@ from __future__ import annotations
 
 import numpy as np
 
+from acq4.util import Qt
 from acq4.util.imaging.sequencer import run_image_sequence
 from acq4.util.model_config import segmenter_path
 from acq4.util.task import run_in_gui_thread
 
 from ..exceptions import OrchestrationError
+
+# Retained trace length per sweep. More than a plot's pixel width, and small
+# enough that a 20-sweep sequence costs the pane well under a megabyte per cell
+# rather than the 16 MB the undecimated sweeps would. The full data is in the
+# saved ProtocolSequence directory either way.
+_MAX_TRACE_POINTS = 4000
 
 
 def _move(ctx, name: str, position: str, speed: str) -> None:
@@ -230,6 +237,27 @@ def load_preset(ctx, preset: str | None = None) -> None:
             ) from e
 
 
+def _decimate(times, values, maxPoints: int = _MAX_TRACE_POINTS):
+    """(times, values, factor) reduced to at most `maxPoints` samples.
+
+    A factor of 1 means nothing was dropped. The factor is returned rather than
+    swallowed so the pane can say what it is not showing.
+    """
+    times = np.asarray(times)
+    values = np.asarray(values)
+    if len(values) <= maxPoints:
+        return times, values, 1
+    factor = int(np.ceil(len(values) / maxPoints))
+    return times[::factor], values[::factor], factor
+
+
+def _sequenceDirName(taskrunner) -> str:
+    """The short name of the directory the sequence saved into, or "" if it did
+    not save one (store=False, or a run that never got that far)."""
+    sequenceDir = getattr(taskrunner, "lastSequenceDir", None)
+    return "" if sequenceDir is None else sequenceDir.shortName()
+
+
 def run_task(ctx, store: bool = True, timeout: float = 0.0):
     """Run the sequence already loaded into an open TaskRunner module.
 
@@ -256,5 +284,50 @@ def run_task(ctx, store: bool = True, timeout: float = 0.0):
         info = taskrunner.sequenceInfo
         expected_duration = info["period"] * info["totalParams"]
         timeout = timeout or max(30, expected_duration * 20)
+        clampName = ctx.pipette.clampDevice.name()
+        traces = []
+        decimation = 1
+
+        def onNewFrame(frame):
+            """Collect one sweep's clamp trace. Reads the result the way
+            MultiClamp's own task GUI does: result['primary'] against
+            result.xvals('Time')."""
+            nonlocal decimation
+            result = frame.get("result", {}).get(clampName)
+            if result is None:
+                return
+            try:
+                times, values, factor = _decimate(
+                    result.xvals("Time"), result["primary"]
+                )
+            except Exception:
+                # A device whose result is not shaped like a clamp recording is
+                # not a reason to fail the sequence; the data is saved on disk
+                # regardless of whether the pane can plot it.
+                return
+            traces.append((times, values))
+            decimation = max(decimation, factor)
+
+        # Queued by default, so sweeps arriving on the task thread do not touch
+        # this action's collection from there.
+        taskrunner.sigNewFrame.connect(onNewFrame)
         action_entry.set_status("running task runner sequence")
-        run_in_gui_thread(taskrunner.runSequence, store=store).wait(timeout=timeout)
+        try:
+            run_in_gui_thread(taskrunner.runSequence, store=store).wait(timeout=timeout)
+        finally:
+            Qt.disconnect(taskrunner.sigNewFrame, onNewFrame)
+            if decimation > 1:
+                ctx.log(
+                    f"{action_entry.name}: plotting sweeps decimated {decimation}x; "
+                    f"full data saved on disk"
+                )
+            action_entry.set_details(
+                "task_results",
+                {
+                    "traces": traces,
+                    "sequence_dir": _sequenceDirName(taskrunner),
+                    "sweep_count": len(traces),
+                    "decimation": decimation,
+                    "units": "A",
+                },
+            )

--- a/acq4/experiment/actions/device.py
+++ b/acq4/experiment/actions/device.py
@@ -132,14 +132,14 @@ def _trackerStack(cell):
         return None
     try:
         stack = tracker.motion_estimator.original_object_stack.data
+        if stack is None:
+            return None
+        stack = np.asarray(stack)
+        if stack.ndim >= 2:
+            stack = np.swapaxes(stack, -2, -1)
+        return stack
     except Exception:
         return None
-    if stack is None:
-        return None
-    stack = np.asarray(stack)
-    if stack.ndim >= 2:
-        stack = np.swapaxes(stack, -2, -1)
-    return stack
 
 
 def cellfie(ctx, height: float = 30e-6, step: float = 1e-6) -> None:

--- a/acq4/experiment/actions/device.py
+++ b/acq4/experiment/actions/device.py
@@ -11,6 +11,7 @@ ctx.pipette is a PatchPipette; the underlying manipulator is ctx.pipette.pipette
 from __future__ import annotations
 
 import numpy as np
+import pyqtgraph as pg
 
 from acq4.util import Qt
 from acq4.util.imaging.sequencer import run_image_sequence
@@ -122,6 +123,9 @@ def find_surface(ctx):
             depth = scope.findSurfaceDepth(imager)
         except ValueError as e:
             raise OrchestrationError(f"{action_entry.name}: {e}") from e
+        action_entry.set_details(
+            "text", {"lines": [f"surface detected at {pg.siFormat(depth, suffix='m')}"]}
+        )
         return depth
 
 

--- a/acq4/experiment/actions/fsm.py
+++ b/acq4/experiment/actions/fsm.py
@@ -97,8 +97,12 @@ def _openLivePlot(ctx, action_entry) -> object | None:
     is forming, so it is what Area 5 shows while the FSM drives (design doc
     §4.5). Reuses MultiPatch's PlotWidget rather than reimplementing it.
 
-    Built through run_in_gui_thread because this runs on the orchestrator's
-    worker thread and a widget must not be constructed off the GUI thread.
+    Built and connected through run_in_gui_thread because this runs on the
+    orchestrator's worker thread: a widget must not be constructed off the GUI
+    thread, and PyQt gives a plain callable slot the affinity of the thread that
+    called connect(). Connecting from the worker thread -- which is a gentletask
+    ThreadTask with no Qt event loop -- would queue every test pulse to a thread
+    that never pumps events, so the plot would mount and never update.
     """
     clamp = getattr(ctx.pipette, "clampDevice", None)
     if clamp is None:
@@ -113,30 +117,38 @@ def _openLivePlot(ctx, action_entry) -> object | None:
         # Autopatch picks the mode; the operator does not need the combo while
         # an action is driving (design doc §4.5). The frozen plot shows it.
         widget.hideHeader()
-        return widget
 
-    widget = run_in_gui_thread(build)
+        def onTestPulse(_device, testPulse):
+            # Deliberately clamp.testPulseHistory(), not the recorder's: a live
+            # view of "now" should show the device's own current history. The
+            # frozen payload below reads the recorder instead, because the
+            # device's history is reset mid-patch (approach.py:251) and would
+            # silently lose whatever preceded the reset -- see _setFsmDetails.
+            widget.newTestPulse(testPulse, clamp.testPulseHistory())
 
-    def onTestPulse(_device, testPulse):
-        # Deliberately clamp.testPulseHistory(), not the recorder's: a live view
-        # of "now" should show the device's own current history. The frozen
-        # payload below reads the recorder instead, because the device's history
-        # is reset mid-patch (approach.py:251) and would silently lose whatever
-        # preceded the reset -- see _setFsmDetails.
-        widget.newTestPulse(testPulse, clamp.testPulseHistory())
+        # Default (queued) connection deliberately: PatchPipetteState connects
+        # to this same signal with an explicit DirectConnection, which is
+        # correct for a state machine and wrong for a widget -- it would mutate
+        # the plot from the clamp's thread.
+        clamp.sigTestPulseFinished.connect(onTestPulse)
+        return widget, onTestPulse
 
-    # Default (queued) connection deliberately: PatchPipetteState connects to
-    # this same signal with an explicit DirectConnection, which is correct for a
-    # state machine and wrong for a widget -- it would mutate the plot from the
-    # clamp's thread.
-    clamp.sigTestPulseFinished.connect(onTestPulse)
-    action_entry.set_details_widget(widget)
+    widget, onTestPulse = run_in_gui_thread(build)
 
     def teardown():
         # A live connection from a device signal into a widget the panel has
         # moved on from is the cross-module reference neither Autopatch's widget
         # -tree teardown nor unbindOrchestrator reaches (design doc §4.5).
         Qt.disconnect(clamp.sigTestPulseFinished, onTestPulse)
+
+    try:
+        action_entry.set_details_widget(widget)
+    except Exception:
+        # The connection is live but the caller never receives the teardown that
+        # would drop it, so nothing else would ever disconnect the clamp from
+        # this now-ownerless widget. Drop it here before the failure propagates.
+        teardown()
+        raise
 
     return teardown
 
@@ -230,17 +242,34 @@ def _drive_fsm(
             # ActionLogEntry.set_details). And in a finally, so a stopped,
             # abandoned, or failed attempt retains its plot too, which is
             # exactly when an operator wants to read one.
+            #
+            # Each guarded independently, and none allowed to raise: this runs
+            # on every attempt, in a finally. A raise from the plot teardown
+            # would otherwise skip the recorder's stop() -- leaking a file
+            # handle and an HDF5 file per attempt -- and the payload with it,
+            # and a raise from any of the three would replace whatever
+            # exception is propagating (a Stopped or an AdvanceToNextCell, i.e.
+            # an orderly operator stop) with an unrelated failure.
             if teardownPlot is not None:
-                teardownPlot()
+                try:
+                    teardownPlot()
+                except Exception as exc:
+                    ctx.log(f"could not tear down live plot: {exc}")
             if recorder is not None:
-                recorder.stop()
+                try:
+                    recorder.stop()
+                except Exception as exc:
+                    ctx.log(f"could not stop event recording: {exc}")
             if record:
                 # recorder.stop() above must run first: the payload below names
                 # the log file, and the file has to be flushed and closed before
                 # anything is told where to find it.
-                _setFsmDetails(
-                    action_entry, entry_state, reached, transitions, recorder
-                )
+                try:
+                    _setFsmDetails(
+                        action_entry, entry_state, reached, transitions, recorder
+                    )
+                except Exception as exc:
+                    ctx.log(f"could not retain test-pulse details: {exc}")
 
 
 def patch(ctx, record_events: bool = True, record_full_test_pulses: bool = True, **entry_config) -> str:

--- a/acq4/experiment/actions/fsm.py
+++ b/acq4/experiment/actions/fsm.py
@@ -1,7 +1,13 @@
 """FSM-driving actions: drive acq4's PatchPipette state machine from a declared
 entry state to one of this action's declared terminal states, mapping unexpected
-abnormal states to orchestration exceptions."""
+abnormal states to orchestration exceptions, and retaining each drive's
+test-pulse analysis and state transitions for Area 5."""
 from __future__ import annotations
+
+import os
+import time
+
+import numpy as np
 
 from acq4.util.task import Stopped, check_stop, sleep
 
@@ -20,13 +26,62 @@ def _safe_abort(ctx) -> None:
             state_job.stop("orchestration abort", wait=True)
 
 
-def _drive_fsm(ctx, name, entry_state, terminals, entry_config=None, poll_interval=0.1) -> str:
+def _setFsmDetails(action_entry, entry_state, reached, transitions, recorder=None) -> None:
+    """Retain this drive's Area 5 payload: the test-pulse analysis observed
+    during it, and the states it walked.
+
+    An empty history rather than None when there is no recorder, so the renderer
+    has one payload shape to handle rather than two.
+    """
+    from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
+
+    if recorder is None:
+        history = np.empty(0, dtype=TEST_PULSE_NUMPY_DTYPE)
+        log_file = None
+    else:
+        history = recorder.testPulseAnalysis()
+        log_file = recorder.logFileName()
+        if log_file is not None:
+            log_file = os.path.basename(log_file)
+    action_entry.set_details(
+        "test_pulse_history",
+        {
+            "history": history,
+            "transitions": list(transitions),
+            "entry_state": entry_state,
+            "reached": reached,
+            "log_file": log_file,
+        },
+    )
+
+
+def _drive_fsm(
+    ctx,
+    name,
+    entry_state,
+    terminals,
+    entry_config=None,
+    poll_interval=0.1,
+    record=True,
+    record_full_test_pulses=True,
+) -> str:
     """Drive the PatchPipette FSM from entry_state and return the terminal state
-    it reaches. Abnormal states not in `terminals` raise (see raise_if_abnormal)."""
+    it reaches. Abnormal states not in `terminals` raise (see raise_if_abnormal).
+
+    With `record` true, this action also retains a "test_pulse_history" details
+    payload for Area 5 -- the test-pulse analysis observed during the drive, and
+    the pipette states it walked. `clean` passes false: there is nothing an
+    operator reads off a clean (design doc §4.5).
+    """
     with ctx.log_action(name) as action_entry:
         pip = ctx.pipette
         action_entry.set_status(f"driving FSM from {entry_state!r}")
         last_state = entry_state
+        # (timestamp, state) for the entry state and every change the poll loop
+        # observes. Reading a failed patch is mostly "where did it stall", and
+        # this is what answers it; the loop already detects the changes.
+        transitions = [(time.time(), entry_state)]
+        reached = None
         try:
             # Fresh dict per call so no caller shares a mutable default.
             pip.setState(entry_state, **dict(entry_config or {}))
@@ -37,6 +92,9 @@ def _drive_fsm(ctx, name, entry_state, terminals, entry_config=None, poll_interv
                 state = pip.getState().stateName
                 if state in terminals:
                     action_entry.set_status(f"reached {state!r}")
+                    if state != last_state:
+                        transitions.append((time.time(), state))
+                    reached = state
                     return state
                 if state != last_state:
                     # Only on change: re-setting the same string every poll
@@ -44,17 +102,33 @@ def _drive_fsm(ctx, name, entry_state, terminals, entry_config=None, poll_interv
                     # would hide a pipette parked in a non-terminal state
                     # (e.g. "cell attached") behind a stale row otherwise.
                     action_entry.set_status(f"now in {state!r}")
+                    transitions.append((time.time(), state))
                     last_state = state
                 raise_if_abnormal(state, terminals, name)
                 sleep(poll_interval)
         except (Stopped, AdvanceToNextCell):
             _safe_abort(ctx)
             raise
+        finally:
+            # Inside the `with`, so this runs before the entry finishes -- a
+            # payload set afterwards has no timeline row to attach to (see
+            # ActionLogEntry.set_details). And in a finally, so a stopped,
+            # abandoned, or failed attempt retains its plot too, which is
+            # exactly when an operator wants to read one.
+            if record:
+                _setFsmDetails(action_entry, entry_state, reached, transitions)
 
 
-def patch(ctx, **entry_config) -> str:
+def patch(ctx, record_events: bool = True, record_full_test_pulses: bool = True, **entry_config) -> str:
     """Drive approach through detection, sealing, and break-in to a resting
-    terminal state."""
+    terminal state.
+
+    `record_events` and `record_full_test_pulses` are this action's own options,
+    consumed here and never forwarded to pip.setState; a protocol may expose
+    them to its author. See _drive_fsm for what they control. Neither disables
+    the Area 5 payload -- turning off the disk-side recording they will govern
+    is not a reason to lose the pane's plot; only `clean` opts out of that.
+    """
     return _drive_fsm(
         ctx,
         "Patch",
@@ -68,16 +142,28 @@ def patch(ctx, **entry_config) -> str:
         # profiles.
         {"whole cell", "bath", "broken", "fouled"},
         entry_config,
+        record_full_test_pulses=record_full_test_pulses,
     )
 
 
-def reseal(ctx, **entry_config) -> str:
+def reseal(ctx, record_events: bool = True, record_full_test_pulses: bool = True, **entry_config) -> str:
     """Reseal from whole-cell toward an outside-out patch, else fall back to
     whole cell."""
-    return _drive_fsm(ctx, "Reseal", "reseal", {"outside out", "whole cell"}, entry_config)
+    return _drive_fsm(
+        ctx,
+        "Reseal",
+        "reseal",
+        {"outside out", "whole cell"},
+        entry_config,
+        record_full_test_pulses=record_full_test_pulses,
+    )
 
 
 def clean(ctx, **entry_config) -> str:
     """Run the pipette-cleaning cycle and return once it settles at its resting
-    state (``out``)."""
-    return _drive_fsm(ctx, "Clean Pipette", "clean", {"out"}, entry_config)
+    state (``out``).
+
+    Records nothing: there is nothing an operator reads off a clean (design doc
+    §4.5), so it gets neither a details payload nor an event log.
+    """
+    return _drive_fsm(ctx, "Clean Pipette", "clean", {"out"}, entry_config, record=False)

--- a/acq4/experiment/actions/fsm.py
+++ b/acq4/experiment/actions/fsm.py
@@ -9,7 +9,9 @@ import time
 
 import numpy as np
 
-from acq4.util.task import Stopped, check_stop, sleep
+from acq4.util import Qt
+from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+from acq4.util.task import Stopped, check_stop, run_in_gui_thread, sleep
 
 from ..exceptions import AdvanceToNextCell, raise_if_abnormal
 
@@ -33,12 +35,24 @@ def _setFsmDetails(action_entry, entry_state, reached, transitions, recorder=Non
     An empty history rather than None when there is no recorder, so the renderer
     has one payload shape to handle rather than two.
     """
+    # Deferred rather than joining the top-of-file imports: importing anything
+    # from acq4.filetypes runs that package's __init__, which eagerly imports
+    # and registers every sibling FileType module (acq4/filetypes/filetypes.py's
+    # module-level listFileTypes() call). Keeping it here means that cost is
+    # paid only when a payload is actually being built, not by every import of
+    # this module.
     from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
 
     if recorder is None:
         history = np.empty(0, dtype=TEST_PULSE_NUMPY_DTYPE)
         log_file = None
     else:
+        # The recorder's own accumulated rows, not clampDevice.testPulseHistory():
+        # the device's history is reset mid-patch (approach.py:251), so slicing
+        # it by this drive's time window would silently lose whatever preceded
+        # the reset. The live plot in _openLivePlot reads the device instead,
+        # deliberately, because a live view of "now" should show its own
+        # current history.
         history = recorder.testPulseAnalysis()
         log_file = recorder.logFileName()
         if log_file is not None:
@@ -55,6 +69,78 @@ def _setFsmDetails(action_entry, entry_state, reached, transitions, recorder=Non
     )
 
 
+def _openRecorder(ctx, record_full_test_pulses: bool):
+    """A recorder writing this drive's events into the current storage
+    directory, or None if one could not be opened.
+
+    Never raises: the patch attempt is the experiment and the log is a record of
+    it, so an unset storage directory or a full disk must not stop a pipette
+    from patching. The reason goes to the cell's log instead.
+    """
+    try:
+        return MultiPatchLogRecorder(
+            ctx.manager.getCurrentDir(),
+            pipettes=(ctx.pipette,),
+            record_full_test_pulses=record_full_test_pulses,
+        )
+    except Exception as exc:
+        ctx.log(f"could not start event recording: {exc}")
+        return None
+
+
+def _openLivePlot(ctx, action_entry) -> object | None:
+    """Mount a live steady-state resistance plot for this drive, returning a
+    zero-argument teardown to call when it ends, or None if there is no clamp to
+    plot from.
+
+    Rss over time is the measurement an operator watches to judge whether a seal
+    is forming, so it is what Area 5 shows while the FSM drives (design doc
+    §4.5). Reuses MultiPatch's PlotWidget rather than reimplementing it.
+
+    Built through run_in_gui_thread because this runs on the orchestrator's
+    worker thread and a widget must not be constructed off the GUI thread.
+    """
+    clamp = getattr(ctx.pipette, "clampDevice", None)
+    if clamp is None:
+        return None
+
+    def build():
+        # Imported here: pipetteControl pulls in the MultiPatch module's device
+        # imports, and acq4.experiment must stay importable without them.
+        from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+        widget = PlotWidget(mode="ss resistance")
+        # Autopatch picks the mode; the operator does not need the combo while
+        # an action is driving (design doc §4.5). The frozen plot shows it.
+        widget.hideHeader()
+        return widget
+
+    widget = run_in_gui_thread(build)
+
+    def onTestPulse(_device, testPulse):
+        # Deliberately clamp.testPulseHistory(), not the recorder's: a live view
+        # of "now" should show the device's own current history. The frozen
+        # payload below reads the recorder instead, because the device's history
+        # is reset mid-patch (approach.py:251) and would silently lose whatever
+        # preceded the reset -- see _setFsmDetails.
+        widget.newTestPulse(testPulse, clamp.testPulseHistory())
+
+    # Default (queued) connection deliberately: PatchPipetteState connects to
+    # this same signal with an explicit DirectConnection, which is correct for a
+    # state machine and wrong for a widget -- it would mutate the plot from the
+    # clamp's thread.
+    clamp.sigTestPulseFinished.connect(onTestPulse)
+    action_entry.set_details_widget(widget)
+
+    def teardown():
+        # A live connection from a device signal into a widget the panel has
+        # moved on from is the cross-module reference neither Autopatch's widget
+        # -tree teardown nor unbindOrchestrator reaches (design doc §4.5).
+        Qt.disconnect(clamp.sigTestPulseFinished, onTestPulse)
+
+    return teardown
+
+
 def _drive_fsm(
     ctx,
     name,
@@ -63,19 +149,31 @@ def _drive_fsm(
     entry_config=None,
     poll_interval=0.1,
     record=True,
+    record_events=True,
     record_full_test_pulses=True,
 ) -> str:
     """Drive the PatchPipette FSM from entry_state and return the terminal state
     it reaches. Abnormal states not in `terminals` raise (see raise_if_abnormal).
 
-    With `record` true, this action also retains a "test_pulse_history" details
+    With `record` true, this action retains a "test_pulse_history" details
     payload for Area 5 -- the test-pulse analysis observed during the drive, and
-    the pipette states it walked. `clean` passes false: there is nothing an
-    operator reads off a clean (design doc §4.5).
+    the pipette states it walked -- and mounts the live Rss plot. `clean` passes
+    false for both: there is nothing an operator reads off a clean (design doc
+    §4.5).
+
+    With `record` and `record_events` both true, this action also opens a
+    MultiPatchLogRecorder that writes the drive's events to disk; `record_events`
+    is the disk-side switch alone, so turning it off still leaves the Area 5
+    payload (and its plot) intact, just with an empty history.
     """
     with ctx.log_action(name) as action_entry:
         pip = ctx.pipette
         action_entry.set_status(f"driving FSM from {entry_state!r}")
+        # record_events gates the disk recorder alone -- record gates the whole
+        # Area 5 payload (and the live plot that shares its life), which is why
+        # `clean` (record=False) opens neither regardless of record_events.
+        recorder = _openRecorder(ctx, record_full_test_pulses) if record and record_events else None
+        teardownPlot = _openLivePlot(ctx, action_entry) if record else None
         last_state = entry_state
         # (timestamp, state) for the entry state and every change the poll loop
         # observes. Reading a failed patch is mostly "where did it stall", and
@@ -115,8 +213,17 @@ def _drive_fsm(
             # ActionLogEntry.set_details). And in a finally, so a stopped,
             # abandoned, or failed attempt retains its plot too, which is
             # exactly when an operator wants to read one.
+            if teardownPlot is not None:
+                teardownPlot()
+            if recorder is not None:
+                recorder.stop()
             if record:
-                _setFsmDetails(action_entry, entry_state, reached, transitions)
+                # recorder.stop() above must run first: the payload below names
+                # the log file, and the file has to be flushed and closed before
+                # anything is told where to find it.
+                _setFsmDetails(
+                    action_entry, entry_state, reached, transitions, recorder
+                )
 
 
 def patch(ctx, record_events: bool = True, record_full_test_pulses: bool = True, **entry_config) -> str:
@@ -125,9 +232,13 @@ def patch(ctx, record_events: bool = True, record_full_test_pulses: bool = True,
 
     `record_events` and `record_full_test_pulses` are this action's own options,
     consumed here and never forwarded to pip.setState; a protocol may expose
-    them to its author. See _drive_fsm for what they control. Neither disables
-    the Area 5 payload -- turning off the disk-side recording they will govern
-    is not a reason to lose the pane's plot; only `clean` opts out of that.
+    them to its author. `record_events=False` opens no MultiPatchLogRecorder for
+    this drive, so nothing is written to disk; `record_full_test_pulses=False`
+    forwards to the recorder that does open, so it captures test-pulse analysis
+    without the full waveform sidecar. Neither disables the Area 5 payload or its
+    live plot -- turning off the disk-side recording they will draw from is not
+    a reason to lose the pane; with no recorder the payload's history is simply
+    empty. Only `clean` opts out of the payload and plot entirely.
     """
     return _drive_fsm(
         ctx,
@@ -142,19 +253,32 @@ def patch(ctx, record_events: bool = True, record_full_test_pulses: bool = True,
         # profiles.
         {"whole cell", "bath", "broken", "fouled"},
         entry_config,
+        record_events=record_events,
         record_full_test_pulses=record_full_test_pulses,
     )
 
 
 def reseal(ctx, record_events: bool = True, record_full_test_pulses: bool = True, **entry_config) -> str:
     """Reseal from whole-cell toward an outside-out patch, else fall back to
-    whole cell."""
+    whole cell.
+
+    `record_events` and `record_full_test_pulses` are this action's own options,
+    consumed here and never forwarded to pip.setState; a protocol may expose
+    them to its author. `record_events=False` opens no MultiPatchLogRecorder for
+    this drive, so nothing is written to disk; `record_full_test_pulses=False`
+    forwards to the recorder that does open, so it captures test-pulse analysis
+    without the full waveform sidecar. Neither disables the Area 5 payload or its
+    live plot -- turning off the disk-side recording they will draw from is not
+    a reason to lose the pane; with no recorder the payload's history is simply
+    empty.
+    """
     return _drive_fsm(
         ctx,
         "Reseal",
         "reseal",
         {"outside out", "whole cell"},
         entry_config,
+        record_events=record_events,
         record_full_test_pulses=record_full_test_pulses,
     )
 

--- a/acq4/experiment/actions/fsm.py
+++ b/acq4/experiment/actions/fsm.py
@@ -158,8 +158,9 @@ def _drive_fsm(
     With `record` true, this action retains a "test_pulse_history" details
     payload for Area 5 -- the test-pulse analysis observed during the drive, and
     the pipette states it walked -- and mounts the live Rss plot. `clean` passes
-    false for both: there is nothing an operator reads off a clean (design doc
-    §4.5).
+    `record=False`, which short-circuits both regardless of record_events (clean
+    has no record_events parameter): there is nothing an operator reads off a
+    clean (design doc §4.5).
 
     With `record` and `record_events` both true, this action also opens a
     MultiPatchLogRecorder that writes the drive's events to disk; `record_events`
@@ -169,11 +170,12 @@ def _drive_fsm(
     with ctx.log_action(name) as action_entry:
         pip = ctx.pipette
         action_entry.set_status(f"driving FSM from {entry_state!r}")
-        # record_events gates the disk recorder alone -- record gates the whole
-        # Area 5 payload (and the live plot that shares its life), which is why
-        # `clean` (record=False) opens neither regardless of record_events.
-        recorder = _openRecorder(ctx, record_full_test_pulses) if record and record_events else None
-        teardownPlot = _openLivePlot(ctx, action_entry) if record else None
+        # Both initialised before the try so that if one opener succeeds and
+        # the other raises, the finally below still sees whichever one opened
+        # and tears it down -- otherwise a raise from the second opener would
+        # leak whatever the first one already opened.
+        recorder = None
+        teardownPlot = None
         last_state = entry_state
         # (timestamp, state) for the entry state and every change the poll loop
         # observes. Reading a failed patch is mostly "where did it stall", and
@@ -181,6 +183,21 @@ def _drive_fsm(
         transitions = [(time.time(), entry_state)]
         reached = None
         try:
+            # record_events gates the disk recorder alone -- record gates the
+            # whole Area 5 payload (and the live plot that shares its life),
+            # which is why `clean` (record=False) opens neither regardless of
+            # record_events.
+            recorder = _openRecorder(ctx, record_full_test_pulses) if record and record_events else None
+            if record:
+                try:
+                    teardownPlot = _openLivePlot(ctx, action_entry)
+                except Exception as exc:
+                    # A live plot is a display convenience layered on top of the
+                    # drive, not the drive itself -- mirrors _openRecorder's own
+                    # never-raises contract so a widget-construction failure
+                    # cannot fail a patch attempt. The recorder opened above, if
+                    # any, is still torn down by the finally below.
+                    ctx.log(f"could not start live plot: {exc}")
             # Fresh dict per call so no caller shares a mutable default.
             pip.setState(entry_state, **dict(entry_config or {}))
             while True:

--- a/acq4/experiment/actions/prompt.py
+++ b/acq4/experiment/actions/prompt.py
@@ -27,6 +27,11 @@ def prompt(ctx, message: str = "", title: str = "Prompt", choices=("OK",)) -> st
     with ctx.log_action("Operator Prompt") as action_entry:
         action_entry.set_status(message)
         ctx.log(message)
-        if _is_headless():
-            return labels[0]
-        return prompt_user(title, message, labels)
+        # Bound to a local rather than returned directly, so the choice can be
+        # retained for Area 5 before this entry finishes -- a payload set after
+        # the block exits has no timeline row to attach to (see set_details).
+        chosen = labels[0] if _is_headless() else prompt_user(title, message, labels)
+        action_entry.set_details(
+            "text", {"lines": [message, f"operator chose: {chosen}"]}
+        )
+        return chosen

--- a/acq4/experiment/actions/storage.py
+++ b/acq4/experiment/actions/storage.py
@@ -55,5 +55,7 @@ def new_data_dir(ctx, level: str = "Cell", set_current: bool = True):
     The protocol-facing wrapper around create_data_dir: same behaviour, plus the
     log_action entry that puts it in Area 5's timeline.
     """
-    with ctx.log_action("New Data Directory"):
-        return create_data_dir(ctx.manager, level=level, set_current=set_current)
+    with ctx.log_action("New Data Directory") as action_entry:
+        new_dir = create_data_dir(ctx.manager, level=level, set_current=set_current)
+        action_entry.set_details("text", {"lines": [f"created {new_dir.name()}"]})
+        return new_dir

--- a/acq4/experiment/log_entry.py
+++ b/acq4/experiment/log_entry.py
@@ -25,6 +25,10 @@ class ActionLogEntry:
         self.status: str = ""
         self.outcome: str | None = None
         self.details_widget: Any = None
+        # Retained counterpart to details_widget: a GUI-free description of what
+        # this action found, which outlives the action (see set_details).
+        self.details_kind: str | None = None
+        self.details_payload: Any = None
         # Populated by _finish() for an error outcome only, and never with the
         # exception itself -- see error_record.describe_exception. A finished
         # entry is retained for the session in CellPanel's per-cell stores, so
@@ -34,6 +38,7 @@ class ActionLogEntry:
         self.traceback_text: str | None = None
         self.on_status: Callable | None = None
         self.on_widget: Callable | None = None
+        self.on_details: Callable | None = None
         self.on_finish: Callable | None = None
 
     def set_status(self, message: str) -> None:
@@ -55,6 +60,34 @@ class ActionLogEntry:
         self.details_widget = widget
         if self.on_widget is not None:
             self.on_widget(self, widget)
+
+    def set_details(self, kind: str, payload) -> None:
+        """Hand the UI a retained description of what this action found, stored
+        and passed to on_details(entry, kind, payload).
+
+        The counterpart to set_details_widget(), and different from it in the one
+        way that matters: what is passed here *outlives the action*. CellPanel
+        keeps it for the rest of the session so the operator can re-read a
+        finished action's results, which is why `payload` must be plain data --
+        numpy arrays, strings, numbers, and dicts/lists of those -- and never a
+        Qt object, a Cell, an exception, or a file handle. What a payload holds
+        is what one action costs in memory for the rest of the run; see
+        error_record.describe_exception for the same rule applied to tracebacks.
+
+        `kind` selects how the UI renders the payload. An unrecognized kind
+        renders as plain text rather than raising.
+
+        **Must be called before this entry finishes.** CellPanel resolves an
+        entry to its timeline row through bookkeeping that the entry's finish
+        tears down, so a payload set afterwards has no row to attach to. Actions
+        satisfy this by calling from a try/finally *inside* the
+        `with ctx.log_action(...)` block, which runs before the context
+        manager's __exit__.
+        """
+        self.details_kind = kind
+        self.details_payload = payload
+        if self.on_details is not None:
+            self.on_details(self, kind, payload)
 
     def _finish(self, exc: BaseException | None) -> None:
         self.end_time = time.time()

--- a/acq4/experiment/tests/test_actions_device.py
+++ b/acq4/experiment/tests/test_actions_device.py
@@ -812,3 +812,28 @@ def test_run_task_retains_its_sweeps_even_when_the_sequence_raises(ctx, pip, mon
         run_task(ctx)
 
     assert details[0][1]["sweep_count"] == 1
+
+
+def test_run_task_decimation_reports_the_largest_factor_across_sweeps(ctx, pip, monkeypatch):
+    import numpy as np
+
+    clampName = pip.clampDevice.name()
+    module = FakeTaskRunnerModule({clampName: object()})
+    ctx.manager.modules["TaskRunner"] = module
+    monkeypatch.setattr(device_mod, "run_in_gui_thread", lambda fn, *a, **k: fn(*a, **k))
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+    short = np.linspace(0, 1, 100)
+    long = np.linspace(0, 1, 40000)
+    module.frames = [
+        _sequence_frame(clampName, short, short),
+        _sequence_frame(clampName, long, long),
+    ]
+
+    run_task(ctx)
+
+    assert details[0][1]["decimation"] == 10
+    assert details[0][1]["sweep_count"] == 2
+    assert len(details[0][1]["traces"]) == 2

--- a/acq4/experiment/tests/test_actions_device.py
+++ b/acq4/experiment/tests/test_actions_device.py
@@ -20,6 +20,7 @@ from acq4.experiment.actions.device import (
     load_preset,
 )
 from acq4.experiment.actions import device as device_mod
+from acq4.util import Qt
 
 # cellfie reaches acq4_automation twice at call time: for CellTrackingLost, and for
 # DEFORMATION_TOLERANCE by way of AutomationDebug.feature_tracking. That package is
@@ -159,15 +160,34 @@ class FakeManager:
         return self.modules[name]
 
 
-class FakeTaskRunnerModule:
+class FakeTaskRunnerModule(Qt.QObject):
+    sigNewFrame = Qt.Signal(object)
+
     def __init__(self, docks, period=1.0, totalParams=5):
+        super().__init__()
         self.docks = docks
         self.sequenceInfo = {"period": period, "totalParams": totalParams}
         self.run_calls = []
+        self.run_error = None
+        # Frames the run emits, standing in for the real module's per-sweep
+        # sigNewFrame; and the directory handle run_task reads the saved
+        # sequence's name off, mirroring TaskRunner.lastSequenceDir.
+        self.frames = []
+        self.lastSequenceDir = _FakeSequenceDir("protocol_000")
 
     def runSequence(self, store=True):
         self.run_calls.append(store)
-        return _Waitable()
+        for frame in self.frames:
+            self.sigNewFrame.emit(frame)
+        return _Waitable(self.run_error)
+
+
+class _FakeSequenceDir:
+    def __init__(self, name):
+        self._name = name
+
+    def shortName(self):
+        return self._name
 
 
 class _FakeObjectStack:
@@ -664,3 +684,131 @@ def test_cellfie_sets_no_payload_when_the_cell_is_lost(monkeypatch, tmp_path):
         cellfie(ctx)
 
     assert details == []
+
+
+# -- run_task: sweep retention -------------------------------------------
+
+
+class _FakeMetaArray:
+    """Stands in for a clamp device's task result: indexable by channel name,
+    with an xvals('Time') axis, the shape MultiClamp's task GUI reads."""
+
+    def __init__(self, times, primary):
+        self._times = times
+        self._primary = primary
+
+    def __getitem__(self, key):
+        assert key == "primary"
+        return self._primary
+
+    def xvals(self, axis):
+        assert axis == "Time"
+        return self._times
+
+
+def _sequence_frame(clampName, times, primary, params=None):
+    return {"result": {clampName: _FakeMetaArray(times, primary)}, "params": params or {}}
+
+
+def test_decimate_leaves_a_short_trace_alone():
+    import numpy as np
+
+    t = np.linspace(0, 1, 100)
+    times, values, factor = device_mod._decimate(t, t * 2.0, maxPoints=4000)
+
+    assert factor == 1
+    assert len(times) == 100
+    assert np.array_equal(values, t * 2.0)
+
+
+def test_decimate_reduces_a_long_trace_and_reports_the_factor():
+    import numpy as np
+
+    t = np.linspace(0, 1, 40000)
+    times, values, factor = device_mod._decimate(t, t, maxPoints=4000)
+
+    assert factor == 10
+    assert len(times) == len(values) == 4000
+
+
+def test_run_task_retains_each_sweep_as_a_task_results_payload(ctx, pip, monkeypatch):
+    import numpy as np
+
+    clampName = pip.clampDevice.name()
+    module = FakeTaskRunnerModule({clampName: object()})
+    ctx.manager.modules["TaskRunner"] = module
+    monkeypatch.setattr(device_mod, "run_in_gui_thread", lambda fn, *a, **k: fn(*a, **k))
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+    t = np.linspace(0, 1, 10)
+    module.frames = [
+        _sequence_frame(clampName, t, t * 1.0),
+        _sequence_frame(clampName, t, t * 2.0),
+    ]
+
+    run_task(ctx)
+
+    assert len(details) == 1
+    kind, payload = details[0]
+    assert kind == "task_results"
+    assert payload["sweep_count"] == 2
+    assert len(payload["traces"]) == 2
+    assert payload["decimation"] == 1
+    assert np.array_equal(payload["traces"][1][1], t * 2.0)
+
+
+def test_run_task_payload_names_the_sequence_directory(ctx, pip, monkeypatch):
+    clampName = pip.clampDevice.name()
+    module = FakeTaskRunnerModule({clampName: object()})
+    module.lastSequenceDir = _FakeSequenceDir("protocol_003")
+    ctx.manager.modules["TaskRunner"] = module
+    monkeypatch.setattr(device_mod, "run_in_gui_thread", lambda fn, *a, **k: fn(*a, **k))
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+    module.frames = []
+
+    run_task(ctx)
+
+    assert details[0][1]["sequence_dir"] == "protocol_003"
+
+
+def test_run_task_retains_nothing_but_still_reports_when_no_sweeps_arrive(ctx, pip, monkeypatch):
+    clampName = pip.clampDevice.name()
+    module = FakeTaskRunnerModule({clampName: object()})
+    ctx.manager.modules["TaskRunner"] = module
+    monkeypatch.setattr(device_mod, "run_in_gui_thread", lambda fn, *a, **k: fn(*a, **k))
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+    module.frames = []
+
+    run_task(ctx)
+
+    assert details[0][1]["sweep_count"] == 0
+    assert details[0][1]["traces"] == []
+
+
+def test_run_task_retains_its_sweeps_even_when_the_sequence_raises(ctx, pip, monkeypatch):
+    import numpy as np
+
+    clampName = pip.clampDevice.name()
+    module = FakeTaskRunnerModule({clampName: object()})
+    module.run_error = RuntimeError("amplifier fell over")
+    ctx.manager.modules["TaskRunner"] = module
+    monkeypatch.setattr(device_mod, "run_in_gui_thread", lambda fn, *a, **k: fn(*a, **k))
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+    t = np.linspace(0, 1, 10)
+    module.frames = [_sequence_frame(clampName, t, t)]
+
+    with pytest.raises(RuntimeError):
+        run_task(ctx)
+
+    assert details[0][1]["sweep_count"] == 1

--- a/acq4/experiment/tests/test_actions_device.py
+++ b/acq4/experiment/tests/test_actions_device.py
@@ -866,3 +866,59 @@ def test_find_surface_retains_nothing_when_detection_fails(ctx, pip):
         find_surface(ctx)
 
     assert details == []
+
+
+# -- run_task: thread affinity ----------------------------------------------
+
+
+def test_run_task_collects_sweeps_when_driven_from_a_worker_thread(qapp, qtbot, pip):
+    """run_task runs on the orchestrator's worker thread -- a gentletask
+    ThreadTask with no Qt event loop -- while TaskRunner.sigNewFrame is emitted
+    on the GUI thread. PyQt gives a plain callable slot the affinity of the
+    thread that called connect(), so the subscription has to be established on
+    the GUI thread; made from the worker, every frame would be queued to a loop
+    that never runs and the payload would report no sweeps at all.
+
+    Genuinely cross-thread on purpose: driven from a worker while this (GUI)
+    thread pumps and emits. run_in_gui_thread is deliberately left unpatched.
+    """
+    import threading
+
+    import numpy as np
+
+    clampName = pip.clampDevice.name()
+    module = FakeTaskRunnerModule({clampName: object()})
+    ctx = ExecutionContext(pipette=pip, manager=FakeManager(), cell=FakeCell())
+    ctx.manager.modules["TaskRunner"] = module
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+    t = np.linspace(0, 1, 10)
+    module.frames = [
+        _sequence_frame(clampName, t, t * 1.0),
+        _sequence_frame(clampName, t, t * 2.0),
+    ]
+    done = threading.Event()
+    ranOn = {}
+
+    def runOnWorker():
+        try:
+            ranOn["thread"] = Qt.QtCore.QThread.currentThread()
+            run_task(ctx, store=False)
+        finally:
+            done.set()
+
+    worker = threading.Thread(target=runOnWorker, name="run-task-driver")
+    worker.start()
+    # This thread has to keep pumping: run_task marshals both its subscription
+    # and runSequence itself here through run_in_gui_thread.
+    qtbot.waitUntil(done.is_set, timeout=5000)
+    worker.join(5)
+
+    assert ranOn["thread"] is not Qt.QtCore.QThread.currentThread()
+    assert len(details) == 1
+    kind, payload = details[0]
+    assert kind == "task_results"
+    assert payload["sweep_count"] == 2
+    assert np.array_equal(payload["traces"][1][1], t * 2.0)

--- a/acq4/experiment/tests/test_actions_device.py
+++ b/acq4/experiment/tests/test_actions_device.py
@@ -753,7 +753,6 @@ def test_run_task_retains_each_sweep_as_a_task_results_payload(ctx, pip, monkeyp
     assert len(details) == 1
     kind, payload = details[0]
     assert kind == "task_results"
-    assert payload["sweep_count"] == 2
     assert len(payload["traces"]) == 2
     assert payload["decimation"] == 1
     assert np.array_equal(payload["traces"][1][1], t * 2.0)
@@ -789,7 +788,6 @@ def test_run_task_retains_nothing_but_still_reports_when_no_sweeps_arrive(ctx, p
 
     run_task(ctx)
 
-    assert details[0][1]["sweep_count"] == 0
     assert details[0][1]["traces"] == []
 
 
@@ -811,7 +809,7 @@ def test_run_task_retains_its_sweeps_even_when_the_sequence_raises(ctx, pip, mon
     with pytest.raises(RuntimeError):
         run_task(ctx)
 
-    assert details[0][1]["sweep_count"] == 1
+    assert len(details[0][1]["traces"]) == 1
 
 
 def test_run_task_decimation_reports_the_largest_factor_across_sweeps(ctx, pip, monkeypatch):
@@ -835,7 +833,6 @@ def test_run_task_decimation_reports_the_largest_factor_across_sweeps(ctx, pip, 
     run_task(ctx)
 
     assert details[0][1]["decimation"] == 10
-    assert details[0][1]["sweep_count"] == 2
     assert len(details[0][1]["traces"]) == 2
 
 
@@ -920,5 +917,5 @@ def test_run_task_collects_sweeps_when_driven_from_a_worker_thread(qapp, qtbot, 
     assert len(details) == 1
     kind, payload = details[0]
     assert kind == "task_results"
-    assert payload["sweep_count"] == 2
+    assert len(payload["traces"]) == 2
     assert np.array_equal(payload["traces"][1][1], t * 2.0)

--- a/acq4/experiment/tests/test_actions_device.py
+++ b/acq4/experiment/tests/test_actions_device.py
@@ -170,11 +170,30 @@ class FakeTaskRunnerModule:
         return _Waitable()
 
 
+class _FakeObjectStack:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeMotionEstimator:
+    def __init__(self, data):
+        self.original_object_stack = _FakeObjectStack(data)
+
+
+class _FakeTracker:
+    """Stands in for the acq4_automation tracker cellfie initializes: exposes
+    the one attribute chain the details payload reads."""
+
+    def __init__(self, data):
+        self.motion_estimator = _FakeMotionEstimator(data)
+
+
 class FakeCell:
     def __init__(self):
         self.tracker_calls = []
         self.tracker_kwargs = []
         self.tracker_error = None
+        self.tracker_stack = None
 
     def initializeTracker(self, imager, use_cellpose=False, **tracker_kwargs):
         # Mirror Cell.initializeTracker's **tracker_kwargs passthrough so callers can
@@ -185,6 +204,8 @@ class FakeCell:
         self.tracker_kwargs.append(tracker_kwargs)
         if self.tracker_error is not None:
             raise self.tracker_error
+        if self.tracker_stack is not None:
+            self._tracker = _FakeTracker(self.tracker_stack)
 
 
 @pytest.fixture
@@ -566,3 +587,86 @@ def test_load_preset_unknown_name_with_no_presets_configured_reads_sensibly(ctx,
     # No dangling "(available: )" -- say plainly that nothing is configured.
     assert "available:" not in message
     assert "no presets are configured" in message
+
+
+def test_cellfie_retains_the_trackers_stack_as_an_image_stack_payload(ctx, pip, monkeypatch):
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
+    import numpy as np
+
+    monkeypatch.setattr(device_mod, "run_image_sequence", lambda *a, **k: _Waitable())
+    ctx.cell.tracker_stack = np.arange(5 * 4 * 3, dtype=float).reshape(5, 4, 3)
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    cellfie(ctx)
+
+    assert len(details) == 1
+    kind, payload = details[0]
+    assert kind == "image_stack"
+    # Rows/cols swapped so it displays in the same orientation as the Camera
+    # module, matching AutomationDebug's own cell stack view.
+    assert payload["stack"].shape == (5, 3, 4)
+    assert payload["center_index"] == 2
+    assert payload["title"] == "Cellfie"
+
+
+def test_cellfie_center_index_is_none_for_a_single_frame_stack(ctx, pip, monkeypatch):
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
+    import numpy as np
+
+    monkeypatch.setattr(device_mod, "run_image_sequence", lambda *a, **k: _Waitable())
+    ctx.cell.tracker_stack = np.zeros((1, 4, 3))
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    cellfie(ctx)
+
+    assert details[0][1]["center_index"] is None
+
+
+def test_cellfie_sets_no_payload_when_the_tracker_exposes_no_stack(ctx, pip, monkeypatch):
+    # A cell whose tracker did not expose a stack must not make cellfie raise
+    # out of the orchestrator's worker thread over a display concern.
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
+    monkeypatch.setattr(device_mod, "run_image_sequence", lambda *a, **k: _Waitable())
+    ctx.cell.tracker_stack = None
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    cellfie(ctx)
+
+    assert details == []
+
+
+def test_cellfie_sets_no_payload_when_the_cell_is_lost(monkeypatch, tmp_path):
+    # tissue_moved never returns, so there is nothing to retain -- the accepted
+    # gap in the spec's §8.
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
+    from acq4_automation.feature_tracking import CellTrackingLost
+
+    monkeypatch.setattr(device_mod, "run_image_sequence", lambda *a, **k: _Waitable())
+    cell = FakeCell()
+    cell.tracker_error = CellTrackingLost("gone")
+    details = []
+
+    def hook(action_entry):
+        action_entry.on_details = lambda e, kind, payload: details.append(kind)
+
+    ctx = ExecutionContext(
+        cell=cell,
+        pipette=FakePipette(),
+        manager=FakeManager(),
+        tissue_moved_hook=lambda c, reason: (_ for _ in ()).throw(AdvanceToNextCell(reason)),
+    )
+    ctx.on_log_action = hook
+
+    with pytest.raises(AdvanceToNextCell):
+        cellfie(ctx)
+
+    assert details == []

--- a/acq4/experiment/tests/test_actions_device.py
+++ b/acq4/experiment/tests/test_actions_device.py
@@ -650,21 +650,15 @@ def test_cellfie_sets_no_payload_when_the_cell_is_lost(monkeypatch, tmp_path):
     pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
     from acq4_automation.feature_tracking import CellTrackingLost
 
-    monkeypatch.setattr(device_mod, "run_image_sequence", lambda *a, **k: _Waitable())
-    cell = FakeCell()
-    cell.tracker_error = CellTrackingLost("gone")
+    def hook(c, reason):
+        raise AdvanceToNextCell(reason)
+
+    ctx = _cellfie_context(monkeypatch, tmp_path, tissue_moved_hook=hook)
+    ctx.cell.tracker_error = CellTrackingLost("gone")
     details = []
-
-    def hook(action_entry):
-        action_entry.on_details = lambda e, kind, payload: details.append(kind)
-
-    ctx = ExecutionContext(
-        cell=cell,
-        pipette=FakePipette(),
-        manager=FakeManager(),
-        tissue_moved_hook=lambda c, reason: (_ for _ in ()).throw(AdvanceToNextCell(reason)),
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
     )
-    ctx.on_log_action = hook
 
     with pytest.raises(AdvanceToNextCell):
         cellfie(ctx)

--- a/acq4/experiment/tests/test_actions_device.py
+++ b/acq4/experiment/tests/test_actions_device.py
@@ -837,3 +837,32 @@ def test_run_task_decimation_reports_the_largest_factor_across_sweeps(ctx, pip, 
     assert details[0][1]["decimation"] == 10
     assert details[0][1]["sweep_count"] == 2
     assert len(details[0][1]["traces"]) == 2
+
+
+def test_find_surface_retains_the_detected_depth(ctx, pip):
+    pip.scope.depth = -1.2e-3
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    depth = find_surface(ctx)
+
+    assert depth == -1.2e-3
+    kind, payload = details[0]
+    assert kind == "text"
+    assert "surface" in payload["lines"][0]
+    assert "1.2 mm" in payload["lines"][0]
+
+
+def test_find_surface_retains_nothing_when_detection_fails(ctx, pip):
+    pip.scope.error = ValueError("no surface found")
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    with pytest.raises(OrchestrationError):
+        find_surface(ctx)
+
+    assert details == []

--- a/acq4/experiment/tests/test_actions_fsm.py
+++ b/acq4/experiment/tests/test_actions_fsm.py
@@ -2,6 +2,7 @@
 PatchPipette FSM to a declared terminal state via the shared fake pipette."""
 import pytest
 
+from acq4.util import Qt
 from acq4.util.task import Stopped
 from acq4.experiment.context import ExecutionContext
 from acq4.experiment.exceptions import AdvanceToNextCell, BrokenPipette, Fouled
@@ -719,3 +720,203 @@ def test_a_recorder_already_opened_is_stopped_even_if_the_live_plot_fails(
 
     assert fake_recorder.instances[0].stopped is True
     assert any("no display available" in message for message in logged)
+
+
+# -- the live plot's thread affinity ------------------------------------------
+
+
+class _FakeClamp(Qt.QObject):
+    """Stands in for a PatchClamp for the live plot's two needs: the
+    sigTestPulseFinished stream and the history behind it."""
+
+    sigTestPulseFinished = Qt.Signal(object, object)  # self, PatchClampTestPulse
+
+    def __init__(self, history):
+        super().__init__()
+        self._history = history
+
+    def testPulseHistory(self):
+        return self._history
+
+
+class _FakeTestPulse:
+    """A test pulse for the analysis modes, which read only .analysis."""
+
+    def __init__(self, resistance):
+        self.analysis = {"steady_state_resistance": resistance}
+
+
+class _FakeClampedPipette:
+    def __init__(self, clamp):
+        self.clampDevice = clamp
+
+
+class _RecordingEntry:
+    """Stands in for an ActionLogEntry for the one call _openLivePlot makes."""
+
+    def __init__(self, error=None):
+        self.widgets = []
+        self.error = error
+
+    def set_details_widget(self, widget):
+        self.widgets.append(widget)
+        if self.error is not None:
+            raise self.error
+
+
+def _tpHistory(count=4):
+    import numpy as np
+
+    from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
+
+    history = np.zeros(count, dtype=TEST_PULSE_NUMPY_DTYPE)
+    history["event_time"] = np.arange(count, dtype=float)
+    history["steady_state_resistance"] = np.linspace(1e6, 1e9, count)
+    return history
+
+
+def test_the_live_plot_updates_from_a_test_pulse_emitted_on_another_thread(qapp, qtbot):
+    """_openLivePlot runs on the orchestrator's worker thread -- a gentletask
+    ThreadTask with no Qt event loop -- while sigTestPulseFinished is emitted
+    from the clamp's test-pulse thread. PyQt gives a plain callable slot the
+    affinity of the thread that called connect(), so the connection has to be
+    made on the GUI thread or every test pulse is queued to a loop that never
+    runs and the plot mounts but never updates.
+
+    Genuinely cross-thread on purpose: opened on one thread, emitted from a
+    second, pumped on this one. A same-thread version passes either way.
+    """
+    import threading
+
+    clamp = _FakeClamp(_tpHistory())
+    ctx = _ctx(_FakeClampedPipette(clamp))
+    entry = _RecordingEntry()
+    opened = {}
+    ready = threading.Event()
+    release = threading.Event()
+
+    def openOnWorker():
+        opened["teardown"] = fsm_mod._openLivePlot(ctx, entry)
+        opened["thread"] = Qt.QtCore.QThread.currentThread()
+        ready.set()
+        # Held open without an event loop for the rest of the test, the shape
+        # of a real drive.
+        release.wait(10)
+
+    worker = threading.Thread(target=openOnWorker, name="live-plot-opener")
+    worker.start()
+    # This thread has to keep pumping: _openLivePlot builds its widget through
+    # run_in_gui_thread, which blocks the worker until this loop runs it.
+    qtbot.waitUntil(ready.is_set, timeout=5000)
+    assert opened["thread"] is not Qt.QtCore.QThread.currentThread()
+    widget = entry.widgets[0]
+    assert widget.plot.plotItem.listDataItems() == []
+
+    emitter = threading.Thread(
+        target=lambda: clamp.sigTestPulseFinished.emit(clamp, _FakeTestPulse(1e9)),
+        name="clamp-emitter",
+    )
+    emitter.start()
+    emitter.join(5)
+
+    try:
+        qtbot.waitUntil(
+            lambda: len(widget.plot.plotItem.listDataItems()) == 1, timeout=3000
+        )
+    finally:
+        release.set()
+        worker.join(5)
+        opened["teardown"]()
+
+
+def test_the_live_plot_disconnects_when_mounting_the_widget_fails(qapp):
+    # The connect is live before set_details_widget is called; if that raises,
+    # the caller never receives the teardown, so nothing else would ever drop
+    # the clamp's reference into a widget nobody owns.
+    clamp = _FakeClamp(_tpHistory())
+    ctx = _ctx(_FakeClampedPipette(clamp))
+    entry = _RecordingEntry(error=RuntimeError("no pane to mount into"))
+
+    with pytest.raises(RuntimeError, match="no pane to mount into"):
+        fsm_mod._openLivePlot(ctx, entry)
+
+    widget = entry.widgets[0]
+    clamp.sigTestPulseFinished.emit(clamp, _FakeTestPulse(1e9))
+
+    assert widget.plot.plotItem.listDataItems() == []
+
+
+# -- the finally is guarded ---------------------------------------------------
+
+
+def test_a_failing_plot_teardown_still_stops_the_recorder_and_retains_details(
+    fake_pip_factory, monkeypatch, fake_recorder
+):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+
+    def openPlot(ctx, entry):
+        def teardown():
+            raise RuntimeError("plot teardown exploded")
+
+        return teardown
+
+    monkeypatch.setattr(fsm_mod, "_openLivePlot", openPlot)
+    pip = fake_pip_factory(["whole cell"])
+    ctx = _ctx(pip, manager=_FakeManagerWithDir())
+    logged = []
+    ctx.log = logged.append
+    seen = _details(ctx)
+
+    assert patch(ctx) == "whole cell"
+
+    assert fake_recorder.instances[0].stopped is True
+    assert len(seen) == 1
+    assert any("plot teardown exploded" in message for message in logged)
+
+
+def test_a_failing_recorder_stop_still_retains_details(
+    fake_pip_factory, monkeypatch, fake_recorder
+):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+
+    def boom(self):
+        raise OSError("disk full on close")
+
+    monkeypatch.setattr(_FakeRecorder, "stop", boom)
+    pip = fake_pip_factory(["whole cell"])
+    ctx = _ctx(pip, manager=_FakeManagerWithDir())
+    logged = []
+    ctx.log = logged.append
+    seen = _details(ctx)
+
+    assert patch(ctx) == "whole cell"
+
+    assert len(seen) == 1
+    assert any("disk full on close" in message for message in logged)
+
+
+def test_a_failing_details_payload_does_not_replace_a_stop(
+    fake_pip_factory, monkeypatch, fake_recorder
+):
+    # An orderly operator stop must surface as Stopped, not as whatever the
+    # payload builder happened to trip over on the way out.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+
+    def boom(*a, **k):
+        raise ValueError("payload exploded")
+
+    monkeypatch.setattr(fsm_mod, "_setFsmDetails", boom)
+    pip = fake_pip_factory([])
+    ctx = _ctx(pip, manager=_FakeManagerWithDir())
+    logged = []
+    ctx.log = logged.append
+    monkeypatch.setattr(fsm_mod, "check_stop", _raiseStopped)
+
+    with pytest.raises(Stopped):
+        patch(ctx)
+
+    assert any("payload exploded" in message for message in logged)
+
+
+def _raiseStopped():
+    raise Stopped("operator stop")

--- a/acq4/experiment/tests/test_actions_fsm.py
+++ b/acq4/experiment/tests/test_actions_fsm.py
@@ -518,3 +518,179 @@ def test_record_kwargs_do_not_reach_set_state(fake_pip_factory, monkeypatch):
 
     _state, config = pip.setState_calls[0]
     assert config == {"autoBreakInDelay": 2.0}
+
+
+def test_advance_to_next_cell_still_retains_its_payload(fake_pip_factory, monkeypatch):
+    # AdvanceToNextCell shares _drive_fsm's finally with Stopped -- covered
+    # separately here since a shared code path can still silently regress on
+    # only one of its callers.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory([])
+    ctx = _ctx(pip, next_cell_requested=lambda: True)
+    seen = _details(ctx)
+
+    with pytest.raises(AdvanceToNextCell):
+        patch(ctx)
+
+    assert len(seen) == 1
+    assert seen[0][1]["reached"] is None
+
+
+# -- the recorder and the live plot -----------------------------------------
+
+
+class _FakeRecorder:
+    instances = []
+
+    def __init__(self, directory, pipettes=(), record_full_test_pulses=True):
+        import numpy as np
+        from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
+
+        self.directory = directory
+        self.pipettes = list(pipettes)
+        self.record_full_test_pulses = record_full_test_pulses
+        self.stopped = False
+        self._history = np.zeros(3, dtype=TEST_PULSE_NUMPY_DTYPE)
+        self._history["steady_state_resistance"] = [1e6, 1e8, 1e9]
+        _FakeRecorder.instances.append(self)
+
+    def testPulseAnalysis(self):
+        return self._history
+
+    def logFileName(self):
+        return "/data/cell_000/MultiPatch_004.log"
+
+    def stop(self):
+        self.stopped = True
+
+
+class _FakeDir:
+    pass
+
+
+class _FakeManagerWithDir:
+    def __init__(self):
+        self.dir = _FakeDir()
+
+    def getCurrentDir(self):
+        return self.dir
+
+
+@pytest.fixture
+def fake_recorder(monkeypatch):
+    _FakeRecorder.instances = []
+    monkeypatch.setattr(fsm_mod, "MultiPatchLogRecorder", _FakeRecorder)
+    # The live plot needs a real Qt widget and a real clamp device; those are
+    # live-tested, so this suite stubs the plot out entirely.
+    monkeypatch.setattr(fsm_mod, "_openLivePlot", lambda ctx, entry: None)
+    return _FakeRecorder
+
+
+def test_patch_opens_a_recorder_in_the_current_directory(fake_pip_factory, monkeypatch, fake_recorder):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+    manager = _FakeManagerWithDir()
+
+    patch(_ctx(pip, manager=manager))
+
+    assert len(fake_recorder.instances) == 1
+    recorder = fake_recorder.instances[0]
+    assert recorder.directory is manager.dir
+    assert recorder.pipettes == [pip]
+    assert recorder.record_full_test_pulses is True
+
+
+def test_the_recorder_is_stopped_when_the_drive_ends(fake_pip_factory, monkeypatch, fake_recorder):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+
+    patch(_ctx(pip, manager=_FakeManagerWithDir()))
+
+    assert fake_recorder.instances[0].stopped is True
+
+
+def test_the_recorder_is_stopped_even_when_the_drive_raises(fake_pip_factory, monkeypatch, fake_recorder):
+    # An unclosed file handle per failed patch attempt is a leak, not a nuisance.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["broken"])
+
+    with pytest.raises(BrokenPipette):
+        reseal(_ctx(pip, manager=_FakeManagerWithDir()))
+
+    assert fake_recorder.instances[0].stopped is True
+
+
+def test_the_payload_carries_the_recorders_history(fake_pip_factory, monkeypatch, fake_recorder):
+    import numpy as np
+
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+    ctx = _ctx(pip, manager=_FakeManagerWithDir())
+    seen = _details(ctx)
+
+    patch(ctx)
+
+    history = seen[0][1]["history"]
+    assert len(history) == 3
+    assert np.array_equal(history["steady_state_resistance"], [1e6, 1e8, 1e9])
+
+
+def test_the_payload_names_the_log_file_without_its_path(fake_pip_factory, monkeypatch, fake_recorder):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+    ctx = _ctx(pip, manager=_FakeManagerWithDir())
+    seen = _details(ctx)
+
+    patch(ctx)
+
+    assert seen[0][1]["log_file"] == "MultiPatch_004.log"
+
+
+def test_record_full_test_pulses_is_forwarded(fake_pip_factory, monkeypatch, fake_recorder):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+
+    patch(_ctx(pip, manager=_FakeManagerWithDir()), record_full_test_pulses=False)
+
+    assert fake_recorder.instances[0].record_full_test_pulses is False
+
+
+def test_record_events_false_opens_no_recorder(fake_pip_factory, monkeypatch, fake_recorder):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+
+    patch(_ctx(pip, manager=_FakeManagerWithDir()), record_events=False)
+
+    assert fake_recorder.instances == []
+
+
+def test_clean_opens_no_recorder(fake_pip_factory, monkeypatch, fake_recorder):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["out"])
+
+    clean(_ctx(pip, manager=_FakeManagerWithDir()))
+
+    assert fake_recorder.instances == []
+
+
+def test_a_recorder_that_will_not_open_does_not_fail_the_patch(fake_pip_factory, monkeypatch):
+    # An unset storage directory must not stop the pipette from patching; the
+    # attempt is the experiment, and the log is a record of it.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(fsm_mod, "_openLivePlot", lambda ctx, entry: None)
+
+    def boom(*a, **k):
+        raise OSError("no current directory")
+
+    monkeypatch.setattr(fsm_mod, "MultiPatchLogRecorder", boom)
+    pip = fake_pip_factory(["whole cell"])
+    ctx = _ctx(pip, manager=_FakeManagerWithDir())
+    logged = []
+    ctx.log = logged.append
+    seen = _details(ctx)
+
+    assert patch(ctx) == "whole cell"
+
+    assert any("no current directory" in message for message in logged)
+    assert len(seen) == 1  # still retains the transitions, with an empty history
+    assert len(seen[0][1]["history"]) == 0

--- a/acq4/experiment/tests/test_actions_fsm.py
+++ b/acq4/experiment/tests/test_actions_fsm.py
@@ -805,28 +805,34 @@ def test_the_live_plot_updates_from_a_test_pulse_emitted_on_another_thread(qapp,
 
     worker = threading.Thread(target=openOnWorker, name="live-plot-opener")
     worker.start()
-    # This thread has to keep pumping: _openLivePlot builds its widget through
-    # run_in_gui_thread, which blocks the worker until this loop runs it.
-    qtbot.waitUntil(ready.is_set, timeout=5000)
-    assert opened["thread"] is not Qt.QtCore.QThread.currentThread()
-    widget = entry.widgets[0]
-    assert widget.plot.plotItem.listDataItems() == []
-
-    emitter = threading.Thread(
-        target=lambda: clamp.sigTestPulseFinished.emit(clamp, _FakeTestPulse(1e9)),
-        name="clamp-emitter",
-    )
-    emitter.start()
-    emitter.join(5)
-
+    # From here down, everything runs under try/finally: worker sits in
+    # release.wait(10) until release.set() below, so a failed assertion above
+    # a bare `qtbot.waitUntil(ready.is_set, ...)` would otherwise leave that
+    # non-daemon thread parked for up to 10s past this test's own failure.
     try:
+        # This thread has to keep pumping: _openLivePlot builds its widget
+        # through run_in_gui_thread, which blocks the worker until this loop
+        # runs it.
+        qtbot.waitUntil(ready.is_set, timeout=5000)
+        assert opened["thread"] is not Qt.QtCore.QThread.currentThread()
+        widget = entry.widgets[0]
+        assert widget.plot.plotItem.listDataItems() == []
+
+        emitter = threading.Thread(
+            target=lambda: clamp.sigTestPulseFinished.emit(clamp, _FakeTestPulse(1e9)),
+            name="clamp-emitter",
+        )
+        emitter.start()
+        emitter.join(5)
+
         qtbot.waitUntil(
             lambda: len(widget.plot.plotItem.listDataItems()) == 1, timeout=3000
         )
     finally:
         release.set()
         worker.join(5)
-        opened["teardown"]()
+        if "teardown" in opened:
+            opened["teardown"]()
 
 
 def test_the_live_plot_disconnects_when_mounting_the_widget_fails(qapp):

--- a/acq4/experiment/tests/test_actions_fsm.py
+++ b/acq4/experiment/tests/test_actions_fsm.py
@@ -364,3 +364,157 @@ def test_fake_pipette_with_no_declared_sequence_repeats_forever(fake_pip_factory
     pip = fake_pip_factory([])
     for _ in range(5):
         assert pip.getState().stateName == "out"
+
+
+# -- details payloads -------------------------------------------------------
+
+
+def _details(ctx):
+    """Collect (kind, payload) from every entry this context opens."""
+    seen = []
+
+    def hook(action_entry):
+        action_entry.on_details = lambda e, kind, payload: seen.append((kind, payload))
+
+    ctx.on_log_action = hook
+    return seen
+
+
+def test_patch_retains_a_test_pulse_history_payload(fake_pip_factory, monkeypatch):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["cell detect", "seal", "whole cell"])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    patch(ctx)
+
+    assert len(seen) == 1
+    kind, payload = seen[0]
+    assert kind == "test_pulse_history"
+    assert payload["entry_state"] == "approach"
+    assert payload["reached"] == "whole cell"
+
+
+def test_the_payload_lists_every_state_the_fsm_walked(fake_pip_factory, monkeypatch):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["cell detect", "seal", "cell attached", "break in", "whole cell"])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    patch(ctx)
+
+    states = [state for _when, state in seen[0][1]["transitions"]]
+    # The entry state first, then each change the poll loop observed --
+    # including the internal hops the drive continues through.
+    assert states == [
+        "approach",
+        "cell detect",
+        "seal",
+        "cell attached",
+        "break in",
+        "whole cell",
+    ]
+
+
+def test_transitions_carry_a_timestamp(fake_pip_factory, monkeypatch):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["seal", "whole cell"])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    patch(ctx)
+
+    times = [when for when, _state in seen[0][1]["transitions"]]
+    assert times == sorted(times)
+    assert all(isinstance(t, float) for t in times)
+
+
+def test_the_payload_arrives_before_the_entry_finishes(fake_pip_factory, monkeypatch):
+    # CellPanel resolves the payload to a timeline row through bookkeeping the
+    # entry's finish tears down.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+    ctx = _ctx(pip)
+    order = []
+
+    def hook(action_entry):
+        action_entry.on_details = lambda e, k, p: order.append("details")
+        action_entry.on_finish = lambda e: order.append("finish")
+
+    ctx.on_log_action = hook
+
+    patch(ctx)
+
+    assert order == ["details", "finish"]
+
+
+def test_a_stopped_patch_still_retains_its_payload(fake_pip_factory, monkeypatch):
+    # An interrupted attempt is exactly when an operator wants the plot.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(
+        fsm_mod, "check_stop", lambda *a, **k: (_ for _ in ()).throw(Stopped("stop"))
+    )
+    pip = fake_pip_factory([])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    with pytest.raises(Stopped):
+        patch(ctx)
+
+    assert len(seen) == 1
+    assert seen[0][1]["reached"] is None
+
+
+def test_a_failed_patch_still_retains_its_payload(fake_pip_factory, monkeypatch):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["cell detect", "broken"])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    with pytest.raises(BrokenPipette):
+        reseal(ctx)
+
+    assert len(seen) == 1
+    assert seen[0][1]["reached"] is None
+    assert "broken" in [state for _when, state in seen[0][1]["transitions"]]
+
+
+def test_clean_retains_nothing(fake_pip_factory, monkeypatch):
+    # There is nothing an operator reads off a clean (design doc §4.5).
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["out"])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    clean(ctx)
+
+    assert seen == []
+
+
+def test_record_events_false_still_retains_the_payload(fake_pip_factory, monkeypatch):
+    # Switching off the disk log is not a reason to lose the pane's plot.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    patch(ctx, record_events=False)
+
+    assert len(seen) == 1
+
+
+def test_record_kwargs_do_not_reach_set_state(fake_pip_factory, monkeypatch):
+    # entry_config is forwarded to pip.setState; these two are this action's own
+    # options and must not be.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+
+    patch(
+        _ctx(pip),
+        record_events=False,
+        record_full_test_pulses=False,
+        autoBreakInDelay=2.0,
+    )
+
+    _state, config = pip.setState_calls[0]
+    assert config == {"autoBreakInDelay": 2.0}

--- a/acq4/experiment/tests/test_actions_fsm.py
+++ b/acq4/experiment/tests/test_actions_fsm.py
@@ -694,3 +694,28 @@ def test_a_recorder_that_will_not_open_does_not_fail_the_patch(fake_pip_factory,
     assert any("no current directory" in message for message in logged)
     assert len(seen) == 1  # still retains the transitions, with an empty history
     assert len(seen[0][1]["history"]) == 0
+
+
+def test_a_recorder_already_opened_is_stopped_even_if_the_live_plot_fails(
+    fake_pip_factory, monkeypatch, fake_recorder
+):
+    # If _openLivePlot raises after _openRecorder has already succeeded, the
+    # recorder must still be torn down -- an unclosed log file handle per
+    # failed plot mount is a leak, not a nuisance. A widget-construction
+    # failure is a display problem, not a reason to fail the patch attempt
+    # itself, so it is logged and the drive continues with no plot.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+
+    def boom(ctx, entry):
+        raise RuntimeError("no display available")
+
+    monkeypatch.setattr(fsm_mod, "_openLivePlot", boom)
+    pip = fake_pip_factory(["whole cell"])
+    ctx = _ctx(pip, manager=_FakeManagerWithDir())
+    logged = []
+    ctx.log = logged.append
+
+    assert patch(ctx) == "whole cell"
+
+    assert fake_recorder.instances[0].stopped is True
+    assert any("no display available" in message for message in logged)

--- a/acq4/experiment/tests/test_actions_prompt_storage.py
+++ b/acq4/experiment/tests/test_actions_prompt_storage.py
@@ -298,3 +298,83 @@ def test_new_data_dir_still_behaves_identically_through_the_wrapper(root_dir):
 
     assert created.info()["dirType"] == "Slice"
     assert [e.name for e in entries] == ["New Data Directory"]
+
+
+def test_prompt_retains_the_message_and_the_clicked_label(monkeypatch):
+    monkeypatch.setattr(prompt_mod, "_is_headless", lambda: False)
+    monkeypatch.setattr(prompt_mod, "prompt_user", lambda title, message, labels: "Retry")
+    ctx = ExecutionContext()
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    assert prompt(ctx, message="Replace the pipette", choices=("Retry", "Skip")) == "Retry"
+
+    assert details == [
+        ("text", {"lines": ["Replace the pipette", "operator chose: Retry"]})
+    ]
+
+
+def test_prompt_retains_the_default_choice_when_headless(monkeypatch):
+    monkeypatch.setattr(prompt_mod, "_is_headless", lambda: True)
+    ctx = ExecutionContext()
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    prompt(ctx, message="carry on", choices=("OK", "Cancel"))
+
+    assert details[0][1]["lines"][1] == "operator chose: OK"
+
+
+def test_new_data_dir_retains_the_directory_it_created():
+    from acq4.experiment.actions.storage import new_data_dir
+    from acq4.experiment.context import ExecutionContext
+
+    class _Dir:
+        def __init__(self, name):
+            self._name = name
+
+        def name(self):
+            return self._name
+
+        def isManaged(self):
+            return True
+
+        def info(self):
+            return {"dirType": "Slice"}
+
+        def mkdir(self, name, autoIncrement=False, info=None):
+            return _Dir(f"/data/{name}")
+
+        def parent(self):
+            return self
+
+        def setInfo(self, info):
+            return None
+
+    class _Manager:
+        def __init__(self):
+            self.current = _Dir("/data/slice_000")
+            self.set_calls = []
+
+        def getCurrentDir(self):
+            return self.current
+
+        def folderTypesConfig(self):
+            return {"Cell": {"name": "cell_000"}}
+
+        def setCurrentDir(self, d):
+            self.set_calls.append(d)
+
+    ctx = ExecutionContext(manager=_Manager())
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    created = new_data_dir(ctx, level="Cell")
+
+    assert details == [("text", {"lines": [f"created {created.name()}"]})]

--- a/acq4/experiment/tests/test_log_entry.py
+++ b/acq4/experiment/tests/test_log_entry.py
@@ -165,3 +165,63 @@ def test_error_fields_are_populated_before_on_finish_fires():
         entry._finish(exc)
     assert seen["exc_type"] == "BrokenPipette"
     assert "tip sheared off" in seen["traceback_text"]
+
+
+def test_details_default_to_none():
+    action_entry = ActionLogEntry("Patch")
+    assert action_entry.details_kind is None
+    assert action_entry.details_payload is None
+
+
+def test_set_details_stores_kind_and_payload():
+    action_entry = ActionLogEntry("Patch")
+    action_entry.set_details("text", {"lines": ["hello"]})
+    assert action_entry.details_kind == "text"
+    assert action_entry.details_payload == {"lines": ["hello"]}
+
+
+def test_on_details_hook_receives_entry_kind_and_payload():
+    ctx = ExecutionContext()
+    calls = []
+
+    def hook(action_entry):
+        action_entry.on_details = lambda e, kind, payload: calls.append((e, kind, payload))
+
+    ctx.on_log_action = hook
+    with ctx.log_action("Patch") as action_entry:
+        action_entry.set_details("text", {"lines": ["a"]})
+    assert calls == [(action_entry, "text", {"lines": ["a"]})]
+
+
+def test_details_set_in_a_finally_arrive_before_finish():
+    # CellPanel resolves an entry to its timeline row through bookkeeping that
+    # the entry's finish tears down, so a payload set afterwards has no row to
+    # attach to. An action's try/finally inside the `with` is what orders them.
+    ctx = ExecutionContext()
+    order = []
+
+    def hook(action_entry):
+        action_entry.on_details = lambda e, k, p: order.append("details")
+        action_entry.on_finish = lambda e: order.append("finish")
+
+    ctx.on_log_action = hook
+    with ctx.log_action("Patch") as action_entry:
+        try:
+            pass
+        finally:
+            action_entry.set_details("text", {"lines": []})
+    assert order == ["details", "finish"]
+
+
+def test_details_survive_an_error_outcome():
+    # An action that gathered data and then failed keeps the data: it is more
+    # informative than the traceback, which the row's outcome also carries.
+    ctx = ExecutionContext()
+    with pytest.raises(BrokenPipette):
+        with ctx.log_action("Patch") as action_entry:
+            try:
+                raise BrokenPipette("tip sheared off")
+            finally:
+                action_entry.set_details("text", {"lines": ["got this far"]})
+    assert action_entry.outcome == "error"
+    assert action_entry.details_payload == {"lines": ["got this far"]}

--- a/acq4/filetypes/MultiPatchLog.py
+++ b/acq4/filetypes/MultiPatchLog.py
@@ -231,7 +231,11 @@ class MultiPatchLogData(object):
             return uses
 
         with open(filename, 'rb') as fh:
-            events: list[dict[str, Any]] = [json.loads(line.rstrip(b',\r\n')) for line in fh]
+            events: list[dict[str, Any]] = [
+                json.loads(stripped)
+                for stripped in (line.rstrip(b',\r\n') for line in fh)
+                if stripped.strip()
+            ]
 
             events_by_dev_and_use = {}
             bool_fields = ('clean', 'broken', 'active', 'enabled')

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -10,6 +10,7 @@ from coorx import Point
 from acq4_automation.feature_tracking.cell import Cell
 from acq4.util import Qt
 
+from .details_renderers import buildDetailsWidget
 from .error_display import ErrorBlock
 
 # Random scatter radius for the "Scatter fake cells" demo button (meters).
@@ -80,6 +81,20 @@ class CellPanel(Qt.QWidget):
         # cell's row, so a later "finished" phase can update it in place.
         # Cleared (not just overwritten) on every selection change.
         self._timelineItems: dict[int, Qt.QListWidgetItem] = {}
+        # id(entry) -> the live widget that entry handed over via
+        # set_details_widget(), held only while that entry's action is in
+        # flight: dropped the moment it finishes, or earlier still if it hands
+        # over a retained payload first (set_details() is documented to be
+        # called before finishing, and once it has, that payload is this
+        # entry's final word -- see the "details" phase below).
+        #
+        # Required for row navigation rather than merely convenient: selecting
+        # another row clears showContainer, which reparents the live widget out
+        # of the GUI tree, and without a reference here Python would collect it
+        # before the operator could select its row again. Dropping it by the
+        # time the entry finishes is what keeps the module's "no widget
+        # outlives its action" invariant (see tests/test_teardown.py).
+        self._liveWidgets: dict[int, object] = {}
         self._logs: dict[int, list[str]] = {}
         # (id(cell), timeline row index) -> (kind, payload) from that action's
         # ActionLogEntry.set_details(). Keyed by row rather than by entry
@@ -195,6 +210,7 @@ class CellPanel(Qt.QWidget):
         self.setLayout(layout)
 
         self.cellList.currentItemChanged.connect(self._onCellSelectionChanged)
+        self.timelineList.currentItemChanged.connect(self._onTimelineSelectionChanged)
         self.sigLogMessage.connect(self._onLogMessage)
         self.sigActionEntry.connect(self._onActionEntry)
         self.sigCellsDiscarded.connect(self._onCellsDiscarded)
@@ -743,6 +759,7 @@ class CellPanel(Qt.QWidget):
         if phase == "started":
             self._appendTimelineRow(cell, entry)
         elif phase == "finished":
+            self._liveWidgets.pop(id(entry), None)
             self._finishTimelineRow(cell, entry)
             if cell is self._currentSelectedCell() and self._shownEntryId == id(entry):
                 self._clearShowContainer()
@@ -756,20 +773,28 @@ class CellPanel(Qt.QWidget):
                 if cell is self._currentSelectedCell():
                     self._showErrorBlock(cell)
         elif phase == "widget":
-            if cell is self._currentSelectedCell():
-                self._clearShowContainer()
-                self._shownEntryId = None
-                widget = entry.details_widget
-                if widget is not None:
-                    self.showContainer.layout().addWidget(widget)
-                    self._shownEntryId = id(entry)
+            widget = entry.details_widget
+            if widget is None:
+                self._liveWidgets.pop(id(entry), None)
+            else:
+                self._liveWidgets[id(entry)] = widget
+            loc = self._entryTimelineLoc.get(id(entry))
+            if loc is not None and self._isSelectedRow(loc):
+                self._mountSelectedRow()
         elif phase == "details":
-            # Stored only; mounting it is Task 5's job, once rows are
-            # individually selectable and there is a notion of "the selected
-            # row" to mount into.
             loc = self._entryTimelineLoc.get(id(entry))
             if loc is not None:
                 self._details[loc] = (entry.details_kind, entry.details_payload)
+                # A payload is this action's final word for its row (see
+                # set_details' docstring: it must be called before the entry
+                # finishes), so it supersedes that same entry's live widget from
+                # here on -- even though the entry has not reached "finished"
+                # yet and _liveWidgets would otherwise still hold it. Without
+                # this, _mountSelectedRow's live-widget-first preference would
+                # keep showing a plot the action itself has just moved past.
+                self._liveWidgets.pop(id(entry), None)
+                if self._isSelectedRow(loc):
+                    self._mountSelectedRow()
         # "status" intentionally leaves the timeline row and details container
         # alone: Area 5's timeline only ever shows "running" then the finished
         # outcome, never each intermediate ctx.log_action status message (see
@@ -782,9 +807,12 @@ class CellPanel(Qt.QWidget):
         rows.append(text)
         self._entryTimelineLoc[id(entry)] = (id(cell), index)
         if cell is self._currentSelectedCell():
+            following = self._isFollowingLastRow()
             item = Qt.QListWidgetItem(text)
             self.timelineList.addItem(item)
             self._timelineItems[id(entry)] = item
+            if following:
+                self.timelineList.setCurrentItem(item)
 
     # Glyph shown in a finished timeline row for each ActionLogEntry.outcome
     # value (see ActionLogEntry._finish); an outcome this doesn't recognize
@@ -811,6 +839,86 @@ class CellPanel(Qt.QWidget):
             child = showLayout.takeAt(0)
             if child.widget() is not None:
                 child.widget().setParent(None)
+
+    def _isSelectedRow(self, loc) -> bool:
+        """Whether (cellId, rowIndex) is the row the operator is looking at."""
+        cellId, index = loc
+        cell = self._currentSelectedCell()
+        return (
+            cell is not None
+            and id(cell) == cellId
+            and self.timelineList.currentRow() == index
+        )
+
+    def _mountSelectedRow(self) -> None:
+        """Show whatever the currently selected timeline row has to show.
+
+        Preference order: that row's live widget if its action is still in
+        flight, else its retained payload, else nothing. A live action's widget
+        wins because it is still being updated; the payload only exists once the
+        action has something final to say.
+        """
+        self._clearShowContainer()
+        self._shownEntryId = None
+        cell = self._currentSelectedCell()
+        index = self.timelineList.currentRow()
+        if cell is None or index < 0:
+            return
+        loc = (id(cell), index)
+        for entryId, entryLoc in self._entryTimelineLoc.items():
+            if entryLoc == loc and entryId in self._liveWidgets:
+                self.showContainer.layout().addWidget(self._liveWidgets[entryId])
+                self._shownEntryId = entryId
+                return
+        stored = self._details.get(loc)
+        if stored is None:
+            return
+        kind, payload = stored
+        self.showContainer.layout().addWidget(buildDetailsWidget(kind, payload))
+
+    def _onTimelineSelectionChanged(self, _current, _previous) -> None:
+        self._mountSelectedRow()
+
+    def _isFollowingLastRow(self) -> bool:
+        """Whether the operator is watching the newest row rather than reading
+        back through earlier ones.
+
+        The auto-scroll rule: while the last row is selected, a new action's row
+        takes the selection with it; once the operator selects an earlier row,
+        it does not, until they return to the last row. A timeline with no
+        selection at all counts as following, so the first row of a freshly
+        followed cell is shown rather than requiring a click.
+        """
+        count = self.timelineList.count()
+        return count == 0 or self.timelineList.currentRow() in (-1, count - 1)
+
+    def _autoSelectRow(self, cellId: int) -> None:
+        """Select the row worth looking at for the cell just selected: the
+        action still running, else the most recent one that failed, else the
+        last one.
+
+        Without this, switching to a cell would leave the pane blank until the
+        operator clicked a row -- and, for a failed cell, would lose the
+        traceback that used to mount on cell selection alone.
+        """
+        count = self.timelineList.count()
+        if count == 0:
+            self.timelineList.setCurrentRow(-1)
+            return
+        running = {
+            index
+            for entryId, (locCellId, index) in self._entryTimelineLoc.items()
+            if locCellId == cellId
+        }
+        if running:
+            self.timelineList.setCurrentRow(max(running))
+            return
+        failed = [
+            index
+            for (storeCellId, index), (kind, _payload) in self._details.items()
+            if storeCellId == cellId and kind == "error"
+        ]
+        self.timelineList.setCurrentRow(max(failed) if failed else count - 1)
 
     def _showErrorBlock(self, cell) -> None:
         """Mount the stored error block for `cell` in the details container.
@@ -895,7 +1003,7 @@ class CellPanel(Qt.QWidget):
                 self._timelineItems[entryId] = item
         for line in self._logs.get(cellId, []):
             self.logView.appendPlainText(line)
-        self._showErrorBlock(cell)
+        self._autoSelectRow(cellId)
 
     def _currentSelectedCell(self):
         item = self.cellList.currentItem()

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -648,11 +648,12 @@ class CellPanel(Qt.QWidget):
             # timeline and log for the same reason (design doc §7).
             self._dropDetailsFor(id(cell))
             # A stored error describes the pass that just ended, not the one
-            # about to start. Left in place, _onCellSelectionChanged would
-            # re-mount it beside a row that now reads "queued" and a timeline
-            # that is empty -- and it would stay mounted until _onCurrentCell
-            # eventually fires for this cell, which a Stop or a queue that
-            # never reaches it can leave never happening.
+            # about to start. errorText() reports it to anything that asks --
+            # including a caller reading it after this row already reads
+            # "queued" beside an empty timeline -- so it is dropped here with
+            # the rest of that pass's UI history rather than left to
+            # _onCurrentCell, which a Stop or a queue that never reaches this
+            # cell can leave never firing.
             self._cellErrors.pop(id(cell), None)
             # Queued again, so no longer holding a finished disposition -- but
             # remembered, so a rescan that discards this cell before the new

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -80,6 +80,14 @@ class CellPanel(Qt.QWidget):
         # Cleared (not just overwritten) on every selection change.
         self._timelineItems: dict[int, Qt.QListWidgetItem] = {}
         self._logs: dict[int, list[str]] = {}
+        # (id(cell), timeline row index) -> (kind, payload) from that action's
+        # ActionLogEntry.set_details(). Keyed by row rather than by entry
+        # because the row key is what outlives the entry, which is the whole
+        # point of retaining anything; it is also the key self._timelines
+        # already uses. Holds only plain data -- never an entry, a cell, or a
+        # widget -- so nothing here can form the reference cycle
+        # tests/test_teardown.py exists to prevent (see set_details' docstring).
+        self._details: dict[tuple[int, int], tuple[str, object]] = {}
         # id(cell) -> (exc_type, exc_message, traceback_text) for the most
         # recent action of that cell's that failed. Ids and plain strings,
         # never the entry and never the exception: an ActionLogEntry's
@@ -308,6 +316,7 @@ class CellPanel(Qt.QWidget):
         self._entryTimelineLoc.clear()
         self._timelineItems.clear()
         self._logs.clear()
+        self._details.clear()
         self._cellErrors.clear()
         self.cellList.clear()
         self._clearShowContainer()
@@ -365,6 +374,7 @@ class CellPanel(Qt.QWidget):
             self._timelines.pop(cellId, None)
             self._logs.pop(cellId, None)
             self._cellErrors.pop(cellId, None)
+            self._dropDetailsFor(cellId)
         self._updateCheckAllButton()
         self._updateReuseButton()
         self.sigCellStateChanged.emit()
@@ -498,6 +508,21 @@ class CellPanel(Qt.QWidget):
         after the failed action."""
         return self._cellErrors.get(id(cell))
 
+    def detailsFor(self, cell, rowIndex: int):
+        """The (kind, payload) an action retained for `cell`'s row `rowIndex`,
+        or None if that row's action retained nothing."""
+        return self._details.get((id(cell), rowIndex))
+
+    def _dropDetailsFor(self, cellId: int) -> None:
+        """Forget every retained payload belonging to `cellId`.
+
+        Scans rather than indexing by cell: the keys are (cell, row) pairs, and
+        a per-cell index would be a second store to keep in sync with this one
+        on all three of the paths that drop rows.
+        """
+        for key in [k for k in self._details if k[0] == cellId]:
+            del self._details[key]
+
     def _onCheckAllCompleted(self) -> None:
         """Tick every row whose cell ran its protocol to completion.
 
@@ -587,6 +612,9 @@ class CellPanel(Qt.QWidget):
             # the cell's physical continuity is untouched.
             self._timelines[id(cell)] = []
             self._logs[id(cell)] = []
+            # Earlier-pass details are that pass's UI history, cleared with the
+            # timeline and log for the same reason (design doc §7).
+            self._dropDetailsFor(id(cell))
             # A stored error describes the pass that just ended, not the one
             # about to start. Left in place, _onCellSelectionChanged would
             # re-mount it beside a row that now reads "queued" and a timeline
@@ -696,11 +724,18 @@ class CellPanel(Qt.QWidget):
         entry itself, and this panel never stores the entry object anywhere
         (see self._entryTimelineLoc's docstring) -- so an entry's lifetime is
         whatever the action function that created it gives it, and no
-        panel<->entry reference cycle is created.
+        panel<->entry reference cycle is created. on_details is assigned here
+        for the same reason and marshaled the same way; like the others it
+        closes over `self` and `cell` only, and the payload is read back off
+        the entry in the slot rather than carried through the signal, so
+        sigActionEntry's signature is unchanged.
         """
         entry.on_status = lambda e: self.sigActionEntry.emit(cell, e, "status")
         entry.on_widget = lambda e, w: self.sigActionEntry.emit(cell, e, "widget")
         entry.on_finish = lambda e: self.sigActionEntry.emit(cell, e, "finished")
+        entry.on_details = lambda e, kind, payload: self.sigActionEntry.emit(
+            cell, e, "details"
+        )
         self.sigActionEntry.emit(cell, entry, "started")
 
     def _onActionEntry(self, cell, entry, phase: str) -> None:
@@ -727,6 +762,13 @@ class CellPanel(Qt.QWidget):
                 if widget is not None:
                     self.showContainer.layout().addWidget(widget)
                     self._shownEntryId = id(entry)
+        elif phase == "details":
+            # Stored only; mounting it is Task 5's job, once rows are
+            # individually selectable and there is a notion of "the selected
+            # row" to mount into.
+            loc = self._entryTimelineLoc.get(id(entry))
+            if loc is not None:
+                self._details[loc] = (entry.details_kind, entry.details_payload)
         # "status" intentionally leaves the timeline row and details container
         # alone: Area 5's timeline only ever shows "running" then the finished
         # outcome, never each intermediate ctx.log_action status message (see

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -39,7 +39,8 @@ class CellPanel(Qt.QWidget):
     # marshaled onto the GUI thread the same way -- cell, the ActionLogEntry,
     # and which phase of its life this is: "started" (onLogAction itself, right
     # after ctx.log_action() creates the entry), "status" (entry.set_status()),
-    # "widget" (entry.set_details_widget()), or "finished" (entry._finish()).
+    # "widget" (entry.set_details_widget()), "details" (entry.set_details()),
+    # or "finished" (entry._finish()).
     sigActionEntry = Qt.Signal(object, object, str)
     # Emitted by discardCells() so a rescan's row removal, arriving from the
     # orchestrator's worker thread the same way appendLog()/onLogAction() do,

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -11,7 +11,6 @@ from acq4_automation.feature_tracking.cell import Cell
 from acq4.util import Qt
 
 from .details_renderers import buildDetailsWidget
-from .error_display import ErrorBlock
 
 # Random scatter radius for the "Scatter fake cells" demo button (meters).
 _SCATTER_RADIUS = 40e-6
@@ -760,18 +759,31 @@ class CellPanel(Qt.QWidget):
             self._appendTimelineRow(cell, entry)
         elif phase == "finished":
             self._liveWidgets.pop(id(entry), None)
+            # Read before _finishTimelineRow: that method pops this entry's
+            # location, and the error payload below needs the row it names.
+            loc = self._entryTimelineLoc.get(id(entry))
             self._finishTimelineRow(cell, entry)
-            if cell is self._currentSelectedCell() and self._shownEntryId == id(entry):
-                self._clearShowContainer()
-                self._shownEntryId = None
             if entry.outcome == "error":
                 self._cellErrors[id(cell)] = (
                     entry.exc_type,
                     entry.exc_message,
                     entry.traceback_text,
                 )
-                if cell is self._currentSelectedCell():
-                    self._showErrorBlock(cell)
+                # An action that gathered data before failing keeps that data:
+                # it says more than the traceback, which the log and this row's
+                # own outcome glyph both still carry.
+                if loc is not None and loc not in self._details:
+                    self._details[loc] = (
+                        "error",
+                        {
+                            "exc_type": entry.exc_type,
+                            "exc_message": entry.exc_message,
+                            "traceback_text": entry.traceback_text,
+                            "cell_repr": repr(cell),
+                        },
+                    )
+            if cell is self._currentSelectedCell():
+                self._mountSelectedRow()
         elif phase == "widget":
             widget = entry.details_widget
             if widget is None:
@@ -919,24 +931,6 @@ class CellPanel(Qt.QWidget):
             if storeCellId == cellId and kind == "error"
         ]
         self.timelineList.setCurrentRow(max(failed) if failed else count - 1)
-
-    def _showErrorBlock(self, cell) -> None:
-        """Mount the stored error block for `cell` in the details container.
-
-        Built fresh from the stored text on every mount rather than kept as a
-        widget: _onCellSelectionChanged clears showContainer on every selection
-        change, so a retained widget would be reparented away and would also be
-        one more thing to drop on teardown.
-        """
-        stored = self._cellErrors.get(id(cell))
-        if stored is None:
-            return
-        exc_type, exc_message, traceback_text = stored
-        self._clearShowContainer()
-        self._shownEntryId = None
-        self.showContainer.layout().addWidget(
-            ErrorBlock(exc_type, exc_message, traceback_text, repr(cell))
-        )
 
     def _onCellFinished(self, cell, status: str) -> None:
         # A cell can finish (e.g. the "skipped" outcome in

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -103,6 +103,11 @@ class CellPanel(Qt.QWidget):
         # widget -- so nothing here can form the reference cycle
         # tests/test_teardown.py exists to prevent (see set_details' docstring).
         self._details: dict[tuple[int, int], tuple[str, object]] = {}
+        # (id(cell), timeline row index) -> that action's most recent
+        # set_status() text. Retained alongside the payload so a finished row
+        # still says what it was doing when it ended; a row absent from here
+        # never reported a status.
+        self._statuses: dict[tuple[int, int], str] = {}
         # id(cell) -> (exc_type, exc_message, traceback_text) for the most
         # recent action of that cell's that failed. Ids and plain strings,
         # never the entry and never the exception: an ActionLogEntry's
@@ -175,6 +180,12 @@ class CellPanel(Qt.QWidget):
         self.logView.setReadOnly(True)
         self.showContainer = Qt.QWidget()
         self.showContainer.setLayout(Qt.QVBoxLayout())
+        # Header above the mounted details widget, carrying the selected
+        # action's set_status() text -- which nothing displayed before this,
+        # so every FSM state-transition message was thrown away. The timeline
+        # rows deliberately do not show it (design doc §7).
+        self.statusLabel = Qt.QLabel()
+        self.statusLabel.setWordWrap(True)
 
         self.addFromTargetBtn = Qt.QPushButton("Add from target")
         self.scatterFakeCellsBtn = Qt.QPushButton("Scatter fake cells")
@@ -204,6 +215,7 @@ class CellPanel(Qt.QWidget):
         layout = Qt.QVBoxLayout()
         layout.addLayout(btnRow)
         layout.addLayout(listsRow)
+        layout.addWidget(self.statusLabel)
         layout.addWidget(self.showContainer)
         layout.addWidget(self.logView)
         self.setLayout(layout)
@@ -333,6 +345,8 @@ class CellPanel(Qt.QWidget):
         self._timelineItems.clear()
         self._logs.clear()
         self._details.clear()
+        self._statuses.clear()
+        self.statusLabel.setText("")
         self._cellErrors.clear()
         self.cellList.clear()
         self._clearShowContainer()
@@ -530,14 +544,16 @@ class CellPanel(Qt.QWidget):
         return self._details.get((id(cell), rowIndex))
 
     def _dropDetailsFor(self, cellId: int) -> None:
-        """Forget every retained payload belonging to `cellId`.
+        """Forget every retained payload and status belonging to `cellId`.
 
         Scans rather than indexing by cell: the keys are (cell, row) pairs, and
-        a per-cell index would be a second store to keep in sync with this one
+        a per-cell index would be a second store to keep in sync with these two
         on all three of the paths that drop rows.
         """
         for key in [k for k in self._details if k[0] == cellId]:
             del self._details[key]
+        for key in [k for k in self._statuses if k[0] == cellId]:
+            del self._statuses[key]
 
     def _onCheckAllCompleted(self) -> None:
         """Tick every row whose cell ran its protocol to completion.
@@ -807,10 +823,15 @@ class CellPanel(Qt.QWidget):
                 self._liveWidgets.pop(id(entry), None)
                 if self._isSelectedRow(loc):
                     self._mountSelectedRow()
-        # "status" intentionally leaves the timeline row and details container
-        # alone: Area 5's timeline only ever shows "running" then the finished
-        # outcome, never each intermediate ctx.log_action status message (see
-        # module docstring / design doc §7).
+        elif phase == "status":
+            # Recorded and shown in the pane's header, but deliberately NOT in
+            # the timeline row: rows show "running" then the outcome and
+            # nothing else (design doc §7).
+            loc = self._entryTimelineLoc.get(id(entry))
+            if loc is not None:
+                self._statuses[loc] = entry.status
+                if self._isSelectedRow(loc):
+                    self.statusLabel.setText(entry.status)
 
     def _appendTimelineRow(self, cell, entry) -> None:
         text = f"{entry.name} — ⏳ running"
@@ -875,8 +896,10 @@ class CellPanel(Qt.QWidget):
         cell = self._currentSelectedCell()
         index = self.timelineList.currentRow()
         if cell is None or index < 0:
+            self.statusLabel.setText("")
             return
         loc = (id(cell), index)
+        self.statusLabel.setText(self._statuses.get(loc, ""))
         for entryId, entryLoc in self._entryTimelineLoc.items():
             if entryLoc == loc and entryId in self._liveWidgets:
                 self.showContainer.layout().addWidget(self._liveWidgets[entryId])

--- a/acq4/modules/Autopatch/details_renderers.py
+++ b/acq4/modules/Autopatch/details_renderers.py
@@ -91,7 +91,7 @@ def buildTaskResults(payload) -> Qt.QWidget:
             pen=pg.intColor(index, hues=max(len(traces), 1)),
         )
     lines = [
-        f"{payload.get('sweep_count', len(traces))} sweeps"
+        f"{len(traces)} sweeps"
         f" — saved to {payload.get('sequence_dir') or 'nowhere'}"
     ]
     decimation = payload.get("decimation", 1)

--- a/acq4/modules/Autopatch/details_renderers.py
+++ b/acq4/modules/Autopatch/details_renderers.py
@@ -100,6 +100,51 @@ def buildTaskResults(payload) -> Qt.QWidget:
     return captioned(plot, lines)
 
 
+def buildTestPulseHistory(payload) -> Qt.QWidget:
+    """One FSM action's steady-state resistance plot beside the pipette states it
+    walked.
+
+    Reuses MultiPatch's PlotWidget rather than reimplementing the plot. The
+    mode combo stays visible, unlike the live plot's: because the whole
+    analysis array is retained, re-reading the same attempt through
+    capacitance or holding current costs nothing. setFrozen drops the two modes
+    that would need the recording itself.
+    """
+    # Imported here, not at module scope: pipetteControl pulls in PatchPipette
+    # and the rest of the MultiPatch module's device imports, and this module is
+    # imported by cell_panel at Autopatch startup.
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    plot = PlotWidget(mode="ss resistance")
+    plot.setFrozen(True)
+    plot.newTestPulse(None, payload["history"])
+
+    transitions = Qt.QListWidget()
+    rows = list(payload.get("transitions", ()))
+    firstTime = rows[0][0] if rows else 0.0
+    for when, state in rows:
+        # Elapsed rather than absolute: an epoch timestamp says nothing, and how
+        # long the FSM sat in each state is what reading a failed patch needs.
+        transitions.addItem(f"{when - firstTime:8.2f}s  {state}")
+
+    split = Qt.QWidget()
+    splitLayout = Qt.QHBoxLayout()
+    splitLayout.setContentsMargins(0, 0, 0, 0)
+    splitLayout.addWidget(plot, 2)
+    splitLayout.addWidget(transitions, 1)
+    split.setLayout(splitLayout)
+
+    reached = payload.get("reached")
+    caption = [
+        f"entered at {payload.get('entry_state')!r}, "
+        + (f"reached {reached!r}" if reached else "no terminal state reached")
+    ]
+    logFile = payload.get("log_file")
+    if logFile:
+        caption.append(f"events logged to {logFile}")
+    return captioned(split, caption)
+
+
 # kind -> builder, keyed by the string an action passes to set_details(). A
 # builder takes only the payload and returns a widget: it never sees a Cell, an
 # ActionLogEntry, or the panel, so nothing it builds can retain any of them.
@@ -108,6 +153,7 @@ BUILDERS = {
     "error": buildError,
     "image_stack": buildImageStack,
     "task_results": buildTaskResults,
+    "test_pulse_history": buildTestPulseHistory,
 }
 
 

--- a/acq4/modules/Autopatch/details_renderers.py
+++ b/acq4/modules/Autopatch/details_renderers.py
@@ -2,6 +2,9 @@
 turning an action's retained plain-data payload into a widget to mount."""
 from __future__ import annotations
 
+import numpy as np
+import pyqtgraph as pg
+
 from acq4.util import Qt
 
 from .error_display import ErrorBlock
@@ -47,12 +50,64 @@ def buildError(payload) -> Qt.QWidget:
     )
 
 
+def buildImageStack(payload) -> Qt.QWidget:
+    """A z-stack in a pg.ImageView, opened at the frame the cell was found on.
+
+    setImage jumps to frame 0, which for a cellfie is the top of the stack and
+    shows nothing; center_index is the plane the cell actually sits on.
+    """
+    view = pg.ImageView()
+    stack = np.asarray(payload["stack"])
+    # Provide frame indices as xvals so setCurrentIndex works. Explicitly set
+    # axes for 3D arrays so the first dimension (z-stack) is treated as time,
+    # not as color (which would be the default guess for small last dimensions).
+    axes_dict = None
+    if stack.ndim == 3:
+        axes_dict = {'t': 0, 'x': 1, 'y': 2}
+        n_frames = stack.shape[0]
+        xvals = np.arange(n_frames, dtype=float)
+    else:
+        xvals = None
+    view.setImage(stack, autoRange=True, autoLevels=True, xvals=xvals, axes=axes_dict)
+    centerIndex = payload.get("center_index")
+    if centerIndex is not None:
+        view.setCurrentIndex(centerIndex)
+    title = payload.get("title") or ""
+    return captioned(view, [title] if title else [])
+
+
+def buildTaskResults(payload) -> Qt.QWidget:
+    """One TaskRunner sequence's sweeps, coloured over sequence index so the
+    order they ran in is readable at a glance."""
+    plot = pg.PlotWidget()
+    plot.setLabels(left=("primary", payload.get("units") or ""), bottom=("time", "s"))
+    traces = list(payload.get("traces", ()))
+    for index, (times, values) in enumerate(traces):
+        plot.plot(
+            np.asarray(times),
+            np.asarray(values),
+            pen=pg.intColor(index, hues=max(len(traces), 1)),
+        )
+    lines = [
+        f"{payload.get('sweep_count', len(traces))} sweeps"
+        f" — saved to {payload.get('sequence_dir') or 'nowhere'}"
+    ]
+    decimation = payload.get("decimation", 1)
+    if decimation > 1:
+        # Never silent: the pane says what it is not showing, and the
+        # undecimated data is in the saved sequence directory named above.
+        lines.append(f"plotted decimated {decimation}x; full data on disk")
+    return captioned(plot, lines)
+
+
 # kind -> builder, keyed by the string an action passes to set_details(). A
 # builder takes only the payload and returns a widget: it never sees a Cell, an
 # ActionLogEntry, or the panel, so nothing it builds can retain any of them.
 BUILDERS = {
     "text": buildText,
     "error": buildError,
+    "image_stack": buildImageStack,
+    "task_results": buildTaskResults,
 }
 
 

--- a/acq4/modules/Autopatch/details_renderers.py
+++ b/acq4/modules/Autopatch/details_renderers.py
@@ -58,17 +58,19 @@ def buildImageStack(payload) -> Qt.QWidget:
     """
     view = pg.ImageView()
     stack = np.asarray(payload["stack"])
-    # Provide frame indices as xvals so setCurrentIndex works. Explicitly set
-    # axes for 3D arrays so the first dimension (z-stack) is treated as time,
-    # not as color (which would be the default guess for small last dimensions).
-    axes_dict = None
+    # The axes override is what makes a 3D stack navigable at all: without it
+    # pg.ImageView guesses, and a small last dimension is read as color rather
+    # than the first dimension as time, leaving no frame axis for
+    # setCurrentIndex to move along. xvals then labels those frames by index,
+    # since the payload carries no real z coordinates.
+    axesDict = None
     if stack.ndim == 3:
-        axes_dict = {'t': 0, 'x': 1, 'y': 2}
-        n_frames = stack.shape[0]
-        xvals = np.arange(n_frames, dtype=float)
+        axesDict = {"t": 0, "x": 1, "y": 2}
+        nFrames = stack.shape[0]
+        xvals = np.arange(nFrames, dtype=float)
     else:
         xvals = None
-    view.setImage(stack, autoRange=True, autoLevels=True, xvals=xvals, axes=axes_dict)
+    view.setImage(stack, autoRange=True, autoLevels=True, xvals=xvals, axes=axesDict)
     centerIndex = payload.get("center_index")
     if centerIndex is not None:
         view.setCurrentIndex(centerIndex)

--- a/acq4/modules/Autopatch/details_renderers.py
+++ b/acq4/modules/Autopatch/details_renderers.py
@@ -1,0 +1,71 @@
+"""Builders for Area 5's detail pane: one per ActionLogEntry.set_details() kind,
+turning an action's retained plain-data payload into a widget to mount."""
+from __future__ import annotations
+
+from acq4.util import Qt
+
+from .error_display import ErrorBlock
+
+
+def captioned(widget, lines) -> Qt.QWidget:
+    """`widget` under a caption of `lines`, or `widget` itself if there are none.
+
+    Returning the bare widget for an empty caption keeps the pane's widget tree
+    as shallow as the payload warrants, rather than wrapping everything in a
+    layout that holds an empty label.
+    """
+    if not lines:
+        return widget
+    caption = Qt.QLabel("\n".join(str(line) for line in lines))
+    caption.setWordWrap(True)
+    # Selectable so a directory name or a measured value can be copied out.
+    caption.setTextInteractionFlags(Qt.Qt.TextSelectableByMouse)
+    wrapper = Qt.QWidget()
+    layout = Qt.QVBoxLayout()
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.addWidget(caption)
+    layout.addWidget(widget)
+    wrapper.setLayout(layout)
+    return wrapper
+
+
+def buildText(payload) -> Qt.QWidget:
+    """Plain lines, read-only and selectable so values can be copied out."""
+    view = Qt.QPlainTextEdit("\n".join(str(line) for line in payload.get("lines", ())))
+    view.setReadOnly(True)
+    return view
+
+
+def buildError(payload) -> Qt.QWidget:
+    """One failed action's traceback. Takes strings, never an exception -- see
+    ErrorBlock's own docstring for why."""
+    return ErrorBlock(
+        payload["exc_type"],
+        payload["exc_message"],
+        payload["traceback_text"],
+        payload.get("cell_repr"),
+    )
+
+
+# kind -> builder, keyed by the string an action passes to set_details(). A
+# builder takes only the payload and returns a widget: it never sees a Cell, an
+# ActionLogEntry, or the panel, so nothing it builds can retain any of them.
+BUILDERS = {
+    "text": buildText,
+    "error": buildError,
+}
+
+
+def buildDetailsWidget(kind: str, payload) -> Qt.QWidget:
+    """The widget for one retained payload.
+
+    An unregistered kind renders as text rather than raising. A payload crosses
+    a thread boundary out of protocol code, and a protocol author's typo must
+    leave the pane usable instead of taking it down.
+    """
+    builder = BUILDERS.get(kind)
+    if builder is None:
+        return buildText(
+            {"lines": [f"unrecognized details kind {kind!r}", repr(payload)]}
+        )
+    return builder(payload)

--- a/acq4/modules/Autopatch/tests/test_details_navigation.py
+++ b/acq4/modules/Autopatch/tests/test_details_navigation.py
@@ -368,3 +368,70 @@ def test_selecting_a_cell_with_no_rows_selects_nothing(panel):
 
     assert panel.timelineList.currentRow() == -1
     assert _mounted(panel) == []
+
+
+def test_a_failed_action_records_an_error_payload_on_its_row(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry._finish(RuntimeError("boom"))
+
+    kind, payload = panel.detailsFor(cell, 0)
+    assert kind == "error"
+    assert payload["exc_type"] == "RuntimeError"
+    assert payload["exc_message"] == "boom"
+    assert "RuntimeError: boom" in payload["traceback_text"]
+    assert payload["cell_repr"] == repr(cell)
+
+
+def test_a_failed_actions_row_mounts_an_error_block(panel):
+    from acq4.modules.Autopatch.error_display import ErrorBlock
+
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry._finish(RuntimeError("boom"))
+
+    panel.timelineList.setCurrentRow(0)
+
+    assert isinstance(_mounted(panel)[0], ErrorBlock)
+
+
+def test_a_failed_action_that_set_a_payload_keeps_the_payload(panel):
+    # The data it gathered before dying beats the traceback, which the log and
+    # the row's outcome glyph both still carry.
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry.set_details("text", {"lines": ["got this far"]})
+    entry._finish(RuntimeError("boom"))
+
+    kind, payload = panel.detailsFor(cell, 0)
+    assert kind == "text"
+    assert payload == {"lines": ["got this far"]}
+
+
+def test_error_text_still_answers_which_cell_failed(panel):
+    # _cellErrors and errorText() are a different question from "what did this
+    # row do", and tests/test_teardown.py asserts against errorText.
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry._finish(RuntimeError("boom"))
+
+    assert panel.errorText(cell)[0] == "RuntimeError"
+    assert panel.errorText(cell)[1] == "boom"
+
+
+def test_a_successful_action_records_no_error_payload(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry._finish(None)
+
+    assert panel.detailsFor(cell, 0) is None

--- a/acq4/modules/Autopatch/tests/test_details_navigation.py
+++ b/acq4/modules/Autopatch/tests/test_details_navigation.py
@@ -434,6 +434,8 @@ def test_a_successful_action_records_no_error_payload(panel):
     panel.onLogAction(cell, entry)
     entry._finish(None)
 
+    assert panel.detailsFor(cell, 0) is None
+
 
 def test_status_shows_for_the_selected_row(panel):
     (cell,) = _seed(panel)
@@ -516,5 +518,3 @@ def test_clear_cells_drops_retained_statuses(panel):
 
     assert panel._statuses == {}
     assert panel.statusLabel.text() == ""
-
-    assert panel.detailsFor(cell, 0) is None

--- a/acq4/modules/Autopatch/tests/test_details_navigation.py
+++ b/acq4/modules/Autopatch/tests/test_details_navigation.py
@@ -1,0 +1,151 @@
+"""Tests for CellPanel's retention of ActionLogEntry.set_details() payloads and
+the timeline-row navigation that mounts them in the detail pane."""
+import pytest
+
+from acq4.experiment.log_entry import ActionLogEntry
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+class _FakeOrchestrator(Qt.QObject):
+    sigCurrentCell = Qt.Signal(object)
+    sigCellFinished = Qt.Signal(object, str)
+
+    def __init__(self):
+        super().__init__()
+        self.enqueued = []
+
+    def enqueue(self, cell):
+        self.enqueued.append(cell)
+
+    def pendingCells(self):
+        return []
+
+
+class _FakeManipulator:
+    def __init__(self, target):
+        self._target = target
+
+    def targetPosition(self):
+        return self._target
+
+
+class _FakePipette:
+    def __init__(self, target):
+        self.pipetteDevice = _FakeManipulator(target)
+
+
+@pytest.fixture
+def panel(qapp):
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    return CellPanel(pipetteGetter=lambda: _FakePipette((0, 0, 0)))
+
+
+def _seed(panel, count=1):
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch)
+    for _ in range(count):
+        panel.addFromTargetBtn.click()
+    return orch.enqueued
+
+
+def test_payload_is_retained_against_the_entrys_row(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    entry.set_details("text", {"lines": ["saved"]})
+
+    assert panel.detailsFor(cell, 0) == ("text", {"lines": ["saved"]})
+
+
+def test_payload_survives_the_entry_finishing(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    entry.set_details("text", {"lines": ["saved"]})
+    entry._finish(None)
+
+    assert panel.detailsFor(cell, 0) == ("text", {"lines": ["saved"]})
+
+
+def test_payloads_are_retained_per_row(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+
+    first = ActionLogEntry("First")
+    panel.onLogAction(cell, first)
+    first.set_details("text", {"lines": ["one"]})
+    first._finish(None)
+
+    second = ActionLogEntry("Second")
+    panel.onLogAction(cell, second)
+    second.set_details("text", {"lines": ["two"]})
+    second._finish(None)
+
+    assert panel.detailsFor(cell, 0) == ("text", {"lines": ["one"]})
+    assert panel.detailsFor(cell, 1) == ("text", {"lines": ["two"]})
+
+
+def test_payloads_are_retained_for_an_unselected_cell(panel):
+    cellA, cellB = _seed(panel, 2)
+    panel.cellList.setCurrentRow(0)  # follow cellA while cellB works
+
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cellB, entry)
+    entry.set_details("text", {"lines": ["B's stack"]})
+
+    assert panel.detailsFor(cellB, 0) == ("text", {"lines": ["B's stack"]})
+
+
+def test_clear_cells_drops_retained_payloads(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    entry.set_details("text", {"lines": ["saved"]})
+
+    panel.clearCells()
+
+    assert panel._details == {}
+
+
+def test_discarding_an_unattempted_cell_drops_its_payloads(panel):
+    cellA, cellB = _seed(panel, 2)
+    panel.cellList.setCurrentRow(0)
+    entryA = ActionLogEntry("A")
+    panel.onLogAction(cellA, entryA)
+    entryA.set_details("text", {"lines": ["A"]})
+    entryB = ActionLogEntry("B")
+    panel.onLogAction(cellB, entryB)
+    entryB.set_details("text", {"lines": ["B"]})
+
+    panel._onCellsDiscarded([cellA])
+
+    assert panel.detailsFor(cellA, 0) is None
+    assert panel.detailsFor(cellB, 0) == ("text", {"lines": ["B"]})
+
+
+def test_reuse_clears_the_cells_payloads(panel):
+    # Pass 2 starts with a fresh timeline and log; retained details are that
+    # same earlier-pass UI history and must go with them.
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    entry.set_details("text", {"lines": ["pass 1"]})
+    entry._finish(None)
+    panel._onCellFinished(cell, "done")
+
+    panel.cellList.item(0).setCheckState(Qt.Qt.Checked)
+    panel.reuseCheckedCellsBtn.click()
+
+    assert panel.detailsFor(cell, 0) is None

--- a/acq4/modules/Autopatch/tests/test_details_navigation.py
+++ b/acq4/modules/Autopatch/tests/test_details_navigation.py
@@ -149,3 +149,222 @@ def test_reuse_clears_the_cells_payloads(panel):
     panel.reuseCheckedCellsBtn.click()
 
     assert panel.detailsFor(cell, 0) is None
+
+
+def _mounted(panel):
+    layout = panel.showContainer.layout()
+    return [layout.itemAt(i).widget() for i in range(layout.count())]
+
+
+def test_selecting_a_finished_row_mounts_its_payload(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    entry.set_details("text", {"lines": ["the cellfie stack"]})
+    entry._finish(None)
+
+    panel.timelineList.setCurrentRow(0)
+
+    assert len(_mounted(panel)) == 1
+    assert "the cellfie stack" in _mounted(panel)[0].toPlainText()
+
+
+def test_selecting_a_different_row_swaps_the_mounted_payload(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    first = ActionLogEntry("First")
+    panel.onLogAction(cell, first)
+    first.set_details("text", {"lines": ["one"]})
+    first._finish(None)
+    second = ActionLogEntry("Second")
+    panel.onLogAction(cell, second)
+    second.set_details("text", {"lines": ["two"]})
+    second._finish(None)
+
+    panel.timelineList.setCurrentRow(0)
+    assert "one" in _mounted(panel)[0].toPlainText()
+
+    panel.timelineList.setCurrentRow(1)
+    assert "two" in _mounted(panel)[0].toPlainText()
+
+
+def test_selecting_a_row_with_no_payload_leaves_the_pane_empty(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Pipette To Home")
+    panel.onLogAction(cell, entry)
+    entry._finish(None)
+
+    panel.timelineList.setCurrentRow(0)
+
+    assert _mounted(panel) == []
+
+
+def test_a_live_widget_is_remounted_when_its_row_is_reselected(panel):
+    # Navigating away clears the container, which reparents the live widget out.
+    # Coming back must put the same widget back, not a dead one.
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    finished = ActionLogEntry("Earlier")
+    panel.onLogAction(cell, finished)
+    finished._finish(None)
+
+    live = ActionLogEntry("Patch")
+    panel.onLogAction(cell, live)
+    liveWidget = Qt.QLabel("live plot")
+    live.set_details_widget(liveWidget)
+    assert liveWidget in _mounted(panel)
+
+    panel.timelineList.setCurrentRow(0)
+    assert liveWidget not in _mounted(panel)
+
+    panel.timelineList.setCurrentRow(1)
+    assert liveWidget in _mounted(panel)
+
+
+def test_a_finished_entrys_live_widget_is_forgotten(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry.set_details_widget(Qt.QLabel("live plot"))
+    entry._finish(None)
+
+    assert panel._liveWidgets == {}
+
+
+def test_a_payload_arriving_for_the_selected_row_mounts_immediately(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    panel.timelineList.setCurrentRow(0)
+
+    entry.set_details("text", {"lines": ["just arrived"]})
+
+    assert "just arrived" in _mounted(panel)[0].toPlainText()
+
+
+def test_a_payload_replaces_the_live_widget_on_the_same_row(panel):
+    # patch()'s finally sets its payload while its live plot is still mounted.
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    liveWidget = Qt.QLabel("live plot")
+    entry.set_details_widget(liveWidget)
+    panel.timelineList.setCurrentRow(0)
+    assert liveWidget in _mounted(panel)
+
+    entry.set_details("text", {"lines": ["frozen"]})
+
+    assert liveWidget not in _mounted(panel)
+    assert "frozen" in _mounted(panel)[0].toPlainText()
+
+
+def test_a_new_row_is_followed_while_the_last_row_is_selected(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    first = ActionLogEntry("First")
+    panel.onLogAction(cell, first)
+    first._finish(None)
+    assert panel.timelineList.currentRow() == 0
+
+    second = ActionLogEntry("Second")
+    panel.onLogAction(cell, second)
+
+    assert panel.timelineList.currentRow() == 1
+
+
+def test_selecting_an_earlier_row_stops_following(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    for name in ("First", "Second"):
+        entry = ActionLogEntry(name)
+        panel.onLogAction(cell, entry)
+        entry._finish(None)
+
+    panel.timelineList.setCurrentRow(0)  # operator navigates back
+
+    third = ActionLogEntry("Third")
+    panel.onLogAction(cell, third)
+
+    assert panel.timelineList.currentRow() == 0
+
+
+def test_returning_to_the_last_row_resumes_following(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    for name in ("First", "Second"):
+        entry = ActionLogEntry(name)
+        panel.onLogAction(cell, entry)
+        entry._finish(None)
+    panel.timelineList.setCurrentRow(0)
+    third = ActionLogEntry("Third")
+    panel.onLogAction(cell, third)
+    third._finish(None)
+    assert panel.timelineList.currentRow() == 0
+
+    panel.timelineList.setCurrentRow(panel.timelineList.count() - 1)
+
+    fourth = ActionLogEntry("Fourth")
+    panel.onLogAction(cell, fourth)
+
+    assert panel.timelineList.currentRow() == panel.timelineList.count() - 1
+
+
+def test_selecting_a_cell_auto_selects_its_running_row(panel):
+    cellA, cellB = _seed(panel, 2)
+    panel.cellList.setCurrentRow(1)  # look at B so A's rows build unrendered
+    done = ActionLogEntry("Done")
+    panel.onLogAction(cellA, done)
+    done._finish(None)
+    running = ActionLogEntry("Running")
+    panel.onLogAction(cellA, running)
+
+    panel.cellList.setCurrentRow(0)
+
+    assert panel.timelineList.currentRow() == 1
+    assert "running" in panel.timelineList.item(1).text()
+
+
+def test_selecting_a_cell_auto_selects_its_failed_row(panel):
+    cellA, cellB = _seed(panel, 2)
+    panel.cellList.setCurrentRow(1)
+    failed = ActionLogEntry("Patch")
+    panel.onLogAction(cellA, failed)
+    failed._finish(RuntimeError("boom"))
+    later = ActionLogEntry("Pipette To Home")
+    panel.onLogAction(cellA, later)
+    later._finish(None)
+
+    panel.cellList.setCurrentRow(0)
+
+    assert panel.timelineList.currentRow() == 0
+
+
+def test_selecting_a_cell_auto_selects_the_last_row_when_nothing_stands_out(panel):
+    cellA, cellB = _seed(panel, 2)
+    panel.cellList.setCurrentRow(1)
+    for name in ("First", "Second"):
+        entry = ActionLogEntry(name)
+        panel.onLogAction(cellA, entry)
+        entry._finish(None)
+
+    panel.cellList.setCurrentRow(0)
+
+    assert panel.timelineList.currentRow() == 1
+
+
+def test_selecting_a_cell_with_no_rows_selects_nothing(panel):
+    cellA, cellB = _seed(panel, 2)
+    entry = ActionLogEntry("First")
+    panel.onLogAction(cellA, entry)
+    entry._finish(None)
+    panel.cellList.setCurrentRow(0)
+
+    panel.cellList.setCurrentRow(1)
+
+    assert panel.timelineList.currentRow() == -1
+    assert _mounted(panel) == []

--- a/acq4/modules/Autopatch/tests/test_details_navigation.py
+++ b/acq4/modules/Autopatch/tests/test_details_navigation.py
@@ -434,4 +434,87 @@ def test_a_successful_action_records_no_error_payload(panel):
     panel.onLogAction(cell, entry)
     entry._finish(None)
 
+
+def test_status_shows_for_the_selected_row(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+
+    entry.set_status("driving FSM from 'approach'")
+
+    assert "driving FSM from 'approach'" in panel.statusLabel.text()
+
+
+def test_status_updates_in_place_as_the_action_progresses(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+
+    entry.set_status("now in 'seal'")
+    entry.set_status("reached 'whole cell'")
+
+    assert "reached 'whole cell'" in panel.statusLabel.text()
+    assert "now in 'seal'" not in panel.statusLabel.text()
+
+
+def test_status_is_not_shown_for_an_unselected_row(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    earlier = ActionLogEntry("Earlier")
+    panel.onLogAction(cell, earlier)
+    earlier.set_status("earlier status")
+    earlier._finish(None)
+    later = ActionLogEntry("Later")
+    panel.onLogAction(cell, later)
+    later.set_status("later status")
+
+    panel.timelineList.setCurrentRow(0)
+
+    assert "earlier status" in panel.statusLabel.text()
+    assert "later status" not in panel.statusLabel.text()
+
+
+def test_last_status_is_retained_after_the_action_finishes(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    entry.set_status("saving cellfie z-stack")
+    entry._finish(None)
+
+    panel.timelineList.setCurrentRow(0)
+
+    assert "saving cellfie z-stack" in panel.statusLabel.text()
+
+
+def test_status_clears_for_a_row_that_never_reported_one(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    withStatus = ActionLogEntry("With")
+    panel.onLogAction(cell, withStatus)
+    withStatus.set_status("something")
+    withStatus._finish(None)
+    withoutStatus = ActionLogEntry("Without")
+    panel.onLogAction(cell, withoutStatus)
+    withoutStatus._finish(None)
+
+    panel.timelineList.setCurrentRow(1)
+
+    assert panel.statusLabel.text() == ""
+
+
+def test_clear_cells_drops_retained_statuses(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry.set_status("something")
+
+    panel.clearCells()
+
+    assert panel._statuses == {}
+    assert panel.statusLabel.text() == ""
+
     assert panel.detailsFor(cell, 0) is None

--- a/acq4/modules/Autopatch/tests/test_details_renderers.py
+++ b/acq4/modules/Autopatch/tests/test_details_renderers.py
@@ -151,7 +151,6 @@ def test_task_results_builder_plots_one_curve_per_sweep(qapp):
     payload = {
         "traces": [(t, t * 1.0), (t, t * 2.0), (t, t * 3.0)],
         "sequence_dir": "protocol_000",
-        "sweep_count": 3,
         "decimation": 1,
         "units": "A",
     }
@@ -173,7 +172,6 @@ def test_task_results_caption_reports_sweeps_directory_and_decimation(qapp):
         {
             "traces": [(t, t)],
             "sequence_dir": "protocol_007",
-            "sweep_count": 1,
             "decimation": 25,
             "units": "A",
         },
@@ -195,7 +193,6 @@ def test_task_results_caption_omits_decimation_when_undecimated(qapp):
         {
             "traces": [(t, t)],
             "sequence_dir": "protocol_000",
-            "sweep_count": 1,
             "decimation": 1,
             "units": "A",
         },
@@ -213,7 +210,6 @@ def test_task_results_builder_tolerates_no_traces(qapp):
         {
             "traces": [],
             "sequence_dir": "protocol_000",
-            "sweep_count": 0,
             "decimation": 1,
             "units": "A",
         },

--- a/acq4/modules/Autopatch/tests/test_details_renderers.py
+++ b/acq4/modules/Autopatch/tests/test_details_renderers.py
@@ -220,3 +220,131 @@ def test_task_results_builder_tolerates_no_traces(qapp):
     )
 
     assert wrapper is not None
+
+
+def _tpHistory(count=5):
+    import numpy as np
+    from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
+
+    history = np.zeros(count, dtype=TEST_PULSE_NUMPY_DTYPE)
+    history["event_time"] = np.arange(count, dtype=float)
+    history["steady_state_resistance"] = np.linspace(1e6, 1e9, count)
+    return history
+
+
+def _tpPayload(**overrides):
+    payload = {
+        "history": _tpHistory(),
+        "transitions": [(0.0, "approach"), (1.5, "seal"), (3.0, "whole cell")],
+        "entry_state": "approach",
+        "reached": "whole cell",
+        "log_file": "MultiPatch_004.log",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_test_pulse_history_plots_the_retained_history(qapp):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("test_pulse_history", _tpPayload())
+
+    plot = widget.findChild(PlotWidget)
+    assert plot is not None
+    assert len(plot.plot.plotItem.listDataItems()) == 1
+
+
+def test_test_pulse_history_keeps_the_mode_combo_visible(qapp):
+    # Re-reading a finished attempt through a different field is what the
+    # dropdown is for; only the live plot hides it.
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("test_pulse_history", _tpPayload())
+
+    plot = widget.findChild(PlotWidget)
+    assert not plot.modeCombo.isHidden()
+
+
+def test_test_pulse_history_offers_no_live_only_modes(qapp):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("test_pulse_history", _tpPayload())
+
+    plot = widget.findChild(PlotWidget)
+    items = [plot.modeCombo.itemText(i) for i in range(plot.modeCombo.count())]
+    assert "test pulse" not in items
+    assert "tp analysis" not in items
+
+
+def test_test_pulse_history_lists_the_state_transitions(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("test_pulse_history", _tpPayload())
+
+    transitions = widget.findChild(Qt.QListWidget)
+    assert transitions is not None
+    rows = [transitions.item(i).text() for i in range(transitions.count())]
+    assert len(rows) == 3
+    assert "approach" in rows[0]
+    assert "seal" in rows[1]
+    assert "whole cell" in rows[2]
+
+
+def test_transition_rows_show_the_elapsed_time_from_the_first(qapp):
+    # Absolute epoch timestamps are unreadable; what matters is how long the
+    # FSM sat in each state.
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget(
+        "test_pulse_history",
+        _tpPayload(transitions=[(1000.0, "approach"), (1002.5, "seal")]),
+    )
+
+    transitions = widget.findChild(Qt.QListWidget)
+    assert "0.00" in transitions.item(0).text()
+    assert "2.50" in transitions.item(1).text()
+
+
+def test_test_pulse_history_caption_reports_the_terminal_state_and_log(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("test_pulse_history", _tpPayload())
+
+    caption = widget.layout().itemAt(0).widget().text()
+    assert "approach" in caption
+    assert "whole cell" in caption
+    assert "MultiPatch_004.log" in caption
+
+
+def test_test_pulse_history_caption_handles_never_reaching_a_terminal(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget(
+        "test_pulse_history", _tpPayload(reached=None, log_file=None)
+    )
+
+    caption = widget.layout().itemAt(0).widget().text()
+    assert "approach" in caption
+    assert "no terminal state" in caption
+
+
+def test_test_pulse_history_tolerates_an_empty_history(qapp):
+    # A patch stopped before its first test pulse landed.
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget(
+        "test_pulse_history", _tpPayload(history=_tpHistory(count=0), transitions=[])
+    )
+
+    assert widget is not None
+
+
+def test_test_pulse_history_tolerates_no_transitions(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("test_pulse_history", _tpPayload(transitions=[]))
+
+    assert widget.findChild(Qt.QListWidget).count() == 0

--- a/acq4/modules/Autopatch/tests/test_details_renderers.py
+++ b/acq4/modules/Autopatch/tests/test_details_renderers.py
@@ -348,3 +348,58 @@ def test_test_pulse_history_tolerates_no_transitions(qapp):
     widget = buildDetailsWidget("test_pulse_history", _tpPayload(transitions=[]))
 
     assert widget.findChild(Qt.QListWidget).count() == 0
+
+
+def _curveData(plot):
+    """The (x, y) a PlotWidget's single curve was given.
+
+    The underlying data, not getData()'s display copy: the display copy is
+    log-transformed with the mode's log setting, so it moves whenever the mode
+    does, whether or not anything re-plotted.
+    """
+    items = plot.plot.plotItem.listDataItems()
+    assert len(items) == 1
+    return items[0].xData, items[0].yData
+
+
+def test_switching_a_frozen_plots_mode_replots_the_new_field(qapp):
+    # setMode only moves the axis label, the log mode and the Y range. A live
+    # plot redraws on its next test pulse; a frozen one never gets another, so
+    # without a re-plot the resistance curve would sit under a "Capacitance / F"
+    # axis -- wrong scientific data in front of an operator judging an attempt.
+    import numpy as np
+
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    history = _tpHistory()
+    history["capacitance"] = np.linspace(1e-12, 50e-12, len(history))
+    widget = buildDetailsWidget("test_pulse_history", _tpPayload(history=history))
+    plot = widget.findChild(PlotWidget)
+    before = _curveData(plot)
+
+    plot.modeCombo.setText("capacitance")
+
+    assert plot.mode == "capacitance"
+    after = _curveData(plot)
+    assert not np.array_equal(after[1], before[1])
+    assert np.allclose(after[1], history["capacitance"])
+
+
+def test_a_live_plot_does_not_replot_on_a_mode_change(qapp):
+    # The live path is unchanged: its next test pulse is what redraws it, and a
+    # mode change must not re-read a history that is about to be superseded.
+    import numpy as np
+
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    history = _tpHistory()
+    history["capacitance"] = np.linspace(1e-12, 50e-12, len(history))
+    plot = PlotWidget(mode="ss resistance")
+    plot.newTestPulse(None, history)
+    before = _curveData(plot)
+
+    plot.modeCombo.setText("capacitance")
+
+    assert plot.mode == "capacitance"
+    assert np.array_equal(_curveData(plot)[1], before[1])

--- a/acq4/modules/Autopatch/tests/test_details_renderers.py
+++ b/acq4/modules/Autopatch/tests/test_details_renderers.py
@@ -97,3 +97,126 @@ def test_captioned_with_no_lines_returns_the_widget_itself(qapp):
     inner = Qt.QLabel("inner")
 
     assert captioned(inner, []) is inner
+
+
+def test_image_stack_builder_opens_at_the_center_index(qapp):
+    import numpy as np
+    import pyqtgraph as pg
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    stack = np.arange(5 * 4 * 3, dtype=float).reshape(5, 4, 3)
+    wrapper = buildDetailsWidget(
+        "image_stack", {"stack": stack, "center_index": 2, "title": "Cellfie"}
+    )
+
+    view = wrapper.findChild(pg.ImageView)
+    assert view is not None
+    assert view.currentIndex == 2
+
+
+def test_image_stack_builder_shows_the_title_as_its_caption(qapp):
+    import numpy as np
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    wrapper = buildDetailsWidget(
+        "image_stack",
+        {"stack": np.zeros((3, 4, 4)), "center_index": 1, "title": "Cellfie"},
+    )
+
+    caption = wrapper.layout().itemAt(0).widget()
+    assert "Cellfie" in caption.text()
+
+
+def test_image_stack_builder_tolerates_a_none_center_index(qapp):
+    # A 2D image or a single-frame stack has no meaningful center frame.
+    import numpy as np
+    import pyqtgraph as pg
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    wrapper = buildDetailsWidget(
+        "image_stack", {"stack": np.zeros((4, 4)), "center_index": None, "title": ""}
+    )
+
+    # An empty title means captioned() returns the view itself, unwrapped.
+    assert isinstance(wrapper, pg.ImageView)
+    assert wrapper.currentIndex == 0
+
+
+def test_task_results_builder_plots_one_curve_per_sweep(qapp):
+    import numpy as np
+    import pyqtgraph as pg
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    t = np.linspace(0, 1, 10)
+    payload = {
+        "traces": [(t, t * 1.0), (t, t * 2.0), (t, t * 3.0)],
+        "sequence_dir": "protocol_000",
+        "sweep_count": 3,
+        "decimation": 1,
+        "units": "A",
+    }
+
+    wrapper = buildDetailsWidget("task_results", payload)
+
+    plot = wrapper.findChild(pg.PlotWidget)
+    assert plot is not None
+    assert len(plot.plotItem.listDataItems()) == 3
+
+
+def test_task_results_caption_reports_sweeps_directory_and_decimation(qapp):
+    import numpy as np
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    t = np.linspace(0, 1, 10)
+    wrapper = buildDetailsWidget(
+        "task_results",
+        {
+            "traces": [(t, t)],
+            "sequence_dir": "protocol_007",
+            "sweep_count": 1,
+            "decimation": 25,
+            "units": "A",
+        },
+    )
+
+    text = wrapper.layout().itemAt(0).widget().text()
+    assert "1" in text
+    assert "protocol_007" in text
+    assert "25" in text
+
+
+def test_task_results_caption_omits_decimation_when_undecimated(qapp):
+    import numpy as np
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    t = np.linspace(0, 1, 10)
+    wrapper = buildDetailsWidget(
+        "task_results",
+        {
+            "traces": [(t, t)],
+            "sequence_dir": "protocol_000",
+            "sweep_count": 1,
+            "decimation": 1,
+            "units": "A",
+        },
+    )
+
+    assert "decimated" not in wrapper.layout().itemAt(0).widget().text()
+
+
+def test_task_results_builder_tolerates_no_traces(qapp):
+    # A sequence stopped before its first sweep completed.
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    wrapper = buildDetailsWidget(
+        "task_results",
+        {
+            "traces": [],
+            "sequence_dir": "protocol_000",
+            "sweep_count": 0,
+            "decimation": 1,
+            "units": "A",
+        },
+    )
+
+    assert wrapper is not None

--- a/acq4/modules/Autopatch/tests/test_details_renderers.py
+++ b/acq4/modules/Autopatch/tests/test_details_renderers.py
@@ -1,0 +1,99 @@
+"""Tests for the kind -> widget builders behind Area 5's detail pane, each
+given the plain-data payload an action's set_details() hands over."""
+import pytest
+
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+def test_text_builder_renders_each_line_read_only(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("text", {"lines": ["surface at 1.2 mm", "depth ok"]})
+
+    assert widget.isReadOnly()
+    assert "surface at 1.2 mm" in widget.toPlainText()
+    assert "depth ok" in widget.toPlainText()
+
+
+def test_text_builder_tolerates_a_missing_lines_key(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("text", {})
+
+    assert widget.toPlainText() == ""
+
+
+def test_text_builder_stringifies_non_strings(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("text", {"lines": [42, None]})
+
+    assert "42" in widget.toPlainText()
+    assert "None" in widget.toPlainText()
+
+
+def test_error_builder_returns_an_error_block(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+    from acq4.modules.Autopatch.error_display import ErrorBlock
+
+    widget = buildDetailsWidget(
+        "error",
+        {
+            "exc_type": "BrokenPipette",
+            "exc_message": "tip sheared off",
+            "traceback_text": "Traceback...\nBrokenPipette: tip sheared off",
+            "cell_repr": "<Cell 0x1>",
+        },
+    )
+
+    assert isinstance(widget, ErrorBlock)
+    assert "BrokenPipette" in widget.headlineLabel.text()
+    assert "tip sheared off" in widget.headlineLabel.text()
+    assert "<Cell 0x1>" in widget.cellLabel.text()
+
+
+def test_error_builder_tolerates_a_missing_cell_repr(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget(
+        "error",
+        {"exc_type": "E", "exc_message": "m", "traceback_text": "t"},
+    )
+
+    assert not widget.cellLabel.isVisible()
+
+
+def test_unregistered_kind_renders_as_text_rather_than_raising(qapp):
+    # A payload crosses a thread boundary out of protocol code. A protocol
+    # author's typo must leave the pane usable, not take it down.
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("no_such_kind", {"a": 1})
+
+    assert "no_such_kind" in widget.toPlainText()
+    assert "'a': 1" in widget.toPlainText()
+
+
+def test_captioned_puts_the_caption_above_the_widget(qapp):
+    from acq4.modules.Autopatch.details_renderers import captioned
+
+    inner = Qt.QLabel("inner")
+    wrapper = captioned(inner, ["12 sweeps", "saved to protocol_000"])
+
+    assert wrapper.layout().indexOf(inner) != -1
+    caption = wrapper.layout().itemAt(0).widget()
+    assert "12 sweeps" in caption.text()
+    assert "saved to protocol_000" in caption.text()
+
+
+def test_captioned_with_no_lines_returns_the_widget_itself(qapp):
+    from acq4.modules.Autopatch.details_renderers import captioned
+
+    inner = Qt.QLabel("inner")
+
+    assert captioned(inner, []) is inner

--- a/acq4/modules/MultiPatch/multipatch.py
+++ b/acq4/modules/MultiPatch/multipatch.py
@@ -623,26 +623,40 @@ class MultiPatchWindow(Qt.QWidget):
 
         The buttons are independent -- test-pulse capture works with the event
         log off -- so a recorder exists while *either* is on, with each button
-        mapped to one of its options. Switching a button that does not need a
-        different recorder adjusts the live one in place, so toggling test
-        pulses mid-session does not start a second log file.
+        mapped to one of its options. Either button switching while the other
+        keeps a recorder alive adjusts that live recorder in place, so one
+        session produces one log file and one test-pulse sidecar however the
+        two buttons are worked. A recorder is only ever built when none is
+        running, and only ever stopped when both buttons are off.
+
+        Events are recorded from every pipette, but whole test-pulse recordings
+        only from the selected ones, which is the far more expensive half. That
+        selection is handed to the recorder once, so changing which pipettes are
+        selected mid-recording does not re-scope capture.
         """
         if not writeEvents and not recordTestPulses:
             if self._recorder is not None:
                 self._recorder.stop()
                 self._recorder = None
             return
-        if self._recorder is not None and self._recorder.write_events == writeEvents:
-            self._recorder.setRecordFullTestPulses(recordTestPulses)
-            return
         if self._recorder is not None:
-            self._recorder.stop()
+            wasWritingEvents = self._recorder.writesEvents()
+            self._recorder.setRecordFullTestPulses(recordTestPulses)
+            self._recorder.setWriteEvents(writeEvents)
+            if replayHistory and writeEvents and not wasWritingEvents:
+                # The log has just opened on a recorder that was capturing test
+                # pulses only, so what came before it still has to be replayed
+                # in -- the same thing initial_records does for a fresh one.
+                for record in list(self.eventHistory):
+                    self._recorder.record(record)
+            return
         self._recorder = MultiPatchLogRecorder(
             getManager().getCurrentDir(),
             pipettes=[p for p in self.pips if isinstance(p, PatchPipette)],
             microscope=self.microscope,
             record_full_test_pulses=recordTestPulses,
             write_events=writeEvents,
+            full_test_pulse_pipettes=self.selectedPipettes(),
             initial_records=list(self.eventHistory) if replayHistory else (),
         )
 

--- a/acq4/modules/MultiPatch/multipatch.py
+++ b/acq4/modules/MultiPatch/multipatch.py
@@ -5,14 +5,12 @@ import re
 from collections import OrderedDict
 from typing import List
 
-import h5py
-
 import pyqtgraph as pg
 from acq4 import getManager
 from acq4.devices.PatchPipette import PatchPipette
 from acq4.modules.Module import Module
 from acq4.util import Qt, ptime
-from neuroanalysis.test_pulse_stack import H5BackedTestPulseStack
+from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
 from .mockPatch import MockPatch
 from .pipetteControl import PipetteControl
 from ...devices.PatchPipette.statemanager import PatchPipetteStateManager
@@ -47,8 +45,11 @@ class MultiPatch(Module):
 
 class MultiPatchWindow(Qt.QWidget):
     def __init__(self, module):
-        self._eventStorageFile = None
-        self._testPulseStacks = {}
+        # The single recorder this window's two record buttons drive, or None
+        # while both are off. One instance covering every pipette, the
+        # microscope, and this window's own profile records -- the same
+        # single-file behavior the two buttons have always produced.
+        self._recorder = None
         self.eventHistory = []
         self._pipsToSetTips = []
         self._setTargetPips = []
@@ -587,7 +588,7 @@ class MultiPatchWindow(Qt.QWidget):
         self.updateXKeysBacklight()
 
     def pipetteEvent(self, pip, ev):
-        self.recordEvent(ev)
+        self._rememberEvent(ev)
 
     def surfaceDepthChanged(self, depth):
         event = OrderedDict([
@@ -596,50 +597,85 @@ class MultiPatchWindow(Qt.QWidget):
             ("event", "surface_depth_changed"),
             ("surface_depth", depth),
         ])
-        self.recordEvent(event)
+        self._rememberEvent(event)
 
     def recordToggled(self, rec):
-        if self._eventStorageFile is not None:
-            self._eventStorageFile.close()
-            self._eventStorageFile = None
+        if not rec:
             self.resetHistory()
-        if rec is True:
-            man = getManager()
-            sdir = man.getCurrentDir()
-            self._eventStorageFile = open(sdir.createFile('MultiPatch.log', autoIncrement=True).name(), 'ab')
-            self.writeRecords(self.eventHistory)
+        self._syncRecorder(
+            writeEvents=rec,
+            recordTestPulses=self.ui.recordTestPulsesBtn.isChecked(),
+            replayHistory=rec,
+        )
+        if rec:
             profile_data = PatchPipetteStateManager.buildPatchProfilesParameters().getValues()
             self.patchProfilesChanged(profile_data)
 
     def recordTestPulsesToggled(self, rec):
-        files = set()
-        for stack in self._testPulseStacks.values():
-            files.update(stack.files)
-        self._testPulseStacks = {}
-        for f in files:
-            f.close()
-        if rec is True:
-            man = getManager()
-            sdir = man.getCurrentDir()
-            name = sdir.createFile('TestPulses.hdf5', autoIncrement=True).name()
-            container = h5py.File(name, 'a')
-            group = container.create_group('test_pulses')
-            for dev in self.pips:
-                dev_gr = group.create_group(dev.name())
-                dev_gr.attrs['device'] = dev.name()
-                self._testPulseStacks[dev.name()] = H5BackedTestPulseStack(dev_gr)
-        for pip in self.selectedPipettes():
-            if rec:
-                pip.requestFullTestPulseData(self)
-            else:
-                pip.releaseFullTestPulseData(self)
+        self._syncRecorder(
+            writeEvents=self.ui.recordBtn.isChecked(),
+            recordTestPulses=rec,
+            replayHistory=False,
+        )
+
+    def _syncRecorder(self, writeEvents: bool, recordTestPulses: bool, replayHistory: bool):
+        """Bring self._recorder in line with the two record buttons.
+
+        The buttons are independent -- test-pulse capture works with the event
+        log off -- so a recorder exists while *either* is on, with each button
+        mapped to one of its options. Switching a button that does not need a
+        different recorder adjusts the live one in place, so toggling test
+        pulses mid-session does not start a second log file.
+        """
+        if not writeEvents and not recordTestPulses:
+            if self._recorder is not None:
+                self._recorder.stop()
+                self._recorder = None
+            return
+        if self._recorder is not None and self._recorder.write_events == writeEvents:
+            self._recorder.setRecordFullTestPulses(recordTestPulses)
+            return
+        if self._recorder is not None:
+            self._recorder.stop()
+        self._recorder = MultiPatchLogRecorder(
+            getManager().getCurrentDir(),
+            pipettes=[p for p in self.pips if isinstance(p, PatchPipette)],
+            microscope=self.microscope,
+            record_full_test_pulses=recordTestPulses,
+            write_events=writeEvents,
+            initial_records=list(self.eventHistory) if replayHistory else (),
+        )
 
     def recordEvent(self, event):
+        """Record one event this window originates: a patch-profile change.
+
+        Pipette events and microscope surface-depth changes are NOT routed
+        through here. The recorder subscribes to each pipette's sigNewEvent and
+        to the microscope's sigSurfaceDepthChanged directly, so passing those
+        along as well would write every one of them twice; they go through
+        _rememberEvent instead.
+        """
         if not self.eventHistory:
             self.resetHistory()
-        self.writeRecords([event])
+        if self._recorder is not None:
+            self._recorder.record(event)
         event = {k: v for k, v in event.items() if k != 'full_test_pulse'}
         self.eventHistory.append(event)
+
+    def _rememberEvent(self, event):
+        """Keep an event in this window's in-memory history without recording it.
+
+        For the events the recorder subscribes to itself, this is the whole of
+        the window's job. The history is still needed: it is what replays into a
+        freshly opened log, so that a log started mid-session begins with what
+        came before it.
+
+        The full test pulse is dropped: it belongs in the recorder's HDF5
+        sidecar, and a replay of this history is JSON.
+        """
+        if not self.eventHistory:
+            self.resetHistory()
+        self.eventHistory.append({k: v for k, v in event.items() if k != 'full_test_pulse'})
 
     def resetHistory(self):
         self.eventHistory = []
@@ -648,21 +684,3 @@ class MultiPatchWindow(Qt.QWidget):
                 pip.clampDevice.resetTestPulseHistory()
         for ctrl in self.pipCtrls:
             ctrl.clearEventLog()
-
-    def writeRecords(self, recs):
-        for rec in recs:
-            if 'full_test_pulse' in rec:
-                if self._testPulseStacks.get(rec['device'], None) is not None:
-                    filename, path = self._testPulseStacks[rec['device']].append(rec['full_test_pulse'])
-                    if self._eventStorageFile:
-                        filename = os.path.relpath(filename, os.path.dirname(self._eventStorageFile.name))
-                    rec = {k: v for k, v in rec.items() if k != 'full_test_pulse'}
-                    rec['full_test_pulse'] = f"{filename}:{path}"
-                else:
-                    rec = {k: v for k, v in rec.items() if k != 'full_test_pulse'}
-            if self._eventStorageFile:
-                self._eventStorageFile.write(json.dumps(rec, cls=ACQ4JSONEncoder).encode("utf8") + b",\n")
-        if self._eventStorageFile:
-            self._eventStorageFile.flush()
-        for stack in self._testPulseStacks.values():
-            stack.flush()

--- a/acq4/modules/MultiPatch/multipatch.py
+++ b/acq4/modules/MultiPatch/multipatch.py
@@ -629,7 +629,10 @@ class MultiPatchWindow(Qt.QWidget):
                 dev_gr.attrs['device'] = dev.name()
                 self._testPulseStacks[dev.name()] = H5BackedTestPulseStack(dev_gr)
         for pip in self.selectedPipettes():
-            pip.emitFullTestPulseData(rec)
+            if rec:
+                pip.requestFullTestPulseData(self)
+            else:
+                pip.releaseFullTestPulseData(self)
 
     def recordEvent(self, event):
         if not self.eventHistory:

--- a/acq4/modules/MultiPatch/pipetteControl.py
+++ b/acq4/modules/MultiPatch/pipetteControl.py
@@ -441,7 +441,37 @@ class PlotWidget(Qt.QWidget):
         self.modeCombo.hide()
         # self.closeBtn.hide()
 
-    def newTestPulse(self, tp: PatchClampTestPulse, history):
+    # Modes that need the PatchClampTestPulse recording itself, rather than just
+    # the analysis history. Unavailable to a caller plotting a retained history.
+    _LIVE_ONLY_MODES = ('test pulse', 'tp analysis')
+
+    def setFrozen(self, frozen: bool) -> None:
+        """Restrict the mode combo to what a retained history can serve.
+
+        Autopatch's frozen plots keep the combo visible -- re-reading a finished
+        attempt through a different field is what it is for -- but must not offer
+        the two modes that need a recording nobody retained.
+        """
+        if not frozen:
+            return
+        with pg.SignalBlock(self.modeCombo.currentIndexChanged, self.modeComboChanged):
+            current = self.mode
+            for mode in self._LIVE_ONLY_MODES:
+                index = self.modeCombo.findText(mode)
+                if index >= 0:
+                    self.modeCombo.removeItem(index)
+            self.modeCombo.setText(current)
+
+    def newTestPulse(self, tp: PatchClampTestPulse | None, history):
+        """Update the plot from the latest test pulse and the history behind it.
+
+        `tp` may be None, which is how Autopatch's Area 5 reuses this widget for
+        a finished action: its retained payload holds the history but no
+        PatchClampTestPulse, since a recording is not plain data (see
+        ActionLogEntry.set_details). With no `tp` the analysis modes plot the
+        history and leave the current-value label blank, and the two modes that
+        need the recording itself clear instead.
+        """
         if self._analysisLabel is not None:
             self.plot.plotItem.vb.removeItem(self._analysisLabel)
             self._analysisLabel = None
@@ -451,8 +481,9 @@ class PlotWidget(Qt.QWidget):
                 self._plotTestPulse(tp)
         elif self.mode == 'tp analysis':
             self.plot.clear()
-            tp.plot(self.plot, label=False)
-            self._analysisLabel = tp.label_for_plot(self.plot.plotItem)
+            if tp is not None:
+                tp.plot(self.plot, label=False)
+                self._analysisLabel = tp.label_for_plot(self.plot.plotItem)
         else:
             analysis_by_mode = {
                 'ss resistance': ('steady_state_resistance', u'Ω'),
@@ -465,10 +496,14 @@ class PlotWidget(Qt.QWidget):
             key, units = analysis_by_mode[self.mode]
             if len(history['event_time']) > 0:
                 self.plot.plot(history['event_time'] - history['event_time'][0], history[key], clear=True)
-            val = tp.analysis[key]
-            if val is None:
-                val = np.nan
-            self.tpLabel.setPlainText(pg.siFormat(val, suffix=units))
+            if tp is None:
+                # No live value to report; the plot is the whole story.
+                self.tpLabel.setPlainText("")
+            else:
+                val = tp.analysis[key]
+                if val is None:
+                    val = np.nan
+                self.tpLabel.setPlainText(pg.siFormat(val, suffix=units))
 
     def _plotTestPulse(self, tp):
         pri: TSeries = tp.recording['primary']

--- a/acq4/modules/MultiPatch/pipetteControl.py
+++ b/acq4/modules/MultiPatch/pipetteControl.py
@@ -450,17 +450,25 @@ class PlotWidget(Qt.QWidget):
 
         Autopatch's frozen plots keep the combo visible -- re-reading a finished
         attempt through a different field is what it is for -- but must not offer
-        the two modes that need a recording nobody retained.
+        the two modes that need a recording nobody retained. Passing False leaves
+        the combo and the current mode untouched.
         """
         if not frozen:
             return
+        current = self.mode
+        removing_current = current in self._LIVE_ONLY_MODES
         with pg.SignalBlock(self.modeCombo.currentIndexChanged, self.modeComboChanged):
-            current = self.mode
             for mode in self._LIVE_ONLY_MODES:
                 index = self.modeCombo.findText(mode)
                 if index >= 0:
                     self.modeCombo.removeItem(index)
-            self.modeCombo.setText(current)
+            if not removing_current:
+                self.modeCombo.setText(current)
+        if removing_current:
+            # The removed mode can no longer be restored; adopt whatever
+            # retained mode Qt landed the combo's selection on, routing
+            # through setMode so self.mode and the combo stay in agreement.
+            self.setMode(self.modeCombo.currentText())
 
     def newTestPulse(self, tp: PatchClampTestPulse | None, history):
         """Update the plot from the latest test pulse and the history behind it.

--- a/acq4/modules/MultiPatch/pipetteControl.py
+++ b/acq4/modules/MultiPatch/pipetteControl.py
@@ -413,6 +413,10 @@ class PlotWidget(Qt.QWidget):
         Qt.QWidget.__init__(self)
         self.mode = None
         self._analysisLabel = None
+        self._frozen = False
+        # The history behind the most recent newTestPulse(), retained so a
+        # frozen plot can re-read it when its mode changes.
+        self._history = None
         self.layout = Qt.QGridLayout()
         self.layout.setContentsMargins(0, 0, 0, 0)
         self.layout.setSpacing(0)
@@ -452,9 +456,13 @@ class PlotWidget(Qt.QWidget):
         attempt through a different field is what it is for -- but must not offer
         the two modes that need a recording nobody retained. Passing False leaves
         the combo and the current mode untouched.
+
+        A frozen plot also re-plots its retained history whenever the combo
+        changes, since no further test pulse will arrive to do it (see replot).
         """
         if not frozen:
             return
+        self._frozen = True
         current = self.mode
         removing_current = current in self._LIVE_ONLY_MODES
         with pg.SignalBlock(self.modeCombo.currentIndexChanged, self.modeComboChanged):
@@ -480,6 +488,7 @@ class PlotWidget(Qt.QWidget):
         history and leave the current-value label blank, and the two modes that
         need the recording itself clear instead.
         """
+        self._history = history
         if self._analysisLabel is not None:
             self.plot.plotItem.vb.removeItem(self._analysisLabel)
             self._analysisLabel = None
@@ -553,9 +562,25 @@ class PlotWidget(Qt.QWidget):
             self.plot.setYRange(0, 100e-12)
             self.plot.setLabels(left=('Capacitance', u'F'))
 
+    def replot(self):
+        """Re-draw the retained history under the current mode.
+
+        setMode only adjusts the axis label, log mode and Y range; the curve
+        itself is drawn by newTestPulse. A live plot redraws on its next test
+        pulse, so nothing else is needed there. A frozen plot never gets
+        another, so without this a mode change would leave the previous field's
+        curve on screen beneath the new field's axis -- wrong data under a label
+        that says otherwise.
+        """
+        if self._history is None:
+            return
+        self.newTestPulse(None, self._history)
+
     def modeComboChanged(self):
         mode = self.modeCombo.currentText()
         self.setMode(mode)
+        if self._frozen:
+            self.replot()
         self.sigModeChanged.emit(self, mode)
 
     def closeClicked(self):

--- a/acq4/modules/MultiPatch/tests/test_logfile.py
+++ b/acq4/modules/MultiPatch/tests/test_logfile.py
@@ -1,4 +1,7 @@
+import json
+
 import numpy as np
+import pytest
 
 from acq4.filetypes.MultiPatchLog import IrregularTimeSeries
 
@@ -69,16 +72,9 @@ def test_timeseries_index():
                     assert ts[t] == lookup(t, ts)
     
 
-"""Also: the record-button toggles map onto one MultiPatchLogRecorder, whose
-options are what the two independent buttons switch."""
-import pytest
-
-from acq4.util import Qt
-
-
-@pytest.fixture(scope="module")
-def qapp():
-    return Qt.QApplication.instance() or Qt.QApplication([])
+# The rest of this module covers the other half of the file's subject: the two
+# record-button toggles map onto one MultiPatchLogRecorder, whose options are
+# what the buttons switch.
 
 
 class _RecorderSpy:
@@ -88,12 +84,16 @@ class _RecorderSpy:
     instances = []
 
     def __init__(self, directory, pipettes=(), microscope=None,
-                 record_full_test_pulses=True, write_events=True, initial_records=()):
+                 record_full_test_pulses=True, write_events=True,
+                 full_test_pulse_pipettes=None, initial_records=()):
         self.directory = directory
         self.pipettes = list(pipettes)
         self.microscope = microscope
         self.record_full_test_pulses = record_full_test_pulses
         self.write_events = write_events
+        self.full_test_pulse_pipettes = (
+            None if full_test_pulse_pipettes is None else list(full_test_pulse_pipettes)
+        )
         self.initial_records = list(initial_records)
         self.records = []
         self.stopped = False
@@ -107,6 +107,12 @@ class _RecorderSpy:
 
     def recordsFullTestPulses(self):
         return self.record_full_test_pulses
+
+    def writesEvents(self):
+        return self.write_events
+
+    def setWriteEvents(self, write):
+        self.write_events = bool(write)
 
     def stop(self):
         self.stopped = True
@@ -175,10 +181,16 @@ class _StandInWindow:
     def __init__(self, directory, recording=False, recordingTestPulses=False):
         self.ui = _StandInUi(recording, recordingTestPulses)
         self.pips = []
+        self.selected = []
         self.microscope = None
         self.eventHistory = []
         self._recorder = None
         self.resetCount = 0
+
+    def selectedPipettes(self):
+        """The real one reads the per-pipette controls, and returns a single
+        pipette in solo mode."""
+        return list(self.selected)
 
     def resetHistory(self):
         """The real one also resets clamp test-pulse history and clears the
@@ -188,6 +200,15 @@ class _StandInWindow:
 
     def _syncRecorder(self, *args, **kwargs):
         return self._call("_syncRecorder", *args, **kwargs)
+
+    def recordToggled(self, *args, **kwargs):
+        return self._call("recordToggled", *args, **kwargs)
+
+    def recordTestPulsesToggled(self, *args, **kwargs):
+        return self._call("recordTestPulsesToggled", *args, **kwargs)
+
+    def patchProfilesChanged(self, *args, **kwargs):
+        return self._call("patchProfilesChanged", *args, **kwargs)
 
     def recordEvent(self, *args, **kwargs):
         return self._call("recordEvent", *args, **kwargs)
@@ -301,16 +322,36 @@ def test_turning_both_buttons_off_stops_the_recorder(spy, storageDir):
 
 
 def test_turning_the_event_log_off_leaves_test_pulses_recording(spy, storageDir):
+    # In place, not replaced: a second instance here would close TestPulses.hdf5
+    # and open TestPulses_001.hdf5 for the rest of the same session.
     win = _StandInWindow(storageDir, recording=True, recordingTestPulses=True)
     win._syncRecorder(writeEvents=True, recordTestPulses=True, replayHistory=True)
     first = win._recorder
 
     win._syncRecorder(writeEvents=False, recordTestPulses=True, replayHistory=False)
 
-    assert first.stopped is True
-    assert win._recorder is not first
-    assert win._recorder.write_events is False
-    assert win._recorder.record_full_test_pulses is True
+    assert win._recorder is first
+    assert len(spy.instances) == 1
+    assert first.stopped is False
+    assert first.write_events is False
+    assert first.record_full_test_pulses is True
+
+
+def test_turning_the_event_log_back_on_keeps_the_same_recorder(spy, storageDir):
+    win = _StandInWindow(storageDir, recording=True, recordingTestPulses=True)
+    win._syncRecorder(writeEvents=True, recordTestPulses=True, replayHistory=True)
+    first = win._recorder
+    win._syncRecorder(writeEvents=False, recordTestPulses=True, replayHistory=False)
+    win.eventHistory = [{"event": "state_change", "device": "Pipette1"}]
+
+    win._syncRecorder(writeEvents=True, recordTestPulses=True, replayHistory=True)
+
+    assert win._recorder is first
+    assert len(spy.instances) == 1
+    assert first.write_events is True
+    # Whatever happened while the log was shut has to reach the reopened log,
+    # exactly as initial_records does for a freshly built recorder.
+    assert first.records == win.eventHistory
 
 
 def test_starting_the_event_log_replays_the_in_memory_history(spy, storageDir):
@@ -407,3 +448,152 @@ def test_events_arriving_with_no_recorder_still_reach_the_history(spy, storageDi
 
     assert win._recorder is None
     assert len(win.eventHistory) == 2
+
+
+class _StandInPipette:
+    """_syncRecorder filters self.pips by isinstance(p, PatchPipette), and a
+    real one needs a Manager and a hardware config."""
+
+    def __init__(self, name):
+        self._name = name
+
+    def name(self):
+        return self._name
+
+
+@pytest.fixture
+def pipetteClass(monkeypatch):
+    import acq4.modules.MultiPatch.multipatch as mp
+
+    monkeypatch.setattr(mp, "PatchPipette", _StandInPipette)
+    return _StandInPipette
+
+
+@pytest.fixture
+def profiles(monkeypatch):
+    """The patch profiles recordToggled snapshots into a freshly opened log. The
+    real ones come off the Manager's configuration."""
+    import acq4.modules.MultiPatch.multipatch as mp
+
+    values = {"default": {"bath": {"testPulseEnabled": True}}}
+
+    class _Parameters:
+        def getValues(self):
+            return values
+
+    class _StandInStateManager:
+        @staticmethod
+        def buildPatchProfilesParameters():
+            return _Parameters()
+
+    monkeypatch.setattr(mp, "PatchPipetteStateManager", _StandInStateManager)
+    return values
+
+
+def test_full_test_pulses_are_captured_for_the_selected_pipettes_only(
+    spy, storageDir, pipetteClass
+):
+    # Every pipette's events are logged, but a whole test-pulse recording costs
+    # orders of magnitude more disk, so only the selected ones are captured.
+    win = _StandInWindow(storageDir, recordingTestPulses=True)
+    win.pips = [_StandInPipette("Pipette1"), _StandInPipette("Pipette2")]
+    win.selected = win.pips[:1]
+
+    win.recordTestPulsesToggled(True)
+
+    assert win._recorder.pipettes == win.pips
+    assert win._recorder.full_test_pulse_pipettes == win.pips[:1]
+
+
+def test_the_record_button_replays_the_history_then_records_the_profile(
+    spy, storageDir, profiles
+):
+    win = _StandInWindow(storageDir)
+    history = [{"event": "state_change", "device": "Pipette1"}]
+    win.eventHistory = list(history)
+    win.ui.recordBtn.setChecked(True)
+
+    win.recordToggled(True)
+
+    recorder = win._recorder
+    assert recorder.write_events is True
+    assert recorder.record_full_test_pulses is False
+    # The history goes in as the fresh file's first records...
+    assert recorder.initial_records == history
+    # ...and the profile snapshot lands after it, as a live record.
+    assert [e["event"] for e in recorder.records] == ["global patch profiles changed"]
+    assert json.loads(recorder.records[0]["profile"]) == profiles
+
+
+def test_the_record_button_off_resets_the_history_and_stops_the_recorder(
+    spy, storageDir, profiles
+):
+    win = _StandInWindow(storageDir, recording=True)
+    win.recordToggled(True)
+    recorder = win._recorder
+    resetsBefore = win.resetCount
+
+    win.ui.recordBtn.setChecked(False)
+    win.recordToggled(False)
+
+    assert win.resetCount == resetsBefore + 1
+    assert win.eventHistory == []
+    assert win._recorder is None
+    assert recorder.stopped is True
+
+
+def test_the_record_button_off_with_test_pulses_on_keeps_the_live_recorder(
+    spy, storageDir, profiles
+):
+    # Both buttons on, then the event log alone off: replacing the recorder here
+    # would close TestPulses.hdf5 mid-session and open TestPulses_001.hdf5.
+    win = _StandInWindow(storageDir, recording=True, recordingTestPulses=True)
+    win.recordToggled(True)
+    recorder = win._recorder
+
+    win.ui.recordBtn.setChecked(False)
+    win.recordToggled(False)
+
+    assert win._recorder is recorder
+    assert len(spy.instances) == 1
+    assert recorder.stopped is False
+    assert recorder.write_events is False
+    assert recorder.record_full_test_pulses is True
+
+
+def test_the_test_pulse_button_reads_the_event_log_button_not_its_own(spy, storageDir):
+    # recordTestPulsesToggled maps the *other* button onto write_events. Reading
+    # its own would open an event log nobody asked for.
+    win = _StandInWindow(storageDir, recording=False, recordingTestPulses=True)
+
+    win.recordTestPulsesToggled(True)
+
+    assert win._recorder.write_events is False
+    assert win._recorder.record_full_test_pulses is True
+    # And it never replays: with the event log off, these events have been
+    # written nowhere, so replaying them would record them for the first time
+    # out of order with the live stream.
+    assert win._recorder.initial_records == []
+
+
+def test_the_test_pulse_button_leaves_a_running_event_log_alone(
+    spy, storageDir, profiles
+):
+    win = _StandInWindow(storageDir, recording=True)
+    win.recordToggled(True)
+    recorder = win._recorder
+
+    win.ui.recordTestPulsesBtn.setChecked(True)
+    win.recordTestPulsesToggled(True)
+
+    assert win._recorder is recorder
+    assert recorder.write_events is True
+    assert recorder.record_full_test_pulses is True
+
+    win.ui.recordTestPulsesBtn.setChecked(False)
+    win.recordTestPulsesToggled(False)
+
+    assert win._recorder is recorder
+    assert len(spy.instances) == 1
+    assert recorder.write_events is True
+    assert recorder.record_full_test_pulses is False

--- a/acq4/modules/MultiPatch/tests/test_logfile.py
+++ b/acq4/modules/MultiPatch/tests/test_logfile.py
@@ -68,3 +68,342 @@ def test_timeseries_index():
                 for t in np.arange(-1, 40, 0.05):
                     assert ts[t] == lookup(t, ts)
     
+
+"""Also: the record-button toggles map onto one MultiPatchLogRecorder, whose
+options are what the two independent buttons switch."""
+import pytest
+
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+class _RecorderSpy:
+    """Stands in for MultiPatchLogRecorder so the toggle mapping can be tested
+    without a Manager, real devices, or a storage directory."""
+
+    instances = []
+
+    def __init__(self, directory, pipettes=(), microscope=None,
+                 record_full_test_pulses=True, write_events=True, initial_records=()):
+        self.directory = directory
+        self.pipettes = list(pipettes)
+        self.microscope = microscope
+        self.record_full_test_pulses = record_full_test_pulses
+        self.write_events = write_events
+        self.initial_records = list(initial_records)
+        self.records = []
+        self.stopped = False
+        _RecorderSpy.instances.append(self)
+
+    def record(self, event):
+        self.records.append(event)
+
+    def setRecordFullTestPulses(self, record):
+        self.record_full_test_pulses = bool(record)
+
+    def recordsFullTestPulses(self):
+        return self.record_full_test_pulses
+
+    def stop(self):
+        self.stopped = True
+
+
+@pytest.fixture
+def spy(monkeypatch):
+    import acq4.modules.MultiPatch.multipatch as mp
+
+    _RecorderSpy.instances = []
+    monkeypatch.setattr(mp, "MultiPatchLogRecorder", _RecorderSpy)
+    return _RecorderSpy
+
+
+def test_write_records_is_gone():
+    # Its whole job moved into the recorder; leaving it would be a second
+    # implementation of the format to drift from the first.
+    from acq4.modules.MultiPatch.multipatch import MultiPatchWindow
+
+    assert not hasattr(MultiPatchWindow, "writeRecords")
+
+
+def test_reset_history_still_resets_the_clamp_history():
+    # resetHistory is MultiPatch's Reset button, deliberately NOT moved into the
+    # recorder: a recorder that reset device state would let one module wipe the
+    # history another is plotting.
+    import inspect
+
+    from acq4.modules.MultiPatch.multipatch import MultiPatchWindow
+
+    source = inspect.getsource(MultiPatchWindow.resetHistory)
+    assert "resetTestPulseHistory" in source
+
+
+def test_the_recorder_never_resets_device_state():
+    import inspect
+
+    from acq4.util import multipatch_log_recorder
+
+    source = inspect.getsource(multipatch_log_recorder)
+    assert "resetTestPulseHistory" not in source
+
+
+class _FakeToggleButton:
+    """One of the window's two record buttons, reduced to the checked state
+    _syncRecorder reads off it."""
+
+    def __init__(self, checked=False):
+        self._checked = bool(checked)
+
+    def isChecked(self):
+        return self._checked
+
+    def setChecked(self, checked):
+        self._checked = bool(checked)
+
+
+class _StandInWindow:
+    """The parts of MultiPatchWindow that _syncRecorder touches.
+
+    Instantiating the real window needs a Manager and real patch-pipette
+    devices, which no fixture in this repo provides, so the recorder mapping is
+    exercised against this instead and the method under test is the real one.
+    """
+
+    def __init__(self, directory, recording=False, recordingTestPulses=False):
+        self.ui = _StandInUi(recording, recordingTestPulses)
+        self.pips = []
+        self.microscope = None
+        self.eventHistory = []
+        self._recorder = None
+        self.resetCount = 0
+
+    def resetHistory(self):
+        """The real one also resets clamp test-pulse history and clears the
+        pipette controls' event logs, both of which need real devices."""
+        self.eventHistory = []
+        self.resetCount += 1
+
+    def _syncRecorder(self, *args, **kwargs):
+        return self._call("_syncRecorder", *args, **kwargs)
+
+    def recordEvent(self, *args, **kwargs):
+        return self._call("recordEvent", *args, **kwargs)
+
+    def _rememberEvent(self, *args, **kwargs):
+        return self._call("_rememberEvent", *args, **kwargs)
+
+    def pipetteEvent(self, *args, **kwargs):
+        return self._call("pipetteEvent", *args, **kwargs)
+
+    def surfaceDepthChanged(self, *args, **kwargs):
+        return self._call("surfaceDepthChanged", *args, **kwargs)
+
+    def _call(self, name, *args, **kwargs):
+        from acq4.modules.MultiPatch.multipatch import MultiPatchWindow
+
+        return getattr(MultiPatchWindow, name)(self, *args, **kwargs)
+
+
+class _StandInUi:
+    def __init__(self, recording, recordingTestPulses):
+        self.recordBtn = _FakeToggleButton(recording)
+        self.recordTestPulsesBtn = _FakeToggleButton(recordingTestPulses)
+
+
+@pytest.fixture
+def storageDir(monkeypatch):
+    """The current storage directory _syncRecorder hands the recorder. Returned
+    as a sentinel so tests can assert it reached the recorder unchanged."""
+    import acq4.modules.MultiPatch.multipatch as mp
+
+    directory = object()
+
+    class _DirectoryOnlyManager:
+        def getCurrentDir(self):
+            return directory
+
+    monkeypatch.setattr(mp, "getManager", _DirectoryOnlyManager)
+    return directory
+
+
+def test_no_recorder_while_both_buttons_are_off(spy, storageDir):
+    win = _StandInWindow(storageDir)
+
+    win._syncRecorder(writeEvents=False, recordTestPulses=False, replayHistory=False)
+
+    assert win._recorder is None
+    assert spy.instances == []
+
+
+def test_event_log_button_alone_records_events_only(spy, storageDir):
+    win = _StandInWindow(storageDir, recording=True)
+
+    win._syncRecorder(writeEvents=True, recordTestPulses=False, replayHistory=True)
+
+    assert win._recorder is spy.instances[-1]
+    assert win._recorder.directory is storageDir
+    assert win._recorder.write_events is True
+    assert win._recorder.record_full_test_pulses is False
+
+
+def test_test_pulse_button_alone_records_pulses_without_an_event_log(spy, storageDir):
+    win = _StandInWindow(storageDir, recordingTestPulses=True)
+
+    win._syncRecorder(writeEvents=False, recordTestPulses=True, replayHistory=False)
+
+    assert win._recorder is spy.instances[-1]
+    assert win._recorder.write_events is False
+    assert win._recorder.record_full_test_pulses is True
+
+
+def test_both_buttons_record_events_and_full_test_pulses(spy, storageDir):
+    win = _StandInWindow(storageDir, recording=True, recordingTestPulses=True)
+
+    win._syncRecorder(writeEvents=True, recordTestPulses=True, replayHistory=True)
+
+    assert len(spy.instances) == 1
+    assert win._recorder.write_events is True
+    assert win._recorder.record_full_test_pulses is True
+
+
+def test_toggling_test_pulses_mid_session_adjusts_the_live_recorder(spy, storageDir):
+    # A second instance here would mean a second log file for one session.
+    win = _StandInWindow(storageDir, recording=True)
+    win._syncRecorder(writeEvents=True, recordTestPulses=False, replayHistory=True)
+    recorder = win._recorder
+
+    win._syncRecorder(writeEvents=True, recordTestPulses=True, replayHistory=False)
+
+    assert win._recorder is recorder
+    assert len(spy.instances) == 1
+    assert recorder.stopped is False
+    assert recorder.record_full_test_pulses is True
+
+    win._syncRecorder(writeEvents=True, recordTestPulses=False, replayHistory=False)
+
+    assert win._recorder is recorder
+    assert len(spy.instances) == 1
+    assert recorder.record_full_test_pulses is False
+
+
+def test_turning_both_buttons_off_stops_the_recorder(spy, storageDir):
+    win = _StandInWindow(storageDir, recording=True)
+    win._syncRecorder(writeEvents=True, recordTestPulses=False, replayHistory=True)
+    recorder = win._recorder
+
+    win._syncRecorder(writeEvents=False, recordTestPulses=False, replayHistory=False)
+
+    assert win._recorder is None
+    assert recorder.stopped is True
+
+
+def test_turning_the_event_log_off_leaves_test_pulses_recording(spy, storageDir):
+    win = _StandInWindow(storageDir, recording=True, recordingTestPulses=True)
+    win._syncRecorder(writeEvents=True, recordTestPulses=True, replayHistory=True)
+    first = win._recorder
+
+    win._syncRecorder(writeEvents=False, recordTestPulses=True, replayHistory=False)
+
+    assert first.stopped is True
+    assert win._recorder is not first
+    assert win._recorder.write_events is False
+    assert win._recorder.record_full_test_pulses is True
+
+
+def test_starting_the_event_log_replays_the_in_memory_history(spy, storageDir):
+    win = _StandInWindow(storageDir, recording=True)
+    win.eventHistory = [{"event": "state_change", "device": "Pipette1"}]
+
+    win._syncRecorder(writeEvents=True, recordTestPulses=False, replayHistory=True)
+
+    assert win._recorder.initial_records == win.eventHistory
+
+
+def test_test_pulse_toggle_does_not_replay_the_history_into_a_new_recorder(spy, storageDir):
+    # The event log is off here, so the history has not been written anywhere;
+    # replaying it into the test-pulse-only recorder would be the first time
+    # these events were ever recorded, out of order with the live stream.
+    win = _StandInWindow(storageDir, recordingTestPulses=True)
+    win.eventHistory = [{"event": "state_change", "device": "Pipette1"}]
+
+    win._syncRecorder(writeEvents=False, recordTestPulses=True, replayHistory=False)
+
+    assert win._recorder.initial_records == []
+
+
+class _StandInMicroscope:
+    def name(self):
+        return "Microscope"
+
+
+def test_window_originated_events_reach_the_recorder(spy, storageDir):
+    win = _StandInWindow(storageDir, recording=True)
+    win._syncRecorder(writeEvents=True, recordTestPulses=False, replayHistory=True)
+    event = {"device": None, "event": "global patch profiles changed", "profile": "{}"}
+
+    win.recordEvent(event)
+
+    assert win._recorder.records == [event]
+    assert win.eventHistory == [event]
+
+
+def test_pipette_events_are_not_handed_to_the_recorder(spy, storageDir):
+    # The recorder subscribes to sigNewEvent itself, so handing it the event
+    # here as well would write every pipette event twice.
+    win = _StandInWindow(storageDir, recording=True)
+    win._syncRecorder(writeEvents=True, recordTestPulses=True, replayHistory=True)
+
+    win.pipetteEvent(object(), {"device": "Pipette1", "event": "state_change", "state": "bath"})
+
+    assert win._recorder.records == []
+    assert [e["event"] for e in win.eventHistory] == ["state_change"]
+
+
+def test_surface_depth_changes_are_not_handed_to_the_recorder(spy, storageDir):
+    # Same reason: _syncRecorder gives the recorder the microscope, so the
+    # recorder is already subscribed to sigSurfaceDepthChanged.
+    win = _StandInWindow(storageDir, recording=True)
+    win.microscope = _StandInMicroscope()
+    win._syncRecorder(writeEvents=True, recordTestPulses=False, replayHistory=True)
+
+    win.surfaceDepthChanged(-1e-3)
+
+    assert win._recorder.records == []
+    assert [e["event"] for e in win.eventHistory] == ["surface_depth_changed"]
+    assert win.eventHistory[0]["surface_depth"] == -1e-3
+
+
+def test_the_recorder_is_given_the_microscope(spy, storageDir):
+    win = _StandInWindow(storageDir, recording=True)
+    win.microscope = _StandInMicroscope()
+
+    win._syncRecorder(writeEvents=True, recordTestPulses=False, replayHistory=True)
+
+    assert win._recorder.microscope is win.microscope
+
+
+def test_the_in_memory_history_never_holds_a_full_test_pulse(spy, storageDir):
+    # The history is replayed into a freshly opened log, where a whole test
+    # pulse recording is neither serializable nor wanted.
+    win = _StandInWindow(storageDir, recordingTestPulses=True)
+    win._syncRecorder(writeEvents=False, recordTestPulses=True, replayHistory=False)
+
+    win.pipetteEvent(
+        object(),
+        {"device": "Pipette1", "event": "test_pulse", "full_test_pulse": object()},
+    )
+
+    assert "full_test_pulse" not in win.eventHistory[0]
+
+
+def test_events_arriving_with_no_recorder_still_reach_the_history(spy, storageDir):
+    win = _StandInWindow(storageDir)
+
+    win.recordEvent({"device": None, "event": "global patch profiles changed"})
+    win.pipetteEvent(object(), {"device": "Pipette1", "event": "state_change"})
+
+    assert win._recorder is None
+    assert len(win.eventHistory) == 2

--- a/acq4/modules/MultiPatch/tests/test_plot_widget_frozen.py
+++ b/acq4/modules/MultiPatch/tests/test_plot_widget_frozen.py
@@ -1,0 +1,105 @@
+"""Tests for PlotWidget's frozen mode: plotting a retained test-pulse history
+with no live PatchClampTestPulse to read a current value from.
+
+Autopatch's Area 5 reuses this widget for a finished action's plot (design doc
+§4.5, "reuse, do not reimplement"), and its retained payload deliberately holds
+no PatchClampTestPulse -- so tp is None there."""
+import numpy as np
+import pytest
+
+from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+def _history(count=5):
+    history = np.zeros(count, dtype=TEST_PULSE_NUMPY_DTYPE)
+    history["event_time"] = np.arange(count, dtype=float)
+    history["steady_state_resistance"] = np.linspace(1e6, 1e9, count)
+    history["access_resistance"] = np.linspace(1e6, 2e7, count)
+    history["baseline_current"] = np.linspace(-1e-10, 1e-10, count)
+    history["baseline_potential"] = np.linspace(-0.07, -0.06, count)
+    history["time_constant"] = np.linspace(1e-4, 1e-3, count)
+    history["capacitance"] = np.linspace(1e-12, 5e-12, count)
+    return history
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "ss resistance",
+        "peak resistance",
+        "holding current",
+        "holding potential",
+        "time constant",
+        "capacitance",
+    ],
+)
+def test_analysis_modes_plot_a_history_with_no_test_pulse(qapp, mode):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode=mode)
+
+    widget.newTestPulse(None, _history())
+
+    assert len(widget.plot.plotItem.listDataItems()) == 1
+
+
+def test_the_current_value_label_is_blank_with_no_test_pulse(qapp):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode="ss resistance")
+
+    widget.newTestPulse(None, _history())
+
+    assert widget.tpLabel.toPlainText() == ""
+
+
+def test_an_empty_history_plots_nothing_and_does_not_raise(qapp):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode="ss resistance")
+
+    widget.newTestPulse(None, _history(count=0))
+
+    assert widget.plot.plotItem.listDataItems() == []
+
+
+def test_test_pulse_modes_clear_rather_than_raise_with_no_test_pulse(qapp):
+    # 'test pulse' and 'tp analysis' need the recording itself, which a frozen
+    # payload deliberately does not retain. They must degrade, not crash.
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    for mode in ("test pulse", "tp analysis"):
+        widget = PlotWidget(mode=mode)
+        widget.newTestPulse(None, _history())
+        assert widget.plot.plotItem.listDataItems() == []
+
+
+def test_set_frozen_removes_the_modes_a_history_cannot_serve(qapp):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode="ss resistance")
+
+    widget.setFrozen(True)
+
+    items = [widget.modeCombo.itemText(i) for i in range(widget.modeCombo.count())]
+    assert "test pulse" not in items
+    assert "tp analysis" not in items
+    assert "ss resistance" in items
+    assert "capacitance" in items
+
+
+def test_set_frozen_keeps_the_current_mode_selected(qapp):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode="capacitance")
+
+    widget.setFrozen(True)
+
+    assert widget.modeCombo.currentText() == "capacitance"
+    assert widget.mode == "capacitance"

--- a/acq4/modules/MultiPatch/tests/test_plot_widget_frozen.py
+++ b/acq4/modules/MultiPatch/tests/test_plot_widget_frozen.py
@@ -53,6 +53,7 @@ def test_the_current_value_label_is_blank_with_no_test_pulse(qapp):
     from acq4.modules.MultiPatch.pipetteControl import PlotWidget
 
     widget = PlotWidget(mode="ss resistance")
+    widget.tpLabel.setPlainText("1.0 MOhm")
 
     widget.newTestPulse(None, _history())
 
@@ -103,3 +104,19 @@ def test_set_frozen_keeps_the_current_mode_selected(qapp):
 
     assert widget.modeCombo.currentText() == "capacitance"
     assert widget.mode == "capacitance"
+
+
+@pytest.mark.parametrize("mode", ["test pulse", "tp analysis"])
+def test_set_frozen_on_a_live_only_mode_lands_on_a_retained_mode(qapp, mode):
+    # Freezing while one of the two removed modes is selected must not raise,
+    # and must leave self.mode and the combo's displayed text agreeing on
+    # whatever mode the combo landed on.
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode=mode)
+
+    widget.setFrozen(True)
+
+    items = [widget.modeCombo.itemText(i) for i in range(widget.modeCombo.count())]
+    assert widget.modeCombo.currentText() in items
+    assert widget.mode == widget.modeCombo.currentText()

--- a/acq4/modules/TaskRunner/TaskRunner.py
+++ b/acq4/modules/TaskRunner/TaskRunner.py
@@ -130,6 +130,11 @@ class TaskRunner(Module):
 
         self.currentTask = None  ## pointer to current task object
 
+        # The directory the most recent stored sequence saved into, so a caller
+        # driving runSequence() can report where the data went. None until a
+        # sequence runs with store=True.
+        self.lastSequenceDir = None
+
         for m in analysisModules.MODULES:
             item = Qt.QListWidgetItem(m, self.ui.analysisList)
             item.setFlags(Qt.Qt.ItemIsSelectable | Qt.Qt.ItemIsEnabled | Qt.Qt.ItemIsUserCheckable)
@@ -646,8 +651,10 @@ class TaskRunner(Module):
                 info = self.taskInfo(params)
                 info['dirType'] = 'ProtocolSequence'
                 dh = storeDirHandle.mkdir(name, autoIncrement=True, info=info)
+                self.lastSequenceDir = dh
             else:
                 dh = None
+                self.lastSequenceDir = None
 
             ## Tell devices to prepare for task start.
             for d in self.currentTask.devices:

--- a/acq4/util/multipatch_log_recorder.py
+++ b/acq4/util/multipatch_log_recorder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 
 import h5py
 import numpy as np
@@ -53,6 +54,15 @@ class MultiPatchLogRecorder(Qt.QObject):
     before anything is written. __init__ pins that affinity itself rather than
     trusting the constructing thread, so a recorder opened from a worker thread
     with no Qt event loop still receives its events.
+
+    stop(), though, is called directly -- not through a queued connection --
+    typically from the orchestrator's worker thread while the GUI thread is
+    off writing a queued event. self._lock is what keeps those two from
+    interleaving on the log file handle: both the write path and stop()'s
+    close of it run under the same lock, so a write already past record()'s
+    _stopped check either finishes before stop() closes the handle or sees
+    _stopped turn true inside the lock and skips the write instead of raising
+    on a closed file.
 
     Parameters
     ----------
@@ -117,6 +127,12 @@ class MultiPatchLogRecorder(Qt.QObject):
         )
         self._microscope = microscope
         self._stopped = False
+        # Guards the write path (_writeRecords) and stop()'s close of the log
+        # file against each other -- see the class docstring. RLock rather
+        # than Lock so a guarded call that ends up re-entering (directly or
+        # through a signal handler further down the call stack) blocks
+        # nowhere it does not already, instead of deadlocking the recorder.
+        self._lock = threading.RLock()
         self._writeEvents = bool(write_events)
         # Kept separately from the file object so it survives the file being
         # closed and reopened by setWriteEvents, which is what keeps one
@@ -308,15 +324,23 @@ class MultiPatchLogRecorder(Qt.QObject):
         for record in records:
             if "full_test_pulse" in record:
                 record = self._divertFullTestPulse(record)
-            if self._logFile is not None:
+            # Locked so this can never land between stop()'s _stopped flip and
+            # its close of self._logFile: that close does not clear the
+            # attribute (see logFileName()), so checking "is not None" alone
+            # would still pass on a closed handle. Re-checking _stopped here,
+            # under the same lock stop() sets it under, is what actually
+            # excludes a write that arrives after record()'s own check but
+            # loses the race to stop().
+            with self._lock:
+                if self._stopped or self._logFile is None:
+                    continue
                 # One JSON object per line, with no trailing comma. Both readers
                 # strip b",\r\n" as a character set rather than as a suffix, so
                 # they parse this and the historical comma-terminated form alike.
                 self._logFile.write(
                     json.dumps(record, cls=ACQ4JSONEncoder).encode("utf8") + b"\n"
                 )
-        if self._logFile is not None:
-            self._logFile.flush()
+                self._logFile.flush()
         for stack in self._testPulseStacks.values():
             stack.flush()
 
@@ -324,7 +348,13 @@ class MultiPatchLogRecorder(Qt.QObject):
         """Release everything this recorder holds. Idempotent."""
         if self._stopped:
             return
-        self._stopped = True
+        with self._lock:
+            # Re-checked under the lock: a second stop() call racing this one
+            # would otherwise both see _stopped False from the unlocked check
+            # above and both try to tear down the same subscriptions.
+            if self._stopped:
+                return
+            self._stopped = True
         self._releaseFullTestPulseData()
         for pip in self._pipettes:
             Qt.disconnect(pip.sigNewEvent, self._onPipetteEvent)
@@ -353,6 +383,10 @@ class MultiPatchLogRecorder(Qt.QObject):
             # However the sidecar teardown above turns out, the event log
             # must still be closed and flushed -- a raise here must never
             # leave it open for the rest of the process, since _stopped is
-            # already set and every later stop() call is now a no-op.
-            if self._logFile is not None:
-                self._logFile.close()
+            # already set and every later stop() call is now a no-op. Under
+            # the same lock _writeRecords writes under, so this close can
+            # never land in the middle of a write already past that method's
+            # own _stopped check.
+            with self._lock:
+                if self._logFile is not None:
+                    self._logFile.close()

--- a/acq4/util/multipatch_log_recorder.py
+++ b/acq4/util/multipatch_log_recorder.py
@@ -87,8 +87,12 @@ class MultiPatchLogRecorder(Qt.QObject):
         self._pipettes = list(pipettes)
         self._microscope = microscope
         self._stopped = False
+        # Public because a caller driving one recorder from several independent
+        # switches needs to know whether the live recorder already writes an
+        # event log, to choose between adjusting it and replacing it.
+        self.write_events = bool(write_events)
         self._logFile = None
-        if write_events:
+        if self.write_events:
             handle = directory.createFile(LOG_FILE_NAME, autoIncrement=True)
             self._logFile = open(handle.name(), "ab")
         self._recordFullTestPulses = record_full_test_pulses

--- a/acq4/util/multipatch_log_recorder.py
+++ b/acq4/util/multipatch_log_recorder.py
@@ -174,11 +174,22 @@ class MultiPatchLogRecorder(Qt.QObject):
         if self._stopped:
             return
         self._stopped = True
-        for stack in self._testPulseStacks.values():
-            stack.close()
-        self._testPulseStacks = {}
-        if self._testPulseContainer is not None:
-            self._testPulseContainer.close()
-            self._testPulseContainer = None
-        if self._logFile is not None:
-            self._logFile.close()
+        try:
+            # All of self._testPulseStacks share one h5py.File --
+            # self._testPulseContainer, opened once in _makeTestPulseStack --
+            # so closing it here is sufficient for every stack. Do not also
+            # call stack.close() per stack: H5BackedTestPulseStack.close()
+            # closes the *file* its groups belong to, so the first call would
+            # close the file out from under every other device's stack and
+            # the next call would raise trying to close it again.
+            self._testPulseStacks = {}
+            if self._testPulseContainer is not None:
+                self._testPulseContainer.close()
+                self._testPulseContainer = None
+        finally:
+            # However the sidecar teardown above turns out, the event log
+            # must still be closed and flushed -- a raise here must never
+            # leave it open for the rest of the process, since _stopped is
+            # already set and every later stop() call is now a no-op.
+            if self._logFile is not None:
+                self._logFile.close()

--- a/acq4/util/multipatch_log_recorder.py
+++ b/acq4/util/multipatch_log_recorder.py
@@ -1,0 +1,107 @@
+"""MultiPatchLogRecorder: writes a PatchPipette event stream to a MultiPatch-
+format log file, with an optional full-test-pulse HDF5 sidecar beside it."""
+from __future__ import annotations
+
+import json
+
+from acq4.util import Qt
+from acq4.util.json_encoder import ACQ4JSONEncoder
+
+# Base name of the log file, matched case-insensitively by
+# acq4.filetypes.MultiPatchLog and by tools/autopatch_analysis. Changing it
+# makes the resulting file invisible to both readers.
+LOG_FILE_NAME = "MultiPatch.log"
+
+
+class MultiPatchLogRecorder(Qt.QObject):
+    """One MultiPatch-format log file and the subscriptions that fill it.
+
+    Owns a file and (optionally) an HDF5 test-pulse stack, and **nothing else**:
+    it never touches device state. In particular it never resets a clamp's
+    test-pulse history -- that is MultiPatch's Reset button, and a recorder
+    doing it would let one module wipe the history another is plotting.
+
+    Any number of recorders may observe the same pipette. That is what lets
+    Autopatch record a patch attempt while MultiPatch records the session, with
+    neither able to switch the other off (see
+    PatchPipette.requestFullTestPulseData).
+
+    A QObject on the GUI thread: events are emitted from clamp and state-machine
+    threads, and the default (queued) connections are what marshal them here
+    before anything is written.
+
+    Parameters
+    ----------
+    directory : DirHandle
+        Where the log file and its sidecar are created.
+    pipettes : iterable of PatchPipette
+        Whose sigNewEvent streams to record. One for an Autopatch action, all of
+        them for MultiPatch.
+    microscope : Microscope or None
+        Optional; its surface-depth changes are recorded too.
+    record_full_test_pulses : bool
+        Whether test_pulse events carry the whole recording into an HDF5
+        sidecar, rather than just their analysis.
+    write_events : bool
+        Whether to write the log file at all. False records full test pulses
+        without an event log, which is a combination MultiPatch's two
+        independent record buttons allow.
+    initial_records : iterable of dict
+        Records replayed into the fresh file before any live event, for a caller
+        that has been accumulating events before recording started.
+    """
+
+    def __init__(
+        self,
+        directory,
+        pipettes=(),
+        microscope=None,
+        record_full_test_pulses: bool = True,
+        write_events: bool = True,
+        initial_records=(),
+    ):
+        super().__init__()
+        self._directory = directory
+        self._pipettes = list(pipettes)
+        self._microscope = microscope
+        self._stopped = False
+        self._logFile = None
+        if write_events:
+            handle = directory.createFile(LOG_FILE_NAME, autoIncrement=True)
+            self._logFile = open(handle.name(), "ab")
+        for record in initial_records:
+            self.record(record)
+
+    def logFileName(self) -> str | None:
+        return None if self._logFile is None else self._logFile.name
+
+    def isRecording(self) -> bool:
+        return not self._stopped
+
+    def record(self, event) -> None:
+        """Write one record. Ignored once stopped, so a late queued event
+        arriving after the action that opened this recorder has ended does not
+        reopen a closed file."""
+        if self._stopped:
+            return
+        self._writeRecords([event])
+
+    def _writeRecords(self, records) -> None:
+        if self._logFile is None:
+            return
+        for record in records:
+            # One JSON object per line, with no trailing comma. Both readers
+            # strip b",\r\n" as a character set rather than as a suffix, so
+            # they parse this and the historical comma-terminated form alike.
+            self._logFile.write(
+                json.dumps(record, cls=ACQ4JSONEncoder).encode("utf8") + b"\n"
+            )
+        self._logFile.flush()
+
+    def stop(self) -> None:
+        """Release everything this recorder holds. Idempotent."""
+        if self._stopped:
+            return
+        self._stopped = True
+        if self._logFile is not None:
+            self._logFile.close()

--- a/acq4/util/multipatch_log_recorder.py
+++ b/acq4/util/multipatch_log_recorder.py
@@ -50,7 +50,9 @@ class MultiPatchLogRecorder(Qt.QObject):
 
     A QObject on the GUI thread: events are emitted from clamp and state-machine
     threads, and the default (queued) connections are what marshal them here
-    before anything is written.
+    before anything is written. __init__ pins that affinity itself rather than
+    trusting the constructing thread, so a recorder opened from a worker thread
+    with no Qt event loop still receives its events.
 
     Parameters
     ----------
@@ -93,6 +95,19 @@ class MultiPatchLogRecorder(Qt.QObject):
         initial_records=(),
     ):
         super().__init__()
+        # Pin signal affinity to the GUI thread when there is one, before any
+        # connect below. A recorder is routinely constructed from a worker
+        # thread (an Autopatch action runs on a gentletask ThreadTask, which has
+        # no Qt event loop); without this the queued sigNewEvent connections
+        # would target that loop-less thread and the slots would silently never
+        # fire, so test_pulse events emitted from the clamp's own thread would
+        # never be recorded. moveToThread is legal from the constructing thread
+        # because this object is parentless. Headless contexts have no
+        # QApplication; there the QObject stays on its creating thread and
+        # events still arrive via direct connection.
+        app = Qt.QApplication.instance()
+        if app is not None:
+            self.moveToThread(app.thread())
         self._directory = directory
         self._pipettes = list(pipettes)
         self._fullTestPulsePipettes = (

--- a/acq4/util/multipatch_log_recorder.py
+++ b/acq4/util/multipatch_log_recorder.py
@@ -68,6 +68,15 @@ class MultiPatchLogRecorder(Qt.QObject):
         Whether to write the log file at all. False records full test pulses
         without an event log, which is a combination MultiPatch's two
         independent record buttons allow.
+    full_test_pulse_pipettes : iterable of PatchPipette or None
+        The narrower set whose *whole* test-pulse recordings go into the
+        sidecar; None means every pipette in `pipettes`. The two scopes differ
+        because a full recording costs orders of magnitude more disk than the
+        analysis fields in an event, so MultiPatch logs events from every
+        pipette while capturing waveforms only from the selected ones. This set
+        is fixed when the recorder is built: changing which pipettes are
+        selected while recording does not re-scope capture, and only stopping
+        and restarting the recorder will.
     initial_records : iterable of dict
         Records replayed into the fresh file before any live event, for a caller
         that has been accumulating events before recording started.
@@ -80,21 +89,27 @@ class MultiPatchLogRecorder(Qt.QObject):
         microscope=None,
         record_full_test_pulses: bool = True,
         write_events: bool = True,
+        full_test_pulse_pipettes=None,
         initial_records=(),
     ):
         super().__init__()
         self._directory = directory
         self._pipettes = list(pipettes)
+        self._fullTestPulsePipettes = (
+            list(self._pipettes)
+            if full_test_pulse_pipettes is None
+            else list(full_test_pulse_pipettes)
+        )
         self._microscope = microscope
         self._stopped = False
-        # Public because a caller driving one recorder from several independent
-        # switches needs to know whether the live recorder already writes an
-        # event log, to choose between adjusting it and replacing it.
-        self.write_events = bool(write_events)
+        self._writeEvents = bool(write_events)
+        # Kept separately from the file object so it survives the file being
+        # closed and reopened by setWriteEvents, which is what keeps one
+        # recorder's records pointing at one log.
+        self._logFileName = None
         self._logFile = None
-        if self.write_events:
-            handle = directory.createFile(LOG_FILE_NAME, autoIncrement=True)
-            self._logFile = open(handle.name(), "ab")
+        if self._writeEvents:
+            self._openLogFile()
         self._recordFullTestPulses = record_full_test_pulses
         # device name -> its H5BackedTestPulseStack, created on first use so a
         # recorder that never sees a full test pulse writes no sidecar at all.
@@ -128,10 +143,41 @@ class MultiPatchLogRecorder(Qt.QObject):
             raise
 
     def logFileName(self) -> str | None:
-        return None if self._logFile is None else self._logFile.name
+        """This recorder's log file, or None if it has never opened one. Still
+        the name after setWriteEvents(False) closed it, since that is the file
+        every record written by this recorder is in."""
+        return self._logFileName
 
     def isRecording(self) -> bool:
         return not self._stopped
+
+    def writesEvents(self) -> bool:
+        return self._writeEvents
+
+    def setWriteEvents(self, write: bool) -> None:
+        """Open or close the event log for the rest of this recorder's life.
+
+        Touches nothing else: subscriptions, full-test-pulse tokens and the HDF5
+        sidecar all carry on across the switch, so a caller whose event log and
+        test-pulse capture are separate switches can adjust a live recorder
+        instead of replacing it -- and one session keeps one sidecar. Reopening
+        appends to the same log file rather than starting a second one.
+        """
+        write = bool(write)
+        if self._stopped or write == self._writeEvents:
+            return
+        self._writeEvents = write
+        if write:
+            self._openLogFile()
+        else:
+            self._logFile.close()
+            self._logFile = None
+
+    def _openLogFile(self) -> None:
+        if self._logFileName is None:
+            handle = self._directory.createFile(LOG_FILE_NAME, autoIncrement=True)
+            self._logFileName = handle.name()
+        self._logFile = open(self._logFileName, "ab")
 
     def record(self, event) -> None:
         """Write one record. Ignored once stopped, so a late queued event
@@ -158,11 +204,11 @@ class MultiPatchLogRecorder(Qt.QObject):
             self._releaseFullTestPulseData()
 
     def _requestFullTestPulseData(self) -> None:
-        for pip in self._pipettes:
+        for pip in self._fullTestPulsePipettes:
             pip.requestFullTestPulseData(self)
 
     def _releaseFullTestPulseData(self) -> None:
-        for pip in self._pipettes:
+        for pip in self._fullTestPulsePipettes:
             pip.releaseFullTestPulseData(self)
 
     def _onPipetteEvent(self, _pipette, event) -> None:
@@ -238,8 +284,8 @@ class MultiPatchLogRecorder(Qt.QObject):
         if stack is None:
             stack = self._testPulseStacks[deviceName] = self._makeTestPulseStack(deviceName)
         filename, h5path = stack.append(testPulse)
-        if self._logFile is not None:
-            filename = os.path.relpath(filename, os.path.dirname(self._logFile.name))
+        if self._logFileName is not None:
+            filename = os.path.relpath(filename, os.path.dirname(self._logFileName))
         record["full_test_pulse"] = f"{filename}:{h5path}"
         return record
 
@@ -270,6 +316,7 @@ class MultiPatchLogRecorder(Qt.QObject):
         # Dropped so a stopped recorder is not what keeps a device object
         # alive, and so a second stop() has nothing left to disconnect.
         self._pipettes = []
+        self._fullTestPulsePipettes = []
         if self._microscope is not None:
             Qt.disconnect(
                 self._microscope.sigSurfaceDepthChanged, self._onSurfaceDepthChanged

--- a/acq4/util/multipatch_log_recorder.py
+++ b/acq4/util/multipatch_log_recorder.py
@@ -162,13 +162,25 @@ class MultiPatchLogRecorder(Qt.QObject):
             pip.releaseFullTestPulseData(self)
 
     def _onPipetteEvent(self, _pipette, event) -> None:
-        if event.get("event") == "test_pulse":
+        # Guarded the same way record() guards itself: sigNewEvent is a queued
+        # connection, so a test_pulse event already in flight when stop() runs
+        # can still reach this slot afterward. Without this check that event
+        # would add a row here even though record() below silently drops it,
+        # leaving testPulseAnalysis() disagreeing with what was actually
+        # logged.
+        if not self._stopped and event.get("event") == "test_pulse":
             self._testPulseRows.append(
                 tuple(_nanIfNone(event.get(field)) for field in _TEST_PULSE_FIELDS)
             )
         self.record(event)
 
     def _onSurfaceDepthChanged(self, depth) -> None:
+        # Guarded for the same reason as _onPipetteEvent above: this is a
+        # queued connection, and stop() sets self._microscope to None, so a
+        # surface-depth signal already in flight when stop() runs would
+        # otherwise dereference None here.
+        if self._stopped:
+            return
         self.record(
             {
                 "device": self._microscope.name(),
@@ -186,6 +198,11 @@ class MultiPatchLogRecorder(Qt.QObject):
         action's span: the device's is reset mid-patch by the approach state, so
         slicing it by the action's start and end times loses whatever preceded
         the reset.
+
+        Meaningful only when this recorder watches a single pipette: rows carry
+        no device field, so a recorder watching several pipettes interleaves
+        their rows in event order with no way to tell which device any row came
+        from. Attributing rows to a device would need a dtype that carries one.
         """
         return np.array(self._testPulseRows, dtype=TEST_PULSE_NUMPY_DTYPE)
 

--- a/acq4/util/multipatch_log_recorder.py
+++ b/acq4/util/multipatch_log_recorder.py
@@ -6,9 +6,11 @@ import json
 import os
 
 import h5py
+import numpy as np
 from neuroanalysis.test_pulse_stack import H5BackedTestPulseStack
 
-from acq4.util import Qt
+from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
+from acq4.util import Qt, ptime
 from acq4.util.json_encoder import ACQ4JSONEncoder
 
 # Base name of the log file, matched case-insensitively by
@@ -20,6 +22,17 @@ LOG_FILE_NAME = "MultiPatch.log"
 # lives at inside it. MultiPatchLogData reads exactly `test_pulses/{device}`.
 TEST_PULSE_FILE_NAME = "TestPulses.hdf5"
 TEST_PULSE_GROUP = "test_pulses"
+
+# The analysis field names a test_pulse event can carry, taken from the dtype
+# the readers and PatchClamp's own history both use, so an accumulated array is
+# interchangeable with clampDevice.testPulseHistory()'s.
+_TEST_PULSE_FIELDS = tuple(name for name, _type in TEST_PULSE_NUMPY_DTYPE)
+
+
+def _nanIfNone(value):
+    """NaN for a missing or None analysis field, matching how PatchClamp's own
+    test-pulse history records one."""
+    return np.nan if value is None else value
 
 
 class MultiPatchLogRecorder(Qt.QObject):
@@ -83,17 +96,30 @@ class MultiPatchLogRecorder(Qt.QObject):
         # recorder that never sees a full test pulse writes no sidecar at all.
         self._testPulseStacks = {}
         self._testPulseContainer = None
+        # One row per test_pulse event this recorder saw, in order. Accumulated
+        # here rather than read from clampDevice.testPulseHistory() because the
+        # device's history is reset mid-patch -- approach.py:251 does it on every
+        # attempt -- so slicing that by time silently loses data.
+        self._testPulseRows: list[tuple] = []
         try:
+            for pip in self._pipettes:
+                pip.sigNewEvent.connect(self._onPipetteEvent)
+            if microscope is not None:
+                microscope.sigSurfaceDepthChanged.connect(self._onSurfaceDepthChanged)
+            if self._recordFullTestPulses:
+                self._requestFullTestPulseData()
             for record in initial_records:
                 self.record(record)
         except Exception:
-            # A record that ACQ4JSONEncoder cannot serialize raises out of
-            # this loop before the caller ever gets an instance back to call
-            # stop() on. Without this, the open file handle would be
-            # reachable only through a partially-constructed self, leaving
-            # its release to refcounting -- and a traceback holding this
-            # frame's locals can keep it open well past the raise. stop() is
-            # idempotent, so it is safe to call even if nothing was opened.
+            # A record that ACQ4JSONEncoder cannot serialize, or any failure
+            # in the subscription setup above, raises out of this block
+            # before the caller ever gets an instance back to call stop() on.
+            # Without this, the open file handle and any subscriptions/tokens
+            # would be reachable only through a partially-constructed self,
+            # leaving their release to refcounting -- and a traceback holding
+            # this frame's locals can keep them alive well past the raise.
+            # stop() is idempotent, so it is safe to call even if nothing was
+            # opened or subscribed yet.
             self.stop()
             raise
 
@@ -118,7 +144,50 @@ class MultiPatchLogRecorder(Qt.QObject):
         """Turn full-test-pulse capture on or off for the rest of this
         recorder's life. Existing stacks are kept: turning capture back on
         appends to the same sidecar rather than starting a second one."""
-        self._recordFullTestPulses = bool(record)
+        record = bool(record)
+        if record == self._recordFullTestPulses:
+            return
+        self._recordFullTestPulses = record
+        if record:
+            self._requestFullTestPulseData()
+        else:
+            self._releaseFullTestPulseData()
+
+    def _requestFullTestPulseData(self) -> None:
+        for pip in self._pipettes:
+            pip.requestFullTestPulseData(self)
+
+    def _releaseFullTestPulseData(self) -> None:
+        for pip in self._pipettes:
+            pip.releaseFullTestPulseData(self)
+
+    def _onPipetteEvent(self, _pipette, event) -> None:
+        if event.get("event") == "test_pulse":
+            self._testPulseRows.append(
+                tuple(_nanIfNone(event.get(field)) for field in _TEST_PULSE_FIELDS)
+            )
+        self.record(event)
+
+    def _onSurfaceDepthChanged(self, depth) -> None:
+        self.record(
+            {
+                "device": self._microscope.name(),
+                "event_time": ptime.time(),
+                "event": "surface_depth_changed",
+                "surface_depth": depth,
+            }
+        )
+
+    def testPulseAnalysis(self) -> np.ndarray:
+        """Every test_pulse event this recorder saw, as a structured array with
+        the same dtype as clampDevice.testPulseHistory().
+
+        This -- not the device's own history -- is what a UI should plot for one
+        action's span: the device's is reset mid-patch by the approach state, so
+        slicing it by the action's start and end times loses whatever preceded
+        the reset.
+        """
+        return np.array(self._testPulseRows, dtype=TEST_PULSE_NUMPY_DTYPE)
 
     def _makeTestPulseStack(self, deviceName: str):
         """The HDF5 stack for one device, creating the sidecar on first use."""
@@ -174,6 +243,17 @@ class MultiPatchLogRecorder(Qt.QObject):
         if self._stopped:
             return
         self._stopped = True
+        self._releaseFullTestPulseData()
+        for pip in self._pipettes:
+            Qt.disconnect(pip.sigNewEvent, self._onPipetteEvent)
+        # Dropped so a stopped recorder is not what keeps a device object
+        # alive, and so a second stop() has nothing left to disconnect.
+        self._pipettes = []
+        if self._microscope is not None:
+            Qt.disconnect(
+                self._microscope.sigSurfaceDepthChanged, self._onSurfaceDepthChanged
+            )
+            self._microscope = None
         try:
             # All of self._testPulseStacks share one h5py.File --
             # self._testPulseContainer, opened once in _makeTestPulseStack --

--- a/acq4/util/multipatch_log_recorder.py
+++ b/acq4/util/multipatch_log_recorder.py
@@ -3,6 +3,10 @@ format log file, with an optional full-test-pulse HDF5 sidecar beside it."""
 from __future__ import annotations
 
 import json
+import os
+
+import h5py
+from neuroanalysis.test_pulse_stack import H5BackedTestPulseStack
 
 from acq4.util import Qt
 from acq4.util.json_encoder import ACQ4JSONEncoder
@@ -11,6 +15,11 @@ from acq4.util.json_encoder import ACQ4JSONEncoder
 # acq4.filetypes.MultiPatchLog and by tools/autopatch_analysis. Changing it
 # makes the resulting file invisible to both readers.
 LOG_FILE_NAME = "MultiPatch.log"
+
+# Base name of the full-test-pulse sidecar, and the group each device's stack
+# lives at inside it. MultiPatchLogData reads exactly `test_pulses/{device}`.
+TEST_PULSE_FILE_NAME = "TestPulses.hdf5"
+TEST_PULSE_GROUP = "test_pulses"
 
 
 class MultiPatchLogRecorder(Qt.QObject):
@@ -69,6 +78,11 @@ class MultiPatchLogRecorder(Qt.QObject):
         if write_events:
             handle = directory.createFile(LOG_FILE_NAME, autoIncrement=True)
             self._logFile = open(handle.name(), "ab")
+        self._recordFullTestPulses = record_full_test_pulses
+        # device name -> its H5BackedTestPulseStack, created on first use so a
+        # recorder that never sees a full test pulse writes no sidecar at all.
+        self._testPulseStacks = {}
+        self._testPulseContainer = None
         try:
             for record in initial_records:
                 self.record(record)
@@ -97,22 +111,74 @@ class MultiPatchLogRecorder(Qt.QObject):
             return
         self._writeRecords([event])
 
+    def recordsFullTestPulses(self) -> bool:
+        return self._recordFullTestPulses
+
+    def setRecordFullTestPulses(self, record: bool) -> None:
+        """Turn full-test-pulse capture on or off for the rest of this
+        recorder's life. Existing stacks are kept: turning capture back on
+        appends to the same sidecar rather than starting a second one."""
+        self._recordFullTestPulses = bool(record)
+
+    def _makeTestPulseStack(self, deviceName: str):
+        """The HDF5 stack for one device, creating the sidecar on first use."""
+        if self._testPulseContainer is None:
+            handle = self._directory.createFile(TEST_PULSE_FILE_NAME, autoIncrement=True)
+            self._testPulseContainer = h5py.File(handle.name(), "a")
+            self._testPulseContainer.create_group(TEST_PULSE_GROUP)
+        group = self._testPulseContainer[TEST_PULSE_GROUP].create_group(deviceName)
+        group.attrs["device"] = deviceName
+        return H5BackedTestPulseStack(group)
+
+    def _divertFullTestPulse(self, record):
+        """Move a record's full_test_pulse object into the sidecar, replacing the
+        field with the "<relpath>:<h5path>" location the reader resolves.
+
+        The relative path is relative to the *log file's* directory, because
+        that is what MultiPatchLogData joins it against. Returns a copy: the
+        caller's dict belongs to the device that emitted it.
+        """
+        testPulse = record["full_test_pulse"]
+        record = {k: v for k, v in record.items() if k != "full_test_pulse"}
+        if not self._recordFullTestPulses:
+            # Nowhere to put it, and it must never reach the JSON encoder.
+            return record
+        deviceName = record.get("device")
+        stack = self._testPulseStacks.get(deviceName)
+        if stack is None:
+            stack = self._testPulseStacks[deviceName] = self._makeTestPulseStack(deviceName)
+        filename, h5path = stack.append(testPulse)
+        if self._logFile is not None:
+            filename = os.path.relpath(filename, os.path.dirname(self._logFile.name))
+        record["full_test_pulse"] = f"{filename}:{h5path}"
+        return record
+
     def _writeRecords(self, records) -> None:
-        if self._logFile is None:
-            return
         for record in records:
-            # One JSON object per line, with no trailing comma. Both readers
-            # strip b",\r\n" as a character set rather than as a suffix, so
-            # they parse this and the historical comma-terminated form alike.
-            self._logFile.write(
-                json.dumps(record, cls=ACQ4JSONEncoder).encode("utf8") + b"\n"
-            )
-        self._logFile.flush()
+            if "full_test_pulse" in record:
+                record = self._divertFullTestPulse(record)
+            if self._logFile is not None:
+                # One JSON object per line, with no trailing comma. Both readers
+                # strip b",\r\n" as a character set rather than as a suffix, so
+                # they parse this and the historical comma-terminated form alike.
+                self._logFile.write(
+                    json.dumps(record, cls=ACQ4JSONEncoder).encode("utf8") + b"\n"
+                )
+        if self._logFile is not None:
+            self._logFile.flush()
+        for stack in self._testPulseStacks.values():
+            stack.flush()
 
     def stop(self) -> None:
         """Release everything this recorder holds. Idempotent."""
         if self._stopped:
             return
         self._stopped = True
+        for stack in self._testPulseStacks.values():
+            stack.close()
+        self._testPulseStacks = {}
+        if self._testPulseContainer is not None:
+            self._testPulseContainer.close()
+            self._testPulseContainer = None
         if self._logFile is not None:
             self._logFile.close()

--- a/acq4/util/multipatch_log_recorder.py
+++ b/acq4/util/multipatch_log_recorder.py
@@ -69,8 +69,19 @@ class MultiPatchLogRecorder(Qt.QObject):
         if write_events:
             handle = directory.createFile(LOG_FILE_NAME, autoIncrement=True)
             self._logFile = open(handle.name(), "ab")
-        for record in initial_records:
-            self.record(record)
+        try:
+            for record in initial_records:
+                self.record(record)
+        except Exception:
+            # A record that ACQ4JSONEncoder cannot serialize raises out of
+            # this loop before the caller ever gets an instance back to call
+            # stop() on. Without this, the open file handle would be
+            # reachable only through a partially-constructed self, leaving
+            # its release to refcounting -- and a traceback holding this
+            # frame's locals can keep it open well past the raise. stop() is
+            # idempotent, so it is safe to call even if nothing was opened.
+            self.stop()
+            raise
 
     def logFileName(self) -> str | None:
         return None if self._logFile is None else self._logFile.name

--- a/acq4/util/tests/test_multipatch_log_recorder.py
+++ b/acq4/util/tests/test_multipatch_log_recorder.py
@@ -843,34 +843,6 @@ def test_test_pulse_analysis_ignores_other_event_types(qapp, directory):
     assert len(history) == 0
 
 
-def test_test_pulse_analysis_is_unaffected_by_a_device_history_reset(qapp, directory):
-    # approach.py resets the clamp's own test-pulse history mid-patch, which is
-    # exactly why the recorder accumulates its own rather than slicing the
-    # device's.
-    import numpy as np
-    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
-
-    pip = _FakePipette()
-    recorder = MultiPatchLogRecorder(
-        directory, pipettes=(pip,), record_full_test_pulses=False
-    )
-    try:
-        for index, t in enumerate([1.0, 2.0, 3.0]):
-            pip.emit(
-                {
-                    "device": "Clamp1",
-                    "event_time": t,
-                    "event": "test_pulse",
-                    "steady_state_resistance": float(index),
-                }
-            )
-        history = recorder.testPulseAnalysis()
-    finally:
-        recorder.stop()
-
-    assert np.array_equal(history["event_time"], [1.0, 2.0, 3.0])
-
-
 def test_the_recorder_holds_no_reference_to_a_stopped_pipette(qapp, directory):
     from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
 
@@ -1187,3 +1159,70 @@ def test_the_reader_tolerates_blank_lines(qapp, directory):
     data = MultiPatchLogData(recorder.logFileName())
 
     assert "Clamp1" in data.devices()
+
+
+# -- thread affinity ---------------------------------------------------------
+
+
+def test_a_recorder_built_off_the_gui_thread_still_receives_events(qapp, qtbot, directory):
+    """A recorder is routinely opened from an Autopatch action, which runs on a
+    gentletask ThreadTask -- a plain thread with no Qt event loop. Its
+    sigNewEvent connections must not inherit that thread's affinity: queued
+    calls delivered there would never be dispatched, so every test_pulse
+    emitted from the clamp's own thread would be dropped and
+    testPulseAnalysis() would come back empty.
+
+    Genuinely cross-thread on purpose: the recorder is constructed on one
+    thread and the event is emitted from a second, while this (GUI) thread
+    pumps. A same-thread version of this test passes whatever the affinity is.
+    """
+    import threading
+
+    import numpy as np
+
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    built = {}
+    constructed = threading.Event()
+    release = threading.Event()
+
+    def buildOnWorker():
+        built["recorder"] = MultiPatchLogRecorder(
+            directory, pipettes=(pip,), record_full_test_pulses=False
+        )
+        built["thread"] = Qt.QtCore.QThread.currentThread()
+        constructed.set()
+        # Hold the worker open (still without an event loop) for the rest of
+        # the test, which is the shape of a real drive: a thread that exited
+        # would let Qt tear down the very affinity under examination.
+        release.wait(10)
+
+    pip = _FakePipette()
+    worker = threading.Thread(target=buildOnWorker, name="recorder-builder")
+    worker.start()
+    assert constructed.wait(5)
+    recorder = built["recorder"]
+    assert built["thread"] is not Qt.QtCore.QThread.currentThread()
+
+    emitter = threading.Thread(
+        target=lambda: pip.emit(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "steady_state_resistance": 5.0e8,
+            }
+        ),
+        name="clamp-emitter",
+    )
+    emitter.start()
+    emitter.join(5)
+
+    try:
+        qtbot.waitUntil(lambda: len(recorder.testPulseAnalysis()) == 1, timeout=3000)
+    finally:
+        release.set()
+        worker.join(5)
+        recorder.stop()
+
+    assert np.array_equal(recorder.testPulseAnalysis()["event_time"], [1.0])

--- a/acq4/util/tests/test_multipatch_log_recorder.py
+++ b/acq4/util/tests/test_multipatch_log_recorder.py
@@ -212,3 +212,157 @@ def test_unserializable_initial_record_closes_the_file_before_raising(qapp, dire
     assert partial_self is not None
     assert partial_self._logFile is not None
     assert partial_self._logFile.closed
+
+
+class _FakeTestPulse:
+    """Stands in for a PatchClampTestPulse. H5BackedTestPulseStack.append is
+    monkeypatched in these tests, so this only has to be identifiable."""
+
+    def __init__(self, tag):
+        self.tag = tag
+
+
+@pytest.fixture
+def stubbed_stack(monkeypatch):
+    """Replace the HDF5 stack with a recorder of appends, returning the
+    (filename, h5path) pair the real one returns."""
+    import acq4.util.multipatch_log_recorder as mod
+
+    appended = []
+
+    class _Stack:
+        def __init__(self, group):
+            self.group = group
+            self.files = []
+
+        def append(self, test_pulse, retain_data=False):
+            appended.append(test_pulse)
+            return (self.group["filename"], f"{self.group['path']}/{len(appended) - 1}")
+
+        def flush(self):
+            return None
+
+        def close(self):
+            return None
+
+    created = []
+
+    def fakeMakeStack(self, deviceName):
+        stack = _Stack(
+            {
+                "filename": str(self._directory.root / "TestPulses_000.hdf5"),
+                "path": f"test_pulses/{deviceName}",
+            }
+        )
+        created.append((deviceName, stack))
+        return stack
+
+    monkeypatch.setattr(mod.MultiPatchLogRecorder, "_makeTestPulseStack", fakeMakeStack)
+    return appended, created
+
+
+def test_full_test_pulse_is_diverted_into_the_sidecar(qapp, directory, stubbed_stack):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    appended, _created = stubbed_stack
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(), record_full_test_pulses=True
+    )
+    tp = _FakeTestPulse("tp-1")
+    try:
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "full_test_pulse": tp,
+            }
+        )
+    finally:
+        recorder.stop()
+
+    assert appended == [tp]
+    written = json.loads(_lines(recorder.logFileName())[0])
+    assert written["full_test_pulse"] == "TestPulses_000.hdf5:test_pulses/Clamp1/0"
+
+
+def test_the_sidecar_path_is_relative_to_the_log_file(qapp, directory, stubbed_stack):
+    # The reader resolves it with os.path.join(os.path.dirname(logfile), ...),
+    # so an absolute path here would break every viewer that moves the data.
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=True)
+    try:
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "full_test_pulse": _FakeTestPulse("tp"),
+            }
+        )
+    finally:
+        recorder.stop()
+
+    location = json.loads(_lines(recorder.logFileName())[0])["full_test_pulse"]
+    assert not location.startswith("/")
+
+
+def test_the_test_pulse_object_never_reaches_the_json(qapp, directory, stubbed_stack):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=True)
+    try:
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "full_test_pulse": _FakeTestPulse("tp"),
+                "steady_state_resistance": 1.5e9,
+            }
+        )
+    finally:
+        recorder.stop()
+
+    written = json.loads(_lines(recorder.logFileName())[0])
+    assert isinstance(written["full_test_pulse"], str)
+    assert written["steady_state_resistance"] == 1.5e9
+
+
+def test_full_test_pulse_is_stripped_when_not_recording_them(qapp, directory):
+    # No sidecar to divert into, so the object must be dropped rather than
+    # handed to the JSON encoder.
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "full_test_pulse": _FakeTestPulse("tp"),
+                "steady_state_resistance": 1.5e9,
+            }
+        )
+    finally:
+        recorder.stop()
+
+    written = json.loads(_lines(recorder.logFileName())[0])
+    assert "full_test_pulse" not in written
+    assert written["steady_state_resistance"] == 1.5e9
+
+
+def test_set_record_full_test_pulses_toggles_at_runtime(qapp, directory, stubbed_stack):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        assert recorder.recordsFullTestPulses() is False
+        recorder.setRecordFullTestPulses(True)
+        assert recorder.recordsFullTestPulses() is True
+        recorder.setRecordFullTestPulses(False)
+        assert recorder.recordsFullTestPulses() is False
+    finally:
+        recorder.stop()

--- a/acq4/util/tests/test_multipatch_log_recorder.py
+++ b/acq4/util/tests/test_multipatch_log_recorder.py
@@ -1,0 +1,188 @@
+"""Tests for MultiPatchLogRecorder: the writer half of the MultiPatch log
+format, extracted so both MultiPatch and Autopatch can record."""
+import json
+
+import pytest
+
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+class _FakeFileHandle:
+    def __init__(self, path):
+        self._path = str(path)
+
+    def name(self):
+        return self._path
+
+
+class _FakeDir:
+    """Stands in for a DirHandle: createFile hands back a real path under
+    tmp_path, auto-incrementing the way the managed original does."""
+
+    def __init__(self, root):
+        self.root = root
+        self.created = []
+
+    def createFile(self, name, autoIncrement=False):
+        stem, _, ext = name.rpartition(".")
+        index = 0
+        while True:
+            candidate = self.root / (f"{stem}_{index:03d}.{ext}" if autoIncrement else name)
+            if not candidate.exists():
+                break
+            index += 1
+        candidate.touch()
+        self.created.append(candidate)
+        return _FakeFileHandle(candidate)
+
+
+@pytest.fixture
+def directory(tmp_path):
+    return _FakeDir(tmp_path)
+
+
+def _lines(path):
+    with open(path, "rb") as fh:
+        return [line for line in fh if line.strip()]
+
+
+def test_recorder_creates_an_auto_incremented_log_file(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    first = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    second = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        assert first.logFileName().endswith("MultiPatch_000.log")
+        assert second.logFileName().endswith("MultiPatch_001.log")
+    finally:
+        first.stop()
+        second.stop()
+
+
+def test_recorded_events_are_one_json_object_per_line(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+        recorder.record({"device": "Clamp1", "event_time": 2.0, "event": "test_pulse"})
+    finally:
+        recorder.stop()
+
+    lines = _lines(recorder.logFileName())
+    assert len(lines) == 2
+    assert json.loads(lines[0])["event"] == "state_change"
+    assert json.loads(lines[1])["event_time"] == 2.0
+
+
+def test_lines_have_no_trailing_comma(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+    finally:
+        recorder.stop()
+
+    assert _lines(recorder.logFileName())[0].rstrip(b"\r\n").endswith(b"}")
+
+
+def test_records_are_flushed_before_stop(qapp, directory):
+    # An Autopatch action's log has to be readable the moment the action ends,
+    # not whenever the OS gets round to it.
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+        assert len(_lines(recorder.logFileName())) == 1
+    finally:
+        recorder.stop()
+
+
+def test_initial_records_are_replayed_into_the_fresh_file(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    history = [
+        {"device": "Clamp1", "event_time": 0.5, "event": "state_change"},
+        {"device": "Clamp1", "event_time": 0.7, "event": "move_stop"},
+    ]
+    recorder = MultiPatchLogRecorder(
+        directory, record_full_test_pulses=False, initial_records=history
+    )
+    try:
+        pass
+    finally:
+        recorder.stop()
+
+    lines = _lines(recorder.logFileName())
+    assert [json.loads(line)["event"] for line in lines] == ["state_change", "move_stop"]
+
+
+def test_write_events_false_creates_no_log_file(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(
+        directory, record_full_test_pulses=False, write_events=False
+    )
+    try:
+        recorder.record({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+        assert recorder.logFileName() is None
+        assert directory.created == []
+    finally:
+        recorder.stop()
+
+
+def test_is_recording_reflects_the_lifecycle(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    assert recorder.isRecording() is True
+    recorder.stop()
+    assert recorder.isRecording() is False
+
+
+def test_stop_is_idempotent(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    recorder.stop()
+    recorder.stop()  # must not raise on an already-closed file
+
+
+def test_recording_after_stop_is_ignored(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    recorder.stop()
+
+    recorder.record({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+
+    assert _lines(recorder.logFileName()) == []
+
+
+def test_encodes_values_the_plain_json_encoder_cannot(qapp, directory):
+    # State-change events carry numpy scalars; ACQ4JSONEncoder is what handles
+    # them, and the reader expects its output.
+    import numpy as np
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "steady_state_resistance": np.float64(1.5e9),
+            }
+        )
+    finally:
+        recorder.stop()
+
+    assert json.loads(_lines(recorder.logFileName())[0])["steady_state_resistance"] == 1.5e9

--- a/acq4/util/tests/test_multipatch_log_recorder.py
+++ b/acq4/util/tests/test_multipatch_log_recorder.py
@@ -366,3 +366,99 @@ def test_set_record_full_test_pulses_toggles_at_runtime(qapp, directory, stubbed
         assert recorder.recordsFullTestPulses() is False
     finally:
         recorder.stop()
+
+
+def _make_real_test_pulse(start_time, amplitude=-10e-3):
+    """A genuine PatchClampTestPulse -- real PatchClampRecording and TSeries
+    objects wrapping a single square pulse on the command channel -- built
+    without NEURON so it stays cheap to construct in a unit test. Used to
+    exercise the real H5BackedTestPulseStack rather than the monkeypatched
+    stack every other sidecar test in this file uses.
+    """
+    import numpy as np
+    from neuroanalysis.data import PatchClampRecording, TSeries
+    from neuroanalysis.test_pulse import PatchClampTestPulse
+
+    dt = 1e-4
+    n = 100
+    command = np.zeros(n)
+    command[20:80] = amplitude
+    primary = np.zeros(n)
+    primary[20:80] = amplitude * (1 - np.exp(-np.arange(60) / 5.0))
+    rec = PatchClampRecording(
+        channels={"primary": TSeries(primary, dt=dt), "command": TSeries(command, dt=dt)},
+        dt=dt,
+        t0=0,
+        start_time=start_time,
+        clamp_mode="vc",
+        bridge_balance=0,
+        lpf_cutoff=None,
+        pipette_offset=0,
+        holding_current=None,
+        holding_potential=0.0,
+    )
+    return PatchClampTestPulse(rec)
+
+
+def test_stop_closes_the_shared_sidecar_file_with_two_real_devices(qapp, directory):
+    # Regression test for a Critical bug: H5BackedTestPulseStack.close()
+    # closes the *file* its groups belong to, and every device's stack in
+    # one recorder shares the same file (opened once in
+    # _makeTestPulseStack). Closing each stack in turn used to close the
+    # file out from under the next device's stack, raising ValueError on
+    # the second close and skipping the log file's own close() -- and since
+    # every other sidecar test here stubs out _makeTestPulseStack with a
+    # single device, none of them could have caught it. This one uses the
+    # real stack with two devices.
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=True)
+    recorder.record(
+        {
+            "device": "Clamp1",
+            "event_time": 1.0,
+            "event": "test_pulse",
+            "full_test_pulse": _make_real_test_pulse(1000.0),
+        }
+    )
+    recorder.record(
+        {
+            "device": "Clamp2",
+            "event_time": 2.0,
+            "event": "test_pulse",
+            "full_test_pulse": _make_real_test_pulse(2000.0),
+        }
+    )
+
+    container = recorder._testPulseContainer
+    log_file = recorder._logFile
+    recorder.stop()  # must not raise
+
+    assert not bool(container)  # the shared h5py.File is actually closed
+    assert log_file.closed
+    assert recorder.isRecording() is False
+
+
+def test_second_stop_after_two_real_devices_is_still_a_no_op(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=True)
+    recorder.record(
+        {
+            "device": "Clamp1",
+            "event_time": 1.0,
+            "event": "test_pulse",
+            "full_test_pulse": _make_real_test_pulse(1000.0),
+        }
+    )
+    recorder.record(
+        {
+            "device": "Clamp2",
+            "event_time": 2.0,
+            "event": "test_pulse",
+            "full_test_pulse": _make_real_test_pulse(2000.0),
+        }
+    )
+    recorder.stop()
+    recorder.stop()  # must not raise on an already-closed shared file
+    assert recorder.isRecording() is False

--- a/acq4/util/tests/test_multipatch_log_recorder.py
+++ b/acq4/util/tests/test_multipatch_log_recorder.py
@@ -462,3 +462,239 @@ def test_second_stop_after_two_real_devices_is_still_a_no_op(qapp, directory):
     recorder.stop()
     recorder.stop()  # must not raise on an already-closed shared file
     assert recorder.isRecording() is False
+
+
+class _FakePipette(Qt.QObject):
+    sigNewEvent = Qt.Signal(object, object)
+
+    def __init__(self, name="Clamp1"):
+        super().__init__()
+        self._name = name
+        self.requested = []
+        self.released = []
+
+    def name(self):
+        return self._name
+
+    def requestFullTestPulseData(self, token):
+        self.requested.append(token)
+
+    def releaseFullTestPulseData(self, token):
+        self.released.append(token)
+
+    def emit(self, event):
+        self.sigNewEvent.emit(self, event)
+
+
+class _FakeMicroscope(Qt.QObject):
+    sigSurfaceDepthChanged = Qt.Signal(object)
+
+    def name(self):
+        return "Microscope"
+
+
+def test_pipette_events_are_recorded(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        pip.emit({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+    finally:
+        recorder.stop()
+
+    assert json.loads(_lines(recorder.logFileName())[0])["event"] == "state_change"
+
+
+def test_events_after_stop_are_not_recorded(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    recorder.stop()
+
+    pip.emit({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+
+    assert _lines(recorder.logFileName()) == []
+
+
+def test_full_test_pulse_data_is_requested_and_released(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=True
+    )
+    assert pip.requested == [recorder]
+    assert pip.released == []
+
+    recorder.stop()
+
+    assert pip.released == [recorder]
+
+
+def test_no_full_test_pulse_request_when_not_recording_them(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        assert pip.requested == []
+    finally:
+        recorder.stop()
+
+
+def test_toggling_full_test_pulses_requests_and_releases(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        recorder.setRecordFullTestPulses(True)
+        assert pip.requested == [recorder]
+        recorder.setRecordFullTestPulses(False)
+        assert pip.released == [recorder]
+    finally:
+        recorder.stop()
+
+
+def test_microscope_surface_depth_changes_are_recorded(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    scope = _FakeMicroscope()
+    recorder = MultiPatchLogRecorder(
+        directory, microscope=scope, record_full_test_pulses=False
+    )
+    try:
+        scope.sigSurfaceDepthChanged.emit(-1.5e-3)
+    finally:
+        recorder.stop()
+
+    written = json.loads(_lines(recorder.logFileName())[0])
+    assert written["event"] == "surface_depth_changed"
+    assert written["surface_depth"] == -1.5e-3
+    assert written["device"] == "Microscope"
+
+
+def test_test_pulse_analysis_accumulates_the_events_seen(qapp, directory):
+    import numpy as np
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        pip.emit(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "steady_state_resistance": 1.0e9,
+                "capacitance": 5e-12,
+            }
+        )
+        pip.emit(
+            {
+                "device": "Clamp1",
+                "event_time": 2.0,
+                "event": "test_pulse",
+                "steady_state_resistance": 2.0e9,
+                "capacitance": 6e-12,
+            }
+        )
+        history = recorder.testPulseAnalysis()
+    finally:
+        recorder.stop()
+
+    assert len(history) == 2
+    assert np.array_equal(history["event_time"], [1.0, 2.0])
+    assert np.array_equal(history["steady_state_resistance"], [1.0e9, 2.0e9])
+
+
+def test_test_pulse_analysis_records_missing_fields_as_nan(qapp, directory):
+    import numpy as np
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        pip.emit(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "steady_state_resistance": None,
+            }
+        )
+        history = recorder.testPulseAnalysis()
+    finally:
+        recorder.stop()
+
+    assert np.isnan(history["steady_state_resistance"][0])
+
+
+def test_test_pulse_analysis_ignores_other_event_types(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        pip.emit({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+        history = recorder.testPulseAnalysis()
+    finally:
+        recorder.stop()
+
+    assert len(history) == 0
+
+
+def test_test_pulse_analysis_is_unaffected_by_a_device_history_reset(qapp, directory):
+    # approach.py resets the clamp's own test-pulse history mid-patch, which is
+    # exactly why the recorder accumulates its own rather than slicing the
+    # device's.
+    import numpy as np
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        for index, t in enumerate([1.0, 2.0, 3.0]):
+            pip.emit(
+                {
+                    "device": "Clamp1",
+                    "event_time": t,
+                    "event": "test_pulse",
+                    "steady_state_resistance": float(index),
+                }
+            )
+        history = recorder.testPulseAnalysis()
+    finally:
+        recorder.stop()
+
+    assert np.array_equal(history["event_time"], [1.0, 2.0, 3.0])
+
+
+def test_the_recorder_holds_no_reference_to_a_stopped_pipette(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    recorder.stop()
+
+    assert recorder._pipettes == []

--- a/acq4/util/tests/test_multipatch_log_recorder.py
+++ b/acq4/util/tests/test_multipatch_log_recorder.py
@@ -837,3 +837,170 @@ def test_construction_failure_releases_the_pipettes_subscriptions(qapp, director
     assert pip.released == [partial_self]
     assert pip.receivers(pip.sigNewEvent) == 0
     assert scope.receivers(scope.sigSurfaceDepthChanged) == 0
+
+
+# -- golden output vs. the implementation being replaced ----------------------
+
+
+def _referenceWriteRecords(records, logPath):
+    """The pre-refactor MultiPatchWindow.writeRecords, verbatim apart from the
+    test-pulse-stack branch, held here as the reference the recorder's output is
+    checked against. Deliberately duplicated rather than imported: its whole
+    job is to keep saying what the old code said after the old code is gone."""
+    from acq4.util.json_encoder import ACQ4JSONEncoder
+
+    with open(logPath, "ab") as fh:
+        for rec in records:
+            rec = {k: v for k, v in rec.items() if k != "full_test_pulse"}
+            fh.write(json.dumps(rec, cls=ACQ4JSONEncoder).encode("utf8") + b",\n")
+        fh.flush()
+
+
+_GOLDEN_EVENTS = [
+    {"device": "Clamp1", "event_time": 1.0, "event": "state_change", "state": "bath"},
+    {"device": "Clamp1", "event_time": 1.5, "event": "move_stop", "position": [1.0, 2.0, 3.0]},
+    {
+        "device": "Clamp1",
+        "event_time": 2.0,
+        "event": "test_pulse",
+        "start_time": 2.0,
+        "baseline_potential": -0.07,
+        "baseline_current": 5e-13,
+        "input_resistance": 1.4e9,
+        "access_resistance": 1e8,
+        "steady_state_resistance": 1.5e9,
+        "fit_amplitude": -7e-10,
+        "time_constant": 0.001,
+        "fit_yoffset": -1e-11,
+        "fit_xoffset": 0.005,
+        "capacitance": None,
+    },
+    {
+        "device": "Clamp1",
+        "event_time": 2.5,
+        "event": "pressure_changed",
+        "pressure": 0.0,
+        "source": "user",
+    },
+    {"device": None, "event_time": 3.0, "event": "global patch profiles changed", "profile": "{}"},
+]
+
+
+def test_recorder_output_matches_the_reference_apart_from_the_comma(qapp, directory, tmp_path):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        for event in _GOLDEN_EVENTS:
+            recorder.record(event)
+    finally:
+        recorder.stop()
+
+    referencePath = tmp_path / "reference.log"
+    _referenceWriteRecords(_GOLDEN_EVENTS, referencePath)
+
+    ours = _lines(recorder.logFileName())
+    theirs = _lines(referencePath)
+    assert len(ours) == len(theirs)
+    for ourLine, theirLine in zip(ours, theirs):
+        # Byte-for-byte the same record; only the trailing comma differs.
+        assert ourLine.rstrip(b"\r\n") == theirLine.rstrip(b"\r\n").rstrip(b",")
+
+
+def test_recorder_output_parses_identically_to_the_reference(qapp, directory, tmp_path):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        for event in _GOLDEN_EVENTS:
+            recorder.record(event)
+    finally:
+        recorder.stop()
+    referencePath = tmp_path / "reference.log"
+    _referenceWriteRecords(_GOLDEN_EVENTS, referencePath)
+
+    def parse(path):
+        return [json.loads(line.rstrip(b",\r\n")) for line in _lines(path)]
+
+    assert parse(recorder.logFileName()) == parse(referencePath)
+
+
+# -- reader round-trips ------------------------------------------------------
+
+
+def test_the_multipatch_log_reader_parses_a_recorder_file(qapp, directory):
+    from acq4.filetypes.MultiPatchLog import MultiPatchLogData
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        for event in _GOLDEN_EVENTS:
+            if event["device"] is not None:
+                recorder.record(event)
+    finally:
+        recorder.stop()
+
+    data = MultiPatchLogData(recorder.logFileName())
+
+    assert "Clamp1" in data.devices()
+    assert data.firstTime() == 1.0
+    assert data.lastTime() == 2.5
+
+
+def test_the_analysis_tool_parses_a_recorder_file(qapp, directory):
+    import sys
+    from pathlib import Path
+
+    toolsPath = str(Path(__file__).resolve().parents[3] / "tools" / "autopatch_analysis")
+    if toolsPath not in sys.path:
+        sys.path.insert(0, toolsPath)
+    import autopatch_log
+
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "state_change",
+                "state": "bath",
+                "old_state": "out",
+            }
+        )
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 2.0,
+                "event": "state_change",
+                "state": "approach",
+                "old_state": "bath",
+            }
+        )
+    finally:
+        recorder.stop()
+
+    events = autopatch_log.parse_log_events(recorder.logFileName())
+
+    assert [e["state"] for e in events] == ["bath", "approach"]
+
+
+def test_the_reader_tolerates_blank_lines(qapp, directory):
+    # Parity with tools/autopatch_analysis, which has always skipped them.
+    from acq4.filetypes.MultiPatchLog import MultiPatchLogData
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record(
+            {"device": "Clamp1", "event_time": 1.0, "event": "state_change", "state": "bath"}
+        )
+    finally:
+        recorder.stop()
+    with open(recorder.logFileName(), "ab") as fh:
+        fh.write(b"\n")
+
+    data = MultiPatchLogData(recorder.logFileName())
+
+    assert "Clamp1" in data.devices()

--- a/acq4/util/tests/test_multipatch_log_recorder.py
+++ b/acq4/util/tests/test_multipatch_log_recorder.py
@@ -138,6 +138,125 @@ def test_write_events_false_creates_no_log_file(qapp, directory):
         recorder.stop()
 
 
+def test_writes_events_reflects_the_log_state(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        assert recorder.writesEvents() is True
+        recorder.setWriteEvents(False)
+        assert recorder.writesEvents() is False
+        recorder.setWriteEvents(True)
+        assert recorder.writesEvents() is True
+    finally:
+        recorder.stop()
+
+
+def test_turning_the_event_log_off_and_on_keeps_one_log_file(qapp, directory):
+    # One recorder writes one log: reopening appends rather than starting
+    # MultiPatch_001.log alongside it.
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+        name = recorder.logFileName()
+
+        recorder.setWriteEvents(False)
+        recorder.record({"device": "Clamp1", "event_time": 2.0, "event": "state_change"})
+
+        recorder.setWriteEvents(True)
+        recorder.record({"device": "Clamp1", "event_time": 3.0, "event": "state_change"})
+    finally:
+        recorder.stop()
+
+    assert recorder.logFileName() == name
+    assert len(directory.created) == 1
+    assert [json.loads(line)["event_time"] for line in _lines(name)] == [1.0, 3.0]
+
+
+def test_turning_the_event_log_on_opens_a_log_for_a_pulses_only_recorder(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(
+        directory, record_full_test_pulses=False, write_events=False
+    )
+    try:
+        assert recorder.logFileName() is None
+
+        recorder.setWriteEvents(True)
+        recorder.record({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+    finally:
+        recorder.stop()
+
+    assert [json.loads(line)["event"] for line in _lines(recorder.logFileName())] == [
+        "state_change"
+    ]
+
+
+def test_turning_the_event_log_off_keeps_the_open_sidecar(qapp, directory):
+    # The whole point of adjusting the live recorder: one session's full test
+    # pulses stay in one TestPulses.hdf5 however the event-log button moves.
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=True)
+    try:
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "full_test_pulse": _make_real_test_pulse(1000.0),
+            }
+        )
+        container = recorder._testPulseContainer
+
+        recorder.setWriteEvents(False)
+
+        assert recorder._testPulseContainer is container
+        assert bool(container)  # still open
+        assert recorder.recordsFullTestPulses() is True
+    finally:
+        recorder.stop()
+
+
+def test_stop_after_turning_the_event_log_off_closes_the_sidecar(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=True)
+    recorder.record(
+        {
+            "device": "Clamp1",
+            "event_time": 1.0,
+            "event": "test_pulse",
+            "full_test_pulse": _make_real_test_pulse(1000.0),
+        }
+    )
+    logFile = recorder._logFile
+    recorder.setWriteEvents(False)
+    container = recorder._testPulseContainer
+
+    recorder.stop()  # must not raise with no log file left to close
+
+    assert logFile.closed
+    assert not bool(container)
+    assert recorder.isRecording() is False
+
+
+def test_setting_write_events_on_a_stopped_recorder_reopens_nothing(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(
+        directory, record_full_test_pulses=False, write_events=False
+    )
+    recorder.stop()
+
+    recorder.setWriteEvents(True)
+
+    assert recorder._logFile is None
+    assert directory.created == []
+
+
 def test_is_recording_reflects_the_lifecycle(qapp, directory):
     from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
 
@@ -562,6 +681,70 @@ def test_toggling_full_test_pulses_requests_and_releases(qapp, directory):
         assert pip.requested == [recorder]
         recorder.setRecordFullTestPulses(False)
         assert pip.released == [recorder]
+    finally:
+        recorder.stop()
+
+
+def test_full_test_pulses_are_captured_only_for_the_named_subset(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    watched = _FakePipette("Clamp1")
+    unwatched = _FakePipette("Clamp2")
+    recorder = MultiPatchLogRecorder(
+        directory,
+        pipettes=(watched, unwatched),
+        full_test_pulse_pipettes=(watched,),
+        record_full_test_pulses=True,
+    )
+    try:
+        assert watched.requested == [recorder]
+        assert unwatched.requested == []
+
+        # Events, unlike full test pulses, come from every pipette in `pipettes`.
+        watched.emit({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+        unwatched.emit({"device": "Clamp2", "event_time": 2.0, "event": "state_change"})
+        logFileName = recorder.logFileName()
+    finally:
+        recorder.stop()
+
+    assert watched.released == [recorder]
+    assert unwatched.released == []
+    assert [json.loads(line)["device"] for line in _lines(logFileName)] == ["Clamp1", "Clamp2"]
+
+
+def test_toggling_full_test_pulses_uses_only_the_named_subset(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    watched = _FakePipette("Clamp1")
+    unwatched = _FakePipette("Clamp2")
+    recorder = MultiPatchLogRecorder(
+        directory,
+        pipettes=(watched, unwatched),
+        full_test_pulse_pipettes=(watched,),
+        record_full_test_pulses=False,
+    )
+    try:
+        recorder.setRecordFullTestPulses(True)
+        assert watched.requested == [recorder]
+        assert unwatched.requested == []
+        recorder.setRecordFullTestPulses(False)
+        assert watched.released == [recorder]
+        assert unwatched.released == []
+    finally:
+        recorder.stop()
+
+
+def test_full_test_pulse_pipettes_defaults_to_every_pipette(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    first = _FakePipette("Clamp1")
+    second = _FakePipette("Clamp2")
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(first, second), record_full_test_pulses=True
+    )
+    try:
+        assert first.requested == [recorder]
+        assert second.requested == [recorder]
     finally:
         recorder.stop()
 

--- a/acq4/util/tests/test_multipatch_log_recorder.py
+++ b/acq4/util/tests/test_multipatch_log_recorder.py
@@ -698,3 +698,142 @@ def test_the_recorder_holds_no_reference_to_a_stopped_pipette(qapp, directory):
     recorder.stop()
 
     assert recorder._pipettes == []
+
+
+class _FakeClampDevice:
+    """Stands in for a PatchClamp for the one thing these tests need: a
+    testPulseHistory() a caller can empty out from under the recorder, the way
+    approach.py's mid-patch reset empties the real one."""
+
+    def __init__(self):
+        self._history = []
+
+    def testPulseHistory(self):
+        return list(self._history)
+
+    def resetTestPulseHistory(self):
+        self._history = []
+
+
+def test_test_pulse_analysis_is_unaffected_by_a_device_history_reset(qapp, directory):
+    # approach.py resets the clamp's own test-pulse history mid-patch, which is
+    # exactly why the recorder accumulates its own rather than reading
+    # clampDevice.testPulseHistory(). Exercise that directly: reset the fake
+    # clamp's history partway through and confirm the recorder's own
+    # accumulation still holds every row regardless.
+    import numpy as np
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    pip.clampDevice = _FakeClampDevice()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        pip.emit(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "steady_state_resistance": 0.0,
+            }
+        )
+        pip.clampDevice._history.append("whatever the device tracked")
+        pip.clampDevice.resetTestPulseHistory()
+        assert pip.clampDevice.testPulseHistory() == []
+
+        pip.emit(
+            {
+                "device": "Clamp1",
+                "event_time": 2.0,
+                "event": "test_pulse",
+                "steady_state_resistance": 1.0e9,
+            }
+        )
+        pip.emit(
+            {
+                "device": "Clamp1",
+                "event_time": 3.0,
+                "event": "test_pulse",
+                "steady_state_resistance": 2.0e9,
+            }
+        )
+        history = recorder.testPulseAnalysis()
+    finally:
+        recorder.stop()
+
+    assert np.array_equal(history["event_time"], [1.0, 2.0, 3.0])
+
+
+def test_onPipetteEvent_after_stop_does_not_add_a_test_pulse_row(qapp, directory):
+    # sigNewEvent is a queued connection: disconnecting it in stop() does not
+    # cancel a test_pulse event already posted to the event queue, so this
+    # slot can still run once after stop() tears the recorder down. Call it
+    # directly rather than going through the Qt event loop so the test does
+    # not depend on when Qt happens to deliver the queued call.
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    recorder.stop()
+
+    recorder._onPipetteEvent(
+        pip, {"device": "Clamp1", "event_time": 1.0, "event": "test_pulse"}
+    )
+
+    assert recorder._testPulseRows == []
+    assert len(recorder.testPulseAnalysis()) == 0
+
+
+def test_onSurfaceDepthChanged_after_stop_does_not_raise(qapp, directory):
+    # Same late-queued-delivery hazard as above: stop() sets self._microscope
+    # to None, and a surface-depth signal already in flight when stop() runs
+    # would otherwise dereference it. Call the slot directly, as above.
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    scope = _FakeMicroscope()
+    recorder = MultiPatchLogRecorder(
+        directory, microscope=scope, record_full_test_pulses=False
+    )
+    recorder.stop()
+
+    recorder._onSurfaceDepthChanged(-1.5e-3)  # must not raise
+
+    assert _lines(recorder.logFileName()) == []
+
+
+def test_construction_failure_releases_the_pipettes_subscriptions(qapp, directory):
+    # Same failure as test_unserializable_initial_record_closes_the_file_before_raising,
+    # but with a live pipette and microscope subscribed, so it exercises the
+    # rest of what the __init__ try/except's stop() call has to release: not
+    # just the file, but every token and signal connection picked up before
+    # the raise. The caller never gets a reference of its own, so find the
+    # partially-constructed self via the traceback, as that test does.
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    scope = _FakeMicroscope()
+    history = [{"device": "Clamp1", "event_time": 0.5, "bad": {1, 2, 3}}]
+
+    with pytest.raises(TypeError) as excinfo:
+        MultiPatchLogRecorder(
+            directory,
+            pipettes=(pip,),
+            microscope=scope,
+            initial_records=history,
+        )
+
+    partial_self = None
+    tb = excinfo.value.__traceback__
+    while tb is not None:
+        candidate = tb.tb_frame.f_locals.get("self")
+        if isinstance(candidate, MultiPatchLogRecorder):
+            partial_self = candidate
+        tb = tb.tb_next
+
+    assert partial_self is not None
+    assert pip.released == [partial_self]
+    assert pip.receivers(pip.sigNewEvent) == 0
+    assert scope.receivers(scope.sigSurfaceDepthChanged) == 0

--- a/acq4/util/tests/test_multipatch_log_recorder.py
+++ b/acq4/util/tests/test_multipatch_log_recorder.py
@@ -1200,29 +1200,105 @@ def test_a_recorder_built_off_the_gui_thread_still_receives_events(qapp, qtbot, 
     pip = _FakePipette()
     worker = threading.Thread(target=buildOnWorker, name="recorder-builder")
     worker.start()
-    assert constructed.wait(5)
-    recorder = built["recorder"]
-    assert built["thread"] is not Qt.QtCore.QThread.currentThread()
-
-    emitter = threading.Thread(
-        target=lambda: pip.emit(
-            {
-                "device": "Clamp1",
-                "event_time": 1.0,
-                "event": "test_pulse",
-                "steady_state_resistance": 5.0e8,
-            }
-        ),
-        name="clamp-emitter",
-    )
-    emitter.start()
-    emitter.join(5)
-
+    # From here down, everything runs under try/finally: worker sits in
+    # release.wait(10) until release.set() below, so a failed assertion above
+    # a bare `assert constructed.wait(5)` would otherwise leave that non-daemon
+    # thread parked for up to 10s past this test's own failure.
     try:
+        assert constructed.wait(5)
+        recorder = built["recorder"]
+        assert built["thread"] is not Qt.QtCore.QThread.currentThread()
+
+        emitter = threading.Thread(
+            target=lambda: pip.emit(
+                {
+                    "device": "Clamp1",
+                    "event_time": 1.0,
+                    "event": "test_pulse",
+                    "steady_state_resistance": 5.0e8,
+                }
+            ),
+            name="clamp-emitter",
+        )
+        emitter.start()
+        emitter.join(5)
+
         qtbot.waitUntil(lambda: len(recorder.testPulseAnalysis()) == 1, timeout=3000)
     finally:
         release.set()
         worker.join(5)
-        recorder.stop()
+        if "recorder" in built:
+            built["recorder"].stop()
 
     assert np.array_equal(recorder.testPulseAnalysis()["event_time"], [1.0])
+
+
+def test_stop_waits_for_a_write_already_in_progress(qapp, directory):
+    """The recorder is pinned to the GUI thread, so _onPipetteEvent ->
+    record() -> _writeRecords runs there, while stop() is typically called
+    directly from the orchestrator's worker thread. Without the recorder's
+    lock, a write already past record()'s _stopped check can still be
+    sitting inside _writeRecords when stop() closes self._logFile -- closing
+    does not clear that attribute (see logFileName()), so the write's own
+    "is not None" check does not catch it, and the write raises ValueError on
+    a closed file.
+
+    Forces the interleaving deterministically: a wrapped file.write() pauses
+    mid-call on the writer thread, holding the recorder's lock, while a second
+    thread calls stop(). stop() has to block on that same lock, so it cannot
+    reach the point of closing the handle until the write finishes -- which is
+    exactly the property the lock exists for.
+    """
+    import threading
+
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    entered_write = threading.Event()
+    release_write = threading.Event()
+    real_write = recorder._logFile.write
+
+    def blocking_write(data):
+        entered_write.set()
+        release_write.wait(5)
+        return real_write(data)
+
+    recorder._logFile.write = blocking_write
+
+    write_errors = []
+
+    def do_write():
+        try:
+            recorder.record({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+        except Exception as exc:
+            write_errors.append(exc)
+
+    writer = threading.Thread(target=do_write, name="log-writer")
+    writer.start()
+    assert entered_write.wait(5)
+
+    stop_errors = []
+
+    def do_stop():
+        try:
+            recorder.stop()
+        except Exception as exc:
+            stop_errors.append(exc)
+
+    stopper = threading.Thread(target=do_stop, name="log-stopper")
+    stopper.start()
+    # The writer is holding the lock inside blocking_write; stop() has to wait
+    # for it. If this fires while the writer is still blocked, the lock is not
+    # doing its job.
+    stopper.join(0.2)
+    assert stopper.is_alive()
+
+    release_write.set()
+    writer.join(5)
+    stopper.join(5)
+
+    assert write_errors == []
+    assert stop_errors == []
+    assert not stopper.is_alive()
+    assert recorder.isRecording() is False
+    assert recorder._logFile.closed

--- a/acq4/util/tests/test_multipatch_log_recorder.py
+++ b/acq4/util/tests/test_multipatch_log_recorder.py
@@ -186,3 +186,29 @@ def test_encodes_values_the_plain_json_encoder_cannot(qapp, directory):
         recorder.stop()
 
     assert json.loads(_lines(recorder.logFileName())[0])["steady_state_resistance"] == 1.5e9
+
+
+def test_unserializable_initial_record_closes_the_file_before_raising(qapp, directory):
+    # A record ACQ4JSONEncoder can't handle raises out of __init__ before the
+    # caller ever receives an instance to call stop() on. The file opened for
+    # write_events must not depend on refcounting to get closed in that case;
+    # find the partially-constructed self via the traceback and check it
+    # directly, since the caller never gets a reference of its own.
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    history = [{"device": "Clamp1", "event_time": 0.5, "bad": {1, 2, 3}}]
+
+    with pytest.raises(TypeError) as excinfo:
+        MultiPatchLogRecorder(directory, record_full_test_pulses=False, initial_records=history)
+
+    partial_self = None
+    tb = excinfo.value.__traceback__
+    while tb is not None:
+        candidate = tb.tb_frame.f_locals.get("self")
+        if isinstance(candidate, MultiPatchLogRecorder):
+            partial_self = candidate
+        tb = tb.tb_next
+
+    assert partial_self is not None
+    assert partial_self._logFile is not None
+    assert partial_self._logFile.closed

--- a/docs/superpowers/plans/2026-08-17-autopatch-area5-details-pane.md
+++ b/docs/superpowers/plans/2026-08-17-autopatch-area5-details-pane.md
@@ -1193,7 +1193,11 @@ In the `"finished"` branch, add the live-widget drop as its first statement, bef
 
 Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests -v`
 
-Expected: PASS. `test_cell_log_and_show.py`'s existing tests must all still pass — they rely on a followed cell's newly appended row being the selected one, which Task 6 makes explicit but which already holds here because `timelineList`'s first appended item becomes current automatically.
+Expected: **NOT green on its own.** This task and Task 6 must land as a single commit.
+
+The original plan asserted that `timelineList`'s first appended item becomes current automatically, so `test_cell_log_and_show.py` would keep passing. That is false — `QListWidget` does not auto-select a newly-appended row. Without Task 6's follow/auto-select rule, this task leaves five tests red: four in `test_cell_log_and_show.py` (which assert on exactly the mount/clear behavior changed here) and `test_a_live_widget_is_remounted_when_its_row_is_reselected` from this task's own set.
+
+So: implement Task 6 before committing, and commit both together. The two are one unit — the auto-select rule is what makes row-driven mounting observable at all.
 
 - [ ] **Step 7: Commit**
 
@@ -1220,6 +1224,8 @@ EOF
 ---
 
 ### Task 6: Auto-select a row, and follow the running action
+
+> **Lands with Task 5, in one commit.** See Task 5's Step 6 for why: without the follow/auto-select rule below, Task 5's diff leaves five tests red, so neither task is independently reviewable.
 
 **Files:**
 - Modify: `acq4/modules/Autopatch/cell_panel.py`

--- a/docs/superpowers/plans/2026-08-17-autopatch-area5-details-pane.md
+++ b/docs/superpowers/plans/2026-08-17-autopatch-area5-details-pane.md
@@ -476,7 +476,9 @@ def test_image_stack_builder_tolerates_a_none_center_index(qapp):
         "image_stack", {"stack": np.zeros((4, 4)), "center_index": None, "title": ""}
     )
 
-    assert wrapper.findChild(pg.ImageView) is not None or isinstance(wrapper, pg.ImageView)
+    # An empty title means captioned() returns the view itself, unwrapped.
+    assert isinstance(wrapper, pg.ImageView)
+    assert wrapper.currentIndex == 0
 
 
 def test_task_results_builder_plots_one_curve_per_sweep(qapp):
@@ -662,6 +664,8 @@ EOF
 **Interfaces:**
 - Consumes: `ActionLogEntry.on_details` (Task 1).
 - Produces: `CellPanel._details: dict[tuple[int, int], tuple[str, Any]]`; `CellPanel.detailsFor(cell, rowIndex) -> tuple[str, Any] | None`; `CellPanel._dropDetailsFor(cellId) -> None`. The `"details"` phase string on `sigActionEntry`.
+
+This task retains payloads and nothing more — no widget is mounted from one until Task 5. Retention is independently testable (`detailsFor` is the seam), and splitting it this way keeps this diff free of any half-built mounting path.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -884,25 +888,12 @@ In `_onActionEntry`, add a branch before the trailing `"status"` comment:
 
 ```python
         elif phase == "details":
+            # Stored only; mounting it is Task 5's job, once rows are
+            # individually selectable and there is a notion of "the selected
+            # row" to mount into.
             loc = self._entryTimelineLoc.get(id(entry))
             if loc is not None:
                 self._details[loc] = (entry.details_kind, entry.details_payload)
-                if self._isSelectedRow(loc):
-                    self._mountSelectedRow()
-```
-
-Add the two helpers used above, after `_clearShowContainer`:
-
-```python
-    def _isSelectedRow(self, loc) -> bool:
-        """Whether (cellId, rowIndex) is the row the operator is looking at."""
-        cellId, index = loc
-        cell = self._currentSelectedCell()
-        return cell is not None and id(cell) == cellId and self.timelineList.currentRow() == index
-
-    def _mountSelectedRow(self) -> None:
-        """Placeholder until Task 5 gives rows their own mounting."""
-        return None
 ```
 
 - [ ] **Step 5: Drop payloads wherever rows are dropped**
@@ -1086,6 +1077,31 @@ Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Au
 
 Expected: FAIL — `_mounted(panel)` is `[]` where a payload was expected, since `_mountSelectedRow` is still the Task 4 placeholder and `timelineList` has no selection handler.
 
+Task 5 also adds `_isSelectedRow`, used by the `"details"` branch Task 4 left storage-only and by Task 7's status line:
+
+```python
+    def _isSelectedRow(self, loc) -> bool:
+        """Whether (cellId, rowIndex) is the row the operator is looking at."""
+        cellId, index = loc
+        cell = self._currentSelectedCell()
+        return (
+            cell is not None
+            and id(cell) == cellId
+            and self.timelineList.currentRow() == index
+        )
+```
+
+and extends Task 4's `"details"` branch to mount a payload that arrives for the row already being watched:
+
+```python
+        elif phase == "details":
+            loc = self._entryTimelineLoc.get(id(entry))
+            if loc is not None:
+                self._details[loc] = (entry.details_kind, entry.details_payload)
+                if self._isSelectedRow(loc):
+                    self._mountSelectedRow()
+```
+
 - [ ] **Step 3: Add the live-widget store**
 
 In `acq4/modules/Autopatch/cell_panel.py`, in `__init__` immediately after the `self._timelineItems` block:
@@ -1104,9 +1120,9 @@ In `acq4/modules/Autopatch/cell_panel.py`, in `__init__` immediately after the `
         self._liveWidgets: dict[int, object] = {}
 ```
 
-- [ ] **Step 4: Replace the placeholder `_mountSelectedRow` and connect the selection**
+- [ ] **Step 4: Add `_mountSelectedRow` and connect the selection**
 
-Replace the Task 4 placeholder `_mountSelectedRow` with:
+Add after `_clearShowContainer`:
 
 ```python
     def _mountSelectedRow(self) -> None:
@@ -2628,7 +2644,7 @@ Expected: PASS with no failures, no errors, and no new warnings. Test output mus
 
 - [ ] **Step 2: Confirm nothing outside this phase's scope changed**
 
-Run: `git diff --stat cc291fe8e..HEAD -- acq4/ tools/`
+Run: `git diff --stat <phase-1-base>..HEAD -- acq4/ tools/`, where `<phase-1-base>` is the commit recorded in `.superpowers/sdd/progress.md` as this phase's starting point — not `cc291fe8e`, which predates the spec and plan commits.
 
 Expected: changes confined to `acq4/experiment/log_entry.py`, `acq4/experiment/actions/{device,prompt,storage}.py`, `acq4/experiment/tests/`, `acq4/modules/Autopatch/{cell_panel,details_renderers}.py`, `acq4/modules/Autopatch/tests/`, and the two added lines in `acq4/modules/TaskRunner/TaskRunner.py`. Nothing under `acq4/devices/`, `acq4/modules/MultiPatch/`, `acq4/filetypes/`, or `tools/`.
 

--- a/docs/superpowers/plans/2026-08-17-autopatch-area5-details-pane.md
+++ b/docs/superpowers/plans/2026-08-17-autopatch-area5-details-pane.md
@@ -1,0 +1,2651 @@
+# Autopatch Area 5 Details Pane — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give Area 5's detail pane a retained, per-timeline-row record of what each action found, so a finished cell shows its results instead of an empty pane.
+
+**Architecture:** A second engine seam, `ActionLogEntry.set_details(kind, payload)`, carries GUI-free plain data that outlives the action. `CellPanel` retains payloads keyed by `(id(cell), timeline row index)` and mounts them when the operator selects that row; a `kind` → builder registry in a new `details_renderers.py` owns every Qt widget the pane can show. `set_details_widget` keeps its existing contract for genuinely-live widgets.
+
+**Tech Stack:** Python 3, PyQt (via `acq4.util.Qt`), pyqtgraph, numpy, pytest.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-08-17-autopatch-area5-details-widgets-design.md`. This plan implements phase 1 of its §11 phasing.
+- **Payload contract (spec §2):** payloads are plain data only — numpy arrays, strings, numbers, and dicts/lists of those. Never a `Qt` object, a `Cell`, an exception object, or a file handle. `CellPanel` retains them for the session.
+- **Ordering invariant (spec §2):** `set_details` must be called before the entry finishes. Actions call it from a `try/finally` **inside** the `with ctx.log_action(...)` block.
+- **No widget outlives its action.** `tests/test_teardown.py`'s invariants must keep passing unchanged.
+- **Python interpreter:** `/home/martin/.miniforge3/envs/acq4-gl/bin/python`. Run pytest as `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest`.
+- **Commits:** conventional format, `--author="Martin Chase (claude) <outofculture@gmail.com>"`, footer `🤖 Generated with [Claude Code](https://claude.ai/code)`. Never `--no-verify`.
+- **Not in this phase:** anything touching `patch`/`reseal`, `MultiPatchLogRecorder`, `PatchPipette`, `MultiPatch`, or the `"test_pulse_history"` kind. Those are phases 2 and 3.
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `acq4/experiment/log_entry.py` | `ActionLogEntry`; gains `set_details` | Modify |
+| `acq4/experiment/tests/test_log_entry.py` | seam tests | Modify |
+| `acq4/modules/Autopatch/details_renderers.py` | `kind` → widget builders and the registry; the only new Qt in this phase | Create |
+| `acq4/modules/Autopatch/tests/test_details_renderers.py` | builder tests | Create |
+| `acq4/modules/Autopatch/cell_panel.py` | retention, row navigation, status line | Modify |
+| `acq4/modules/Autopatch/tests/test_details_navigation.py` | retention + navigation tests | Create |
+| `acq4/experiment/actions/device.py` | `cellfie`, `run_task`, `find_surface` payloads | Modify |
+| `acq4/experiment/actions/prompt.py` | `prompt` payload | Modify |
+| `acq4/experiment/actions/storage.py` | `new_data_dir` payload | Modify |
+| `acq4/modules/TaskRunner/TaskRunner.py` | expose the sequence directory it creates | Modify |
+| `acq4/experiment/tests/test_actions_device.py` | payload tests | Modify |
+| `acq4/experiment/tests/test_actions_prompt_storage.py` | payload tests | Modify |
+
+`details_renderers.py` is a separate module rather than more methods on `cell_panel.py` because that file is already 868 lines and this phase would add four widget types to it.
+
+---
+
+### Task 1: `ActionLogEntry.set_details`
+
+**Files:**
+- Modify: `acq4/experiment/log_entry.py`
+- Test: `acq4/experiment/tests/test_log_entry.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `ActionLogEntry.set_details(kind: str, payload) -> None`; attributes `details_kind: str | None`, `details_payload: Any`, `on_details: Callable | None` called as `on_details(entry, kind, payload)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/experiment/tests/test_log_entry.py`:
+
+```python
+def test_details_default_to_none():
+    action_entry = ActionLogEntry("Patch")
+    assert action_entry.details_kind is None
+    assert action_entry.details_payload is None
+
+
+def test_set_details_stores_kind_and_payload():
+    action_entry = ActionLogEntry("Patch")
+    action_entry.set_details("text", {"lines": ["hello"]})
+    assert action_entry.details_kind == "text"
+    assert action_entry.details_payload == {"lines": ["hello"]}
+
+
+def test_on_details_hook_receives_entry_kind_and_payload():
+    ctx = ExecutionContext()
+    calls = []
+
+    def hook(action_entry):
+        action_entry.on_details = lambda e, kind, payload: calls.append((e, kind, payload))
+
+    ctx.on_log_action = hook
+    with ctx.log_action("Patch") as action_entry:
+        action_entry.set_details("text", {"lines": ["a"]})
+    assert calls == [(action_entry, "text", {"lines": ["a"]})]
+
+
+def test_details_set_in_a_finally_arrive_before_finish():
+    # CellPanel resolves an entry to its timeline row through bookkeeping that
+    # the entry's finish tears down, so a payload set afterwards has no row to
+    # attach to. An action's try/finally inside the `with` is what orders them.
+    ctx = ExecutionContext()
+    order = []
+
+    def hook(action_entry):
+        action_entry.on_details = lambda e, k, p: order.append("details")
+        action_entry.on_finish = lambda e: order.append("finish")
+
+    ctx.on_log_action = hook
+    with ctx.log_action("Patch") as action_entry:
+        try:
+            pass
+        finally:
+            action_entry.set_details("text", {"lines": []})
+    assert order == ["details", "finish"]
+
+
+def test_details_survive_an_error_outcome():
+    # An action that gathered data and then failed keeps the data: it is more
+    # informative than the traceback, which the row's outcome also carries.
+    ctx = ExecutionContext()
+    with pytest.raises(BrokenPipette):
+        with ctx.log_action("Patch") as action_entry:
+            try:
+                raise BrokenPipette("tip sheared off")
+            finally:
+                action_entry.set_details("text", {"lines": ["got this far"]})
+    assert action_entry.outcome == "error"
+    assert action_entry.details_payload == {"lines": ["got this far"]}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_log_entry.py -v -k details`
+
+Expected: FAIL — `AttributeError: 'ActionLogEntry' object has no attribute 'details_kind'` on the first test, and `no attribute 'set_details'` on the rest.
+
+- [ ] **Step 3: Add the attributes**
+
+In `acq4/experiment/log_entry.py`, inside `__init__`, immediately after `self.details_widget: Any = None`:
+
+```python
+        # Retained counterpart to details_widget: a GUI-free description of what
+        # this action found, which outlives the action (see set_details).
+        self.details_kind: str | None = None
+        self.details_payload: Any = None
+```
+
+and after `self.on_widget: Callable | None = None`:
+
+```python
+        self.on_details: Callable | None = None
+```
+
+- [ ] **Step 4: Add `set_details`**
+
+In `acq4/experiment/log_entry.py`, immediately after `set_details_widget`:
+
+```python
+    def set_details(self, kind: str, payload) -> None:
+        """Hand the UI a retained description of what this action found, stored
+        and passed to on_details(entry, kind, payload).
+
+        The counterpart to set_details_widget(), and different from it in the one
+        way that matters: what is passed here *outlives the action*. CellPanel
+        keeps it for the rest of the session so the operator can re-read a
+        finished action's results, which is why `payload` must be plain data --
+        numpy arrays, strings, numbers, and dicts/lists of those -- and never a
+        Qt object, a Cell, an exception, or a file handle. What a payload holds
+        is what one action costs in memory for the rest of the run; see
+        error_record.describe_exception for the same rule applied to tracebacks.
+
+        `kind` selects how the UI renders the payload. An unrecognized kind
+        renders as plain text rather than raising.
+
+        **Must be called before this entry finishes.** CellPanel resolves an
+        entry to its timeline row through bookkeeping that the entry's finish
+        tears down, so a payload set afterwards has no row to attach to. Actions
+        satisfy this by calling from a try/finally *inside* the
+        `with ctx.log_action(...)` block, which runs before the context
+        manager's __exit__.
+        """
+        self.details_kind = kind
+        self.details_payload = payload
+        if self.on_details is not None:
+            self.on_details(self, kind, payload)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_log_entry.py -v`
+
+Expected: PASS, all tests in the file (the pre-existing ones must be unaffected).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add acq4/experiment/log_entry.py acq4/experiment/tests/test_log_entry.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(experiment): add ActionLogEntry.set_details
+
+The retained counterpart to set_details_widget: a GUI-free payload that
+outlives the action, so Area 5 can show a finished action's results rather
+than clearing its pane. Documents the plain-data contract and the
+before-finish ordering the UI's row bookkeeping depends on.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 2: The renderer registry, with the `text` and `error` builders
+
+**Files:**
+- Create: `acq4/modules/Autopatch/details_renderers.py`
+- Test: `acq4/modules/Autopatch/tests/test_details_renderers.py`
+
+**Interfaces:**
+- Consumes: `acq4.modules.Autopatch.error_display.ErrorBlock(exc_type, exc_message, traceback_text, cell_repr=None)`.
+- Produces: `buildDetailsWidget(kind: str, payload) -> Qt.QWidget`; `BUILDERS: dict[str, Callable]`; `buildText(payload)`; `buildError(payload)`; `captioned(widget, lines) -> Qt.QWidget`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `acq4/modules/Autopatch/tests/test_details_renderers.py`:
+
+```python
+"""Tests for the kind -> widget builders behind Area 5's detail pane, each
+given the plain-data payload an action's set_details() hands over."""
+import pytest
+
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+def test_text_builder_renders_each_line_read_only(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("text", {"lines": ["surface at 1.2 mm", "depth ok"]})
+
+    assert widget.isReadOnly()
+    assert "surface at 1.2 mm" in widget.toPlainText()
+    assert "depth ok" in widget.toPlainText()
+
+
+def test_text_builder_tolerates_a_missing_lines_key(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("text", {})
+
+    assert widget.toPlainText() == ""
+
+
+def test_text_builder_stringifies_non_strings(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("text", {"lines": [42, None]})
+
+    assert "42" in widget.toPlainText()
+    assert "None" in widget.toPlainText()
+
+
+def test_error_builder_returns_an_error_block(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+    from acq4.modules.Autopatch.error_display import ErrorBlock
+
+    widget = buildDetailsWidget(
+        "error",
+        {
+            "exc_type": "BrokenPipette",
+            "exc_message": "tip sheared off",
+            "traceback_text": "Traceback...\nBrokenPipette: tip sheared off",
+            "cell_repr": "<Cell 0x1>",
+        },
+    )
+
+    assert isinstance(widget, ErrorBlock)
+    assert "BrokenPipette" in widget.headlineLabel.text()
+    assert "tip sheared off" in widget.headlineLabel.text()
+    assert "<Cell 0x1>" in widget.cellLabel.text()
+
+
+def test_error_builder_tolerates_a_missing_cell_repr(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget(
+        "error",
+        {"exc_type": "E", "exc_message": "m", "traceback_text": "t"},
+    )
+
+    assert not widget.cellLabel.isVisible()
+
+
+def test_unregistered_kind_renders_as_text_rather_than_raising(qapp):
+    # A payload crosses a thread boundary out of protocol code. A protocol
+    # author's typo must leave the pane usable, not take it down.
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("no_such_kind", {"a": 1})
+
+    assert "no_such_kind" in widget.toPlainText()
+    assert "'a': 1" in widget.toPlainText()
+
+
+def test_captioned_puts_the_caption_above_the_widget(qapp):
+    from acq4.modules.Autopatch.details_renderers import captioned
+
+    inner = Qt.QLabel("inner")
+    wrapper = captioned(inner, ["12 sweeps", "saved to protocol_000"])
+
+    assert wrapper.layout().indexOf(inner) != -1
+    caption = wrapper.layout().itemAt(0).widget()
+    assert "12 sweeps" in caption.text()
+    assert "saved to protocol_000" in caption.text()
+
+
+def test_captioned_with_no_lines_returns_the_widget_itself(qapp):
+    from acq4.modules.Autopatch.details_renderers import captioned
+
+    inner = Qt.QLabel("inner")
+
+    assert captioned(inner, []) is inner
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_details_renderers.py -v`
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'acq4.modules.Autopatch.details_renderers'`.
+
+- [ ] **Step 3: Create the module**
+
+Create `acq4/modules/Autopatch/details_renderers.py`:
+
+```python
+"""Builders for Area 5's detail pane: one per ActionLogEntry.set_details() kind,
+turning an action's retained plain-data payload into a widget to mount."""
+from __future__ import annotations
+
+from acq4.util import Qt
+
+from .error_display import ErrorBlock
+
+
+def captioned(widget, lines) -> Qt.QWidget:
+    """`widget` under a caption of `lines`, or `widget` itself if there are none.
+
+    Returning the bare widget for an empty caption keeps the pane's widget tree
+    as shallow as the payload warrants, rather than wrapping everything in a
+    layout that holds an empty label.
+    """
+    if not lines:
+        return widget
+    caption = Qt.QLabel("\n".join(str(line) for line in lines))
+    caption.setWordWrap(True)
+    # Selectable so a directory name or a measured value can be copied out.
+    caption.setTextInteractionFlags(Qt.Qt.TextSelectableByMouse)
+    wrapper = Qt.QWidget()
+    layout = Qt.QVBoxLayout()
+    layout.setContentsMargins(0, 0, 0, 0)
+    layout.addWidget(caption)
+    layout.addWidget(widget)
+    wrapper.setLayout(layout)
+    return wrapper
+
+
+def buildText(payload) -> Qt.QWidget:
+    """Plain lines, read-only and selectable so values can be copied out."""
+    view = Qt.QPlainTextEdit("\n".join(str(line) for line in payload.get("lines", ())))
+    view.setReadOnly(True)
+    return view
+
+
+def buildError(payload) -> Qt.QWidget:
+    """One failed action's traceback. Takes strings, never an exception -- see
+    ErrorBlock's own docstring for why."""
+    return ErrorBlock(
+        payload["exc_type"],
+        payload["exc_message"],
+        payload["traceback_text"],
+        payload.get("cell_repr"),
+    )
+
+
+# kind -> builder, keyed by the string an action passes to set_details(). A
+# builder takes only the payload and returns a widget: it never sees a Cell, an
+# ActionLogEntry, or the panel, so nothing it builds can retain any of them.
+BUILDERS = {
+    "text": buildText,
+    "error": buildError,
+}
+
+
+def buildDetailsWidget(kind: str, payload) -> Qt.QWidget:
+    """The widget for one retained payload.
+
+    An unregistered kind renders as text rather than raising. A payload crosses
+    a thread boundary out of protocol code, and a protocol author's typo must
+    leave the pane usable instead of taking it down.
+    """
+    builder = BUILDERS.get(kind)
+    if builder is None:
+        return buildText(
+            {"lines": [f"unrecognized details kind {kind!r}", repr(payload)]}
+        )
+    return builder(payload)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_details_renderers.py -v`
+
+Expected: PASS, 8 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/modules/Autopatch/details_renderers.py acq4/modules/Autopatch/tests/test_details_renderers.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(autopatch): add the details-pane renderer registry
+
+A kind -> widget registry so every widget type Area 5's pane can mount lives
+in one module rather than adding four more to cell_panel.py. Builders take
+only a payload, so nothing they build can retain a Cell, an entry, or the
+panel. An unregistered kind renders as text: a payload comes from protocol
+code across a thread boundary, and a typo must not take the pane down.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 3: The `image_stack` and `task_results` builders
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/details_renderers.py`
+- Test: `acq4/modules/Autopatch/tests/test_details_renderers.py`
+
+**Interfaces:**
+- Consumes: `captioned`, `BUILDERS` from Task 2.
+- Produces: `buildImageStack(payload)`, `buildTaskResults(payload)`, both registered in `BUILDERS` under `"image_stack"` and `"task_results"`.
+- Payload shapes, relied on by Tasks 9 and 10: `"image_stack"` = `{"stack": ndarray, "center_index": int | None, "title": str}`; `"task_results"` = `{"traces": [(t_array, y_array), ...], "sequence_dir": str, "sweep_count": int, "decimation": int, "units": str}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/modules/Autopatch/tests/test_details_renderers.py`:
+
+```python
+def test_image_stack_builder_opens_at_the_center_index(qapp):
+    import numpy as np
+    import pyqtgraph as pg
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    stack = np.arange(5 * 4 * 3, dtype=float).reshape(5, 4, 3)
+    wrapper = buildDetailsWidget(
+        "image_stack", {"stack": stack, "center_index": 2, "title": "Cellfie"}
+    )
+
+    view = wrapper.findChild(pg.ImageView)
+    assert view is not None
+    assert view.currentIndex == 2
+
+
+def test_image_stack_builder_shows_the_title_as_its_caption(qapp):
+    import numpy as np
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    wrapper = buildDetailsWidget(
+        "image_stack",
+        {"stack": np.zeros((3, 4, 4)), "center_index": 1, "title": "Cellfie"},
+    )
+
+    caption = wrapper.layout().itemAt(0).widget()
+    assert "Cellfie" in caption.text()
+
+
+def test_image_stack_builder_tolerates_a_none_center_index(qapp):
+    # A 2D image or a single-frame stack has no meaningful center frame.
+    import numpy as np
+    import pyqtgraph as pg
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    wrapper = buildDetailsWidget(
+        "image_stack", {"stack": np.zeros((4, 4)), "center_index": None, "title": ""}
+    )
+
+    assert wrapper.findChild(pg.ImageView) is not None or isinstance(wrapper, pg.ImageView)
+
+
+def test_task_results_builder_plots_one_curve_per_sweep(qapp):
+    import numpy as np
+    import pyqtgraph as pg
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    t = np.linspace(0, 1, 10)
+    payload = {
+        "traces": [(t, t * 1.0), (t, t * 2.0), (t, t * 3.0)],
+        "sequence_dir": "protocol_000",
+        "sweep_count": 3,
+        "decimation": 1,
+        "units": "A",
+    }
+
+    wrapper = buildDetailsWidget("task_results", payload)
+
+    plot = wrapper.findChild(pg.PlotWidget)
+    assert plot is not None
+    assert len(plot.plotItem.listDataItems()) == 3
+
+
+def test_task_results_caption_reports_sweeps_directory_and_decimation(qapp):
+    import numpy as np
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    t = np.linspace(0, 1, 10)
+    wrapper = buildDetailsWidget(
+        "task_results",
+        {
+            "traces": [(t, t)],
+            "sequence_dir": "protocol_007",
+            "sweep_count": 1,
+            "decimation": 25,
+            "units": "A",
+        },
+    )
+
+    text = wrapper.layout().itemAt(0).widget().text()
+    assert "1" in text
+    assert "protocol_007" in text
+    assert "25" in text
+
+
+def test_task_results_caption_omits_decimation_when_undecimated(qapp):
+    import numpy as np
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    t = np.linspace(0, 1, 10)
+    wrapper = buildDetailsWidget(
+        "task_results",
+        {
+            "traces": [(t, t)],
+            "sequence_dir": "protocol_000",
+            "sweep_count": 1,
+            "decimation": 1,
+            "units": "A",
+        },
+    )
+
+    assert "decimated" not in wrapper.layout().itemAt(0).widget().text()
+
+
+def test_task_results_builder_tolerates_no_traces(qapp):
+    # A sequence stopped before its first sweep completed.
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    wrapper = buildDetailsWidget(
+        "task_results",
+        {
+            "traces": [],
+            "sequence_dir": "protocol_000",
+            "sweep_count": 0,
+            "decimation": 1,
+            "units": "A",
+        },
+    )
+
+    assert wrapper is not None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_details_renderers.py -v -k "image_stack or task_results"`
+
+Expected: FAIL — `buildDetailsWidget` falls through to the unknown-kind text renderer, so `wrapper.findChild(...)` returns `None` and `wrapper.layout()` is `None`.
+
+- [ ] **Step 3: Add the two builders**
+
+In `acq4/modules/Autopatch/details_renderers.py`, add the imports at the top after `from acq4.util import Qt`:
+
+```python
+import numpy as np
+import pyqtgraph as pg
+```
+
+Add both builders after `buildError`:
+
+```python
+def buildImageStack(payload) -> Qt.QWidget:
+    """A z-stack in a pg.ImageView, opened at the frame the cell was found on.
+
+    setImage jumps to frame 0, which for a cellfie is the top of the stack and
+    shows nothing; center_index is the plane the cell actually sits on.
+    """
+    view = pg.ImageView()
+    view.setImage(np.asarray(payload["stack"]), autoRange=True, autoLevels=True)
+    centerIndex = payload.get("center_index")
+    if centerIndex is not None:
+        view.setCurrentIndex(centerIndex)
+    title = payload.get("title") or ""
+    return captioned(view, [title] if title else [])
+
+
+def buildTaskResults(payload) -> Qt.QWidget:
+    """One TaskRunner sequence's sweeps, coloured over sequence index so the
+    order they ran in is readable at a glance."""
+    plot = pg.PlotWidget()
+    plot.setLabels(left=("primary", payload.get("units") or ""), bottom=("time", "s"))
+    traces = list(payload.get("traces", ()))
+    for index, (times, values) in enumerate(traces):
+        plot.plot(
+            np.asarray(times),
+            np.asarray(values),
+            pen=pg.intColor(index, hues=max(len(traces), 1)),
+        )
+    lines = [
+        f"{payload.get('sweep_count', len(traces))} sweeps"
+        f" — saved to {payload.get('sequence_dir') or 'nowhere'}"
+    ]
+    decimation = payload.get("decimation", 1)
+    if decimation > 1:
+        # Never silent: the pane says what it is not showing, and the
+        # undecimated data is in the saved sequence directory named above.
+        lines.append(f"plotted decimated {decimation}x; full data on disk")
+    return captioned(plot, lines)
+```
+
+Register both in `BUILDERS`:
+
+```python
+BUILDERS = {
+    "text": buildText,
+    "error": buildError,
+    "image_stack": buildImageStack,
+    "task_results": buildTaskResults,
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_details_renderers.py -v`
+
+Expected: PASS, 15 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/modules/Autopatch/details_renderers.py acq4/modules/Autopatch/tests/test_details_renderers.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(autopatch): render image stacks and task-runner results
+
+The cellfie stack opens at the plane the cell sits on rather than frame 0,
+which for a cellfie is the top of the stack and shows nothing. Task-runner
+sweeps are coloured over sequence index, and the caption names the saved
+sequence directory and reports any decimation rather than plotting a
+reduced trace silently.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 4: `CellPanel` retains payloads
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/cell_panel.py`
+- Test: `acq4/modules/Autopatch/tests/test_details_navigation.py`
+
+**Interfaces:**
+- Consumes: `ActionLogEntry.on_details` (Task 1).
+- Produces: `CellPanel._details: dict[tuple[int, int], tuple[str, Any]]`; `CellPanel.detailsFor(cell, rowIndex) -> tuple[str, Any] | None`; `CellPanel._dropDetailsFor(cellId) -> None`. The `"details"` phase string on `sigActionEntry`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `acq4/modules/Autopatch/tests/test_details_navigation.py`:
+
+```python
+"""Tests for CellPanel's retention of ActionLogEntry.set_details() payloads and
+the timeline-row navigation that mounts them in the detail pane."""
+import pytest
+
+from acq4.experiment.log_entry import ActionLogEntry
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+class _FakeOrchestrator(Qt.QObject):
+    sigCurrentCell = Qt.Signal(object)
+    sigCellFinished = Qt.Signal(object, str)
+
+    def __init__(self):
+        super().__init__()
+        self.enqueued = []
+
+    def enqueue(self, cell):
+        self.enqueued.append(cell)
+
+    def pendingCells(self):
+        return []
+
+
+class _FakeManipulator:
+    def __init__(self, target):
+        self._target = target
+
+    def targetPosition(self):
+        return self._target
+
+
+class _FakePipette:
+    def __init__(self, target):
+        self.pipetteDevice = _FakeManipulator(target)
+
+
+@pytest.fixture
+def panel(qapp):
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    return CellPanel(pipetteGetter=lambda: _FakePipette((0, 0, 0)))
+
+
+def _seed(panel, count=1):
+    orch = _FakeOrchestrator()
+    panel.bindOrchestrator(orch)
+    for _ in range(count):
+        panel.addFromTargetBtn.click()
+    return orch.enqueued
+
+
+def test_payload_is_retained_against_the_entrys_row(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    entry.set_details("text", {"lines": ["saved"]})
+
+    assert panel.detailsFor(cell, 0) == ("text", {"lines": ["saved"]})
+
+
+def test_payload_survives_the_entry_finishing(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    entry.set_details("text", {"lines": ["saved"]})
+    entry._finish(None)
+
+    assert panel.detailsFor(cell, 0) == ("text", {"lines": ["saved"]})
+
+
+def test_payloads_are_retained_per_row(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+
+    first = ActionLogEntry("First")
+    panel.onLogAction(cell, first)
+    first.set_details("text", {"lines": ["one"]})
+    first._finish(None)
+
+    second = ActionLogEntry("Second")
+    panel.onLogAction(cell, second)
+    second.set_details("text", {"lines": ["two"]})
+    second._finish(None)
+
+    assert panel.detailsFor(cell, 0) == ("text", {"lines": ["one"]})
+    assert panel.detailsFor(cell, 1) == ("text", {"lines": ["two"]})
+
+
+def test_payloads_are_retained_for_an_unselected_cell(panel):
+    cellA, cellB = _seed(panel, 2)
+    panel.cellList.setCurrentRow(0)  # follow cellA while cellB works
+
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cellB, entry)
+    entry.set_details("text", {"lines": ["B's stack"]})
+
+    assert panel.detailsFor(cellB, 0) == ("text", {"lines": ["B's stack"]})
+
+
+def test_clear_cells_drops_retained_payloads(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    entry.set_details("text", {"lines": ["saved"]})
+
+    panel.clearCells()
+
+    assert panel._details == {}
+
+
+def test_discarding_an_unattempted_cell_drops_its_payloads(panel):
+    cellA, cellB = _seed(panel, 2)
+    panel.cellList.setCurrentRow(0)
+    entryA = ActionLogEntry("A")
+    panel.onLogAction(cellA, entryA)
+    entryA.set_details("text", {"lines": ["A"]})
+    entryB = ActionLogEntry("B")
+    panel.onLogAction(cellB, entryB)
+    entryB.set_details("text", {"lines": ["B"]})
+
+    panel._onCellsDiscarded([cellA])
+
+    assert panel.detailsFor(cellA, 0) is None
+    assert panel.detailsFor(cellB, 0) == ("text", {"lines": ["B"]})
+
+
+def test_reuse_clears_the_cells_payloads(panel):
+    # Pass 2 starts with a fresh timeline and log; retained details are that
+    # same earlier-pass UI history and must go with them.
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    entry.set_details("text", {"lines": ["pass 1"]})
+    entry._finish(None)
+    panel._onCellFinished(cell, "done")
+
+    panel.cellList.item(0).setCheckState(Qt.Qt.Checked)
+    panel.reuseCheckedCellsBtn.click()
+
+    assert panel.detailsFor(cell, 0) is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_details_navigation.py -v`
+
+Expected: FAIL with `AttributeError: 'CellPanel' object has no attribute 'detailsFor'`.
+
+- [ ] **Step 3: Add the store, the accessor, and the drop helper**
+
+In `acq4/modules/Autopatch/cell_panel.py`, in `__init__` immediately after the `self._logs: dict[int, list[str]] = {}` line:
+
+```python
+        # (id(cell), timeline row index) -> (kind, payload) from that action's
+        # ActionLogEntry.set_details(). Keyed by row rather than by entry
+        # because the row key is what outlives the entry, which is the whole
+        # point of retaining anything; it is also the key self._timelines
+        # already uses. Holds only plain data -- never an entry, a cell, or a
+        # widget -- so nothing here can form the reference cycle
+        # tests/test_teardown.py exists to prevent (see set_details' docstring).
+        self._details: dict[tuple[int, int], tuple[str, object]] = {}
+```
+
+Add these methods immediately after `errorText`:
+
+```python
+    def detailsFor(self, cell, rowIndex: int):
+        """The (kind, payload) an action retained for `cell`'s row `rowIndex`,
+        or None if that row's action retained nothing."""
+        return self._details.get((id(cell), rowIndex))
+
+    def _dropDetailsFor(self, cellId: int) -> None:
+        """Forget every retained payload belonging to `cellId`.
+
+        Scans rather than indexing by cell: the keys are (cell, row) pairs, and
+        a per-cell index would be a second store to keep in sync with this one
+        on all three of the paths that drop rows.
+        """
+        for key in [k for k in self._details if k[0] == cellId]:
+            del self._details[key]
+```
+
+- [ ] **Step 4: Wire the `on_details` callback and the `"details"` phase**
+
+In `onLogAction`, after the `entry.on_finish = ...` assignment:
+
+```python
+        entry.on_details = lambda e, kind, payload: self.sigActionEntry.emit(
+            cell, e, "details"
+        )
+```
+
+Extend `onLogAction`'s docstring by appending to the paragraph that lists the callbacks:
+
+```python
+        on_details is assigned here for the same reason and marshaled the same
+        way; like the others it closes over `self` and `cell` only, and the
+        payload is read back off the entry in the slot rather than carried
+        through the signal, so sigActionEntry's signature is unchanged.
+```
+
+In `_onActionEntry`, add a branch before the trailing `"status"` comment:
+
+```python
+        elif phase == "details":
+            loc = self._entryTimelineLoc.get(id(entry))
+            if loc is not None:
+                self._details[loc] = (entry.details_kind, entry.details_payload)
+                if self._isSelectedRow(loc):
+                    self._mountSelectedRow()
+```
+
+Add the two helpers used above, after `_clearShowContainer`:
+
+```python
+    def _isSelectedRow(self, loc) -> bool:
+        """Whether (cellId, rowIndex) is the row the operator is looking at."""
+        cellId, index = loc
+        cell = self._currentSelectedCell()
+        return cell is not None and id(cell) == cellId and self.timelineList.currentRow() == index
+
+    def _mountSelectedRow(self) -> None:
+        """Placeholder until Task 5 gives rows their own mounting."""
+        return None
+```
+
+- [ ] **Step 5: Drop payloads wherever rows are dropped**
+
+In `clearCells`, beside `self._timelines.clear()`:
+
+```python
+        self._details.clear()
+```
+
+In `_onCellsDiscarded`, in the branch that removes a never-attempted cell, beside `self._timelines.pop(cellId, None)`:
+
+```python
+            self._dropDetailsFor(cellId)
+```
+
+In `_onReuseCheckedCells`, beside `self._logs[id(cell)] = []`:
+
+```python
+            # Earlier-pass details are that pass's UI history, cleared with the
+            # timeline and log for the same reason (design doc §7).
+            self._dropDetailsFor(id(cell))
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_details_navigation.py acq4/modules/Autopatch/tests -v`
+
+Expected: PASS, including every pre-existing Autopatch test.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add acq4/modules/Autopatch/cell_panel.py acq4/modules/Autopatch/tests/test_details_navigation.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(autopatch): retain action details payloads per timeline row
+
+Keyed by (cell, row) rather than by entry: the row key is what outlives the
+entry, which is the point of retaining anything, and it is the key the
+timeline store already uses. Holds only plain data, so nothing retained can
+form the panel<->entry cycle the teardown tests guard against. Dropped
+wherever rows are dropped -- clearCells, a rescan's discard, and reuse.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 5: Selecting a timeline row mounts its details
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/cell_panel.py`
+- Test: `acq4/modules/Autopatch/tests/test_details_navigation.py`
+
+**Interfaces:**
+- Consumes: `detailsFor`, `_details`, `_isSelectedRow` (Task 4); `buildDetailsWidget` (Tasks 2–3).
+- Produces: `CellPanel._liveWidgets: dict[int, Any]`; a real `CellPanel._mountSelectedRow()`; `CellPanel._onTimelineSelectionChanged(current, previous)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/modules/Autopatch/tests/test_details_navigation.py`:
+
+```python
+def _mounted(panel):
+    layout = panel.showContainer.layout()
+    return [layout.itemAt(i).widget() for i in range(layout.count())]
+
+
+def test_selecting_a_finished_row_mounts_its_payload(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    entry.set_details("text", {"lines": ["the cellfie stack"]})
+    entry._finish(None)
+
+    panel.timelineList.setCurrentRow(0)
+
+    assert len(_mounted(panel)) == 1
+    assert "the cellfie stack" in _mounted(panel)[0].toPlainText()
+
+
+def test_selecting_a_different_row_swaps_the_mounted_payload(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    first = ActionLogEntry("First")
+    panel.onLogAction(cell, first)
+    first.set_details("text", {"lines": ["one"]})
+    first._finish(None)
+    second = ActionLogEntry("Second")
+    panel.onLogAction(cell, second)
+    second.set_details("text", {"lines": ["two"]})
+    second._finish(None)
+
+    panel.timelineList.setCurrentRow(0)
+    assert "one" in _mounted(panel)[0].toPlainText()
+
+    panel.timelineList.setCurrentRow(1)
+    assert "two" in _mounted(panel)[0].toPlainText()
+
+
+def test_selecting_a_row_with_no_payload_leaves_the_pane_empty(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Pipette To Home")
+    panel.onLogAction(cell, entry)
+    entry._finish(None)
+
+    panel.timelineList.setCurrentRow(0)
+
+    assert _mounted(panel) == []
+
+
+def test_a_live_widget_is_remounted_when_its_row_is_reselected(panel):
+    # Navigating away clears the container, which reparents the live widget out.
+    # Coming back must put the same widget back, not a dead one.
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    finished = ActionLogEntry("Earlier")
+    panel.onLogAction(cell, finished)
+    finished._finish(None)
+
+    live = ActionLogEntry("Patch")
+    panel.onLogAction(cell, live)
+    liveWidget = Qt.QLabel("live plot")
+    live.set_details_widget(liveWidget)
+    assert liveWidget in _mounted(panel)
+
+    panel.timelineList.setCurrentRow(0)
+    assert liveWidget not in _mounted(panel)
+
+    panel.timelineList.setCurrentRow(1)
+    assert liveWidget in _mounted(panel)
+
+
+def test_a_finished_entrys_live_widget_is_forgotten(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry.set_details_widget(Qt.QLabel("live plot"))
+    entry._finish(None)
+
+    assert panel._liveWidgets == {}
+
+
+def test_a_payload_arriving_for_the_selected_row_mounts_immediately(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    panel.timelineList.setCurrentRow(0)
+
+    entry.set_details("text", {"lines": ["just arrived"]})
+
+    assert "just arrived" in _mounted(panel)[0].toPlainText()
+
+
+def test_a_payload_replaces_the_live_widget_on_the_same_row(panel):
+    # patch()'s finally sets its payload while its live plot is still mounted.
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    liveWidget = Qt.QLabel("live plot")
+    entry.set_details_widget(liveWidget)
+    panel.timelineList.setCurrentRow(0)
+    assert liveWidget in _mounted(panel)
+
+    entry.set_details("text", {"lines": ["frozen"]})
+
+    assert liveWidget not in _mounted(panel)
+    assert "frozen" in _mounted(panel)[0].toPlainText()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_details_navigation.py -v -k "selecting or live or arriving"`
+
+Expected: FAIL — `_mounted(panel)` is `[]` where a payload was expected, since `_mountSelectedRow` is still the Task 4 placeholder and `timelineList` has no selection handler.
+
+- [ ] **Step 3: Add the live-widget store**
+
+In `acq4/modules/Autopatch/cell_panel.py`, in `__init__` immediately after the `self._timelineItems` block:
+
+```python
+        # id(entry) -> the live widget that entry handed over via
+        # set_details_widget(), held only while that entry's action is in
+        # flight and dropped the moment it finishes.
+        #
+        # Required for row navigation rather than merely convenient: selecting
+        # another row clears showContainer, which reparents the live widget out
+        # of the GUI tree, and without a reference here Python would collect it
+        # before the operator could select its row again. Dropping it on finish
+        # is what keeps the module's "no widget outlives its action" invariant
+        # (see tests/test_teardown.py).
+        self._liveWidgets: dict[int, object] = {}
+```
+
+- [ ] **Step 4: Replace the placeholder `_mountSelectedRow` and connect the selection**
+
+Replace the Task 4 placeholder `_mountSelectedRow` with:
+
+```python
+    def _mountSelectedRow(self) -> None:
+        """Show whatever the currently selected timeline row has to show.
+
+        Preference order: that row's live widget if its action is still in
+        flight, else its retained payload, else nothing. A live action's widget
+        wins because it is still being updated; the payload only exists once the
+        action has something final to say.
+        """
+        self._clearShowContainer()
+        self._shownEntryId = None
+        cell = self._currentSelectedCell()
+        index = self.timelineList.currentRow()
+        if cell is None or index < 0:
+            return
+        loc = (id(cell), index)
+        for entryId, entryLoc in self._entryTimelineLoc.items():
+            if entryLoc == loc and entryId in self._liveWidgets:
+                self.showContainer.layout().addWidget(self._liveWidgets[entryId])
+                self._shownEntryId = entryId
+                return
+        stored = self._details.get(loc)
+        if stored is None:
+            return
+        kind, payload = stored
+        self.showContainer.layout().addWidget(buildDetailsWidget(kind, payload))
+
+    def _onTimelineSelectionChanged(self, _current, _previous) -> None:
+        self._mountSelectedRow()
+```
+
+Add the import at the top of the file, beside the existing `from .error_display import ErrorBlock`:
+
+```python
+from .details_renderers import buildDetailsWidget
+```
+
+Connect the signal in `__init__`, beside `self.cellList.currentItemChanged.connect(...)`:
+
+```python
+        self.timelineList.currentItemChanged.connect(self._onTimelineSelectionChanged)
+```
+
+- [ ] **Step 5: Route the `"widget"` and `"finished"` phases through the store**
+
+In `_onActionEntry`, replace the `"widget"` branch with:
+
+```python
+        elif phase == "widget":
+            widget = entry.details_widget
+            if widget is None:
+                self._liveWidgets.pop(id(entry), None)
+            else:
+                self._liveWidgets[id(entry)] = widget
+            loc = self._entryTimelineLoc.get(id(entry))
+            if loc is not None and self._isSelectedRow(loc):
+                self._mountSelectedRow()
+```
+
+In the `"finished"` branch, add the live-widget drop as its first statement, before the existing `self._finishTimelineRow(cell, entry)` call:
+
+```python
+            self._liveWidgets.pop(id(entry), None)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests -v`
+
+Expected: PASS. `test_cell_log_and_show.py`'s existing tests must all still pass — they rely on a followed cell's newly appended row being the selected one, which Task 6 makes explicit but which already holds here because `timelineList`'s first appended item becomes current automatically.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add acq4/modules/Autopatch/cell_panel.py acq4/modules/Autopatch/tests/test_details_navigation.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(autopatch): mount a timeline row's details when it is selected
+
+The pane could previously show only the running action's widget or the
+cell's last error. Rows are now individually selectable, mounting the row's
+live widget if its action is in flight and its retained payload otherwise.
+
+Live widgets are held by entry id while in flight, which navigation
+requires rather than merely benefits from: leaving a row reparents the
+widget out of the tree, and without a held reference it would be collected
+before the operator could come back to it. Dropped on finish, so no widget
+outlives its action.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 6: Auto-select a row, and follow the running action
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/cell_panel.py`
+- Test: `acq4/modules/Autopatch/tests/test_details_navigation.py`
+
+**Interfaces:**
+- Consumes: `_mountSelectedRow` (Task 5).
+- Produces: `CellPanel._isFollowingLastRow() -> bool`; `CellPanel._autoSelectRow(cellId) -> None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/modules/Autopatch/tests/test_details_navigation.py`:
+
+```python
+def test_a_new_row_is_followed_while_the_last_row_is_selected(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    first = ActionLogEntry("First")
+    panel.onLogAction(cell, first)
+    first._finish(None)
+    assert panel.timelineList.currentRow() == 0
+
+    second = ActionLogEntry("Second")
+    panel.onLogAction(cell, second)
+
+    assert panel.timelineList.currentRow() == 1
+
+
+def test_selecting_an_earlier_row_stops_following(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    for name in ("First", "Second"):
+        entry = ActionLogEntry(name)
+        panel.onLogAction(cell, entry)
+        entry._finish(None)
+
+    panel.timelineList.setCurrentRow(0)  # operator navigates back
+
+    third = ActionLogEntry("Third")
+    panel.onLogAction(cell, third)
+
+    assert panel.timelineList.currentRow() == 0
+
+
+def test_returning_to_the_last_row_resumes_following(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    for name in ("First", "Second"):
+        entry = ActionLogEntry(name)
+        panel.onLogAction(cell, entry)
+        entry._finish(None)
+    panel.timelineList.setCurrentRow(0)
+    third = ActionLogEntry("Third")
+    panel.onLogAction(cell, third)
+    third._finish(None)
+    assert panel.timelineList.currentRow() == 0
+
+    panel.timelineList.setCurrentRow(panel.timelineList.count() - 1)
+
+    fourth = ActionLogEntry("Fourth")
+    panel.onLogAction(cell, fourth)
+
+    assert panel.timelineList.currentRow() == panel.timelineList.count() - 1
+
+
+def test_selecting_a_cell_auto_selects_its_running_row(panel):
+    cellA, cellB = _seed(panel, 2)
+    panel.cellList.setCurrentRow(1)  # look at B so A's rows build unrendered
+    done = ActionLogEntry("Done")
+    panel.onLogAction(cellA, done)
+    done._finish(None)
+    running = ActionLogEntry("Running")
+    panel.onLogAction(cellA, running)
+
+    panel.cellList.setCurrentRow(0)
+
+    assert panel.timelineList.currentRow() == 1
+    assert "running" in panel.timelineList.item(1).text()
+
+
+def test_selecting_a_cell_auto_selects_its_failed_row(panel):
+    cellA, cellB = _seed(panel, 2)
+    panel.cellList.setCurrentRow(1)
+    failed = ActionLogEntry("Patch")
+    panel.onLogAction(cellA, failed)
+    failed._finish(RuntimeError("boom"))
+    later = ActionLogEntry("Pipette To Home")
+    panel.onLogAction(cellA, later)
+    later._finish(None)
+
+    panel.cellList.setCurrentRow(0)
+
+    assert panel.timelineList.currentRow() == 0
+
+
+def test_selecting_a_cell_auto_selects_the_last_row_when_nothing_stands_out(panel):
+    cellA, cellB = _seed(panel, 2)
+    panel.cellList.setCurrentRow(1)
+    for name in ("First", "Second"):
+        entry = ActionLogEntry(name)
+        panel.onLogAction(cellA, entry)
+        entry._finish(None)
+
+    panel.cellList.setCurrentRow(0)
+
+    assert panel.timelineList.currentRow() == 1
+
+
+def test_selecting_a_cell_with_no_rows_selects_nothing(panel):
+    cellA, cellB = _seed(panel, 2)
+    entry = ActionLogEntry("First")
+    panel.onLogAction(cellA, entry)
+    entry._finish(None)
+    panel.cellList.setCurrentRow(0)
+
+    panel.cellList.setCurrentRow(1)
+
+    assert panel.timelineList.currentRow() == -1
+    assert _mounted(panel) == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_details_navigation.py -v -k "following or auto_select"`
+
+Expected: FAIL — new rows do not move the selection, and switching cells leaves `currentRow()` at whatever Qt's own first-item default produced.
+
+- [ ] **Step 3: Add the follow-live check and the auto-select rule**
+
+In `acq4/modules/Autopatch/cell_panel.py`, add after `_onTimelineSelectionChanged`:
+
+```python
+    def _isFollowingLastRow(self) -> bool:
+        """Whether the operator is watching the newest row rather than reading
+        back through earlier ones.
+
+        The auto-scroll rule: while the last row is selected, a new action's row
+        takes the selection with it; once the operator selects an earlier row,
+        it does not, until they return to the last row. A timeline with no
+        selection at all counts as following, so the first row of a freshly
+        followed cell is shown rather than requiring a click.
+        """
+        count = self.timelineList.count()
+        return count == 0 or self.timelineList.currentRow() in (-1, count - 1)
+
+    def _autoSelectRow(self, cellId: int) -> None:
+        """Select the row worth looking at for the cell just selected: the
+        action still running, else the most recent one that failed, else the
+        last one.
+
+        Without this, switching to a cell would leave the pane blank until the
+        operator clicked a row -- and, for a failed cell, would lose the
+        traceback that used to mount on cell selection alone.
+        """
+        count = self.timelineList.count()
+        if count == 0:
+            self.timelineList.setCurrentRow(-1)
+            return
+        running = {
+            index
+            for entryId, (locCellId, index) in self._entryTimelineLoc.items()
+            if locCellId == cellId
+        }
+        if running:
+            self.timelineList.setCurrentRow(max(running))
+            return
+        failed = [
+            index
+            for (storeCellId, index), (kind, _payload) in self._details.items()
+            if storeCellId == cellId and kind == "error"
+        ]
+        self.timelineList.setCurrentRow(max(failed) if failed else count - 1)
+```
+
+- [ ] **Step 4: Follow on append, and auto-select on cell switch**
+
+In `_appendTimelineRow`, replace the `if cell is self._currentSelectedCell():` block with:
+
+```python
+        if cell is self._currentSelectedCell():
+            following = self._isFollowingLastRow()
+            item = Qt.QListWidgetItem(text)
+            self.timelineList.addItem(item)
+            self._timelineItems[id(entry)] = item
+            if following:
+                self.timelineList.setCurrentItem(item)
+```
+
+In `_onCellSelectionChanged`, replace the trailing `self._showErrorBlock(cell)` call with:
+
+```python
+        self._autoSelectRow(cellId)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests -v`
+
+Expected: PASS. Note `test_cell_error_block.py` will still fail on the tests that assert an `ErrorBlock` mounts, because errors do not become payloads until Task 8 — if any fail here, they are the ones Task 8 fixes; every other test must pass.
+
+If `test_cell_error_block.py` failures appear, record which and proceed; do not weaken `_autoSelectRow` to accommodate them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add acq4/modules/Autopatch/cell_panel.py acq4/modules/Autopatch/tests/test_details_navigation.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(autopatch): follow the running action, and auto-select a row per cell
+
+Row selection needs a default, or switching cells leaves the pane blank
+until the operator clicks. Selecting a cell now selects its running action,
+else its most recent failure, else its last row -- which is also what keeps
+"select a failed cell, see the traceback" working now that the pane is
+driven by rows.
+
+New rows take the selection only while the last row is already selected, so
+reading back through an earlier action is not yanked away by the next one.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 7: The status line
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/cell_panel.py`
+- Test: `acq4/modules/Autopatch/tests/test_details_navigation.py`
+
+**Interfaces:**
+- Consumes: `_isSelectedRow`, `_mountSelectedRow` (Tasks 4–5).
+- Produces: `CellPanel.statusLabel: Qt.QLabel`; `CellPanel._statuses: dict[tuple[int, int], str]`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/modules/Autopatch/tests/test_details_navigation.py`:
+
+```python
+def test_status_shows_for_the_selected_row(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+
+    entry.set_status("driving FSM from 'approach'")
+
+    assert "driving FSM from 'approach'" in panel.statusLabel.text()
+
+
+def test_status_updates_in_place_as_the_action_progresses(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+
+    entry.set_status("now in 'seal'")
+    entry.set_status("reached 'whole cell'")
+
+    assert "reached 'whole cell'" in panel.statusLabel.text()
+    assert "now in 'seal'" not in panel.statusLabel.text()
+
+
+def test_status_is_not_shown_for_an_unselected_row(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    earlier = ActionLogEntry("Earlier")
+    panel.onLogAction(cell, earlier)
+    earlier.set_status("earlier status")
+    earlier._finish(None)
+    later = ActionLogEntry("Later")
+    panel.onLogAction(cell, later)
+    later.set_status("later status")
+
+    panel.timelineList.setCurrentRow(0)
+
+    assert "earlier status" in panel.statusLabel.text()
+    assert "later status" not in panel.statusLabel.text()
+
+
+def test_last_status_is_retained_after_the_action_finishes(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    entry.set_status("saving cellfie z-stack")
+    entry._finish(None)
+
+    panel.timelineList.setCurrentRow(0)
+
+    assert "saving cellfie z-stack" in panel.statusLabel.text()
+
+
+def test_status_clears_for_a_row_that_never_reported_one(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    withStatus = ActionLogEntry("With")
+    panel.onLogAction(cell, withStatus)
+    withStatus.set_status("something")
+    withStatus._finish(None)
+    withoutStatus = ActionLogEntry("Without")
+    panel.onLogAction(cell, withoutStatus)
+    withoutStatus._finish(None)
+
+    panel.timelineList.setCurrentRow(1)
+
+    assert panel.statusLabel.text() == ""
+
+
+def test_clear_cells_drops_retained_statuses(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry.set_status("something")
+
+    panel.clearCells()
+
+    assert panel._statuses == {}
+    assert panel.statusLabel.text() == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_details_navigation.py -v -k status`
+
+Expected: FAIL with `AttributeError: 'CellPanel' object has no attribute 'statusLabel'`.
+
+- [ ] **Step 3: Add the store and the label**
+
+In `acq4/modules/Autopatch/cell_panel.py`, in `__init__` after the `self._details` block:
+
+```python
+        # (id(cell), timeline row index) -> that action's most recent
+        # set_status() text. Retained alongside the payload so a finished row
+        # still says what it was doing when it ended; a row absent from here
+        # never reported a status.
+        self._statuses: dict[tuple[int, int], str] = {}
+```
+
+Create the label beside `self.showContainer`:
+
+```python
+        # Header above the mounted details widget, carrying the selected
+        # action's set_status() text -- which nothing displayed before this,
+        # so every FSM state-transition message was thrown away. The timeline
+        # rows deliberately do not show it (design doc §7).
+        self.statusLabel = Qt.QLabel()
+        self.statusLabel.setWordWrap(True)
+```
+
+Add it to the layout immediately before `layout.addWidget(self.showContainer)`:
+
+```python
+        layout.addWidget(self.statusLabel)
+```
+
+- [ ] **Step 4: Record and render the status**
+
+In `_onActionEntry`, replace the trailing `"status"` comment block with a real branch:
+
+```python
+        elif phase == "status":
+            # Recorded and shown in the pane's header, but deliberately NOT in
+            # the timeline row: rows show "running" then the outcome and
+            # nothing else (design doc §7).
+            loc = self._entryTimelineLoc.get(id(entry))
+            if loc is not None:
+                self._statuses[loc] = entry.status
+                if self._isSelectedRow(loc):
+                    self.statusLabel.setText(entry.status)
+```
+
+In `_mountSelectedRow`, set the label from the store. Replace its opening lines:
+
+```python
+        self._clearShowContainer()
+        self._shownEntryId = None
+        cell = self._currentSelectedCell()
+        index = self.timelineList.currentRow()
+        if cell is None or index < 0:
+            self.statusLabel.setText("")
+            return
+        loc = (id(cell), index)
+        self.statusLabel.setText(self._statuses.get(loc, ""))
+```
+
+In `clearCells`, beside `self._details.clear()`:
+
+```python
+        self._statuses.clear()
+        self.statusLabel.setText("")
+```
+
+In `_dropDetailsFor`, extend it to drop statuses too, and rename its docstring accordingly:
+
+```python
+    def _dropDetailsFor(self, cellId: int) -> None:
+        """Forget every retained payload and status belonging to `cellId`.
+
+        Scans rather than indexing by cell: the keys are (cell, row) pairs, and
+        a per-cell index would be a second store to keep in sync with these two
+        on all three of the paths that drop rows.
+        """
+        for key in [k for k in self._details if k[0] == cellId]:
+            del self._details[key]
+        for key in [k for k in self._statuses if k[0] == cellId]:
+            del self._statuses[key]
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_details_navigation.py -v`
+
+Expected: PASS on every status test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add acq4/modules/Autopatch/cell_panel.py acq4/modules/Autopatch/tests/test_details_navigation.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(autopatch): show the selected action's status in the detail pane
+
+set_status() was write-only: the panel ignored the "status" phase outright,
+so "driving FSM from 'approach'" -> "now in 'seal'" -> "reached 'whole
+cell'" appeared nowhere in the UI at all. It now heads the detail pane, and
+the last status is retained so a finished row still says what it was doing
+when it ended. Timeline rows are unchanged, per design doc §7.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 8: A failed action's error becomes a row payload
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/cell_panel.py`
+- Test: `acq4/modules/Autopatch/tests/test_details_navigation.py`
+
+**Interfaces:**
+- Consumes: `_details` (Task 4), the `"error"` builder (Task 2), `_autoSelectRow` (Task 6).
+- Produces: nothing new. `errorText(cell)` and `_cellErrors` keep their existing signatures and meanings.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/modules/Autopatch/tests/test_details_navigation.py`:
+
+```python
+def test_a_failed_action_records_an_error_payload_on_its_row(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry._finish(RuntimeError("boom"))
+
+    kind, payload = panel.detailsFor(cell, 0)
+    assert kind == "error"
+    assert payload["exc_type"] == "RuntimeError"
+    assert payload["exc_message"] == "boom"
+    assert "RuntimeError: boom" in payload["traceback_text"]
+    assert payload["cell_repr"] == repr(cell)
+
+
+def test_a_failed_actions_row_mounts_an_error_block(panel):
+    from acq4.modules.Autopatch.error_display import ErrorBlock
+
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry._finish(RuntimeError("boom"))
+
+    panel.timelineList.setCurrentRow(0)
+
+    assert isinstance(_mounted(panel)[0], ErrorBlock)
+
+
+def test_a_failed_action_that_set_a_payload_keeps_the_payload(panel):
+    # The data it gathered before dying beats the traceback, which the log and
+    # the row's outcome glyph both still carry.
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry.set_details("text", {"lines": ["got this far"]})
+    entry._finish(RuntimeError("boom"))
+
+    kind, payload = panel.detailsFor(cell, 0)
+    assert kind == "text"
+    assert payload == {"lines": ["got this far"]}
+
+
+def test_error_text_still_answers_which_cell_failed(panel):
+    # _cellErrors and errorText() are a different question from "what did this
+    # row do", and tests/test_teardown.py asserts against errorText.
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry._finish(RuntimeError("boom"))
+
+    assert panel.errorText(cell)[0] == "RuntimeError"
+    assert panel.errorText(cell)[1] == "boom"
+
+
+def test_a_successful_action_records_no_error_payload(panel):
+    (cell,) = _seed(panel)
+    panel.cellList.setCurrentRow(0)
+    entry = ActionLogEntry("Patch")
+    panel.onLogAction(cell, entry)
+    entry._finish(None)
+
+    assert panel.detailsFor(cell, 0) is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_details_navigation.py -v -k "failed or error_text"`
+
+Expected: FAIL — `detailsFor(cell, 0)` returns `None` for a failed action.
+
+- [ ] **Step 3: Record the error as a payload**
+
+In `_onActionEntry`'s `"finished"` branch, the row location must be read **before** `_finishTimelineRow` runs, because that method pops `_entryTimelineLoc`. Replace the whole branch with:
+
+```python
+        elif phase == "finished":
+            self._liveWidgets.pop(id(entry), None)
+            # Read before _finishTimelineRow: that method pops this entry's
+            # location, and the error payload below needs the row it names.
+            loc = self._entryTimelineLoc.get(id(entry))
+            self._finishTimelineRow(cell, entry)
+            if entry.outcome == "error":
+                self._cellErrors[id(cell)] = (
+                    entry.exc_type,
+                    entry.exc_message,
+                    entry.traceback_text,
+                )
+                # An action that gathered data before failing keeps that data:
+                # it says more than the traceback, which the log and this row's
+                # own outcome glyph both still carry.
+                if loc is not None and loc not in self._details:
+                    self._details[loc] = (
+                        "error",
+                        {
+                            "exc_type": entry.exc_type,
+                            "exc_message": entry.exc_message,
+                            "traceback_text": entry.traceback_text,
+                            "cell_repr": repr(cell),
+                        },
+                    )
+            if cell is self._currentSelectedCell():
+                self._mountSelectedRow()
+```
+
+- [ ] **Step 4: Retire the cell-level error mount**
+
+Delete the `_showErrorBlock` method entirely — `_autoSelectRow` reaches the same block through the failed row, and `_onReuseCheckedCells`/`_onCurrentCell` already clear `_cellErrors` on their own. Verify no callers remain:
+
+Run: `grep -rn "_showErrorBlock" acq4/`
+
+Expected: no output.
+
+If `acq4/modules/Autopatch/tests/test_cell_error_block.py` calls it directly, update those tests to select the failed row and assert on the mounted widget instead, matching `test_a_failed_actions_row_mounts_an_error_block` above.
+
+- [ ] **Step 5: Run the full Autopatch and experiment suites**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests acq4/experiment/tests -v`
+
+Expected: PASS, all tests including `test_teardown.py` and `test_cell_error_block.py`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add acq4/modules/Autopatch/cell_panel.py acq4/modules/Autopatch/tests/
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+refactor(autopatch): make a failed action's error an ordinary row payload
+
+ErrorBlock becomes one more renderer instead of a cell-level special case,
+reached through the failed row that _autoSelectRow picks. _cellErrors and
+errorText() are untouched: "which cell failed" is a different question from
+"what did this row do", and the teardown tests assert against errorText.
+
+An action that gathered data and then failed keeps its payload -- that data
+says more than the traceback, which the log and the row's outcome glyph both
+still carry. The row location is read before _finishTimelineRow, which pops
+the bookkeeping the payload key comes from.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 9: `cellfie` retains its stack
+
+**Files:**
+- Modify: `acq4/experiment/actions/device.py`
+- Test: `acq4/experiment/tests/test_actions_device.py`
+
+**Interfaces:**
+- Consumes: `set_details` (Task 1); the `"image_stack"` payload shape (Task 3).
+- Produces: `device._trackerStack(cell) -> np.ndarray | None`.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `acq4/experiment/tests/test_actions_device.py`, give `FakeCell` a tracker. Add to its `__init__`:
+
+```python
+        self.tracker_stack = None
+```
+
+and at the end of `initializeTracker`, after the error check:
+
+```python
+        if self.tracker_stack is not None:
+            self._tracker = _FakeTracker(self.tracker_stack)
+```
+
+Add the supporting fakes above `FakeCell`:
+
+```python
+class _FakeObjectStack:
+    def __init__(self, data):
+        self.data = data
+
+
+class _FakeMotionEstimator:
+    def __init__(self, data):
+        self.original_object_stack = _FakeObjectStack(data)
+
+
+class _FakeTracker:
+    """Stands in for the acq4_automation tracker cellfie initializes: exposes
+    the one attribute chain the details payload reads."""
+
+    def __init__(self, data):
+        self.motion_estimator = _FakeMotionEstimator(data)
+```
+
+Append the tests:
+
+```python
+def test_cellfie_retains_the_trackers_stack_as_an_image_stack_payload(ctx, pip, monkeypatch):
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
+    import numpy as np
+
+    monkeypatch.setattr(device_mod, "run_image_sequence", lambda *a, **k: _Waitable())
+    ctx.cell.tracker_stack = np.arange(5 * 4 * 3, dtype=float).reshape(5, 4, 3)
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    cellfie(ctx)
+
+    assert len(details) == 1
+    kind, payload = details[0]
+    assert kind == "image_stack"
+    # Rows/cols swapped so it displays in the same orientation as the Camera
+    # module, matching AutomationDebug's own cell stack view.
+    assert payload["stack"].shape == (5, 3, 4)
+    assert payload["center_index"] == 2
+    assert payload["title"] == "Cellfie"
+
+
+def test_cellfie_center_index_is_none_for_a_single_frame_stack(ctx, pip, monkeypatch):
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
+    import numpy as np
+
+    monkeypatch.setattr(device_mod, "run_image_sequence", lambda *a, **k: _Waitable())
+    ctx.cell.tracker_stack = np.zeros((1, 4, 3))
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    cellfie(ctx)
+
+    assert details[0][1]["center_index"] is None
+
+
+def test_cellfie_sets_no_payload_when_the_tracker_exposes_no_stack(ctx, pip, monkeypatch):
+    # A cell whose tracker did not expose a stack must not make cellfie raise
+    # out of the orchestrator's worker thread over a display concern.
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
+    monkeypatch.setattr(device_mod, "run_image_sequence", lambda *a, **k: _Waitable())
+    ctx.cell.tracker_stack = None
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    cellfie(ctx)
+
+    assert details == []
+
+
+def test_cellfie_sets_no_payload_when_the_cell_is_lost(monkeypatch, tmp_path):
+    # tissue_moved never returns, so there is nothing to retain -- the accepted
+    # gap in the spec's §8.
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
+    from acq4_automation.feature_tracking import CellTrackingLost
+
+    monkeypatch.setattr(device_mod, "run_image_sequence", lambda *a, **k: _Waitable())
+    cell = FakeCell()
+    cell.tracker_error = CellTrackingLost("gone")
+    details = []
+
+    def hook(action_entry):
+        action_entry.on_details = lambda e, kind, payload: details.append(kind)
+
+    ctx = ExecutionContext(
+        cell=cell,
+        pipette=FakePipette(),
+        manager=FakeManager(),
+        tissue_moved_hook=lambda c, reason: (_ for _ in ()).throw(AdvanceToNextCell(reason)),
+    )
+    ctx.on_log_action = hook
+
+    with pytest.raises(AdvanceToNextCell):
+        cellfie(ctx)
+
+    assert details == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_actions_device.py -v -k "retains_the_trackers or center_index or no_payload"`
+
+Expected: FAIL — `assert len(details) == 1` fails with `details == []`, since `cellfie` sets no payload yet.
+
+- [ ] **Step 3: Add the stack reader and the payload**
+
+In `acq4/experiment/actions/device.py`, add the import at the top beside the existing imports:
+
+```python
+import numpy as np
+```
+
+Add the helper above `cellfie`:
+
+```python
+def _trackerStack(cell):
+    """The 3D stack a cell's tracker holds, oriented for display, or None.
+
+    Reads the same attribute chain AutomationDebug's cell stack view does, and
+    swaps rows/cols the same way so the stack displays in the same orientation
+    as the Camera module. Returns None rather than raising for a cell whose
+    tracker never exposed one: this feeds a display payload, and an action must
+    not fail on the orchestrator's worker thread over what the pane can show.
+    """
+    tracker = getattr(cell, "_tracker", None)
+    if tracker is None:
+        return None
+    try:
+        stack = tracker.motion_estimator.original_object_stack.data
+    except Exception:
+        return None
+    if stack is None:
+        return None
+    stack = np.asarray(stack)
+    if stack.ndim >= 2:
+        stack = np.swapaxes(stack, -2, -1)
+    return stack
+```
+
+In `cellfie`, replace the tracker-initialization `try/except` block's success path so the payload is set after it. The block becomes:
+
+```python
+        # Initialize the tracker reference used to follow the cell during patching.
+        try:
+            ctx.cell.initializeTracker(
+                imager,
+                use_cellpose=True,
+                deformation_tolerance=DEFORMATION_TOLERANCE,
+                segmenter=segmenter_path(),
+            )
+        except CellTrackingLost as exc:
+            # The tracker could not re-find this cell against its own reference
+            # stacks, so the stacks are useless: the cell has drifted out of
+            # reach or died. That is a question about the tissue, not about this
+            # action, and the window is what can answer it. Never returns, so
+            # there is no stack to retain for the pane.
+            ctx.tissue_moved(exc.reason or str(exc))
+        # Retained for Area 5: the cube around the cell, which is what an
+        # operator reads to judge a cellfie. The full acquired z-stack stays on
+        # disk in the cellfie/ directory saved above.
+        stack = _trackerStack(ctx.cell)
+        if stack is not None:
+            action_entry.set_details(
+                "image_stack",
+                {
+                    "stack": stack,
+                    "center_index": (
+                        stack.shape[0] // 2
+                        if stack.ndim >= 3 and stack.shape[0] > 1
+                        else None
+                    ),
+                    "title": "Cellfie",
+                },
+            )
+```
+
+Update `cellfie`'s docstring by appending one line to it:
+
+```python
+    Retains the tracker's cropped object stack as this action's Area 5 details.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_actions_device.py -v`
+
+Expected: PASS, all tests in the file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/experiment/actions/device.py acq4/experiment/tests/test_actions_device.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(experiment): retain the cellfie stack for Area 5
+
+The cube around the cell that the tracker already holds -- the same data
+AutomationDebug's cell view shows, with the same rows/cols swap so it
+displays in the Camera module's orientation. Already in memory on the Cell,
+so retaining it costs the pane nothing, and the full acquired z-stack stays
+on disk where run_image_sequence put it.
+
+Reads defensively and sets no payload when there is no stack: a display
+concern must not fail an action on the orchestrator's worker thread. A
+cellfie that loses the cell never returns from tissue_moved, so it retains
+nothing -- the accepted gap in the spec's §8.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 10: `run_task` shows and retains its sweeps
+
+**Files:**
+- Modify: `acq4/experiment/actions/device.py`
+- Modify: `acq4/modules/TaskRunner/TaskRunner.py:611-672`
+- Test: `acq4/experiment/tests/test_actions_device.py`
+
+**Interfaces:**
+- Consumes: `set_details` (Task 1); the `"task_results"` payload shape (Task 3).
+- Produces: `device._decimate(times, values, maxPoints=_MAX_TRACE_POINTS) -> tuple[np.ndarray, np.ndarray, int]`; module constant `_MAX_TRACE_POINTS = 4000`; `TaskRunner.lastSequenceDir: DirHandle | None`.
+
+**Why `TaskRunner` is touched.** `runSequence` creates its storage directory as a local `dh` and never exposes it, so there is no way to ask the module afterwards where a sequence was saved. The payload's caption would silently read "saved to nowhere" on every real run. Two lines on `TaskRunner` fix that honestly; the alternative — captioning it with `currentTask.name()` — names the task rather than the auto-incremented directory that was actually created, which is the kind of almost-right label that misleads later.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/experiment/tests/test_actions_device.py`:
+
+```python
+class _FakeMetaArray:
+    """Stands in for a clamp device's task result: indexable by channel name,
+    with an xvals('Time') axis, the shape MultiClamp's task GUI reads."""
+
+    def __init__(self, times, primary):
+        self._times = times
+        self._primary = primary
+
+    def __getitem__(self, key):
+        assert key == "primary"
+        return self._primary
+
+    def xvals(self, axis):
+        assert axis == "Time"
+        return self._times
+
+
+def _sequence_frame(clampName, times, primary, params=None):
+    return {"result": {clampName: _FakeMetaArray(times, primary)}, "params": params or {}}
+
+
+def test_decimate_leaves_a_short_trace_alone():
+    import numpy as np
+
+    t = np.linspace(0, 1, 100)
+    times, values, factor = device_mod._decimate(t, t * 2.0, maxPoints=4000)
+
+    assert factor == 1
+    assert len(times) == 100
+    assert np.array_equal(values, t * 2.0)
+
+
+def test_decimate_reduces_a_long_trace_and_reports_the_factor():
+    import numpy as np
+
+    t = np.linspace(0, 1, 40000)
+    times, values, factor = device_mod._decimate(t, t, maxPoints=4000)
+
+    assert factor == 10
+    assert len(times) == len(values) == 4000
+
+
+def test_run_task_retains_each_sweep_as_a_task_results_payload(ctx, pip, monkeypatch):
+    import numpy as np
+
+    clampName = pip.clampDevice.name()
+    module = FakeTaskRunnerModule({clampName: object()})
+    ctx.manager.modules["TaskRunner"] = module
+    monkeypatch.setattr(device_mod, "run_in_gui_thread", lambda fn, *a, **k: fn(*a, **k))
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+    t = np.linspace(0, 1, 10)
+    module.frames = [
+        _sequence_frame(clampName, t, t * 1.0),
+        _sequence_frame(clampName, t, t * 2.0),
+    ]
+
+    run_task(ctx)
+
+    assert len(details) == 1
+    kind, payload = details[0]
+    assert kind == "task_results"
+    assert payload["sweep_count"] == 2
+    assert len(payload["traces"]) == 2
+    assert payload["decimation"] == 1
+    assert np.array_equal(payload["traces"][1][1], t * 2.0)
+
+
+def test_run_task_payload_names_the_sequence_directory(ctx, pip, monkeypatch):
+    clampName = pip.clampDevice.name()
+    module = FakeTaskRunnerModule({clampName: object()})
+    module.sequence_dir_name = "protocol_003"
+    ctx.manager.modules["TaskRunner"] = module
+    monkeypatch.setattr(device_mod, "run_in_gui_thread", lambda fn, *a, **k: fn(*a, **k))
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+    module.frames = []
+
+    run_task(ctx)
+
+    assert details[0][1]["sequence_dir"] == "protocol_003"
+
+
+def test_run_task_retains_nothing_but_still_reports_when_no_sweeps_arrive(ctx, pip, monkeypatch):
+    clampName = pip.clampDevice.name()
+    module = FakeTaskRunnerModule({clampName: object()})
+    ctx.manager.modules["TaskRunner"] = module
+    monkeypatch.setattr(device_mod, "run_in_gui_thread", lambda fn, *a, **k: fn(*a, **k))
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+    module.frames = []
+
+    run_task(ctx)
+
+    assert details[0][1]["sweep_count"] == 0
+    assert details[0][1]["traces"] == []
+
+
+def test_run_task_retains_its_sweeps_even_when_the_sequence_raises(ctx, pip, monkeypatch):
+    import numpy as np
+
+    clampName = pip.clampDevice.name()
+    module = FakeTaskRunnerModule({clampName: object()})
+    module.run_error = RuntimeError("amplifier fell over")
+    ctx.manager.modules["TaskRunner"] = module
+    monkeypatch.setattr(device_mod, "run_in_gui_thread", lambda fn, *a, **k: fn(*a, **k))
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+    t = np.linspace(0, 1, 10)
+    module.frames = [_sequence_frame(clampName, t, t)]
+
+    with pytest.raises(RuntimeError):
+        run_task(ctx)
+
+    assert details[0][1]["sweep_count"] == 1
+```
+
+Extend `FakeTaskRunnerModule` so it can emit frames and fail. Replace it with:
+
+```python
+class FakeTaskRunnerModule(Qt.QObject):
+    sigNewFrame = Qt.Signal(object)
+
+    def __init__(self, docks, period=1.0, totalParams=5):
+        super().__init__()
+        self.docks = docks
+        self.sequenceInfo = {"period": period, "totalParams": totalParams}
+        self.run_calls = []
+        self.run_error = None
+        # Frames the run emits, standing in for the real module's per-sweep
+        # sigNewFrame; and the directory handle run_task reads the saved
+        # sequence's name off, mirroring TaskRunner.lastSequenceDir.
+        self.frames = []
+        self.lastSequenceDir = _FakeSequenceDir("protocol_000")
+
+    def runSequence(self, store=True):
+        self.run_calls.append(store)
+        for frame in self.frames:
+            self.sigNewFrame.emit(frame)
+        return _Waitable(self.run_error)
+
+
+class _FakeSequenceDir:
+    def __init__(self, name):
+        self._name = name
+
+    def shortName(self):
+        return self._name
+```
+
+and add `from acq4.util import Qt` to the file's imports. In `test_run_task_payload_names_the_sequence_directory`, replace `module.sequence_dir_name = "protocol_003"` with `module.lastSequenceDir = _FakeSequenceDir("protocol_003")`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_actions_device.py -v -k "decimate or run_task"`
+
+Expected: FAIL — `AttributeError: module 'acq4.experiment.actions.device' has no attribute '_decimate'`, and `details == []` for the payload tests.
+
+- [ ] **Step 3: Add the decimation helper**
+
+In `acq4/experiment/actions/device.py`, add the constant near the top after the imports:
+
+```python
+# Retained trace length per sweep. More than a plot's pixel width, and small
+# enough that a 20-sweep sequence costs the pane well under a megabyte per cell
+# rather than the 16 MB the undecimated sweeps would. The full data is in the
+# saved ProtocolSequence directory either way.
+_MAX_TRACE_POINTS = 4000
+```
+
+and the helper above `run_task`:
+
+```python
+def _decimate(times, values, maxPoints: int = _MAX_TRACE_POINTS):
+    """(times, values, factor) reduced to at most `maxPoints` samples.
+
+    A factor of 1 means nothing was dropped. The factor is returned rather than
+    swallowed so the pane can say what it is not showing.
+    """
+    times = np.asarray(times)
+    values = np.asarray(values)
+    if len(values) <= maxPoints:
+        return times, values, 1
+    factor = int(np.ceil(len(values) / maxPoints))
+    return times[::factor], values[::factor], factor
+```
+
+- [ ] **Step 4: Collect sweeps and retain them in `run_task`**
+
+Replace `run_task`'s body from the `info = taskrunner.sequenceInfo` line onward:
+
+```python
+        info = taskrunner.sequenceInfo
+        expected_duration = info["period"] * info["totalParams"]
+        timeout = timeout or max(30, expected_duration * 20)
+        clampName = ctx.pipette.clampDevice.name()
+        traces = []
+        decimation = 1
+
+        def onNewFrame(frame):
+            """Collect one sweep's clamp trace. Reads the result the way
+            MultiClamp's own task GUI does: result['primary'] against
+            result.xvals('Time')."""
+            nonlocal decimation
+            result = frame.get("result", {}).get(clampName)
+            if result is None:
+                return
+            try:
+                times, values, factor = _decimate(
+                    result.xvals("Time"), result["primary"]
+                )
+            except Exception:
+                # A device whose result is not shaped like a clamp recording is
+                # not a reason to fail the sequence; the data is saved on disk
+                # regardless of whether the pane can plot it.
+                return
+            traces.append((times, values))
+            decimation = max(decimation, factor)
+
+        # Queued by default, so sweeps arriving on the task thread do not touch
+        # this action's collection from there.
+        taskrunner.sigNewFrame.connect(onNewFrame)
+        action_entry.set_status("running task runner sequence")
+        try:
+            run_in_gui_thread(taskrunner.runSequence, store=store).wait(timeout=timeout)
+        finally:
+            Qt.disconnect(taskrunner.sigNewFrame, onNewFrame)
+            if decimation > 1:
+                ctx.log(
+                    f"{action_entry.name}: plotting sweeps decimated {decimation}x; "
+                    f"full data saved on disk"
+                )
+            action_entry.set_details(
+                "task_results",
+                {
+                    "traces": traces,
+                    "sequence_dir": _sequenceDirName(taskrunner),
+                    "sweep_count": len(traces),
+                    "decimation": decimation,
+                    "units": "A",
+                },
+            )
+```
+
+Add `from acq4.util import Qt` to the file's imports, and this helper beside `_decimate`:
+
+```python
+def _sequenceDirName(taskrunner) -> str:
+    """The short name of the directory the sequence saved into, or "" if it did
+    not save one (store=False, or a run that never got that far)."""
+    sequenceDir = getattr(taskrunner, "lastSequenceDir", None)
+    return "" if sequenceDir is None else sequenceDir.shortName()
+```
+
+- [ ] **Step 5: Expose the sequence directory on `TaskRunner`**
+
+`runSequence` creates its storage directory as a local and never exposes it, so `_sequenceDirName` has nothing to read. In `acq4/modules/TaskRunner/TaskRunner.py`, add to `__init__` beside `self.currentTask = None` (line 131):
+
+```python
+        # The directory the most recent stored sequence saved into, so a caller
+        # driving runSequence() can report where the data went. None until a
+        # sequence runs with store=True.
+        self.lastSequenceDir = None
+```
+
+In `runSequence`, immediately after the `dh = storeDirHandle.mkdir(name, autoIncrement=True, info=info)` line, add:
+
+```python
+                self.lastSequenceDir = dh
+```
+
+and in the `else` branch that sets `dh = None`, add:
+
+```python
+                self.lastSequenceDir = None
+```
+
+`shortName()` is inherited by `DirHandle` from `FileHandle` (`acq4/util/DataManager/dot_index.py:84`), so `_sequenceDirName` works against the real handle.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_actions_device.py -v`
+
+Expected: PASS, all tests in the file.
+
+Then confirm `TaskRunner` still imports, since it has real device imports:
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -c "import acq4.modules.TaskRunner.TaskRunner as t; print(t.TaskRunner)"`
+
+Expected: prints the class with no import error.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add acq4/experiment/actions/device.py acq4/modules/TaskRunner/TaskRunner.py acq4/experiment/tests/test_actions_device.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(experiment): retain the task-runner sequence's sweeps for Area 5
+
+Collects each sweep's clamp trace off sigNewFrame, reading it the way
+MultiClamp's own task GUI does, and retains them as this action's details.
+Set from a finally, so a sequence that fails partway still shows what it
+managed to record.
+
+Traces are decimated to 4000 points -- more than a plot's pixel width, and
+enough to keep 20 sweeps well under a megabyte per cell instead of 16 -- with
+the factor reported through ctx.log and carried in the payload rather than
+reduced silently. The undecimated data is in the saved sequence directory.
+
+TaskRunner gains lastSequenceDir so the payload can name that directory:
+runSequence created it as a local and exposed it nowhere, so the caption had
+nothing truthful to say about where the data went.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 11: `prompt`, `new_data_dir`, and `find_surface` retain their one fact
+
+**Files:**
+- Modify: `acq4/experiment/actions/prompt.py`
+- Modify: `acq4/experiment/actions/storage.py`
+- Modify: `acq4/experiment/actions/device.py`
+- Test: `acq4/experiment/tests/test_actions_prompt_storage.py`
+- Test: `acq4/experiment/tests/test_actions_device.py`
+
+**Interfaces:**
+- Consumes: `set_details` (Task 1); the `"text"` payload shape (Task 2).
+- Produces: nothing new. All three keep their existing return values.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/experiment/tests/test_actions_prompt_storage.py`:
+
+```python
+def test_prompt_retains_the_message_and_the_clicked_label(monkeypatch):
+    from acq4.experiment.actions import prompt as prompt_mod
+    from acq4.experiment.actions.prompt import prompt
+    from acq4.experiment.context import ExecutionContext
+
+    monkeypatch.setattr(prompt_mod, "_is_headless", lambda: False)
+    monkeypatch.setattr(prompt_mod, "prompt_user", lambda title, message, labels: "Retry")
+    ctx = ExecutionContext()
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    assert prompt(ctx, message="Replace the pipette", choices=("Retry", "Skip")) == "Retry"
+
+    assert details == [
+        ("text", {"lines": ["Replace the pipette", "operator chose: Retry"]})
+    ]
+
+
+def test_prompt_retains_the_default_choice_when_headless(monkeypatch):
+    from acq4.experiment.actions import prompt as prompt_mod
+    from acq4.experiment.actions.prompt import prompt
+    from acq4.experiment.context import ExecutionContext
+
+    monkeypatch.setattr(prompt_mod, "_is_headless", lambda: True)
+    ctx = ExecutionContext()
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    prompt(ctx, message="carry on", choices=("OK", "Cancel"))
+
+    assert details[0][1]["lines"][1] == "operator chose: OK"
+
+
+def test_new_data_dir_retains_the_directory_it_created():
+    from acq4.experiment.actions.storage import new_data_dir
+    from acq4.experiment.context import ExecutionContext
+
+    class _Dir:
+        def __init__(self, name):
+            self._name = name
+
+        def name(self):
+            return self._name
+
+        def isManaged(self):
+            return True
+
+        def info(self):
+            return {"dirType": "Slice"}
+
+        def mkdir(self, name, autoIncrement=False, info=None):
+            return _Dir(f"/data/{name}")
+
+        def parent(self):
+            return self
+
+        def setInfo(self, info):
+            return None
+
+    class _Manager:
+        def __init__(self):
+            self.current = _Dir("/data/slice_000")
+            self.set_calls = []
+
+        def getCurrentDir(self):
+            return self.current
+
+        def folderTypesConfig(self):
+            return {"Cell": {"name": "cell_000"}}
+
+        def setCurrentDir(self, d):
+            self.set_calls.append(d)
+
+    ctx = ExecutionContext(manager=_Manager())
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    created = new_data_dir(ctx, level="Cell")
+
+    assert details == [("text", {"lines": [f"created {created.name()}"]})]
+```
+
+Append to `acq4/experiment/tests/test_actions_device.py`:
+
+```python
+def test_find_surface_retains_the_detected_depth(ctx, pip):
+    pip.scope.surface_depth = -1.2e-3
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    depth = find_surface(ctx)
+
+    assert depth == -1.2e-3
+    kind, payload = details[0]
+    assert kind == "text"
+    assert "surface" in payload["lines"][0]
+    assert "1.2 mm" in payload["lines"][0]
+
+
+def test_find_surface_retains_nothing_when_detection_fails(ctx, pip):
+    pip.scope.surface_error = ValueError("no surface found")
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    with pytest.raises(OrchestrationError):
+        find_surface(ctx)
+
+    assert details == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_actions_prompt_storage.py acq4/experiment/tests/test_actions_device.py -v -k "retains"`
+
+Expected: FAIL — `details == []` for all four, since none of the three actions sets a payload.
+
+- [ ] **Step 3: `prompt`**
+
+In `acq4/experiment/actions/prompt.py`, replace the body of the `with` block:
+
+```python
+    with ctx.log_action("Operator Prompt") as action_entry:
+        action_entry.set_status(message)
+        ctx.log(message)
+        # Bound to a local rather than returned directly, so the choice can be
+        # retained for Area 5 before this entry finishes -- a payload set after
+        # the block exits has no timeline row to attach to (see set_details).
+        chosen = labels[0] if _is_headless() else prompt_user(title, message, labels)
+        action_entry.set_details(
+            "text", {"lines": [message, f"operator chose: {chosen}"]}
+        )
+        return chosen
+```
+
+- [ ] **Step 4: `new_data_dir`**
+
+In `acq4/experiment/actions/storage.py`, replace `new_data_dir`'s body:
+
+```python
+    with ctx.log_action("New Data Directory") as action_entry:
+        new_dir = create_data_dir(ctx.manager, level=level, set_current=set_current)
+        action_entry.set_details("text", {"lines": [f"created {new_dir.name()}"]})
+        return new_dir
+```
+
+- [ ] **Step 5: `find_surface`**
+
+In `acq4/experiment/actions/device.py`, replace `find_surface`'s body from the `try` onward:
+
+```python
+        try:
+            depth = scope.findSurfaceDepth(imager)
+        except ValueError as e:
+            raise OrchestrationError(f"{action_entry.name}: {e}") from e
+        action_entry.set_details(
+            "text", {"lines": [f"surface detected at {pg.siFormat(depth, suffix='m')}"]}
+        )
+        return depth
+```
+
+Add the import at the top of `device.py`:
+
+```python
+import pyqtgraph as pg
+```
+
+- [ ] **Step 6: Run the full experiment suite**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests -v`
+
+Expected: PASS, all tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add acq4/experiment/actions/prompt.py acq4/experiment/actions/storage.py acq4/experiment/actions/device.py acq4/experiment/tests/
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(experiment): retain the one fact prompt, new_data_dir, and find_surface produce
+
+Which label the operator clicked, which directory was created, and the
+detected surface depth -- each a fact worth being able to re-read off a
+finished row rather than only finding in the log.
+
+prompt binds its choice to a local before returning, because a payload set
+after the log_action block exits has no timeline row to attach to.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 12: Verify the phase end to end
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the complete affected suites**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests acq4/modules/Autopatch/tests -v`
+
+Expected: PASS with no failures, no errors, and no new warnings. Test output must be pristine.
+
+- [ ] **Step 2: Confirm nothing outside this phase's scope changed**
+
+Run: `git diff --stat cc291fe8e..HEAD -- acq4/ tools/`
+
+Expected: changes confined to `acq4/experiment/log_entry.py`, `acq4/experiment/actions/{device,prompt,storage}.py`, `acq4/experiment/tests/`, `acq4/modules/Autopatch/{cell_panel,details_renderers}.py`, `acq4/modules/Autopatch/tests/`, and the two added lines in `acq4/modules/TaskRunner/TaskRunner.py`. Nothing under `acq4/devices/`, `acq4/modules/MultiPatch/`, `acq4/filetypes/`, or `tools/`.
+
+- [ ] **Step 3: Report**
+
+State which tasks landed, the final test count, and any test you had to modify rather than add — naming it and why.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage for phase 1.** §2 → Task 1. §3 retention → Task 4; navigation → Tasks 5–6; error-as-payload → Task 8; the `errorText` carve-out → Task 8. §4 registry and builders → Tasks 2–3 (the `"test_pulse_history"` row is phase 3). §8 `cellfie` → Task 9; `run_task` → Task 10; `prompt`/`new_data_dir`/`find_surface` → Task 11. §1's status line → Task 7. §9 threading is honored by construction in Tasks 4–5 and asserted by the pre-existing `test_log_action_entries_marshal_from_the_worker_thread_to_the_gui_thread`. §10's phase-1 items are distributed across the tasks that create the behavior.
+
+**Deliberately deferred to phases 2–3:** §5, §6, §7, and §8's `patch`/`reseal`.
+
+**Known test edits, not additions:** Task 8 may need to rewrite parts of `test_cell_error_block.py`, since `_showErrorBlock` is deleted and the error block is now reached through a row. Task 10 rewrites `FakeTaskRunnerModule` to emit frames. Task 9 extends `FakeCell` with a tracker. Each is called out in its task.
+
+**One addition beyond the spec, and why.** Task 10 adds `TaskRunner.lastSequenceDir` (two lines). The spec's §8 says the `run_task` payload "carries" the saved sequence directory's name, but `runSequence` creates that directory as a local and exposes it nowhere — so the payload could not honestly carry it. Captioning with `currentTask.name()` instead would name the task rather than the auto-incremented directory actually created, which is worse than saying nothing.
+
+**Verified against the code while planning:** `shortName()` is inherited by `DirHandle` from `FileHandle` (`acq4/util/DataManager/dot_index.py:84`); a clamp task result is read as `result['primary']` against `result.xvals('Time')` (`acq4/devices/MultiClamp/taskGUI.py:336`); `CellPanel.errorText` has exactly one consumer, `tests/test_teardown.py:351`; and `FakeCell` in `test_actions_device.py` has no `_tracker`, which is why Task 9's stack reader must tolerate its absence.

--- a/docs/superpowers/plans/2026-08-17-autopatch-fsm-details.md
+++ b/docs/superpowers/plans/2026-08-17-autopatch-fsm-details.md
@@ -1,0 +1,1268 @@
+# Autopatch FSM Details — Phase 3 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give `patch` and `reseal` a steady-state resistance plot in Area 5 — live while the FSM drives, frozen and re-readable afterwards — plus the list of pipette states the FSM actually walked, and an event log of their own on disk.
+
+**Architecture:** `_drive_fsm` opens a `MultiPatchLogRecorder` and MultiPatch's `PlotWidget` on entry, records state transitions from the poll loop it already has, and in a `finally` inside its `log_action` block stops the recorder and retains its accumulated test-pulse analysis as a `"test_pulse_history"` payload. The frozen plot reuses the same `PlotWidget`, taught to tolerate `tp=None`. `clean` opts out of all of it.
+
+**Tech Stack:** Python 3, PyQt (via `acq4.util.Qt`), pyqtgraph, numpy, pytest.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-08-17-autopatch-area5-details-widgets-design.md` §4 (the `"test_pulse_history"` row), §8's `patch`/`reseal`. This plan implements phase 3 of its §11 phasing.
+- **Depends on both earlier phases.** Phase 1 supplies `ActionLogEntry.set_details`, `CellPanel`'s retention and row navigation, and the `BUILDERS` registry. Phase 2 supplies `MultiPatchLogRecorder` and `testPulseAnalysis()`. Do not start this until both have landed.
+- **`clean` gets nothing** — no recorder, no plot, no payload. There is nothing an operator reads off a clean (design doc §4.5).
+- **Payload contract (spec §2):** plain data only. In particular the payload must **never** hold a `PatchClampTestPulse`, which is why the `'test pulse'` and `'tp analysis'` plot modes are unavailable on a frozen plot.
+- **Widgets are built on the GUI thread** via `run_in_gui_thread`; the action function runs on the orchestrator's worker thread.
+- **The live plot's device connection must be queued and must be severed when the action ends** (design doc §4.5). `PatchPipetteState` connects to `sigTestPulseFinished` with an explicit `DirectConnection`, which is right for a state machine and wrong for a widget.
+- **Python interpreter:** `/home/martin/.miniforge3/envs/acq4-gl/bin/python`. Run pytest as `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest`.
+- **Commits:** conventional format, `--author="Martin Chase (claude) <outofculture@gmail.com>"`, footer `🤖 Generated with [Claude Code](https://claude.ai/code)`. Never `--no-verify`.
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `acq4/modules/MultiPatch/pipetteControl.py` | `PlotWidget.newTestPulse` tolerating `tp=None` | Modify |
+| `acq4/modules/MultiPatch/tests/test_plot_widget_frozen.py` | that tolerance | Create |
+| `acq4/modules/Autopatch/details_renderers.py` | the `"test_pulse_history"` builder | Modify |
+| `acq4/modules/Autopatch/tests/test_details_renderers.py` | that builder | Modify |
+| `acq4/experiment/actions/fsm.py` | transition capture, the recorder, the payload, the live plot | Modify |
+| `acq4/experiment/tests/test_actions_fsm.py` | all of the above | Modify |
+
+---
+
+### Task 1: `PlotWidget.newTestPulse` tolerates `tp=None`
+
+**Files:**
+- Modify: `acq4/modules/MultiPatch/pipetteControl.py:444-472`
+- Test: `acq4/modules/MultiPatch/tests/test_plot_widget_frozen.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `PlotWidget.newTestPulse(tp: PatchClampTestPulse | None, history)` accepts `None` for `tp` in every analysis mode; `PlotWidget.setFrozen(frozen: bool) -> None`, which trims the mode combo to the modes a history alone can serve.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `acq4/modules/MultiPatch/tests/test_plot_widget_frozen.py`:
+
+```python
+"""Tests for PlotWidget's frozen mode: plotting a retained test-pulse history
+with no live PatchClampTestPulse to read a current value from.
+
+Autopatch's Area 5 reuses this widget for a finished action's plot (design doc
+§4.5, "reuse, do not reimplement"), and its retained payload deliberately holds
+no PatchClampTestPulse -- so tp is None there."""
+import numpy as np
+import pytest
+
+from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+def _history(count=5):
+    history = np.zeros(count, dtype=TEST_PULSE_NUMPY_DTYPE)
+    history["event_time"] = np.arange(count, dtype=float)
+    history["steady_state_resistance"] = np.linspace(1e6, 1e9, count)
+    history["access_resistance"] = np.linspace(1e6, 2e7, count)
+    history["baseline_current"] = np.linspace(-1e-10, 1e-10, count)
+    history["baseline_potential"] = np.linspace(-0.07, -0.06, count)
+    history["time_constant"] = np.linspace(1e-4, 1e-3, count)
+    history["capacitance"] = np.linspace(1e-12, 5e-12, count)
+    return history
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        "ss resistance",
+        "peak resistance",
+        "holding current",
+        "holding potential",
+        "time constant",
+        "capacitance",
+    ],
+)
+def test_analysis_modes_plot_a_history_with_no_test_pulse(qapp, mode):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode=mode)
+
+    widget.newTestPulse(None, _history())
+
+    assert len(widget.plot.plotItem.listDataItems()) == 1
+
+
+def test_the_current_value_label_is_blank_with_no_test_pulse(qapp):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode="ss resistance")
+
+    widget.newTestPulse(None, _history())
+
+    assert widget.tpLabel.toPlainText() == ""
+
+
+def test_an_empty_history_plots_nothing_and_does_not_raise(qapp):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode="ss resistance")
+
+    widget.newTestPulse(None, _history(count=0))
+
+    assert widget.plot.plotItem.listDataItems() == []
+
+
+def test_test_pulse_modes_clear_rather_than_raise_with_no_test_pulse(qapp):
+    # 'test pulse' and 'tp analysis' need the recording itself, which a frozen
+    # payload deliberately does not retain. They must degrade, not crash.
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    for mode in ("test pulse", "tp analysis"):
+        widget = PlotWidget(mode=mode)
+        widget.newTestPulse(None, _history())
+        assert widget.plot.plotItem.listDataItems() == []
+
+
+def test_set_frozen_removes_the_modes_a_history_cannot_serve(qapp):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode="ss resistance")
+
+    widget.setFrozen(True)
+
+    items = [widget.modeCombo.itemText(i) for i in range(widget.modeCombo.count())]
+    assert "test pulse" not in items
+    assert "tp analysis" not in items
+    assert "ss resistance" in items
+    assert "capacitance" in items
+
+
+def test_set_frozen_keeps_the_current_mode_selected(qapp):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode="capacitance")
+
+    widget.setFrozen(True)
+
+    assert widget.modeCombo.currentText() == "capacitance"
+    assert widget.mode == "capacitance"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/MultiPatch/tests/test_plot_widget_frozen.py -v`
+
+Expected: FAIL — `AttributeError: 'NoneType' object has no attribute 'analysis'` in the analysis-mode tests, `'NoneType' object has no attribute 'plot'` for `tp analysis`, and `no attribute 'setFrozen'`.
+
+- [ ] **Step 3: Make `newTestPulse` tolerate `tp=None`**
+
+In `acq4/modules/MultiPatch/pipetteControl.py`, replace `newTestPulse` (lines 444-472) with:
+
+```python
+    def newTestPulse(self, tp: PatchClampTestPulse | None, history):
+        """Update the plot from the latest test pulse and the history behind it.
+
+        `tp` may be None, which is how Autopatch's Area 5 reuses this widget for
+        a finished action: its retained payload holds the history but no
+        PatchClampTestPulse, since a recording is not plain data (see
+        ActionLogEntry.set_details). With no `tp` the analysis modes plot the
+        history and leave the current-value label blank, and the two modes that
+        need the recording itself clear instead.
+        """
+        if self._analysisLabel is not None:
+            self.plot.plotItem.vb.removeItem(self._analysisLabel)
+            self._analysisLabel = None
+        if self.mode == 'test pulse':
+            self.plot.clear()
+            if tp is not None:
+                self._plotTestPulse(tp)
+        elif self.mode == 'tp analysis':
+            self.plot.clear()
+            if tp is not None:
+                tp.plot(self.plot, label=False)
+                self._analysisLabel = tp.label_for_plot(self.plot.plotItem)
+        else:
+            analysis_by_mode = {
+                'ss resistance': ('steady_state_resistance', u'Ω'),
+                'peak resistance': ('access_resistance', u'Ω'),
+                'holding current': ('baseline_current', 'A'),
+                'holding potential': ('baseline_potential', 'V'),
+                'time constant': ('time_constant', 's'),
+                'capacitance': ('capacitance', 'F'),
+            }
+            key, units = analysis_by_mode[self.mode]
+            if len(history['event_time']) > 0:
+                self.plot.plot(history['event_time'] - history['event_time'][0], history[key], clear=True)
+            if tp is None:
+                # No live value to report; the plot is the whole story.
+                self.tpLabel.setPlainText("")
+            else:
+                val = tp.analysis[key]
+                if val is None:
+                    val = np.nan
+                self.tpLabel.setPlainText(pg.siFormat(val, suffix=units))
+```
+
+- [ ] **Step 4: Add `setFrozen`**
+
+Add after `hideHeader` in the same class:
+
+```python
+    # Modes that need the PatchClampTestPulse recording itself, rather than just
+    # the analysis history. Unavailable to a caller plotting a retained history.
+    _LIVE_ONLY_MODES = ('test pulse', 'tp analysis')
+
+    def setFrozen(self, frozen: bool) -> None:
+        """Restrict the mode combo to what a retained history can serve.
+
+        Autopatch's frozen plots keep the combo visible -- re-reading a finished
+        attempt through a different field is what it is for -- but must not offer
+        the two modes that need a recording nobody retained.
+        """
+        if not frozen:
+            return
+        with pg.SignalBlock(self.modeCombo.currentIndexChanged, self.modeComboChanged):
+            current = self.mode
+            for mode in self._LIVE_ONLY_MODES:
+                index = self.modeCombo.findText(mode)
+                if index >= 0:
+                    self.modeCombo.removeItem(index)
+            self.modeCombo.setText(current)
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/MultiPatch/tests -v`
+
+Expected: PASS, 11 new tests plus every pre-existing MultiPatch test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add acq4/modules/MultiPatch/pipetteControl.py acq4/modules/MultiPatch/tests/test_plot_widget_frozen.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(multipatch): let PlotWidget plot a history with no live test pulse
+
+Autopatch's Area 5 reuses this widget for a finished action's plot rather
+than writing a second Rss plot (design doc §4.5). Its retained payload holds
+the analysis history but no PatchClampTestPulse -- a recording is not plain
+data -- so tp is None there.
+
+With no tp, the analysis modes plot the history and blank the current-value
+label, and the two modes that need the recording clear instead of raising.
+setFrozen removes those two from the combo, which frozen plots keep visible:
+re-reading a finished attempt through a different field is the point.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 2: The `"test_pulse_history"` renderer
+
+**Files:**
+- Modify: `acq4/modules/Autopatch/details_renderers.py`
+- Test: `acq4/modules/Autopatch/tests/test_details_renderers.py`
+
+**Interfaces:**
+- Consumes: `captioned` and `BUILDERS` (phase 1, Task 2); `PlotWidget.setFrozen` and `newTestPulse(None, history)` (Task 1).
+- Produces: `buildTestPulseHistory(payload)`, registered under `"test_pulse_history"`.
+- Payload shape, produced by Task 4: `{"history": ndarray (TEST_PULSE_NUMPY_DTYPE), "transitions": [(time, state), ...], "entry_state": str, "reached": str | None, "log_file": str | None}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/modules/Autopatch/tests/test_details_renderers.py`:
+
+```python
+def _tpHistory(count=5):
+    import numpy as np
+    from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
+
+    history = np.zeros(count, dtype=TEST_PULSE_NUMPY_DTYPE)
+    history["event_time"] = np.arange(count, dtype=float)
+    history["steady_state_resistance"] = np.linspace(1e6, 1e9, count)
+    return history
+
+
+def _tpPayload(**overrides):
+    payload = {
+        "history": _tpHistory(),
+        "transitions": [(0.0, "approach"), (1.5, "seal"), (3.0, "whole cell")],
+        "entry_state": "approach",
+        "reached": "whole cell",
+        "log_file": "MultiPatch_004.log",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_test_pulse_history_plots_the_retained_history(qapp):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("test_pulse_history", _tpPayload())
+
+    plot = widget.findChild(PlotWidget)
+    assert plot is not None
+    assert len(plot.plot.plotItem.listDataItems()) == 1
+
+
+def test_test_pulse_history_keeps_the_mode_combo_visible(qapp):
+    # Re-reading a finished attempt through a different field is what the
+    # dropdown is for; only the live plot hides it.
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("test_pulse_history", _tpPayload())
+
+    plot = widget.findChild(PlotWidget)
+    assert not plot.modeCombo.isHidden()
+
+
+def test_test_pulse_history_offers_no_live_only_modes(qapp):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("test_pulse_history", _tpPayload())
+
+    plot = widget.findChild(PlotWidget)
+    items = [plot.modeCombo.itemText(i) for i in range(plot.modeCombo.count())]
+    assert "test pulse" not in items
+    assert "tp analysis" not in items
+
+
+def test_test_pulse_history_lists_the_state_transitions(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("test_pulse_history", _tpPayload())
+
+    transitions = widget.findChild(Qt.QListWidget)
+    assert transitions is not None
+    rows = [transitions.item(i).text() for i in range(transitions.count())]
+    assert len(rows) == 3
+    assert "approach" in rows[0]
+    assert "seal" in rows[1]
+    assert "whole cell" in rows[2]
+
+
+def test_transition_rows_show_the_elapsed_time_from_the_first(qapp):
+    # Absolute epoch timestamps are unreadable; what matters is how long the
+    # FSM sat in each state.
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget(
+        "test_pulse_history",
+        _tpPayload(transitions=[(1000.0, "approach"), (1002.5, "seal")]),
+    )
+
+    transitions = widget.findChild(Qt.QListWidget)
+    assert "0.00" in transitions.item(0).text()
+    assert "2.50" in transitions.item(1).text()
+
+
+def test_test_pulse_history_caption_reports_the_terminal_state_and_log(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("test_pulse_history", _tpPayload())
+
+    caption = widget.layout().itemAt(0).widget().text()
+    assert "approach" in caption
+    assert "whole cell" in caption
+    assert "MultiPatch_004.log" in caption
+
+
+def test_test_pulse_history_caption_handles_never_reaching_a_terminal(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget(
+        "test_pulse_history", _tpPayload(reached=None, log_file=None)
+    )
+
+    caption = widget.layout().itemAt(0).widget().text()
+    assert "approach" in caption
+    assert "no terminal state" in caption
+
+
+def test_test_pulse_history_tolerates_an_empty_history(qapp):
+    # A patch stopped before its first test pulse landed.
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget(
+        "test_pulse_history", _tpPayload(history=_tpHistory(count=0), transitions=[])
+    )
+
+    assert widget is not None
+
+
+def test_test_pulse_history_tolerates_no_transitions(qapp):
+    from acq4.modules.Autopatch.details_renderers import buildDetailsWidget
+
+    widget = buildDetailsWidget("test_pulse_history", _tpPayload(transitions=[]))
+
+    assert widget.findChild(Qt.QListWidget).count() == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_details_renderers.py -v -k test_pulse_history`
+
+Expected: FAIL — the unknown-kind fallback returns a `QPlainTextEdit`, so `findChild(PlotWidget)` is `None`.
+
+- [ ] **Step 3: Add the builder**
+
+In `acq4/modules/Autopatch/details_renderers.py`, add the builder after `buildTaskResults`:
+
+```python
+def buildTestPulseHistory(payload) -> Qt.QWidget:
+    """One FSM action's steady-state resistance plot beside the pipette states it
+    walked.
+
+    Reuses MultiPatch's PlotWidget rather than reimplementing the plot (design
+    doc §4.5). The mode combo stays visible, unlike the live plot's: because the
+    whole analysis array is retained, re-reading the same attempt through
+    capacitance or holding current costs nothing. setFrozen drops the two modes
+    that would need the recording itself.
+    """
+    # Imported here, not at module scope: pipetteControl pulls in PatchPipette
+    # and the rest of the MultiPatch module's device imports, and this module is
+    # imported by cell_panel at Autopatch startup.
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    plot = PlotWidget(mode="ss resistance")
+    plot.setFrozen(True)
+    plot.newTestPulse(None, payload["history"])
+
+    transitions = Qt.QListWidget()
+    rows = list(payload.get("transitions", ()))
+    firstTime = rows[0][0] if rows else 0.0
+    for when, state in rows:
+        # Elapsed rather than absolute: an epoch timestamp says nothing, and how
+        # long the FSM sat in each state is what reading a failed patch needs.
+        transitions.addItem(f"{when - firstTime:8.2f}s  {state}")
+
+    split = Qt.QWidget()
+    splitLayout = Qt.QHBoxLayout()
+    splitLayout.setContentsMargins(0, 0, 0, 0)
+    splitLayout.addWidget(plot, 2)
+    splitLayout.addWidget(transitions, 1)
+    split.setLayout(splitLayout)
+
+    reached = payload.get("reached")
+    caption = [
+        f"entered at {payload.get('entry_state')!r}, "
+        + (f"reached {reached!r}" if reached else "no terminal state reached")
+    ]
+    logFile = payload.get("log_file")
+    if logFile:
+        caption.append(f"events logged to {logFile}")
+    return captioned(split, caption)
+```
+
+Register it:
+
+```python
+BUILDERS = {
+    "text": buildText,
+    "error": buildError,
+    "image_stack": buildImageStack,
+    "task_results": buildTaskResults,
+    "test_pulse_history": buildTestPulseHistory,
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/Autopatch/tests/test_details_renderers.py -v`
+
+Expected: PASS, all tests in the file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/modules/Autopatch/details_renderers.py acq4/modules/Autopatch/tests/test_details_renderers.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(autopatch): render an FSM action's Rss plot and state transitions
+
+Reuses MultiPatch's PlotWidget rather than writing a second Rss plot. The
+mode combo stays visible here, unlike the live plot's: the whole analysis
+array is retained, so re-reading the same attempt through capacitance or
+holding current is free.
+
+Transitions are listed as elapsed times rather than epoch timestamps --
+reading a failed patch is mostly "where did it stall", and how long the FSM
+sat in each state is what answers it.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 3: `_drive_fsm` records its state transitions
+
+**Files:**
+- Modify: `acq4/experiment/actions/fsm.py:23-52`
+- Test: `acq4/experiment/tests/test_actions_fsm.py`
+
+**Interfaces:**
+- Consumes: `ActionLogEntry.set_details` (phase 1, Task 1).
+- Produces: `_drive_fsm(ctx, name, entry_state, terminals, entry_config=None, poll_interval=0.1, record=True)`; `patch`/`reseal` accept `record_events` and `record_full_test_pulses` keyword arguments; `clean` passes `record=False`.
+
+This task lands the transition list and the payload without the recorder, so the payload's shape and the `finally` ordering are proven before device wiring is added in Task 4.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/experiment/tests/test_actions_fsm.py`:
+
+```python
+# -- details payloads -------------------------------------------------------
+
+
+def _details(ctx):
+    """Collect (kind, payload) from every entry this context opens."""
+    seen = []
+
+    def hook(action_entry):
+        action_entry.on_details = lambda e, kind, payload: seen.append((kind, payload))
+
+    ctx.on_log_action = hook
+    return seen
+
+
+def test_patch_retains_a_test_pulse_history_payload(fake_pip_factory, monkeypatch):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["cell detect", "seal", "whole cell"])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    patch(ctx)
+
+    assert len(seen) == 1
+    kind, payload = seen[0]
+    assert kind == "test_pulse_history"
+    assert payload["entry_state"] == "approach"
+    assert payload["reached"] == "whole cell"
+
+
+def test_the_payload_lists_every_state_the_fsm_walked(fake_pip_factory, monkeypatch):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["cell detect", "seal", "cell attached", "break in", "whole cell"])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    patch(ctx)
+
+    states = [state for _when, state in seen[0][1]["transitions"]]
+    # The entry state first, then each change the poll loop observed --
+    # including the internal hops the drive continues through.
+    assert states == [
+        "approach",
+        "cell detect",
+        "seal",
+        "cell attached",
+        "break in",
+        "whole cell",
+    ]
+
+
+def test_transitions_carry_a_timestamp(fake_pip_factory, monkeypatch):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["seal", "whole cell"])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    patch(ctx)
+
+    times = [when for when, _state in seen[0][1]["transitions"]]
+    assert times == sorted(times)
+    assert all(isinstance(t, float) for t in times)
+
+
+def test_the_payload_arrives_before_the_entry_finishes(fake_pip_factory, monkeypatch):
+    # CellPanel resolves the payload to a timeline row through bookkeeping the
+    # entry's finish tears down.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+    ctx = _ctx(pip)
+    order = []
+
+    def hook(action_entry):
+        action_entry.on_details = lambda e, k, p: order.append("details")
+        action_entry.on_finish = lambda e: order.append("finish")
+
+    ctx.on_log_action = hook
+
+    patch(ctx)
+
+    assert order == ["details", "finish"]
+
+
+def test_a_stopped_patch_still_retains_its_payload(fake_pip_factory, monkeypatch):
+    # An interrupted attempt is exactly when an operator wants the plot.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(
+        fsm_mod, "check_stop", lambda *a, **k: (_ for _ in ()).throw(Stopped("stop"))
+    )
+    pip = fake_pip_factory([])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    with pytest.raises(Stopped):
+        patch(ctx)
+
+    assert len(seen) == 1
+    assert seen[0][1]["reached"] is None
+
+
+def test_a_failed_patch_still_retains_its_payload(fake_pip_factory, monkeypatch):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["cell detect", "broken"])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    with pytest.raises(BrokenPipette):
+        reseal(ctx)
+
+    assert len(seen) == 1
+    assert seen[0][1]["reached"] is None
+    assert "broken" in [state for _when, state in seen[0][1]["transitions"]]
+
+
+def test_clean_retains_nothing(fake_pip_factory, monkeypatch):
+    # There is nothing an operator reads off a clean (design doc §4.5).
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["out"])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    clean(ctx)
+
+    assert seen == []
+
+
+def test_record_events_false_still_retains_the_payload(fake_pip_factory, monkeypatch):
+    # Switching off the disk log is not a reason to lose the pane's plot.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+    ctx = _ctx(pip)
+    seen = _details(ctx)
+
+    patch(ctx, record_events=False)
+
+    assert len(seen) == 1
+
+
+def test_record_kwargs_do_not_reach_set_state(fake_pip_factory, monkeypatch):
+    # entry_config is forwarded to pip.setState; these two are this action's own
+    # options and must not be.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+
+    patch(
+        _ctx(pip),
+        record_events=False,
+        record_full_test_pulses=False,
+        autoBreakInDelay=2.0,
+    )
+
+    _state, config = pip.setState_calls[0]
+    assert config == {"autoBreakInDelay": 2.0}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_actions_fsm.py -v -k "payload or transitions or retains or record_"`
+
+Expected: FAIL — `seen == []` everywhere, and `patch() got an unexpected keyword argument 'record_events'` for the last two.
+
+- [ ] **Step 3: Capture transitions and set the payload in `_drive_fsm`**
+
+In `acq4/experiment/actions/fsm.py`, add the import:
+
+```python
+import time
+```
+
+Replace `_drive_fsm` (lines 23-52) with:
+
+```python
+def _drive_fsm(
+    ctx,
+    name,
+    entry_state,
+    terminals,
+    entry_config=None,
+    poll_interval=0.1,
+    record=True,
+    record_full_test_pulses=True,
+) -> str:
+    """Drive the PatchPipette FSM from entry_state and return the terminal state
+    it reaches. Abnormal states not in `terminals` raise (see raise_if_abnormal).
+
+    With `record` true, this action also retains a "test_pulse_history" details
+    payload for Area 5 -- the test-pulse analysis observed during the drive, and
+    the pipette states it walked. `clean` passes false: there is nothing an
+    operator reads off a clean (design doc §4.5).
+    """
+    with ctx.log_action(name) as action_entry:
+        pip = ctx.pipette
+        action_entry.set_status(f"driving FSM from {entry_state!r}")
+        last_state = entry_state
+        # (timestamp, state) for the entry state and every change the poll loop
+        # observes. Reading a failed patch is mostly "where did it stall", and
+        # this is what answers it; the loop already detects the changes.
+        transitions = [(time.time(), entry_state)]
+        reached = None
+        try:
+            # Fresh dict per call so no caller shares a mutable default.
+            pip.setState(entry_state, **dict(entry_config or {}))
+            while True:
+                check_stop()
+                if ctx.next_cell_requested():
+                    ctx.next_cell()
+                state = pip.getState().stateName
+                if state in terminals:
+                    action_entry.set_status(f"reached {state!r}")
+                    if state != last_state:
+                        transitions.append((time.time(), state))
+                    reached = state
+                    return state
+                if state != last_state:
+                    # Only on change: re-setting the same string every poll
+                    # would spam the UI callback for no new information, and
+                    # would hide a pipette parked in a non-terminal state
+                    # (e.g. "cell attached") behind a stale row otherwise.
+                    action_entry.set_status(f"now in {state!r}")
+                    transitions.append((time.time(), state))
+                    last_state = state
+                raise_if_abnormal(state, terminals, name)
+                sleep(poll_interval)
+        except (Stopped, AdvanceToNextCell):
+            _safe_abort(ctx)
+            raise
+        finally:
+            # Inside the `with`, so this runs before the entry finishes -- a
+            # payload set afterwards has no timeline row to attach to (see
+            # ActionLogEntry.set_details). And in a finally, so a stopped,
+            # abandoned, or failed attempt retains its plot too, which is
+            # exactly when an operator wants to read one.
+            if record:
+                _setFsmDetails(action_entry, entry_state, reached, transitions)
+```
+
+`raise_if_abnormal` records the abnormal state before raising, which the tests above rely on: the state is appended by the `state != last_state` branch on the same iteration, before `raise_if_abnormal` is reached.
+
+Add the payload helper above `_drive_fsm`:
+
+```python
+def _setFsmDetails(action_entry, entry_state, reached, transitions, recorder=None) -> None:
+    """Retain this drive's Area 5 payload: the test-pulse analysis observed
+    during it, and the states it walked.
+
+    An empty history rather than None when there is no recorder, so the renderer
+    has one payload shape to handle rather than two.
+    """
+    from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
+
+    if recorder is None:
+        history = np.empty(0, dtype=TEST_PULSE_NUMPY_DTYPE)
+        log_file = None
+    else:
+        history = recorder.testPulseAnalysis()
+        log_file = recorder.logFileName()
+        if log_file is not None:
+            log_file = os.path.basename(log_file)
+    action_entry.set_details(
+        "test_pulse_history",
+        {
+            "history": history,
+            "transitions": list(transitions),
+            "entry_state": entry_state,
+            "reached": reached,
+            "log_file": log_file,
+        },
+    )
+```
+
+Add its imports:
+
+```python
+import os
+
+import numpy as np
+```
+
+- [ ] **Step 4: Give `patch` and `reseal` the new options**
+
+Replace `patch`, `reseal`, and `clean`:
+
+```python
+def patch(ctx, record_events: bool = True, record_full_test_pulses: bool = True, **entry_config) -> str:
+    """Drive approach through detection, sealing, and break-in to a resting
+    terminal state.
+
+    `record_events` and `record_full_test_pulses` are this action's own options,
+    consumed here and never forwarded to pip.setState; a protocol may expose
+    them to its author. See _drive_fsm for what they control.
+    """
+    return _drive_fsm(
+        ctx,
+        "Patch",
+        "approach",
+        # "cell attached" is not a resting state on these rigs: it exits via
+        # spontaneous break-in (routed to "whole cell" by
+        # spontaneousBreakInState) or spontaneous detachment (routed to
+        # "fouled"), so it is an internal hop the poll continues through
+        # rather than a patch outcome. autoBreakInDelay is an optional
+        # wall-clock fallback that ships disabled (None) on both active rig
+        # profiles.
+        {"whole cell", "bath", "broken", "fouled"},
+        entry_config,
+        record=record_events,
+        record_full_test_pulses=record_full_test_pulses,
+    )
+
+
+def reseal(ctx, record_events: bool = True, record_full_test_pulses: bool = True, **entry_config) -> str:
+    """Reseal from whole-cell toward an outside-out patch, else fall back to
+    whole cell."""
+    return _drive_fsm(
+        ctx,
+        "Reseal",
+        "reseal",
+        {"outside out", "whole cell"},
+        entry_config,
+        record=record_events,
+        record_full_test_pulses=record_full_test_pulses,
+    )
+
+
+def clean(ctx, **entry_config) -> str:
+    """Run the pipette-cleaning cycle and return once it settles at its resting
+    state (``out``).
+
+    Records nothing: there is nothing an operator reads off a clean (design doc
+    §4.5), so it gets neither a details payload nor an event log.
+    """
+    return _drive_fsm(ctx, "Clean Pipette", "clean", {"out"}, entry_config, record=False)
+```
+
+Update the module docstring's first line to mention the recording:
+
+```python
+"""FSM-driving actions: drive acq4's PatchPipette state machine from a declared
+entry state to one of this action's declared terminal states, mapping unexpected
+abnormal states to orchestration exceptions, and retaining each drive's
+test-pulse analysis and state transitions for Area 5."""
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_actions_fsm.py -v`
+
+Expected: PASS, all tests in the file including every pre-existing one.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add acq4/experiment/actions/fsm.py acq4/experiment/tests/test_actions_fsm.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(experiment): retain each FSM drive's state transitions for Area 5
+
+The poll loop already detects every state change; this records them with
+timestamps and hands them to Area 5 alongside the entry and terminal states.
+
+Set from a finally inside the log_action block: inside, so the payload
+arrives before the entry finishes and still has a timeline row to attach to;
+in a finally, so a stopped, abandoned, or failed attempt retains its record
+too -- which is exactly when an operator wants to read one.
+
+clean opts out entirely. patch and reseal gain record_events and
+record_full_test_pulses as their own keyword options, consumed rather than
+forwarded to pip.setState.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 4: The recorder and the live plot
+
+**Files:**
+- Modify: `acq4/experiment/actions/fsm.py`
+- Test: `acq4/experiment/tests/test_actions_fsm.py`
+
+**Interfaces:**
+- Consumes: `MultiPatchLogRecorder(directory, pipettes=, record_full_test_pulses=)`, `.testPulseAnalysis()`, `.logFileName()`, `.stop()` (phase 2); `PlotWidget` (Task 1); `_setFsmDetails` (Task 3).
+- Produces: `fsm._openRecorder(ctx, record_full_test_pulses)`, `fsm._openLivePlot(ctx, action_entry)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/experiment/tests/test_actions_fsm.py`:
+
+```python
+# -- the recorder and the live plot -----------------------------------------
+
+
+class _FakeRecorder:
+    instances = []
+
+    def __init__(self, directory, pipettes=(), record_full_test_pulses=True):
+        import numpy as np
+        from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
+
+        self.directory = directory
+        self.pipettes = list(pipettes)
+        self.record_full_test_pulses = record_full_test_pulses
+        self.stopped = False
+        self._history = np.zeros(3, dtype=TEST_PULSE_NUMPY_DTYPE)
+        self._history["steady_state_resistance"] = [1e6, 1e8, 1e9]
+        _FakeRecorder.instances.append(self)
+
+    def testPulseAnalysis(self):
+        return self._history
+
+    def logFileName(self):
+        return "/data/cell_000/MultiPatch_004.log"
+
+    def stop(self):
+        self.stopped = True
+
+
+class _FakeDir:
+    pass
+
+
+class _FakeManagerWithDir:
+    def __init__(self):
+        self.dir = _FakeDir()
+
+    def getCurrentDir(self):
+        return self.dir
+
+
+@pytest.fixture
+def fake_recorder(monkeypatch):
+    _FakeRecorder.instances = []
+    monkeypatch.setattr(fsm_mod, "MultiPatchLogRecorder", _FakeRecorder)
+    # The live plot needs a real Qt widget and a real clamp device; those are
+    # live-tested, so this suite stubs the plot out entirely.
+    monkeypatch.setattr(fsm_mod, "_openLivePlot", lambda ctx, entry: None)
+    return _FakeRecorder
+
+
+def test_patch_opens_a_recorder_in_the_current_directory(fake_pip_factory, monkeypatch, fake_recorder):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+    manager = _FakeManagerWithDir()
+
+    patch(_ctx(pip, manager=manager))
+
+    assert len(fake_recorder.instances) == 1
+    recorder = fake_recorder.instances[0]
+    assert recorder.directory is manager.dir
+    assert recorder.pipettes == [pip]
+    assert recorder.record_full_test_pulses is True
+
+
+def test_the_recorder_is_stopped_when_the_drive_ends(fake_pip_factory, monkeypatch, fake_recorder):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+
+    patch(_ctx(pip, manager=_FakeManagerWithDir()))
+
+    assert fake_recorder.instances[0].stopped is True
+
+
+def test_the_recorder_is_stopped_even_when_the_drive_raises(fake_pip_factory, monkeypatch, fake_recorder):
+    # An unclosed file handle per failed patch attempt is a leak, not a nuisance.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["broken"])
+
+    with pytest.raises(BrokenPipette):
+        reseal(_ctx(pip, manager=_FakeManagerWithDir()))
+
+    assert fake_recorder.instances[0].stopped is True
+
+
+def test_the_payload_carries_the_recorders_history(fake_pip_factory, monkeypatch, fake_recorder):
+    import numpy as np
+
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+    ctx = _ctx(pip, manager=_FakeManagerWithDir())
+    seen = _details(ctx)
+
+    patch(ctx)
+
+    history = seen[0][1]["history"]
+    assert len(history) == 3
+    assert np.array_equal(history["steady_state_resistance"], [1e6, 1e8, 1e9])
+
+
+def test_the_payload_names_the_log_file_without_its_path(fake_pip_factory, monkeypatch, fake_recorder):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+    ctx = _ctx(pip, manager=_FakeManagerWithDir())
+    seen = _details(ctx)
+
+    patch(ctx)
+
+    assert seen[0][1]["log_file"] == "MultiPatch_004.log"
+
+
+def test_record_full_test_pulses_is_forwarded(fake_pip_factory, monkeypatch, fake_recorder):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+
+    patch(_ctx(pip, manager=_FakeManagerWithDir()), record_full_test_pulses=False)
+
+    assert fake_recorder.instances[0].record_full_test_pulses is False
+
+
+def test_record_events_false_opens_no_recorder(fake_pip_factory, monkeypatch, fake_recorder):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["whole cell"])
+
+    patch(_ctx(pip, manager=_FakeManagerWithDir()), record_events=False)
+
+    assert fake_recorder.instances == []
+
+
+def test_clean_opens_no_recorder(fake_pip_factory, monkeypatch, fake_recorder):
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    pip = fake_pip_factory(["out"])
+
+    clean(_ctx(pip, manager=_FakeManagerWithDir()))
+
+    assert fake_recorder.instances == []
+
+
+def test_a_recorder_that_will_not_open_does_not_fail_the_patch(fake_pip_factory, monkeypatch):
+    # An unset storage directory must not stop the pipette from patching; the
+    # attempt is the experiment, and the log is a record of it.
+    monkeypatch.setattr(fsm_mod, "sleep", lambda *a, **k: None)
+    monkeypatch.setattr(fsm_mod, "_openLivePlot", lambda ctx, entry: None)
+
+    def boom(*a, **k):
+        raise OSError("no current directory")
+
+    monkeypatch.setattr(fsm_mod, "MultiPatchLogRecorder", boom)
+    pip = fake_pip_factory(["whole cell"])
+    ctx = _ctx(pip, manager=_FakeManagerWithDir())
+    logged = []
+    ctx.log = logged.append
+    seen = _details(ctx)
+
+    assert patch(ctx) == "whole cell"
+
+    assert any("no current directory" in message for message in logged)
+    assert len(seen) == 1  # still retains the transitions, with an empty history
+    assert len(seen[0][1]["history"]) == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_actions_fsm.py -v -k "recorder or live_plot or log_file"`
+
+Expected: FAIL — `AttributeError: module 'acq4.experiment.actions.fsm' has no attribute 'MultiPatchLogRecorder'` from the fixture's monkeypatch.
+
+- [ ] **Step 3: Add the recorder and live-plot openers**
+
+In `acq4/experiment/actions/fsm.py`, add the imports:
+
+```python
+from acq4.util import Qt
+from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+from acq4.util.task import Stopped, check_stop, run_in_gui_thread, sleep
+```
+
+(the existing `from acq4.util.task import Stopped, check_stop, sleep` line is replaced by the last one above)
+
+Add both openers above `_drive_fsm`:
+
+```python
+def _openRecorder(ctx, record_full_test_pulses: bool):
+    """A recorder writing this drive's events into the current storage
+    directory, or None if one could not be opened.
+
+    Never raises: the patch attempt is the experiment and the log is a record of
+    it, so an unset storage directory or a full disk must not stop a pipette
+    from patching. The reason goes to the cell's log instead.
+    """
+    try:
+        return MultiPatchLogRecorder(
+            ctx.manager.getCurrentDir(),
+            pipettes=(ctx.pipette,),
+            record_full_test_pulses=record_full_test_pulses,
+        )
+    except Exception as exc:
+        ctx.log(f"could not start event recording: {exc}")
+        return None
+
+
+def _openLivePlot(ctx, action_entry) -> object | None:
+    """Mount a live steady-state resistance plot for this drive, returning a
+    zero-argument teardown to call when it ends, or None if there is no clamp to
+    plot from.
+
+    Rss over time is the measurement an operator watches to judge whether a seal
+    is forming, so it is what Area 5 shows while the FSM drives (design doc
+    §4.5). Reuses MultiPatch's PlotWidget rather than reimplementing it.
+
+    Built through run_in_gui_thread because this runs on the orchestrator's
+    worker thread and a widget must not be constructed off the GUI thread.
+    """
+    clamp = getattr(ctx.pipette, "clampDevice", None)
+    if clamp is None:
+        return None
+
+    def build():
+        # Imported here: pipetteControl pulls in the MultiPatch module's device
+        # imports, and acq4.experiment must stay importable without them.
+        from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+        widget = PlotWidget(mode="ss resistance")
+        # Autopatch picks the mode; the operator does not need the combo while
+        # an action is driving (design doc §4.5). The frozen plot shows it.
+        widget.hideHeader()
+        return widget
+
+    widget = run_in_gui_thread(build)
+
+    def onTestPulse(_device, testPulse):
+        widget.newTestPulse(testPulse, clamp.testPulseHistory())
+
+    # Default (queued) connection deliberately: PatchPipetteState connects to
+    # this same signal with an explicit DirectConnection, which is correct for a
+    # state machine and wrong for a widget -- it would mutate the plot from the
+    # clamp's thread.
+    clamp.sigTestPulseFinished.connect(onTestPulse)
+    action_entry.set_details_widget(widget)
+
+    def teardown():
+        # A live connection from a device signal into a widget the panel has
+        # moved on from is the cross-module reference neither Autopatch's widget
+        # -tree teardown nor unbindOrchestrator reaches (design doc §4.5).
+        Qt.disconnect(clamp.sigTestPulseFinished, onTestPulse)
+
+    return teardown
+```
+
+- [ ] **Step 4: Wire them into `_drive_fsm`**
+
+In `_drive_fsm`, open both immediately after `action_entry.set_status(f"driving FSM from {entry_state!r}")`:
+
+```python
+        recorder = _openRecorder(ctx, record_full_test_pulses) if record else None
+        teardownPlot = _openLivePlot(ctx, action_entry) if record else None
+```
+
+and replace the `finally` block with:
+
+```python
+        finally:
+            # Inside the `with`, so this runs before the entry finishes -- a
+            # payload set afterwards has no timeline row to attach to (see
+            # ActionLogEntry.set_details). And in a finally, so a stopped,
+            # abandoned, or failed attempt retains its plot too, which is
+            # exactly when an operator wants to read one.
+            if teardownPlot is not None:
+                teardownPlot()
+            if recorder is not None:
+                recorder.stop()
+            if record:
+                _setFsmDetails(
+                    action_entry, entry_state, reached, transitions, recorder
+                )
+```
+
+`recorder.stop()` runs before `_setFsmDetails` deliberately: the payload names the log file, and the file has to be flushed and closed before anything is told where to find it.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests/test_actions_fsm.py -v`
+
+Expected: PASS, all tests in the file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add acq4/experiment/actions/fsm.py acq4/experiment/tests/test_actions_fsm.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(experiment): give patch and reseal a live Rss plot and an event log
+
+Rss over time is what an operator watches to judge whether a seal is forming,
+so it is what Area 5 shows while the FSM drives, reusing MultiPatch's
+PlotWidget. The device connection is queued deliberately -- PatchPipetteState
+uses a DirectConnection on the same signal, right for a state machine and
+wrong for a widget -- and is severed when the drive ends, since a live device
+signal into an abandoned widget is the cross-module reference neither
+Autopatch's teardown nor unbindOrchestrator reaches.
+
+The recorder writes the attempt's events into the cell's storage directory,
+and its accumulated analysis becomes the frozen plot's data. Opening it never
+raises: the attempt is the experiment and the log is a record of it, so an
+unset storage directory must not stop a pipette from patching.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 5: Verify the phase, and the whole feature
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run every suite the three phases touched**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/experiment/tests acq4/modules/Autopatch/tests acq4/modules/MultiPatch/tests acq4/util/tests acq4/devices/PatchPipette/tests acq4/filetypes/tests tools/autopatch_analysis/tests -v`
+
+Expected: PASS with no failures, errors, or new warnings. Output must be pristine.
+
+- [ ] **Step 2: Confirm the Autopatch module still imports**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -c "import acq4.modules.Autopatch.Autopatch as m; import acq4.modules.Autopatch.details_renderers as r; print(sorted(r.BUILDERS))"`
+
+Expected: `['error', 'image_stack', 'task_results', 'test_pulse_history', 'text']` with no import error. This also proves `details_renderers` does not drag MultiPatch's device imports in at module scope.
+
+- [ ] **Step 3: Write the live-testing checklist**
+
+The device wiring in `patch`, `reseal`, and `run_task` is exercised by live testing rather than the headless suite (`actions/device.py`'s module docstring). Report a checklist for the operator covering:
+
+1. A `patch` action's live Rss plot updating in Area 5 while the FSM drives, with the mode combo hidden.
+2. The same action's row, reselected after it finishes, showing the frozen plot with the combo visible and switchable through `capacitance` and `holding current`.
+3. The state-transition list matching what MultiPatch's own state display showed during the attempt.
+4. A `MultiPatch_*.log` appearing in the cell's directory, opening in the MultiPatch log viewer, and — with MultiPatch also recording — both logs capturing full test pulses simultaneously.
+5. A `cellfie` row showing the cell's stack, opened at the plane the cell sits on.
+6. A `run_task` row showing one curve per sweep.
+7. Switching between cells and between rows without the pane going stale or blank.
+
+- [ ] **Step 4: Report**
+
+State which tasks landed, the final test count, and the live-testing checklist from Step 3.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage for phase 3.** §4's `"test_pulse_history"` row and the hidden-live/shown-frozen combo decision → Tasks 1–2. §8's `patch`/`reseal` paragraph: the recorder → Task 4; `PlotWidget` construction, `hideHeader`, and the queued connection → Task 4; the transition list from the existing poll loop → Task 3; the `finally` inside the `with` → Tasks 3–4; "the payload's history comes from the recorder, not `clampDevice.testPulseHistory()`" → Task 4, and asserted by phase 2's `test_test_pulse_analysis_is_unaffected_by_a_device_history_reset`. §9's thread rules → Task 4's `run_in_gui_thread` and queued connection.
+
+**Type consistency across phases.** The payload keys Task 2's renderer reads (`history`, `transitions`, `entry_state`, `reached`, `log_file`) are exactly those Task 3's `_setFsmDetails` writes. `testPulseAnalysis()` and `logFileName()` are the names phase 2 Task 4 and Task 2 produce.
+
+**Deliberate asymmetry worth noting.** The live plot reads `clamp.testPulseHistory()` (the device's own, which is what a live view of "now" should show), while the frozen payload reads `recorder.testPulseAnalysis()` (immune to the mid-patch resets). Task 4's code comments say so at both sites.
+
+**Not covered by headless tests, by design:** `_openLivePlot` itself, which is stubbed out in `fake_recorder`. It needs a real clamp device and a real `PlotWidget` against live hardware, and it is item 1 of Step 3's checklist.

--- a/docs/superpowers/plans/2026-08-17-autopatch-multipatch-log-recorder.md
+++ b/docs/superpowers/plans/2026-08-17-autopatch-multipatch-log-recorder.md
@@ -1,0 +1,1873 @@
+# MultiPatch Log Recorder — Phase 2 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract MultiPatch's event-log writing into a reusable recorder that Autopatch can also construct, so an Autopatch run produces a log the MultiPatch viewer and `tools/autopatch_analysis` can both read.
+
+**Architecture:** A new `MultiPatchLogRecorder` owns one log file, its optional full-test-pulse HDF5 sidecar, and the signal connections that feed them. It never touches device state. `MultiPatchWindow` is refactored onto it, so there is one implementation of the format rather than two. `PatchPipette.emitFullTestPulseData`'s boolean becomes a subscriber set so two recorders can coexist over one pipette.
+
+**Tech Stack:** Python 3, PyQt (via `acq4.util.Qt`), numpy, h5py, `neuroanalysis.test_pulse_stack.H5BackedTestPulseStack`, pytest.
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-08-17-autopatch-area5-details-widgets-design.md` §5, §6, §7. This plan implements phase 2 of its §11 phasing.
+- **The recorder never touches device state.** In particular it must never call `clampDevice.resetTestPulseHistory()` — that is MultiPatch's Reset button, and a recorder doing it would let Autopatch wipe the history MultiPatch is plotting.
+- **Format compatibility is the whole point.** A recorder-written file must be readable by `acq4.filetypes.MultiPatchLog.MultiPatchLogData` and by `tools/autopatch_analysis.autopatch_log`, and must differ from the current writer's output *only* by the dropped trailing comma.
+- **The recorder lives on the GUI thread.** Its `sigNewEvent` connections must stay queued, since events are emitted from clamp and state-machine threads.
+- **Python interpreter:** `/home/martin/.miniforge3/envs/acq4-gl/bin/python`. Run pytest as `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest`.
+- **Commits:** conventional format, `--author="Martin Chase (claude) <outofculture@gmail.com>"`, footer `🤖 Generated with [Claude Code](https://claude.ai/code)`. Never `--no-verify`.
+- **Not in this phase:** anything in `acq4/experiment/actions/fsm.py`, the `"test_pulse_history"` renderer, or any Autopatch action constructing a recorder. Those are phase 3. Nothing here has an Autopatch caller yet — that is deliberate, so the format lands behind its own tests before anything depends on it.
+
+## File Structure
+
+| File | Responsibility | Action |
+| --- | --- | --- |
+| `acq4/util/multipatch_log_recorder.py` | the recorder: one log file, its HDF5 sidecar, its subscriptions | Create |
+| `acq4/util/tests/test_multipatch_log_recorder.py` | recorder behavior, the golden-output check, reader round-trips | Create |
+| `acq4/devices/PatchPipette/patchpipette.py` | `requestFullTestPulseData` / `releaseFullTestPulseData` | Modify |
+| `acq4/devices/PatchPipette/tests/test_full_test_pulse_subscription.py` | subscription refcounting | Create |
+| `acq4/modules/MultiPatch/multipatch.py` | refactored onto the recorder | Modify |
+| `acq4/modules/MultiPatch/tests/test_logfile.py` | the toggle-combination tests | Modify |
+| `acq4/filetypes/MultiPatchLog.py` | blank-line guard in the reader | Modify |
+| `tools/autopatch_analysis/tests/test_autopatch_log.py` | comma-free / legacy parity | Modify |
+
+The recorder goes in `acq4/util/` rather than `acq4/filetypes/`: that package registers `FileType` *readers* for DataManager, and its `MultiPatchLog.py` is already over 1100 lines. It is not an attribute of `PatchPipette` because one attribute would mean one recorder per pipette, which is exactly the collision this phase exists to prevent.
+
+---
+
+### Task 1: `PatchPipette` full-test-pulse subscriptions
+
+**Files:**
+- Modify: `acq4/devices/PatchPipette/patchpipette.py:91,428-435`
+- Test: `acq4/devices/PatchPipette/tests/test_full_test_pulse_subscription.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `PatchPipette.requestFullTestPulseData(token) -> None`, `PatchPipette.releaseFullTestPulseData(token) -> None`, `PatchPipette.emitsFullTestPulseData() -> bool`. `emitFullTestPulseData(bool)` is **removed**.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `acq4/devices/PatchPipette/tests/test_full_test_pulse_subscription.py`:
+
+```python
+"""Tests for PatchPipette's full-test-pulse subscription: independent recorders
+must each be able to request the full test-pulse object without one's release
+silencing the other's."""
+import pytest
+
+from acq4.devices.PatchPipette.patchpipette import PatchPipette
+
+
+class _Pip:
+    """Exercises the subscription methods against a bare instance, without
+    standing up a real PatchPipette (which needs a Manager and devices)."""
+
+    requestFullTestPulseData = PatchPipette.requestFullTestPulseData
+    releaseFullTestPulseData = PatchPipette.releaseFullTestPulseData
+    emitsFullTestPulseData = PatchPipette.emitsFullTestPulseData
+
+    def __init__(self):
+        self._fullTestPulseSubscribers = set()
+
+
+def test_no_subscribers_means_no_full_data():
+    assert _Pip().emitsFullTestPulseData() is False
+
+
+def test_one_subscriber_turns_it_on():
+    pip = _Pip()
+    pip.requestFullTestPulseData("recorder-a")
+    assert pip.emitsFullTestPulseData() is True
+
+
+def test_releasing_the_only_subscriber_turns_it_off():
+    pip = _Pip()
+    token = object()
+    pip.requestFullTestPulseData(token)
+    pip.releaseFullTestPulseData(token)
+    assert pip.emitsFullTestPulseData() is False
+
+
+def test_one_recorder_releasing_does_not_silence_another():
+    # The whole reason this is a set and not a bool: Autopatch stopping its
+    # recorder must not switch off MultiPatch's full-test-pulse capture.
+    pip = _Pip()
+    autopatch, multipatch = object(), object()
+    pip.requestFullTestPulseData(autopatch)
+    pip.requestFullTestPulseData(multipatch)
+
+    pip.releaseFullTestPulseData(autopatch)
+
+    assert pip.emitsFullTestPulseData() is True
+
+
+def test_requesting_twice_with_one_token_is_idempotent():
+    pip = _Pip()
+    token = object()
+    pip.requestFullTestPulseData(token)
+    pip.requestFullTestPulseData(token)
+    pip.releaseFullTestPulseData(token)
+    assert pip.emitsFullTestPulseData() is False
+
+
+def test_releasing_an_unknown_token_is_harmless():
+    # stop() is idempotent, so it may release a token it already released.
+    pip = _Pip()
+    pip.releaseFullTestPulseData(object())
+    assert pip.emitsFullTestPulseData() is False
+
+
+def test_the_old_boolean_setter_is_gone():
+    # A bare setter is what let the last caller to stop win; leaving it in place
+    # would leave that footgun loaded.
+    assert not hasattr(PatchPipette, "emitFullTestPulseData")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/devices/PatchPipette/tests/test_full_test_pulse_subscription.py -v`
+
+Expected: FAIL with `AttributeError: type object 'PatchPipette' has no attribute 'requestFullTestPulseData'`.
+
+- [ ] **Step 3: Replace the flag with a subscriber set**
+
+In `acq4/devices/PatchPipette/patchpipette.py`, replace line 91's `self._emitTestPulseData = False` with:
+
+```python
+        # Tokens held by whoever currently wants test_pulse events to carry the
+        # full PatchClampTestPulse object, not just its analysis. A set rather
+        # than a bool because independent recorders subscribe independently:
+        # with a bool, whichever one stopped last would silence the others.
+        # Holds tokens, never the subscribers themselves, so nothing here keeps
+        # a recorder alive.
+        self._fullTestPulseSubscribers = set()
+```
+
+Replace `emitFullTestPulseData` (lines 428-429) with:
+
+```python
+    def requestFullTestPulseData(self, token) -> None:
+        """Ask that test_pulse events carry the full PatchClampTestPulse object.
+
+        `token` identifies the subscriber and is what releaseFullTestPulseData()
+        takes back; any hashable will do. Idempotent per token.
+        """
+        self._fullTestPulseSubscribers.add(token)
+
+    def releaseFullTestPulseData(self, token) -> None:
+        """Withdraw `token`'s request. Full data keeps flowing while any other
+        subscriber holds one. Releasing an unknown token is a no-op, so a
+        recorder's idempotent stop() can call it freely."""
+        self._fullTestPulseSubscribers.discard(token)
+
+    def emitsFullTestPulseData(self) -> bool:
+        return bool(self._fullTestPulseSubscribers)
+```
+
+Replace the `if self._emitTestPulseData:` test in `_testPulseFinished` (line 433) with:
+
+```python
+        if self._fullTestPulseSubscribers:
+```
+
+- [ ] **Step 4: Fix the one existing caller**
+
+`acq4/modules/MultiPatch/multipatch.py:632` calls `pip.emitFullTestPulseData(rec)` inside `recordTestPulsesToggled`. Replace that line with:
+
+```python
+            if rec:
+                pip.requestFullTestPulseData(self)
+            else:
+                pip.releaseFullTestPulseData(self)
+```
+
+`self` (the `MultiPatchWindow`) is its token; Task 6 moves this onto the recorder.
+
+Verify no other caller remains:
+
+Run: `grep -rn "emitFullTestPulseData\|_emitTestPulseData" acq4/ tools/`
+
+Expected: no output.
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/devices/PatchPipette/tests -v`
+
+Expected: PASS, 7 new tests plus every pre-existing PatchPipette test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add acq4/devices/PatchPipette/patchpipette.py acq4/devices/PatchPipette/tests/test_full_test_pulse_subscription.py acq4/modules/MultiPatch/multipatch.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+refactor(patchpipette): make full-test-pulse data a subscription
+
+emitFullTestPulseData set a bare boolean, so with two independent recorders
+whichever stopped last won -- one stopping would silence the other's
+full-test-pulse capture. A subscriber set ORs the requests instead, and it
+holds tokens rather than subscribers so nothing keeps a recorder alive.
+
+The boolean setter is removed rather than kept as a wrapper: it had exactly
+one caller, and leaving it would leave the footgun loaded.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 2: The recorder's log file and JSONL writing
+
+**Files:**
+- Create: `acq4/util/multipatch_log_recorder.py`
+- Test: `acq4/util/tests/test_multipatch_log_recorder.py`
+
+**Interfaces:**
+- Consumes: `acq4.util.json_encoder.ACQ4JSONEncoder`.
+- Produces: `MultiPatchLogRecorder(directory, pipettes=(), microscope=None, record_full_test_pulses=True, write_events=True, initial_records=())`; `.record(event) -> None`; `.stop() -> None`; `.logFileName() -> str | None`; `.isRecording() -> bool`.
+
+`write_events` exists because MultiPatch's two record buttons are independent today: test-pulse recording works with the event log switched off. Task 6 maps both toggles onto one recorder, which needs each to be separately switchable.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `acq4/util/tests/test_multipatch_log_recorder.py`:
+
+```python
+"""Tests for MultiPatchLogRecorder: the writer half of the MultiPatch log
+format, extracted so both MultiPatch and Autopatch can record."""
+import json
+
+import pytest
+
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+class _FakeFileHandle:
+    def __init__(self, path):
+        self._path = str(path)
+
+    def name(self):
+        return self._path
+
+
+class _FakeDir:
+    """Stands in for a DirHandle: createFile hands back a real path under
+    tmp_path, auto-incrementing the way the managed original does."""
+
+    def __init__(self, root):
+        self.root = root
+        self.created = []
+
+    def createFile(self, name, autoIncrement=False):
+        stem, _, ext = name.rpartition(".")
+        index = 0
+        while True:
+            candidate = self.root / (f"{stem}_{index:03d}.{ext}" if autoIncrement else name)
+            if not candidate.exists():
+                break
+            index += 1
+        candidate.touch()
+        self.created.append(candidate)
+        return _FakeFileHandle(candidate)
+
+
+@pytest.fixture
+def directory(tmp_path):
+    return _FakeDir(tmp_path)
+
+
+def _lines(path):
+    with open(path, "rb") as fh:
+        return [line for line in fh if line.strip()]
+
+
+def test_recorder_creates_an_auto_incremented_log_file(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    first = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    second = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        assert first.logFileName().endswith("MultiPatch_000.log")
+        assert second.logFileName().endswith("MultiPatch_001.log")
+    finally:
+        first.stop()
+        second.stop()
+
+
+def test_recorded_events_are_one_json_object_per_line(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+        recorder.record({"device": "Clamp1", "event_time": 2.0, "event": "test_pulse"})
+    finally:
+        recorder.stop()
+
+    lines = _lines(recorder.logFileName())
+    assert len(lines) == 2
+    assert json.loads(lines[0])["event"] == "state_change"
+    assert json.loads(lines[1])["event_time"] == 2.0
+
+
+def test_lines_have_no_trailing_comma(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+    finally:
+        recorder.stop()
+
+    assert _lines(recorder.logFileName())[0].rstrip(b"\r\n").endswith(b"}")
+
+
+def test_records_are_flushed_before_stop(qapp, directory):
+    # An Autopatch action's log has to be readable the moment the action ends,
+    # not whenever the OS gets round to it.
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+        assert len(_lines(recorder.logFileName())) == 1
+    finally:
+        recorder.stop()
+
+
+def test_initial_records_are_replayed_into_the_fresh_file(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    history = [
+        {"device": "Clamp1", "event_time": 0.5, "event": "state_change"},
+        {"device": "Clamp1", "event_time": 0.7, "event": "move_stop"},
+    ]
+    recorder = MultiPatchLogRecorder(
+        directory, record_full_test_pulses=False, initial_records=history
+    )
+    try:
+        pass
+    finally:
+        recorder.stop()
+
+    lines = _lines(recorder.logFileName())
+    assert [json.loads(line)["event"] for line in lines] == ["state_change", "move_stop"]
+
+
+def test_write_events_false_creates_no_log_file(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(
+        directory, record_full_test_pulses=False, write_events=False
+    )
+    try:
+        recorder.record({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+        assert recorder.logFileName() is None
+        assert directory.created == []
+    finally:
+        recorder.stop()
+
+
+def test_is_recording_reflects_the_lifecycle(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    assert recorder.isRecording() is True
+    recorder.stop()
+    assert recorder.isRecording() is False
+
+
+def test_stop_is_idempotent(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    recorder.stop()
+    recorder.stop()  # must not raise on an already-closed file
+
+
+def test_recording_after_stop_is_ignored(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    recorder.stop()
+
+    recorder.record({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+
+    assert _lines(recorder.logFileName()) == []
+
+
+def test_encodes_values_the_plain_json_encoder_cannot(qapp, directory):
+    # State-change events carry numpy scalars; ACQ4JSONEncoder is what handles
+    # them, and the reader expects its output.
+    import numpy as np
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "steady_state_resistance": np.float64(1.5e9),
+            }
+        )
+    finally:
+        recorder.stop()
+
+    assert json.loads(_lines(recorder.logFileName())[0])["steady_state_resistance"] == 1.5e9
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/util/tests/test_multipatch_log_recorder.py -v`
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'acq4.util.multipatch_log_recorder'`.
+
+- [ ] **Step 3: Create the module with the file lifecycle**
+
+Create `acq4/util/multipatch_log_recorder.py`:
+
+```python
+"""MultiPatchLogRecorder: writes a PatchPipette event stream to a MultiPatch-
+format log file, with an optional full-test-pulse HDF5 sidecar beside it."""
+from __future__ import annotations
+
+import json
+
+from acq4.util import Qt
+from acq4.util.json_encoder import ACQ4JSONEncoder
+
+# Base name of the log file, matched case-insensitively by
+# acq4.filetypes.MultiPatchLog and by tools/autopatch_analysis. Changing it
+# makes the resulting file invisible to both readers.
+LOG_FILE_NAME = "MultiPatch.log"
+
+
+class MultiPatchLogRecorder(Qt.QObject):
+    """One MultiPatch-format log file and the subscriptions that fill it.
+
+    Owns a file and (optionally) an HDF5 test-pulse stack, and **nothing else**:
+    it never touches device state. In particular it never resets a clamp's
+    test-pulse history -- that is MultiPatch's Reset button, and a recorder
+    doing it would let one module wipe the history another is plotting.
+
+    Any number of recorders may observe the same pipette. That is what lets
+    Autopatch record a patch attempt while MultiPatch records the session, with
+    neither able to switch the other off (see
+    PatchPipette.requestFullTestPulseData).
+
+    A QObject on the GUI thread: events are emitted from clamp and state-machine
+    threads, and the default (queued) connections are what marshal them here
+    before anything is written.
+
+    Parameters
+    ----------
+    directory : DirHandle
+        Where the log file and its sidecar are created.
+    pipettes : iterable of PatchPipette
+        Whose sigNewEvent streams to record. One for an Autopatch action, all of
+        them for MultiPatch.
+    microscope : Microscope or None
+        Optional; its surface-depth changes are recorded too.
+    record_full_test_pulses : bool
+        Whether test_pulse events carry the whole recording into an HDF5
+        sidecar, rather than just their analysis.
+    write_events : bool
+        Whether to write the log file at all. False records full test pulses
+        without an event log, which is a combination MultiPatch's two
+        independent record buttons allow.
+    initial_records : iterable of dict
+        Records replayed into the fresh file before any live event, for a caller
+        that has been accumulating events before recording started.
+    """
+
+    def __init__(
+        self,
+        directory,
+        pipettes=(),
+        microscope=None,
+        record_full_test_pulses: bool = True,
+        write_events: bool = True,
+        initial_records=(),
+    ):
+        super().__init__()
+        self._directory = directory
+        self._pipettes = list(pipettes)
+        self._microscope = microscope
+        self._stopped = False
+        self._logFile = None
+        if write_events:
+            handle = directory.createFile(LOG_FILE_NAME, autoIncrement=True)
+            self._logFile = open(handle.name(), "ab")
+        for record in initial_records:
+            self.record(record)
+
+    def logFileName(self) -> str | None:
+        return None if self._logFile is None else self._logFile.name
+
+    def isRecording(self) -> bool:
+        return not self._stopped
+
+    def record(self, event) -> None:
+        """Write one record. Ignored once stopped, so a late queued event
+        arriving after the action that opened this recorder has ended does not
+        reopen a closed file."""
+        if self._stopped:
+            return
+        self._writeRecords([event])
+
+    def _writeRecords(self, records) -> None:
+        if self._logFile is None:
+            return
+        for record in records:
+            # One JSON object per line, with no trailing comma. Both readers
+            # strip b",\r\n" as a character set rather than as a suffix, so
+            # they parse this and the historical comma-terminated form alike.
+            self._logFile.write(
+                json.dumps(record, cls=ACQ4JSONEncoder).encode("utf8") + b"\n"
+            )
+        self._logFile.flush()
+
+    def stop(self) -> None:
+        """Release everything this recorder holds. Idempotent."""
+        if self._stopped:
+            return
+        self._stopped = True
+        if self._logFile is not None:
+            self._logFile.close()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/util/tests/test_multipatch_log_recorder.py -v`
+
+Expected: PASS, 10 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/util/multipatch_log_recorder.py acq4/util/tests/test_multipatch_log_recorder.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(util): add MultiPatchLogRecorder's log-file writing
+
+The writer half of the MultiPatch log format, extracted so Autopatch can
+produce a log the MultiPatch viewer and tools/autopatch_analysis both read.
+
+Writes clean JSONL rather than the historical trailing-comma form: both
+readers strip b",\r\n" as a character set rather than a suffix, so they
+already parse either. Owns a file and nothing else -- never device state, and
+in particular never a clamp's test-pulse history, which is MultiPatch's Reset
+button and not a recorder's business.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 3: The full-test-pulse HDF5 sidecar
+
+**Files:**
+- Modify: `acq4/util/multipatch_log_recorder.py`
+- Test: `acq4/util/tests/test_multipatch_log_recorder.py`
+
+**Interfaces:**
+- Consumes: Task 2's recorder; `neuroanalysis.test_pulse_stack.H5BackedTestPulseStack`.
+- Produces: `MultiPatchLogRecorder.setRecordFullTestPulses(bool) -> None`; `.recordsFullTestPulses() -> bool`. The `full_test_pulse` field of a written record becomes `"<relpath>:<h5path>"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/util/tests/test_multipatch_log_recorder.py`:
+
+```python
+class _FakeTestPulse:
+    """Stands in for a PatchClampTestPulse. H5BackedTestPulseStack.append is
+    monkeypatched in these tests, so this only has to be identifiable."""
+
+    def __init__(self, tag):
+        self.tag = tag
+
+
+@pytest.fixture
+def stubbed_stack(monkeypatch):
+    """Replace the HDF5 stack with a recorder of appends, returning the
+    (filename, h5path) pair the real one returns."""
+    import acq4.util.multipatch_log_recorder as mod
+
+    appended = []
+
+    class _Stack:
+        def __init__(self, group):
+            self.group = group
+            self.files = []
+
+        def append(self, test_pulse, retain_data=False):
+            appended.append(test_pulse)
+            return (self.group["filename"], f"{self.group['path']}/{len(appended) - 1}")
+
+        def flush(self):
+            return None
+
+        def close(self):
+            return None
+
+    created = []
+
+    def fakeMakeStack(self, deviceName):
+        stack = _Stack(
+            {
+                "filename": str(self._directory.root / "TestPulses_000.hdf5"),
+                "path": f"test_pulses/{deviceName}",
+            }
+        )
+        created.append((deviceName, stack))
+        return stack
+
+    monkeypatch.setattr(mod.MultiPatchLogRecorder, "_makeTestPulseStack", fakeMakeStack)
+    return appended, created
+
+
+def test_full_test_pulse_is_diverted_into_the_sidecar(qapp, directory, stubbed_stack):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    appended, _created = stubbed_stack
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(), record_full_test_pulses=True
+    )
+    tp = _FakeTestPulse("tp-1")
+    try:
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "full_test_pulse": tp,
+            }
+        )
+    finally:
+        recorder.stop()
+
+    assert appended == [tp]
+    written = json.loads(_lines(recorder.logFileName())[0])
+    assert written["full_test_pulse"] == "TestPulses_000.hdf5:test_pulses/Clamp1/0"
+
+
+def test_the_sidecar_path_is_relative_to_the_log_file(qapp, directory, stubbed_stack):
+    # The reader resolves it with os.path.join(os.path.dirname(logfile), ...),
+    # so an absolute path here would break every viewer that moves the data.
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=True)
+    try:
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "full_test_pulse": _FakeTestPulse("tp"),
+            }
+        )
+    finally:
+        recorder.stop()
+
+    location = json.loads(_lines(recorder.logFileName())[0])["full_test_pulse"]
+    assert not location.startswith("/")
+
+
+def test_the_test_pulse_object_never_reaches_the_json(qapp, directory, stubbed_stack):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=True)
+    try:
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "full_test_pulse": _FakeTestPulse("tp"),
+                "steady_state_resistance": 1.5e9,
+            }
+        )
+    finally:
+        recorder.stop()
+
+    written = json.loads(_lines(recorder.logFileName())[0])
+    assert isinstance(written["full_test_pulse"], str)
+    assert written["steady_state_resistance"] == 1.5e9
+
+
+def test_full_test_pulse_is_stripped_when_not_recording_them(qapp, directory):
+    # No sidecar to divert into, so the object must be dropped rather than
+    # handed to the JSON encoder.
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "full_test_pulse": _FakeTestPulse("tp"),
+                "steady_state_resistance": 1.5e9,
+            }
+        )
+    finally:
+        recorder.stop()
+
+    written = json.loads(_lines(recorder.logFileName())[0])
+    assert "full_test_pulse" not in written
+    assert written["steady_state_resistance"] == 1.5e9
+
+
+def test_set_record_full_test_pulses_toggles_at_runtime(qapp, directory, stubbed_stack):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        assert recorder.recordsFullTestPulses() is False
+        recorder.setRecordFullTestPulses(True)
+        assert recorder.recordsFullTestPulses() is True
+        recorder.setRecordFullTestPulses(False)
+        assert recorder.recordsFullTestPulses() is False
+    finally:
+        recorder.stop()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/util/tests/test_multipatch_log_recorder.py -v -k "sidecar or test_pulse_object or stripped or set_record"`
+
+Expected: FAIL — `AttributeError: type object 'MultiPatchLogRecorder' has no attribute '_makeTestPulseStack'` from the fixture's monkeypatch.
+
+- [ ] **Step 3: Add the sidecar**
+
+In `acq4/util/multipatch_log_recorder.py`, add imports:
+
+```python
+import os
+
+import h5py
+from neuroanalysis.test_pulse_stack import H5BackedTestPulseStack
+```
+
+Add the sidecar constant beside `LOG_FILE_NAME`:
+
+```python
+# Base name of the full-test-pulse sidecar, and the group each device's stack
+# lives at inside it. MultiPatchLogData reads exactly `test_pulses/{device}`.
+TEST_PULSE_FILE_NAME = "TestPulses.hdf5"
+TEST_PULSE_GROUP = "test_pulses"
+```
+
+In `__init__`, after the log file is opened and before `initial_records` are replayed:
+
+```python
+        self._recordFullTestPulses = record_full_test_pulses
+        # device name -> its H5BackedTestPulseStack, created on first use so a
+        # recorder that never sees a full test pulse writes no sidecar at all.
+        self._testPulseStacks = {}
+        self._testPulseContainer = None
+```
+
+Add the methods before `stop`:
+
+```python
+    def recordsFullTestPulses(self) -> bool:
+        return self._recordFullTestPulses
+
+    def setRecordFullTestPulses(self, record: bool) -> None:
+        """Turn full-test-pulse capture on or off for the rest of this
+        recorder's life. Existing stacks are kept: turning capture back on
+        appends to the same sidecar rather than starting a second one."""
+        self._recordFullTestPulses = bool(record)
+
+    def _makeTestPulseStack(self, deviceName: str):
+        """The HDF5 stack for one device, creating the sidecar on first use."""
+        if self._testPulseContainer is None:
+            handle = self._directory.createFile(TEST_PULSE_FILE_NAME, autoIncrement=True)
+            self._testPulseContainer = h5py.File(handle.name(), "a")
+            self._testPulseContainer.create_group(TEST_PULSE_GROUP)
+        group = self._testPulseContainer[TEST_PULSE_GROUP].create_group(deviceName)
+        group.attrs["device"] = deviceName
+        return H5BackedTestPulseStack(group)
+
+    def _divertFullTestPulse(self, record):
+        """Move a record's full_test_pulse object into the sidecar, replacing the
+        field with the "<relpath>:<h5path>" location the reader resolves.
+
+        The relative path is relative to the *log file's* directory, because
+        that is what MultiPatchLogData joins it against. Returns a copy: the
+        caller's dict belongs to the device that emitted it.
+        """
+        testPulse = record["full_test_pulse"]
+        record = {k: v for k, v in record.items() if k != "full_test_pulse"}
+        if not self._recordFullTestPulses:
+            # Nowhere to put it, and it must never reach the JSON encoder.
+            return record
+        deviceName = record.get("device")
+        stack = self._testPulseStacks.get(deviceName)
+        if stack is None:
+            stack = self._testPulseStacks[deviceName] = self._makeTestPulseStack(deviceName)
+        filename, h5path = stack.append(testPulse)
+        if self._logFile is not None:
+            filename = os.path.relpath(filename, os.path.dirname(self._logFile.name))
+        record["full_test_pulse"] = f"{filename}:{h5path}"
+        return record
+```
+
+Rewrite `_writeRecords` to divert first and flush the stacks:
+
+```python
+    def _writeRecords(self, records) -> None:
+        for record in records:
+            if "full_test_pulse" in record:
+                record = self._divertFullTestPulse(record)
+            if self._logFile is not None:
+                # One JSON object per line, with no trailing comma. Both readers
+                # strip b",\r\n" as a character set rather than as a suffix, so
+                # they parse this and the historical comma-terminated form alike.
+                self._logFile.write(
+                    json.dumps(record, cls=ACQ4JSONEncoder).encode("utf8") + b"\n"
+                )
+        if self._logFile is not None:
+            self._logFile.flush()
+        for stack in self._testPulseStacks.values():
+            stack.flush()
+```
+
+Note `record()`'s early return on `self._logFile is None` is gone: a recorder with `write_events=False` still has to divert test pulses into its sidecar.
+
+Extend `stop` to close the sidecar:
+
+```python
+    def stop(self) -> None:
+        """Release everything this recorder holds. Idempotent."""
+        if self._stopped:
+            return
+        self._stopped = True
+        for stack in self._testPulseStacks.values():
+            stack.close()
+        self._testPulseStacks = {}
+        if self._testPulseContainer is not None:
+            self._testPulseContainer.close()
+            self._testPulseContainer = None
+        if self._logFile is not None:
+            self._logFile.close()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/util/tests/test_multipatch_log_recorder.py -v`
+
+Expected: PASS, 15 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/util/multipatch_log_recorder.py acq4/util/tests/test_multipatch_log_recorder.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(util): divert full test pulses into the recorder's HDF5 sidecar
+
+Each device's stack lives at test_pulses/{device}, and the event's field
+becomes the "<relpath>:<h5path>" location MultiPatchLogData resolves against
+the log file's own directory -- so an absolute path here would break any
+viewer opening moved data.
+
+The sidecar is created on first use, so a recorder that never sees a full
+test pulse writes no HDF5 at all. With capture off, the test-pulse object is
+dropped rather than handed to the JSON encoder.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 4: Subscriptions, and the accumulated test-pulse analysis
+
+**Files:**
+- Modify: `acq4/util/multipatch_log_recorder.py`
+- Test: `acq4/util/tests/test_multipatch_log_recorder.py`
+
+**Interfaces:**
+- Consumes: Task 1's `requestFullTestPulseData`/`releaseFullTestPulseData`; Task 3's recorder; `acq4.filetypes.MultiPatchLog.TEST_PULSE_NUMPY_DTYPE`.
+- Produces: `MultiPatchLogRecorder.testPulseAnalysis() -> np.ndarray` (structured, `TEST_PULSE_NUMPY_DTYPE`). Phase 3 consumes exactly this.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/util/tests/test_multipatch_log_recorder.py`:
+
+```python
+class _FakePipette(Qt.QObject):
+    sigNewEvent = Qt.Signal(object, object)
+
+    def __init__(self, name="Clamp1"):
+        super().__init__()
+        self._name = name
+        self.requested = []
+        self.released = []
+
+    def name(self):
+        return self._name
+
+    def requestFullTestPulseData(self, token):
+        self.requested.append(token)
+
+    def releaseFullTestPulseData(self, token):
+        self.released.append(token)
+
+    def emit(self, event):
+        self.sigNewEvent.emit(self, event)
+
+
+class _FakeMicroscope(Qt.QObject):
+    sigSurfaceDepthChanged = Qt.Signal(object)
+
+    def name(self):
+        return "Microscope"
+
+
+def test_pipette_events_are_recorded(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        pip.emit({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+    finally:
+        recorder.stop()
+
+    assert json.loads(_lines(recorder.logFileName())[0])["event"] == "state_change"
+
+
+def test_events_after_stop_are_not_recorded(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    recorder.stop()
+
+    pip.emit({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+
+    assert _lines(recorder.logFileName()) == []
+
+
+def test_full_test_pulse_data_is_requested_and_released(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=True
+    )
+    assert pip.requested == [recorder]
+    assert pip.released == []
+
+    recorder.stop()
+
+    assert pip.released == [recorder]
+
+
+def test_no_full_test_pulse_request_when_not_recording_them(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        assert pip.requested == []
+    finally:
+        recorder.stop()
+
+
+def test_toggling_full_test_pulses_requests_and_releases(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        recorder.setRecordFullTestPulses(True)
+        assert pip.requested == [recorder]
+        recorder.setRecordFullTestPulses(False)
+        assert pip.released == [recorder]
+    finally:
+        recorder.stop()
+
+
+def test_microscope_surface_depth_changes_are_recorded(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    scope = _FakeMicroscope()
+    recorder = MultiPatchLogRecorder(
+        directory, microscope=scope, record_full_test_pulses=False
+    )
+    try:
+        scope.sigSurfaceDepthChanged.emit(-1.5e-3)
+    finally:
+        recorder.stop()
+
+    written = json.loads(_lines(recorder.logFileName())[0])
+    assert written["event"] == "surface_depth_changed"
+    assert written["surface_depth"] == -1.5e-3
+    assert written["device"] == "Microscope"
+
+
+def test_test_pulse_analysis_accumulates_the_events_seen(qapp, directory):
+    import numpy as np
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        pip.emit(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "steady_state_resistance": 1.0e9,
+                "capacitance": 5e-12,
+            }
+        )
+        pip.emit(
+            {
+                "device": "Clamp1",
+                "event_time": 2.0,
+                "event": "test_pulse",
+                "steady_state_resistance": 2.0e9,
+                "capacitance": 6e-12,
+            }
+        )
+        history = recorder.testPulseAnalysis()
+    finally:
+        recorder.stop()
+
+    assert len(history) == 2
+    assert np.array_equal(history["event_time"], [1.0, 2.0])
+    assert np.array_equal(history["steady_state_resistance"], [1.0e9, 2.0e9])
+
+
+def test_test_pulse_analysis_records_missing_fields_as_nan(qapp, directory):
+    import numpy as np
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        pip.emit(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "test_pulse",
+                "steady_state_resistance": None,
+            }
+        )
+        history = recorder.testPulseAnalysis()
+    finally:
+        recorder.stop()
+
+    assert np.isnan(history["steady_state_resistance"][0])
+
+
+def test_test_pulse_analysis_ignores_other_event_types(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        pip.emit({"device": "Clamp1", "event_time": 1.0, "event": "state_change"})
+        history = recorder.testPulseAnalysis()
+    finally:
+        recorder.stop()
+
+    assert len(history) == 0
+
+
+def test_test_pulse_analysis_is_unaffected_by_a_device_history_reset(qapp, directory):
+    # approach.py resets the clamp's own test-pulse history mid-patch, which is
+    # exactly why the recorder accumulates its own rather than slicing the
+    # device's.
+    import numpy as np
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    try:
+        for index, t in enumerate([1.0, 2.0, 3.0]):
+            pip.emit(
+                {
+                    "device": "Clamp1",
+                    "event_time": t,
+                    "event": "test_pulse",
+                    "steady_state_resistance": float(index),
+                }
+            )
+        history = recorder.testPulseAnalysis()
+    finally:
+        recorder.stop()
+
+    assert np.array_equal(history["event_time"], [1.0, 2.0, 3.0])
+
+
+def test_the_recorder_holds_no_reference_to_a_stopped_pipette(qapp, directory):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    pip = _FakePipette()
+    recorder = MultiPatchLogRecorder(
+        directory, pipettes=(pip,), record_full_test_pulses=False
+    )
+    recorder.stop()
+
+    assert recorder._pipettes == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/util/tests/test_multipatch_log_recorder.py -v -k "pipette_events or subscription or requested or microscope or analysis or reference"`
+
+Expected: FAIL — nothing connects `sigNewEvent`, so no records are written, and `testPulseAnalysis` does not exist.
+
+- [ ] **Step 3: Add subscriptions and the analysis accumulator**
+
+In `acq4/util/multipatch_log_recorder.py`, add imports:
+
+```python
+import numpy as np
+
+from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
+from acq4.util import ptime
+
+# The analysis field names a test_pulse event can carry, taken from the dtype
+# the readers and PatchClamp's own history both use, so an accumulated array is
+# interchangeable with clampDevice.testPulseHistory()'s.
+_TEST_PULSE_FIELDS = tuple(name for name, _type in TEST_PULSE_NUMPY_DTYPE)
+```
+
+In `__init__`, after the sidecar attributes:
+
+```python
+        # One row per test_pulse event this recorder saw, in order. Accumulated
+        # here rather than read from clampDevice.testPulseHistory() because the
+        # device's history is reset mid-patch -- approach.py:251 does it on every
+        # attempt -- so slicing that by time silently loses data.
+        self._testPulseRows: list[tuple] = []
+        for pip in self._pipettes:
+            pip.sigNewEvent.connect(self._onPipetteEvent)
+        if microscope is not None:
+            microscope.sigSurfaceDepthChanged.connect(self._onSurfaceDepthChanged)
+        if self._recordFullTestPulses:
+            self._requestFullTestPulseData()
+```
+
+Note the `initial_records` replay must move to *after* this block, so a recorder constructed with both history and live pipettes writes history first.
+
+Add the methods before `stop`:
+
+```python
+    def _requestFullTestPulseData(self) -> None:
+        for pip in self._pipettes:
+            pip.requestFullTestPulseData(self)
+
+    def _releaseFullTestPulseData(self) -> None:
+        for pip in self._pipettes:
+            pip.releaseFullTestPulseData(self)
+
+    def _onPipetteEvent(self, _pipette, event) -> None:
+        if event.get("event") == "test_pulse":
+            self._testPulseRows.append(
+                tuple(_nanIfNone(event.get(field)) for field in _TEST_PULSE_FIELDS)
+            )
+        self.record(event)
+
+    def _onSurfaceDepthChanged(self, depth) -> None:
+        self.record(
+            {
+                "device": self._microscope.name(),
+                "event_time": ptime.time(),
+                "event": "surface_depth_changed",
+                "surface_depth": depth,
+            }
+        )
+
+    def testPulseAnalysis(self) -> np.ndarray:
+        """Every test_pulse event this recorder saw, as a structured array with
+        the same dtype as clampDevice.testPulseHistory().
+
+        This -- not the device's own history -- is what a UI should plot for one
+        action's span: the device's is reset mid-patch by the approach state, so
+        slicing it by the action's start and end times loses whatever preceded
+        the reset.
+        """
+        return np.array(self._testPulseRows, dtype=TEST_PULSE_NUMPY_DTYPE)
+```
+
+Add the module-level helper after the constants:
+
+```python
+def _nanIfNone(value):
+    """NaN for a missing or None analysis field, matching how PatchClamp's own
+    test-pulse history records one."""
+    return np.nan if value is None else value
+```
+
+Extend `setRecordFullTestPulses` to move the subscription with the flag:
+
+```python
+    def setRecordFullTestPulses(self, record: bool) -> None:
+        """Turn full-test-pulse capture on or off for the rest of this
+        recorder's life. Existing stacks are kept: turning capture back on
+        appends to the same sidecar rather than starting a second one."""
+        record = bool(record)
+        if record == self._recordFullTestPulses:
+            return
+        self._recordFullTestPulses = record
+        if record:
+            self._requestFullTestPulseData()
+        else:
+            self._releaseFullTestPulseData()
+```
+
+Extend `stop` to sever everything, before it closes the files:
+
+```python
+        self._releaseFullTestPulseData()
+        for pip in self._pipettes:
+            Qt.disconnect(pip.sigNewEvent, self._onPipetteEvent)
+        # Dropped so a stopped recorder is not what keeps a device object
+        # alive, and so a second stop() has nothing left to disconnect.
+        self._pipettes = []
+        if self._microscope is not None:
+            Qt.disconnect(
+                self._microscope.sigSurfaceDepthChanged, self._onSurfaceDepthChanged
+            )
+            self._microscope = None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/util/tests/test_multipatch_log_recorder.py -v`
+
+Expected: PASS, 26 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add acq4/util/multipatch_log_recorder.py acq4/util/tests/test_multipatch_log_recorder.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+feat(util): subscribe the recorder to its pipettes, and accumulate analysis
+
+testPulseAnalysis() returns the same dtype clampDevice.testPulseHistory()
+does, but accumulated from the events this recorder actually saw. That is not
+a convenience: the approach state resets the device's history mid-patch, so
+slicing the device's by an action's start and end times silently loses
+whatever preceded the reset.
+
+stop() releases the full-test-pulse tokens, disconnects every signal, and
+drops its device references, so a stopped recorder holds nothing.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 5: The golden-output check and the reader round-trips
+
+**Files:**
+- Test: `acq4/util/tests/test_multipatch_log_recorder.py`
+- Modify: `acq4/filetypes/MultiPatchLog.py:232`
+- Modify: `tools/autopatch_analysis/tests/test_autopatch_log.py:17-19`
+
+**Interfaces:**
+- Consumes: Tasks 2–4's recorder.
+- Produces: no production API. This is the safety net that makes "identical behavior, so the viewer still renders it" a tested claim.
+
+This task exists because `acq4/modules/MultiPatch/tests/test_logfile.py` covers only `IrregularTimeSeries` and nothing in the logging path — so before Task 6 rewrites that path, its output has to be pinned against the current implementation.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/util/tests/test_multipatch_log_recorder.py`:
+
+```python
+# -- golden output vs. the implementation being replaced ----------------------
+
+
+def _referenceWriteRecords(records, logPath):
+    """The pre-refactor MultiPatchWindow.writeRecords, verbatim apart from the
+    test-pulse-stack branch, held here as the reference the recorder's output is
+    checked against. Deliberately duplicated rather than imported: its whole
+    job is to keep saying what the old code said after the old code is gone."""
+    from acq4.util.json_encoder import ACQ4JSONEncoder
+
+    with open(logPath, "ab") as fh:
+        for rec in records:
+            rec = {k: v for k, v in rec.items() if k != "full_test_pulse"}
+            fh.write(json.dumps(rec, cls=ACQ4JSONEncoder).encode("utf8") + b",\n")
+        fh.flush()
+
+
+_GOLDEN_EVENTS = [
+    {"device": "Clamp1", "event_time": 1.0, "event": "state_change", "state": "bath"},
+    {"device": "Clamp1", "event_time": 1.5, "event": "move_stop", "position": [1.0, 2.0, 3.0]},
+    {
+        "device": "Clamp1",
+        "event_time": 2.0,
+        "event": "test_pulse",
+        "baseline_potential": -0.07,
+        "steady_state_resistance": 1.5e9,
+        "capacitance": None,
+    },
+    {"device": "Clamp1", "event_time": 2.5, "event": "pressure_changed", "pressure": 0.0},
+    {"device": None, "event_time": 3.0, "event": "global patch profiles changed", "profile": "{}"},
+]
+
+
+def test_recorder_output_matches_the_reference_apart_from_the_comma(qapp, directory, tmp_path):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        for event in _GOLDEN_EVENTS:
+            recorder.record(event)
+    finally:
+        recorder.stop()
+
+    referencePath = tmp_path / "reference.log"
+    _referenceWriteRecords(_GOLDEN_EVENTS, referencePath)
+
+    ours = _lines(recorder.logFileName())
+    theirs = _lines(referencePath)
+    assert len(ours) == len(theirs)
+    for ourLine, theirLine in zip(ours, theirs):
+        # Byte-for-byte the same record; only the trailing comma differs.
+        assert ourLine.rstrip(b"\r\n") == theirLine.rstrip(b"\r\n").rstrip(b",")
+
+
+def test_recorder_output_parses_identically_to_the_reference(qapp, directory, tmp_path):
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        for event in _GOLDEN_EVENTS:
+            recorder.record(event)
+    finally:
+        recorder.stop()
+    referencePath = tmp_path / "reference.log"
+    _referenceWriteRecords(_GOLDEN_EVENTS, referencePath)
+
+    def parse(path):
+        return [json.loads(line.rstrip(b",\r\n")) for line in _lines(path)]
+
+    assert parse(recorder.logFileName()) == parse(referencePath)
+
+
+# -- reader round-trips ------------------------------------------------------
+
+
+def test_the_multipatch_log_reader_parses_a_recorder_file(qapp, directory):
+    from acq4.filetypes.MultiPatchLog import MultiPatchLogData
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        for event in _GOLDEN_EVENTS:
+            if event["device"] is not None:
+                recorder.record(event)
+    finally:
+        recorder.stop()
+
+    data = MultiPatchLogData(recorder.logFileName())
+
+    assert "Clamp1" in data.devices()
+    assert data.firstTime() == 1.0
+    assert data.lastTime() == 2.5
+
+
+def test_the_analysis_tool_parses_a_recorder_file(qapp, directory):
+    import sys
+    from pathlib import Path
+
+    toolsPath = str(Path(__file__).resolve().parents[3] / "tools" / "autopatch_analysis")
+    if toolsPath not in sys.path:
+        sys.path.insert(0, toolsPath)
+    import autopatch_log
+
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 1.0,
+                "event": "state_change",
+                "state": "bath",
+                "old_state": "out",
+            }
+        )
+        recorder.record(
+            {
+                "device": "Clamp1",
+                "event_time": 2.0,
+                "event": "state_change",
+                "state": "approach",
+                "old_state": "bath",
+            }
+        )
+    finally:
+        recorder.stop()
+
+    events = autopatch_log.parse_log_events(recorder.logFileName())
+
+    assert [e["state"] for e in events] == ["bath", "approach"]
+```
+
+In `tools/autopatch_analysis/tests/test_autopatch_log.py`, make the comma tolerance explicit. Change `_write` (lines 17-19) to take the terminator, defaulting to the legacy form so every existing caller keeps testing it:
+
+```python
+def _write(tmp_path, lines, name="MultiPatch_000.log", terminator=",\n"):
+    p = tmp_path / name
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("".join(line + terminator for line in lines))
+    return p
+```
+
+and add a parity test at the end of the file:
+
+```python
+def test_comma_free_and_legacy_lines_parse_identically(tmp_path):
+    """The writer emits clean JSONL; historical files end every line with a
+    comma. rstrip(b",\\r\\n") is a character-set strip, not a suffix strip, so
+    both forms must yield the same records -- pinned here rather than left to
+    luck."""
+    events = [_state(0.0, "bath", "out"), _state(5.0, "out", "bath")]
+    legacy = _write(tmp_path / "legacy", events)
+    modern = _write(tmp_path / "modern", events, terminator="\n")
+
+    assert parse_log_events(str(legacy)) == parse_log_events(str(modern))
+```
+
+Add `parse_log_events` to that file's imports if it is not already imported.
+
+- [ ] **Step 2: Run tests to verify they fail or reveal the reader gap**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/util/tests/test_multipatch_log_recorder.py tools/autopatch_analysis/tests/test_autopatch_log.py -v`
+
+Expected: the golden and round-trip tests PASS if Tasks 2–4 are correct. Any failure here is a real format discrepancy — fix the recorder, never the reference implementation or the expected bytes.
+
+The reader entry point is `parse_log_events(path: str) -> list[dict]` at `tools/autopatch_analysis/autopatch_log.py:67`; it takes a `str`, so the tests above pass `str(path)`.
+
+- [ ] **Step 3: Add the reader's blank-line guard**
+
+`acq4/filetypes/MultiPatchLog.py:232` parses every line with no blank-line guard, where `tools/autopatch_analysis/autopatch_log.py:77` has one. It is latent today rather than triggered — a file ending in a newline yields no trailing empty line when iterated — but the two readers should agree. Replace that line:
+
+```python
+            events: list[dict[str, Any]] = [
+                json.loads(stripped)
+                for stripped in (line.rstrip(b',\r\n') for line in fh)
+                if stripped.strip()
+            ]
+```
+
+- [ ] **Step 4: Add a test for the guard**
+
+Append to `acq4/util/tests/test_multipatch_log_recorder.py`:
+
+```python
+def test_the_reader_tolerates_blank_lines(qapp, directory):
+    # Parity with tools/autopatch_analysis, which has always skipped them.
+    from acq4.filetypes.MultiPatchLog import MultiPatchLogData
+    from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+
+    recorder = MultiPatchLogRecorder(directory, record_full_test_pulses=False)
+    try:
+        recorder.record(
+            {"device": "Clamp1", "event_time": 1.0, "event": "state_change", "state": "bath"}
+        )
+    finally:
+        recorder.stop()
+    with open(recorder.logFileName(), "ab") as fh:
+        fh.write(b"\n")
+
+    data = MultiPatchLogData(recorder.logFileName())
+
+    assert "Clamp1" in data.devices()
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/util/tests acq4/filetypes/tests tools/autopatch_analysis/tests -v`
+
+Expected: PASS, all tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add acq4/util/tests/test_multipatch_log_recorder.py acq4/filetypes/MultiPatchLog.py tools/autopatch_analysis/tests/test_autopatch_log.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+test(util): pin the recorder's output against the writer it replaces
+
+MultiPatch's only test file covers IrregularTimeSeries and nothing in the
+logging path, so before that path is rewritten its output has to be pinned.
+A reference copy of the current writeRecords lives in the test, deliberately
+duplicated rather than imported: its job is to keep saying what the old code
+said after the old code is gone.
+
+Also round-trips a recorder file through both readers, pins that comma-free
+and legacy lines parse identically, and gives the MultiPatchLog reader the
+blank-line guard tools/autopatch_analysis has always had.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 6: Refactor `MultiPatchWindow` onto the recorder
+
+**Files:**
+- Modify: `acq4/modules/MultiPatch/multipatch.py:50-52,601-665`
+- Test: `acq4/modules/MultiPatch/tests/test_logfile.py`
+
+**Interfaces:**
+- Consumes: the full recorder from Tasks 2–4.
+- Produces: `MultiPatchWindow._recorder: MultiPatchLogRecorder | None`. `writeRecords` is **removed**; `recordEvent`, `resetHistory`, and `eventHistory` remain.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `acq4/modules/MultiPatch/tests/test_logfile.py`:
+
+```python
+"""Also: the record-button toggles map onto one MultiPatchLogRecorder, whose
+options are what the two independent buttons switch."""
+import pytest
+
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+class _RecorderSpy:
+    """Stands in for MultiPatchLogRecorder so the toggle mapping can be tested
+    without a Manager, real devices, or a storage directory."""
+
+    instances = []
+
+    def __init__(self, directory, pipettes=(), microscope=None,
+                 record_full_test_pulses=True, write_events=True, initial_records=()):
+        self.directory = directory
+        self.pipettes = list(pipettes)
+        self.microscope = microscope
+        self.record_full_test_pulses = record_full_test_pulses
+        self.write_events = write_events
+        self.initial_records = list(initial_records)
+        self.records = []
+        self.stopped = False
+        _RecorderSpy.instances.append(self)
+
+    def record(self, event):
+        self.records.append(event)
+
+    def setRecordFullTestPulses(self, record):
+        self.record_full_test_pulses = bool(record)
+
+    def recordsFullTestPulses(self):
+        return self.record_full_test_pulses
+
+    def stop(self):
+        self.stopped = True
+
+
+@pytest.fixture
+def spy(monkeypatch):
+    import acq4.modules.MultiPatch.multipatch as mp
+
+    _RecorderSpy.instances = []
+    monkeypatch.setattr(mp, "MultiPatchLogRecorder", _RecorderSpy)
+    return _RecorderSpy
+
+
+def test_write_records_is_gone():
+    # Its whole job moved into the recorder; leaving it would be a second
+    # implementation of the format to drift from the first.
+    from acq4.modules.MultiPatch.multipatch import MultiPatchWindow
+
+    assert not hasattr(MultiPatchWindow, "writeRecords")
+
+
+def test_reset_history_still_resets_the_clamp_history():
+    # resetHistory is MultiPatch's Reset button, deliberately NOT moved into the
+    # recorder: a recorder that reset device state would let one module wipe the
+    # history another is plotting.
+    import inspect
+
+    from acq4.modules.MultiPatch.multipatch import MultiPatchWindow
+
+    source = inspect.getsource(MultiPatchWindow.resetHistory)
+    assert "resetTestPulseHistory" in source
+
+
+def test_the_recorder_never_resets_device_state():
+    import inspect
+
+    from acq4.util import multipatch_log_recorder
+
+    source = inspect.getsource(multipatch_log_recorder)
+    assert "resetTestPulseHistory" not in source
+```
+
+The remaining toggle-combination coverage requires a `MultiPatchWindow` instance, which needs a Manager. Add this integration-style test guarded on the manager fixture the repo already uses for module tests; if none exists, note that in the task report and leave the four combinations to live testing rather than inventing a Manager fake:
+
+Run: `grep -rn "def manager\|getManager" acq4/modules/*/tests/*.py | head`
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/MultiPatch/tests/test_logfile.py -v`
+
+Expected: FAIL on `test_write_records_is_gone` (it still exists) and on `test_the_recorder_never_resets_device_state` only if the recorder wrongly touches device state — that one should already pass.
+
+- [ ] **Step 3: Import the recorder and replace the state**
+
+In `acq4/modules/MultiPatch/multipatch.py`, add to the imports:
+
+```python
+from acq4.util.multipatch_log_recorder import MultiPatchLogRecorder
+```
+
+Replace lines 50-51 (`self._eventStorageFile = None` and `self._testPulseStacks = {}`) with:
+
+```python
+        # The single recorder this window's two record buttons drive, or None
+        # while both are off. One instance covering every pipette, the
+        # microscope, and this window's own profile records -- the same
+        # single-file behavior the two buttons have always produced.
+        self._recorder = None
+```
+
+- [ ] **Step 4: Rewrite the two toggles**
+
+Replace `recordToggled` (lines 601-612) and `recordTestPulsesToggled` (lines 614-632) with:
+
+```python
+    def recordToggled(self, rec):
+        if not rec:
+            self.resetHistory()
+        self._syncRecorder(
+            writeEvents=rec,
+            recordTestPulses=self.ui.recordTestPulsesBtn.isChecked(),
+            replayHistory=rec,
+        )
+        if rec:
+            profile_data = PatchPipetteStateManager.buildPatchProfilesParameters().getValues()
+            self.patchProfilesChanged(profile_data)
+
+    def recordTestPulsesToggled(self, rec):
+        self._syncRecorder(
+            writeEvents=self.ui.recordBtn.isChecked(),
+            recordTestPulses=rec,
+            replayHistory=False,
+        )
+
+    def _syncRecorder(self, writeEvents: bool, recordTestPulses: bool, replayHistory: bool):
+        """Bring self._recorder in line with the two record buttons.
+
+        The buttons are independent -- test-pulse capture works with the event
+        log off -- so a recorder exists while *either* is on, with each button
+        mapped to one of its options. Switching a button that does not need a
+        different recorder adjusts the live one in place, so toggling test
+        pulses mid-session does not start a second log file.
+        """
+        if not writeEvents and not recordTestPulses:
+            if self._recorder is not None:
+                self._recorder.stop()
+                self._recorder = None
+            return
+        if self._recorder is not None and self._recorder.write_events == writeEvents:
+            self._recorder.setRecordFullTestPulses(recordTestPulses)
+            return
+        if self._recorder is not None:
+            self._recorder.stop()
+        self._recorder = MultiPatchLogRecorder(
+            getManager().getCurrentDir(),
+            pipettes=[p for p in self.pips if isinstance(p, PatchPipette)],
+            microscope=self.microscope,
+            record_full_test_pulses=recordTestPulses,
+            write_events=writeEvents,
+            initial_records=list(self.eventHistory) if replayHistory else (),
+        )
+```
+
+`write_events` must be readable off the recorder for the in-place branch above, so expose it in `acq4/util/multipatch_log_recorder.py`'s `__init__`:
+
+```python
+        self.write_events = bool(write_events)
+```
+
+and use `self.write_events` in place of the local `write_events` for the rest of that method.
+
+- [ ] **Step 5: Delete the window's own writing, and stop double-recording**
+
+Delete `writeRecords` (lines 649-665) entirely.
+
+Replace `recordEvent` (lines 634-639) with:
+
+```python
+    def recordEvent(self, event):
+        """Record one event this window originates -- a patch-profile change, or
+        a microscope surface-depth change.
+
+        Pipette events are NOT routed through here: the recorder subscribes to
+        each pipette's sigNewEvent directly, so passing them along as well
+        would write every one of them twice.
+        """
+        if not self.eventHistory:
+            self.resetHistory()
+        if self._recorder is not None:
+            self._recorder.record(event)
+        event = {k: v for k, v in event.items() if k != 'full_test_pulse'}
+        self.eventHistory.append(event)
+```
+
+Delete `pipetteEvent` (lines 589-590) and the `pip.sigNewEvent.connect(self.pipetteEvent)` line at line 86 — the recorder owns that subscription now. Then verify the window's in-memory `eventHistory` still gets pipette events, which `PipetteControl`'s own event log does not cover:
+
+Run: `grep -rn "eventHistory" acq4/modules/MultiPatch/multipatch.py`
+
+If `eventHistory`'s only remaining writer is `recordEvent`, keep `pipetteEvent` and its connection but have it append to `eventHistory` **without** calling the recorder:
+
+```python
+    def pipetteEvent(self, pip, ev):
+        """Keep this window's in-memory history, which its Reset button and the
+        replay into a freshly opened log both read. The recorder subscribes to
+        sigNewEvent itself, so this must not also hand the event to it."""
+        if not self.eventHistory:
+            self.resetHistory()
+        self.eventHistory.append({k: v for k, v in ev.items() if k != 'full_test_pulse'})
+```
+
+Also delete the now-dangling `import h5py`, `H5BackedTestPulseStack`, `os`, and `json`/`ACQ4JSONEncoder` imports **only if** nothing else in the file uses them:
+
+Run: `grep -n "h5py\|H5BackedTestPulseStack\|os\.\|json\.\|ACQ4JSONEncoder" acq4/modules/MultiPatch/multipatch.py`
+
+Remove only the imports with no remaining use.
+
+- [ ] **Step 6: Also remove the Task 1 stopgap**
+
+Task 1 left `recordTestPulsesToggled` calling `pip.requestFullTestPulseData(self)` directly. The recorder now owns that, so verify no such call survives in the module:
+
+Run: `grep -n "requestFullTestPulseData\|releaseFullTestPulseData" acq4/modules/MultiPatch/multipatch.py`
+
+Expected: no output.
+
+- [ ] **Step 7: Run the tests**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/modules/MultiPatch/tests acq4/util/tests acq4/devices/PatchPipette/tests acq4/filetypes/tests tools/autopatch_analysis/tests -v`
+
+Expected: PASS, all tests.
+
+- [ ] **Step 8: Import-check the refactored module**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -c "import acq4.modules.MultiPatch.multipatch as m; print(m.MultiPatchWindow)"`
+
+Expected: prints the class with no import error — the module has real device imports, so a broken import is the first thing to catch.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add acq4/modules/MultiPatch/multipatch.py acq4/modules/MultiPatch/tests/test_logfile.py acq4/util/multipatch_log_recorder.py
+git commit --author="Martin Chase (claude) <outofculture@gmail.com>" -m "$(cat <<'EOF'
+refactor(multipatch): record through MultiPatchLogRecorder
+
+One implementation of the log format instead of two, so "identical behavior,
+so the viewer still renders it" holds by construction rather than by
+inspection. The window's writeRecords is deleted; the recorder subscribes to
+each pipette's sigNewEvent itself, so recordEvent now carries only the events
+this window originates and pipetteEvent only maintains the in-memory history.
+
+The two record buttons stay independent -- test-pulse capture works with the
+event log off -- so one recorder exists while either is on and each button
+maps to one of its options. Toggling test pulses mid-session adjusts the live
+recorder rather than starting a second log file.
+
+resetHistory stays in the window on purpose: it resets clamp test-pulse
+history, and a recorder that touched device state would let one module wipe
+the history another is plotting.
+
+🤖 Generated with [Claude Code](https://claude.ai/code)
+EOF
+)"
+```
+
+---
+
+### Task 7: Verify the phase end to end
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run every suite this phase touched**
+
+Run: `/home/martin/.miniforge3/envs/acq4-gl/bin/python -m pytest acq4/util/tests acq4/devices/PatchPipette/tests acq4/modules/MultiPatch/tests acq4/filetypes/tests tools/autopatch_analysis/tests acq4/modules/Autopatch/tests acq4/experiment/tests -v`
+
+Expected: PASS with no failures, errors, or new warnings. Output must be pristine.
+
+- [ ] **Step 2: Confirm the format claim holds against a real historical file**
+
+If any `MultiPatch_*.log` exists under `../minirig-data`, parse one with both readers to confirm the blank-line guard and comma tolerance did not regress reading real data:
+
+```bash
+/home/martin/.miniforge3/envs/acq4-gl/bin/python -c "
+import glob, sys
+from acq4.filetypes.MultiPatchLog import MultiPatchLogData
+paths = sorted(glob.glob('../minirig-data/**/MultiPatch_*.log', recursive=True))
+if not paths:
+    print('no historical logs available; skipped')
+    sys.exit(0)
+d = MultiPatchLogData(paths[0])
+print(paths[0], d.devices(), d.firstTime(), d.lastTime())
+"
+```
+
+Expected: either `no historical logs available; skipped`, or a parsed device list and time range with no exception.
+
+- [ ] **Step 3: Report**
+
+State which tasks landed, the final test count, whether the historical-file check ran or was skipped, and whether the four record-button combinations were covered by tests or deferred to live testing (Task 6, Step 1).
+
+---
+
+## Self-Review Notes
+
+**Spec coverage for phase 2.** §5's placement and rationale → Task 2's module docstring; API → Tasks 2–4; carried-over format behaviors → Tasks 2–3; "deliberately left in MultiPatchWindow" → Task 6, asserted by `test_reset_history_still_resets_the_clamp_history` and `test_the_recorder_never_resets_device_state`; MultiPatch refactored onto it → Task 6; "MultiPatch's UI shows nothing about other recorders" → satisfied by omission, since no registry or indicator is built anywhere in this plan. §6 → Task 1. §7 → Tasks 2 and 5.
+
+**Known risk, and where it is contained.** Task 6 is the only task modifying working code with no pre-existing test coverage of its behavior. Task 5 lands the golden-output check *before* it, deliberately, so the rewrite has something to be wrong against.
+
+**Known test edits, not additions:** Task 5 changes `_write`'s signature in `tools/autopatch_analysis/tests/test_autopatch_log.py`, keeping the legacy terminator as its default so every existing caller keeps exercising the historical format.
+
+**Verified against the code:** the analysis tool's reader is `parse_log_events` at `autopatch_log.py:67` and takes a `str` path; both readers strip `b",\r\n"` as a character set (`MultiPatchLog.py:232`, `autopatch_log.py:76`), which is why dropping the trailing comma needs no reader change; `emitFullTestPulseData` has exactly one caller (`multipatch.py:632`); and `approach.py:251` plus `patchpipette.py:237` are the two mid-patch `resetTestPulseHistory()` calls that make `testPulseAnalysis()` necessary.

--- a/docs/superpowers/specs/2026-08-17-autopatch-area5-details-widgets-design.md
+++ b/docs/superpowers/specs/2026-08-17-autopatch-area5-details-widgets-design.md
@@ -1,0 +1,452 @@
+# Autopatch Area 5 — action details widgets
+
+Design agreed 2026-08-17. Area 5's detail pane can currently show exactly two
+things: the live widget of the action running right now, and the error block of
+the cell's most recent failure. Everything else an action produces is discarded.
+This builds the pane out: every action may hand back a retained, GUI-free
+description of what it found, the timeline becomes the navigator for those
+records, and `patch`/`reseal` gain a real electrophysiology log of their own.
+
+## 1. What this builds, and what it does not
+
+Four things:
+
+- **A second engine seam.** `ActionLogEntry.set_details(kind, payload)` beside
+  the existing `set_details_widget(widget)`. The widget is for what is live; the
+  payload is what survives.
+- **Retention and navigation in `CellPanel`.** Payloads keyed by cell and
+  timeline row, mounted when the operator selects that row, with a follow-live
+  rule for the running action.
+- **`MultiPatchLogRecorder`** — the MultiPatch module's event-log writing,
+  extracted so Autopatch can record too, with MultiPatch refactored onto it.
+- **Details for the actions that have something to say**: `patch`/`reseal` (a
+  steady-state resistance plot, live and frozen, plus the FSM's state
+  transitions), `cellfie` (the cell's stack), `run_task` (the sequence's
+  traces), and one-line records for `prompt`, `new_data_dir`, and
+  `find_surface`.
+
+And one thing the pane gains that costs almost nothing: **the status line**.
+`set_status()` is write-only today — `CellPanel._onActionEntry` deliberately
+ignores the `"status"` phase, so `"driving FSM from 'approach'"` →
+`"now in 'seal'"` → `"reached 'whole cell'"` appears nowhere in the UI at all.
+It becomes a header label above the mounted widget. The timeline rows are
+unchanged: still `⏳ running` then the outcome, per design doc §7.
+
+**Not** built:
+
+- **Reloading a saved record into the pane.** Disk is for post-hoc analysis
+  (`tools/autopatch_analysis`), not for repopulating Area 5. A record the
+  current session did not produce is not viewable in Area 5, and a restarted
+  session starts empty. This was on the table and was declined.
+- **Loading a named protocol file into the TaskRunner.** `run_task` keeps its
+  contract — the operator loads the sequence into an open TaskRunner module —
+  and the `device.py` TODO about that stays open. This pass gives it a results
+  view and nothing else.
+- **Any MultiPatch UI reflecting Autopatch's recording.** See §5.
+- **Live imagery during `cellfie`.** See §8.
+
+## 2. The engine seam — `set_details`
+
+`ActionLogEntry` (`acq4/experiment/log_entry.py`) grows, mirroring the existing
+`set_details_widget`/`on_widget` pair exactly:
+
+```python
+self.details_kind: str | None = None
+self.details_payload: Any = None
+self.on_details: Callable | None = None
+
+def set_details(self, kind: str, payload) -> None:
+    self.details_kind = kind
+    self.details_payload = payload
+    if self.on_details is not None:
+        self.on_details(self, kind, payload)
+```
+
+**The payload contract is GUI-free plain data**: numpy arrays, strings, numbers,
+and dicts/lists of those. No `Qt` objects, no `Cell`, no exception objects, no
+file handles, no `PatchClampTestPulse`. `CellPanel` retains these for the
+session, so what a payload holds is what one action costs in memory for the rest
+of the run — the same reasoning that makes
+`error_record.describe_exception` reduce an exception to three strings before
+`CellPanel` stores it, and the same reference-cycle hazard
+`tests/test_teardown.py` exists to guard.
+
+`set_details_widget` keeps its §4.5 contract completely unchanged, including
+"the connection must be disconnected when the entry's action ends".
+
+**Ordering invariant.** `set_details` must be called before the entry finishes.
+`CellPanel` resolves an entry to its timeline row through `_entryTimelineLoc`,
+which `_finishTimelineRow` pops — so a payload arriving after `_finish` has no
+row to attach to. Actions satisfy this by calling `set_details` from a
+`try/finally` **inside** the `with ctx.log_action(...)` block, which runs before
+the context manager's `__exit__`. Both phases are emitted from the same worker
+thread to the same receiver, so Qt's queued delivery preserves their order.
+This is stated in the method's docstring and pinned by a test.
+
+## 3. Retention and navigation in `CellPanel`
+
+**Retention.** A new store:
+
+```python
+# (id(cell), timeline row index) -> (kind, payload)
+self._details: dict[tuple[int, int], tuple[str, Any]] = {}
+```
+
+Keyed by row rather than by entry, deliberately: the row key is what outlives
+the entry, which is the entire point, and it is already the key `_timelines`
+uses. It never holds an entry, a cell, or a widget, for the reasons in §2.
+Cleared by `clearCells()` and `_onCellsDiscarded()` alongside `_timelines` and
+`_logs`, and by `_onReuseCheckedCells()` for a re-queued cell, whose earlier
+pass's UI history is not retained (design doc §7).
+
+`onLogAction` assigns one more callback beside the three it already assigns:
+
+```python
+entry.on_details = lambda e, kind, payload: self.sigActionEntry.emit(cell, e, "details")
+```
+
+The payload is read off the entry in the slot rather than carried through the
+signal, matching how the `"widget"` phase already reads `entry.details_widget` —
+`sigActionEntry`'s signature does not change.
+
+**Navigation.** `timelineList` gains a `currentItemChanged` handler. Selecting a
+row mounts, in order of preference: the live details widget if that row's action
+is still running; else that row's retained payload rendered per §4; else nothing.
+The status line above it shows that row's status text — live for a running
+action, last-known for a finished one.
+
+**A failed action's error becomes a payload.** The `finished` phase already
+reads `exc_type`/`exc_message`/`traceback_text` off the entry; it now also
+records them as `_details[(cellId, index)] = ("error", {...})`, so the row
+renders through the same registry as everything else and `ErrorBlock` becomes
+one more builder. `self._cellErrors` and the public `errorText(cell)` are
+**unchanged** — they answer "which cell failed", which is a different question
+from "what did this row do", and `tests/test_teardown.py` asserts against
+`errorText`. An action that fails *and* set a payload keeps the payload: the
+data it gathered before failing is more informative than the traceback, which
+the log and the row's outcome glyph both still carry.
+
+Two rules preserve what already shipped:
+
+- **Selecting a cell auto-selects a row** rather than leaving the pane blank:
+  the running action if there is one, else the most recent failed action, else
+  the last row. So "select a failed cell, see its traceback" keeps working —
+  `_showErrorBlock`'s cell-level mount becomes an ordinary row rendering reached
+  by that auto-selection.
+- **Following live** uses the auto-scroll rule. While the selected row is the
+  last row, a newly started action moves the selection to it. The moment the
+  operator selects an earlier row, following stops — until they select the last
+  row again, which resumes it. This is what design doc §7's "selecting the
+  current cell follows it live" means once rows are individually selectable.
+
+`_shownEntryId` keeps its existing job unchanged: it is what lets an inner
+entry's `"finished"` phase avoid tearing down an outer entry's still-live widget
+(`prompt()` opening inside `cellfie`'s still-open entry). Nesting needs nothing
+new from the payload store — each entry has its own row.
+
+## 4. `details_renderers.py`
+
+New module `acq4/modules/Autopatch/details_renderers.py`: a `kind` → builder
+registry, so every `Qt` widget type the pane can mount lives in one focused
+place instead of adding four more to `cell_panel.py` (already 868 lines).
+Builders are plain functions taking a payload and returning a widget. They never
+see a `Cell`, an entry, or the panel.
+
+| kind | payload | rendered as |
+| --- | --- | --- |
+| `"test_pulse_history"` | `history` (a `TEST_PULSE_NUMPY_DTYPE` array), `transitions` (list of `(time, state)`), `entry_state`, `reached`, `log_file` | MultiPatch's `PlotWidget` with its mode combo visible, beside a transition list |
+| `"image_stack"` | `stack` (3D array), `center_index`, `title` | `pg.ImageView`, opened at `center_index` |
+| `"task_results"` | `traces` (list of `(t, y)` arrays), `sequence_dir`, `sweep_count`, `decimation`, `units` | `pg.PlotWidget`, one curve per sweep |
+| `"text"` | `lines` (list of strings) | read-only text |
+| `"error"` | `exc_type`, `exc_message`, `traceback_text`, `cell_repr` | the existing `ErrorBlock` |
+
+An unregistered kind renders as its `repr` in the `"text"` renderer rather than
+raising: a payload is data crossing a thread boundary from protocol code, and a
+protocol author's typo must not take down the pane.
+
+**The frozen Rss plot reuses MultiPatch's `PlotWidget`,** per design doc §4.5's
+"reuse, do not reimplement". Its `newTestPulse(tp, history)` currently requires
+a `tp` for the current-value label; it gains tolerance for `tp=None`, which
+suppresses that label and plots the history alone. That is the whole change to
+it, and it buys the field dropdown: because the payload retains the entire
+structured array, the frozen plot can switch between `ss resistance`,
+`peak resistance`, `holding current`, `holding potential`, `time constant`, and
+`capacitance` with no extra data.
+
+**The mode combo is hidden live and shown frozen.** The live plot calls
+`hideHeader()` — Autopatch picks the mode, and design doc §4.5 says the operator
+does not need the combo while an action is driving. The frozen plot leaves it
+visible, since re-reading a finished attempt through a different field is
+precisely what it is for. The `'test pulse'` and `'tp analysis'` modes are
+removed from the frozen combo: both need an actual `PatchClampTestPulse`, which
+§2's payload contract excludes.
+
+## 5. `MultiPatchLogRecorder`
+
+New module `acq4/util/multipatch_log_recorder.py`.
+
+**Not an attribute of `PatchPipette`.** A recorder owns a file handle and a
+directory lifetime; a device outlives both. More decisively, one attribute means
+one recorder per pipette — which is exactly the collision to avoid, since
+Autopatch and MultiPatch must be able to record the same pipette independently.
+**Not in `acq4/filetypes/`** either: that package registers `FileType` *readers*
+for DataManager, and its `MultiPatchLog.py` is already over 1100 lines.
+
+```python
+recorder = MultiPatchLogRecorder(
+    directory,                      # DirHandle to write into
+    pipettes=(pip,),                # one or more PatchPipettes to observe
+    microscope=None,                # optional; records surface_depth_changed
+    record_full_test_pulses=True,   # Autopatch's default
+    initial_records=(),             # replayed into the fresh file
+)
+recorder.record(event)              # module-level records (e.g. patch profiles)
+recorder.testPulseAnalysis()        # structured array of what this recorder saw
+recorder.stop()
+```
+
+Carried over from `MultiPatchWindow` unchanged, because the log viewer and
+`tools/autopatch_analysis` both have to keep reading the result:
+
+- One `MultiPatch_NNN.log` per recorder, via
+  `directory.createFile('MultiPatch.log', autoIncrement=True)`, opened `'ab'`.
+- One JSON record per line through `ACQ4JSONEncoder`, flushed per batch.
+- `full_test_pulse` diverted into a `TestPulses_NNN.hdf5` at group
+  `test_pulses/{device}`, with the event's field rewritten to
+  `"<relpath>:<h5path>"` relative to the log file's directory — the form
+  `MultiPatchLogData.process` resolves with `loc.split(":")[0]` and
+  `os.path.join(os.path.dirname(filename), ...)`.
+- The patch-profile snapshot (`buildPatchProfilesParameters().getValues()`)
+  written at start. For a per-action Autopatch recorder this records the profile
+  in force for that attempt, which is worth having.
+
+**Deliberately left in `MultiPatchWindow`:** `eventHistory`, the Reset button,
+and `resetHistory()`. That last one is the important one — it calls
+`clampDevice.resetTestPulseHistory()`, and a recorder that did the same would
+let Autopatch starting a recorder wipe the history MultiPatch is plotting. **The
+recorder owns a file and an HDF5 stack; it never touches device state.**
+MultiPatch's `writeRecords(self.eventHistory)` on record-start is preserved
+through `initial_records`.
+
+**MultiPatch is refactored onto it**: `recordToggled` constructs a single
+recorder over all its pipettes, its microscope, and its profile records —
+its current single-file behavior — and `stop()`s it when toggled off.
+`recordTestPulsesToggled` becomes that recorder's `record_full_test_pulses`
+option. One implementation means "identical behavior, so the viewer still
+renders it" holds by construction rather than by inspection.
+
+**MultiPatch's UI shows nothing about other recorders.** No registry, no
+indicator, no discovery seam. Its buttons control its own recorder and nothing
+else, and are entirely orthogonal to Autopatch. Two parallel logs over one
+pipette is an accepted outcome, not a problem to solve.
+
+## 6. `PatchPipette.requestFullTestPulseData`
+
+`emitFullTestPulseData(emit: bool)` sets a bare boolean `_emitTestPulseData`.
+With two independent recorders, whichever stops last wins: Autopatch stopping
+its recorder would silence MultiPatch's full-test-pulse capture, and vice versa.
+
+It has exactly one caller (`multipatch.py:632`), so the boolean setter is
+replaced outright rather than wrapped:
+
+```python
+def requestFullTestPulseData(self, token) -> None:
+    self._fullTestPulseSubscribers.add(token)
+
+def releaseFullTestPulseData(self, token) -> None:
+    self._fullTestPulseSubscribers.discard(token)
+```
+
+with `_testPulseFinished` testing `bool(self._fullTestPulseSubscribers)`. Each
+recorder holds its own token, so neither can silence the other. The subscriber
+set holds tokens, not recorders, so it never keeps a recorder alive; a recorder
+releases its token in `stop()`.
+
+## 7. The log format — dropping the trailing comma
+
+`writeRecords` writes `json.dumps(rec) + b",\n"`, producing not-quite-JSONL with
+a trailing comma on every line. The recorder writes clean JSONL instead.
+
+**This breaks neither reader, verified.** Both use
+`line.rstrip(b",\r\n")` — `MultiPatchLog.py:232` and
+`autopatch_log.py:76` — which is a *character-set* strip, not a suffix strip, so
+it already yields the same bytes for `{...},\n`, `{...},\r\n`, `{...}\n`, and
+`{...}`. Existing logs with commas keep parsing, new logs without them parse
+identically, and no reader change is required. A test pins both forms so the
+tolerance is guaranteed rather than incidental.
+
+One unrelated repair while in the area: `MultiPatchLog.py:232` has no blank-line
+guard, where `autopatch_log.py:77` does. It is latent rather than triggered
+today — a file ending in a newline yields no trailing empty line when iterated —
+but the two readers should agree, so the guard is added.
+
+## 8. Per-action behavior
+
+**`patch(ctx, record_events=True, record_full_test_pulses=True, **entry_config)`
+and `reseal(...)`.** `_drive_fsm` gains a `record` parameter; `clean` passes
+`False` and is otherwise untouched — there is nothing an operator reads off a
+clean (design doc §4.5), and it needs no log of its own. The new named
+parameters are consumed by `_drive_fsm` and never reach `pip.setState`, so
+`entry_config` keeps working as it does. A protocol may pass them through to its
+own author-facing options.
+
+On entry, through `run_in_gui_thread`: construct the recorder in
+`ctx.manager.getCurrentDir()`; construct `PlotWidget(mode='ss resistance')`,
+call `hideHeader()` (Autopatch picks the mode), wire
+`clampDevice.sigTestPulseFinished` to `newTestPulse` with a **default (queued)**
+connection — `PatchPipetteState` uses an explicit `DirectConnection` on that
+same signal, which is right for a state machine and wrong for a widget — and
+`set_details_widget(widget)`.
+
+During: the poll loop's existing `state != last_state` branch also appends
+`(time, state)` to a local list. No new polling.
+
+On exit, in a `try/finally` inside the `with` block so it runs before `_finish`
+(§2) and on every path including `Stopped` and `AdvanceToNextCell`: disconnect
+the plot from the device, `recorder.stop()`, and
+`set_details("test_pulse_history", ...)`. Because it is a `finally`, a failed,
+stopped, or abandoned patch gets its plot and its transition list too — which is
+when an operator most wants them.
+
+**The payload's history comes from the recorder, not from
+`clampDevice.testPulseHistory()`.** Slicing the device's history by the action's
+time window looks simpler and is wrong: `approach.py:251` calls
+`resetTestPulseHistory()` inside the approach state, and `patch()` enters at
+approach, so the device's history is truncated mid-span on every attempt.
+`PatchPipette` line 237 resets it as well. The recorder accumulates the
+`test_pulse` events it observes and is immune to both.
+
+**`cellfie(ctx, ...)`.** No live widget. The cropped object stack does not exist
+until `initializeTracker` returns, and the status line ("focusing on target for
+cellfie" → "saving cellfie z-stack") reports progress honestly in the meantime.
+After the tracker initializes:
+
+```python
+action_entry.set_details("image_stack", {
+    "stack": np.swapaxes(np.asarray(stack), -2, -1),
+    "center_index": stack.shape[0] // 2 if stack.ndim >= 3 and stack.shape[0] > 1 else None,
+    "title": "Cellfie",
+})
+```
+
+The stack is the tracker's `motion_estimator.original_object_stack.data` — the
+cube around the cell, exactly what `AutomationDebug._cellInitialStack` shows,
+including its axis swap so orientation matches the Camera module. It is already
+in memory on the `Cell`, so retaining a reference to the array costs the pane
+nothing, and the full acquired z-stack stays on disk in `cellfie/` where
+`run_image_sequence` already put it.
+
+**Accepted gap:** a cellfie whose tracker init raises `CellTrackingLost` calls
+`ctx.tissue_moved`, which never returns, so no payload is set. That row shows
+its status line and an `abandoned` outcome with no stack. The full frames are
+still on disk; reading them back is the reloading feature §1 declines.
+
+**`run_task(ctx, ...)`.** Live: a `pg.PlotWidget` fed from
+`taskrunner.sigNewFrame` (queued), plotting `frame['result'][clampName]['primary']`
+against `result.xvals('Time')` — the accessor `MultiClamp/taskGUI.py:336` uses —
+coloured over sequence index. On exit, `set_details("task_results", ...)`.
+
+**Retention is capped, and the cap is logged.** A 20-sweep sequence at 100k
+samples per sweep is 16 MB per cell, so retained traces are decimated to ~4000
+points each — more than a plot's pixel width — with the decimation factor
+recorded in the payload and reported through `ctx.log()`. The undecimated data
+is in the saved `ProtocolSequence` directory, whose name the payload also
+carries.
+
+**`prompt`, `new_data_dir`, `find_surface`.** `set_details("text", {"lines": [...]})`
+with, respectively: the message and the label the operator clicked (available as
+`prompt_user`'s return, so the call moves into a local before the `with` block
+ends); the created directory's name; and the detected depth via `pg.siFormat`.
+
+## 9. Threading and lifetime
+
+Every rule here already exists in this module; nothing new is introduced.
+
+- **Payloads cross threads as data.** Actions run on the orchestrator's worker
+  thread. `set_details` emits `sigActionEntry`, and Qt's automatic queued
+  connection marshals it onto the GUI thread — the same discipline
+  `appendLog`, `onLogAction`, and `discardCells` already follow.
+- **Widgets are built on the GUI thread**, via `run_in_gui_thread`, per
+  `set_details_widget`'s docstring. That covers the recorder too: it is a
+  `QObject` whose `sigNewEvent` connections must be queued from device and
+  state-machine threads, which requires it to live on the GUI thread — the same
+  affinity MultiPatch's window already gives it.
+- **No widget outlives its action.** The `finished` phase drops the live widget
+  exactly as it does today; only data is retained. `test_teardown.py`'s
+  invariants hold as written, and no payload can form a panel↔entry cycle
+  because a payload holds neither.
+- **The recorder is always stopped**, from the same `finally` that sets the
+  payload, so no file handle or `full_test_pulse` subscription outlives the
+  action that opened it.
+
+## 10. Testing
+
+Headless, in the existing suites:
+
+- `ActionLogEntry.set_details` — callback firing, and the ordering invariant
+  that a payload set after `_finish` is not attributable to a row (§2).
+- `CellPanel` — payload keying by `(cell, row)`; clearing across `clearCells`,
+  `discardCells`, and reuse; row selection mounting the right thing in the right
+  order of preference; the auto-selected row on cell selection for running,
+  failed, and finished cells; the follow-live rule, including that it stops when
+  an earlier row is selected and resumes at the last row; a failed action's error
+  recorded as an `"error"` payload while `errorText(cell)` keeps its existing
+  answer; and an action that both fails and set a payload keeping the payload.
+- `details_renderers` — each builder against a synthetic payload under the
+  `qapp` fixture, plus the unregistered-kind fallback.
+- `PatchPipette` — `requestFullTestPulseData` refcounting: two tokens, one
+  released, data still flowing.
+- `MultiPatchLogRecorder` — a **golden-output test**: drive a fake pipette
+  through a fixed event sequence and assert the recorder's bytes match a
+  reference implementation of the current `writeRecords` held in the test. This
+  is the actual safety net for "identical behavior", because MultiPatch's only
+  existing test file (`tests/test_logfile.py`) covers `IrregularTimeSeries` and
+  nothing in the logging path at all.
+- Round-trips through both readers — `MultiPatchLogData` and
+  `tools/autopatch_analysis`'s parser — for a recorder-written file, and an
+  explicit test that comma-free and legacy comma-terminated lines parse
+  identically (§7).
+- `PlotWidget.newTestPulse(None, history)` plots without raising and suppresses
+  the label.
+
+Live-only, per `actions/device.py`'s module docstring convention: the real
+device wiring in `patch`, `reseal`, and `run_task`, which drive hardware and are
+exercised by live testing rather than the headless suite.
+
+## 11. Phasing
+
+This spec covers more ground than one landable change, and the two halves are
+separable — the recorder is only reached by `patch`/`reseal`'s payload, and
+nothing else in the pane depends on it. The implementation plan runs in three
+phases, each of which leaves the tree working and testable:
+
+1. **The pane** (§2, §3, §4 minus the test-pulse renderer, §8's `cellfie`,
+   `run_task`, `prompt`, `new_data_dir`, `find_surface`, and the status line).
+   Delivers navigable per-row details, the cellfie stack, and the task-runner
+   results — visible value with no changes outside `acq4/experiment` and
+   `acq4/modules/Autopatch`.
+2. **The recorder** (§5, §6, §7, and MultiPatch's refactor onto it). Touches
+   `PatchPipette`, `MultiPatch`, and the log format; lands behind the
+   golden-output test before anything depends on it.
+3. **The FSM details** (§8's `patch`/`reseal`, and §4's test-pulse renderer),
+   which joins the two.
+
+Phase 2 is the one carrying regression risk to code outside this feature, which
+is why it lands on its own rather than folded into phase 3.
+
+## 12. Open, and deliberately deferred
+
+- **Recording spans only FSM actions.** With one recorder per `patch`/`reseal`
+  call, `cellfie` and `run_task` fall outside any recording window. The recorder
+  is a reusable object with options, so extending it to those actions is a
+  configuration change rather than new mechanism, but it is not this pass.
+- **`clean` records nothing** — no recorder, no details widget.
+- **Loading a named protocol file into the TaskRunner** — `device.py:196`'s TODO
+  stays open.
+- **Reloading saved records into Area 5**, and with it viewing a past session's
+  cells. Declined in §1.
+- **Merging `PipetteEventLog` and system-log lines into the pane** remains P3
+  (design doc §8), untouched by this.
+- **The `'test pulse'` and `'tp analysis'` plot modes on frozen plots**, which
+  would require retaining `PatchClampTestPulse` recordings and so are out under
+  §2's payload contract.

--- a/tools/autopatch_analysis/tests/test_autopatch_log.py
+++ b/tools/autopatch_analysis/tests/test_autopatch_log.py
@@ -12,11 +12,13 @@ import pytest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import autopatch_log as al  # noqa: E402
+from autopatch_log import parse_log_events  # noqa: E402
 
 
-def _write(tmp_path, lines, name="MultiPatch_000.log"):
+def _write(tmp_path, lines, name="MultiPatch_000.log", terminator=",\n"):
     p = tmp_path / name
-    p.write_text("".join(line + ",\n" for line in lines))
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("".join(line + terminator for line in lines))
     return str(p)
 
 
@@ -302,3 +304,15 @@ def test_load_run_tags_source(tmp_path):
     attempts = al.load_run([str(tmp_path)])
     assert len(attempts) == 1
     assert attempts[0].source == path
+
+
+def test_comma_free_and_legacy_lines_parse_identically(tmp_path):
+    """The writer emits clean JSONL; historical files end every line with a
+    comma. rstrip(b",\\r\\n") is a character-set strip, not a suffix strip, so
+    both forms must yield the same records -- pinned here rather than left to
+    luck."""
+    events = [_state(0.0, "bath", "out"), _state(5.0, "out", "bath")]
+    legacy = _write(tmp_path / "legacy", events)
+    modern = _write(tmp_path / "modern", events, terminator="\n")
+
+    assert parse_log_events(str(legacy)) == parse_log_events(str(modern))


### PR DESCRIPTION
Fills in Area 5's detail pane. Before this, the pane could show exactly two things: the live widget of the action running right now, and the error block of the cell's most recent failure. Everything else an action produced was discarded, and `set_status()` was write-only — every FSM state-transition message appeared nowhere in the UI at all.

Spec: `docs/superpowers/specs/2026-08-17-autopatch-area5-details-widgets-design.md`

## What this builds

**A second engine seam.** `ActionLogEntry.set_details(kind, payload)` beside the existing `set_details_widget(widget)`. The widget is for what is live; the payload is GUI-free plain data that outlives the action. `CellPanel` retains payloads keyed by `(id(cell), timeline row index)`, and a `kind` → builder registry in the new `details_renderers.py` turns one into a widget on demand.

**Timeline rows became the pane's navigator.** Selecting a row mounts its live widget if its action is still in flight, else its retained payload. Selecting a cell auto-selects the row worth looking at — the running action, else the most recent failure, else the last — which is also what keeps "select a failed cell, see the traceback" working now that the pane is row-driven. New rows take the selection only while the last row is already selected, so reading back through an earlier action is not yanked away by the next one.

**`MultiPatchLogRecorder`** (`acq4/util/multipatch_log_recorder.py`) — MultiPatch's event-log writing, extracted so Autopatch can record too, with `MultiPatchWindow` refactored onto it. One implementation of the format rather than two, so "the viewer still renders it" holds by construction. `PatchPipette.emitFullTestPulseData`'s boolean became a subscriber set, so two independent recorders can observe one pipette without either silencing the other.

**Details for the actions that have something to say.** `patch`/`reseal` get a steady-state resistance plot — live while the FSM drives, frozen and re-readable afterwards — plus the pipette states they walked and an event log of their own on disk. `cellfie` retains the cell's stack, opened at the plane the cell sits on. `run_task` retains its sweeps. `prompt`, `new_data_dir`, and `find_surface` each retain the one fact they produce. And the status line surfaces `set_status()` for the first time.

`clean` records nothing — there is nothing an operator reads off a clean.

## Deliberately not built

Reloading a saved record into Area 5 (disk is for post-hoc analysis), loading a named protocol file into the TaskRunner (`device.py`'s TODO stays open), any MultiPatch UI reflecting Autopatch's recording, and live imagery during `cellfie`.

## Notable decisions

- **The frozen plot's history comes from the recorder, not `clampDevice.testPulseHistory()`.** `approach.py:251` resets the device's history inside the approach state and `patch` enters at approach, so slicing the device's history by the action's time window silently loses data. The live plot deliberately *does* read the device's history — a live view of "now" should. Both sites carry comments so neither gets "fixed" into the other.
- **Full-test-pulse capture is scoped to selected pipettes**, matching pre-existing behavior, with the known consequence that the scope is fixed when recording starts.
- **The recorder writes clean JSONL**, dropping the historical trailing comma. Both readers strip `b",\r\n"` as a character set rather than a suffix, so they already parse either form — now pinned by test rather than left to luck.
- **`TaskRunner` gains `lastSequenceDir`** (two lines). `runSequence` created its storage directory as a local and exposed it nowhere, so the `run_task` payload had no truthful way to name where the data went.

## Testing

1323 passing across `acq4/experiment`, `acq4/modules/Autopatch`, `acq4/modules/MultiPatch`, `acq4/util`, `acq4/devices/PatchPipette`, `acq4/filetypes`, and `tools/autopatch_analysis`. Output pristine.

The refactor's safety net is a **golden-output test**: a reference copy of the deleted `writeRecords` lives in the test file and the recorder's bytes are asserted against it, differing only by the dropped comma. It is deliberately duplicated rather than imported — its job is to keep saying what the deleted code said. It passed on the first run, and both readers round-trip a recorder-written file.

### What the headless suite cannot reach

Device wiring in `patch`, `reseal`, and `run_task` is exercised by live testing, per `actions/device.py`'s own convention. Before this is trusted on a rig:

1. A `patch()` attempt's live Rss plot updating in Area 5, combo hidden.
2. That row reselected after it finishes: frozen plot with real data, combo visible and switchable through all six fields, transition list matching what MultiPatch showed.
3. The written `MultiPatch_NNN.log` containing `test_pulse` lines (not just `state_change`), with `TestPulses_NNN.hdf5` beside it, opening in the MultiPatch log viewer and parsing with `tools/autopatch_analysis`.
4. MultiPatch still capturing full test pulses *after* an Autopatch attempt finishes — the token refcount's whole purpose — with two independent logs written.
5. The four MultiPatch button combinations in one session: exactly one log and one sidecar however the buttons are worked, and Reset still clearing the plotted clamp history.
6. `run_task` on a real multi-sweep sequence: true sweep count, the actual `ProtocolSequence` directory named, `V` units in current clamp and `A` in voltage clamp, decimation reported through `ctx.log`.
7. `cellfie`'s stack opening on the cell's plane, in the Camera module's orientation.
8. Stop and next-cell mid-patch: both leave a plot, a transition list, and a closed log, with no leaked file handles across several attempts.
9. Module close immediately after an attempt — the path `test_teardown.py` guards, now with payloads retained.

## Review history

Each task had its own spec-and-quality review, and the whole branch had a final pass. That final pass caught a Critical the task-scoped reviews structurally could not see: **all three device-signal subscriptions were made from the orchestrator's worker thread**, a plain `threading.Thread` with no Qt event loop, so their queued connections targeted a thread that never pumps and the slots never fired. On hardware that meant a permanently blank frozen plot, a live plot that never updated, and `run_task` always reporting zero sweeps — while the log looked partially populated, so it would have read as a data problem rather than a wiring one. `acq4/util/task.py:118-136` documents this exact failure mode and its `moveToThread` fix; each site now has a genuinely cross-thread test proven to fail without it.

Also fixed before merge: a frozen mode combo that relabelled the axis without re-plotting (showing a resistance curve under a Capacitance axis — wrong data to an operator judging a patch); an HDF5 shared-file double-close that leaked the log handle with two or more devices; three unguarded statements in `_drive_fsm`'s `finally` that could leak a handle or mask an operator Stop; a `setFrozen` crash reachable from `pipetteControl`'s own default mode; and a test that was defined twice and therefore never ran.

🧙 Built with [WOZCODE](https://wozcode.com)
