### PR TITLE
feat(autopatch): an operator-controlled window layout, saved between sessions

### DIFF
--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -11,6 +11,7 @@ from acq4.experiment.orchestrator import Orchestrator
 from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
 from acq4.experiment.slice import RegionTooLarge, Slice
 from acq4.experiment.tile_detector import make_tile_detector
+from acq4.logging_config import get_logger
 from acq4.modules.Module import Module
 from acq4.util import Qt
 from acq4.util.HelpfulException import HelpfulException
@@ -28,13 +29,56 @@ from .region_panel import RegionPanel
 from .search_panel import SearchPanel
 from .status_panel import StatusPanel
 
+logger = get_logger(__name__)
+
+
+class _AreaViewport(Qt.QScrollArea):
+    """The scrolling viewport one of the window's areas holds its content in:
+    it asks for whatever its content asks for, and insists on nothing.
+
+    Both hints are reported from the content rather than left to
+    QAbstractScrollArea's own answers, which are wrong here in opposite
+    directions.
+
+    The minimum is a floor of roughly 68 pixels square -- Qt's guess at the
+    smallest viewport still worth scrolling -- and inside a QSplitter that guess
+    is what an operator's drag stops against. Insisting on nothing instead is
+    what makes the split theirs: an area can be squeezed down to its title, and
+    its content scrolls in whatever is left.
+
+    The preferred size is computed from the widget the scroll area was handed
+    and then cached until the next setWidget(), and this window hands its
+    viewports over empty and fills them afterwards -- so that cache is the empty
+    hint, forever. Left to it, every area opens at its title bar and the whole
+    window a couple of hundred pixels across, every panel scrolled before the
+    operator has touched a handle. Reading the content's current hint is also
+    the more honest answer as the session goes on: Area 5 mounts a details
+    widget per action, so what its content wants genuinely changes.
+    """
+
+    def minimumSizeHint(self):
+        return Qt.QSize(0, 0)
+
+    def sizeHint(self):
+        # No frame is drawn (see AutopatchWindow._makeArea -- the group box
+        # already borders exactly this rectangle), so the content's own hint is
+        # the whole of it.
+        content = self.widget()
+        return super().sizeHint() if content is None else content.sizeHint()
+
 
 class AutopatchWindow(Qt.QWidget):
     """The Autopatch run window: five labeled areas per the design doc.
 
     Area 1 starts a slice, Area 2 configures the cell search over it, and
     Areas 3/4/5 hold the status/protocol/cell-queue content wired to a live
-    Orchestrator.
+    Orchestrator. The numbers are how this module and that doc refer to them
+    among themselves; the titles the operator reads name their content.
+
+    How the window is divided between them is the operator's, not this
+    constructor's: every boundary is a splitter handle, each area's content fits
+    whatever size it is dragged to (see _makeArea and _AreaViewport), and the
+    division is kept between sessions (see _saveLayout).
     """
 
     def __init__(
@@ -48,36 +92,67 @@ class AutopatchWindow(Qt.QWidget):
         self.module = module
         self.manager = module.manager if module is not None else None
         self.setWindowTitle("Autopatch")
+        # Where this window's layout is kept between sessions, named for the
+        # module so that two Autopatch modules on one rig keep their own -- the
+        # same file name and the same place as every other module's window
+        # state (see CameraWindow, and the Manager and Console modules). None
+        # for a manager-less window: there is no config directory to write into,
+        # and module=None is a mode this window supports by design.
+        self._stateFile = (
+            None if module is None else os.path.join("modules", f"{module.name}_ui.cfg")
+        )
 
-        self.area1Box = Qt.QGroupBox("Area 1 — Slice && region")
-        self.area2Box = Qt.QGroupBox("Area 2 — Cell finding")
-        self.area3Box = Qt.QGroupBox("Area 3 — Status && actions")
-        self.area4Box = Qt.QGroupBox("Area 4 — Protocol && params")
-        self.area5Box = Qt.QGroupBox("Area 5 — Current cell")
+        # Every area's scrolling viewport, in creation order, for the one pass
+        # over them _settleAreaSizes() makes once their content is in.
+        self._areaViewports: list[_AreaViewport] = []
+        # Titles name what is in the box, not which area of the design doc it
+        # is: "Area 3" is how this module's code and that doc refer to the
+        # status/actions box among themselves, and tells an operator nothing.
+        self.area1Box, self.area1Layout = self._makeArea("Slice && region")
+        self.area2Box, self.area2Layout = self._makeArea("Cell finding")
+        self.area3Box, self.area3Layout = self._makeArea("Status && actions")
+        self.area4Box, self.area4Layout = self._makeArea("Protocol && params")
+        self.area5Box, self.area5Layout = self._makeArea("Current cell")
 
-        for box in (self.area1Box, self.area2Box, self.area3Box, self.area4Box, self.area5Box):
-            box.setLayout(Qt.QVBoxLayout())
-
-        # A splitter, not a fixed box layout: Area 1 is a view of a whole slice,
-        # and drawing a region in a strip the operator cannot enlarge is an
-        # exercise in patience.
-        leftCol = Qt.QSplitter(Qt.Qt.Vertical)
-        leftCol.addWidget(self.area1Box)
-        leftCol.addWidget(self.area2Box)
+        # Splitters all the way down, so every boundary in this window is a
+        # handle the operator can drag: the one between the two columns, and the
+        # ones between the areas stacked inside each. Which area deserves the
+        # room depends on what is being done at the time -- drawing a region
+        # over a whole slice, then watching one cell's timeline -- and that is
+        # not a judgement this constructor can make for the whole session. The
+        # stretch factors below decide only which area grows as the *window*
+        # does; where the handles start is _seedOpeningSplit's, where they end up
+        # is the operator's, and a QSplitter holds explicit sizes once dragged.
+        self.leftColumn = Qt.QSplitter(Qt.Qt.Vertical)
+        self.leftColumn.addWidget(self.area1Box)
+        self.leftColumn.addWidget(self.area2Box)
         # Area 1 is the view; Area 2 is four spin boxes and a readout.
-        leftCol.setStretchFactor(0, 3)
-        leftCol.setStretchFactor(1, 1)
+        self.leftColumn.setStretchFactor(0, 3)
+        self.leftColumn.setStretchFactor(1, 1)
 
-        rightCol = Qt.QVBoxLayout()
-        rightCol.addWidget(self.area3Box)
-        rightCol.addWidget(self.area4Box)
-        rightCol.addWidget(self.area5Box)
-        rightColWidget = Qt.QWidget()
-        rightColWidget.setLayout(rightCol)
+        self.rightColumn = Qt.QSplitter(Qt.Qt.Vertical)
+        self.rightColumn.addWidget(self.area3Box)
+        self.rightColumn.addWidget(self.area4Box)
+        self.rightColumn.addWidget(self.area5Box)
+        # Areas 3 and 4 are rows of controls; Area 5 grows a timeline, a log and
+        # a details widget as a cell runs, so the slack starts there.
+        self.rightColumn.setStretchFactor(2, 1)
+
+        self.columnSplitter = Qt.QSplitter(Qt.Qt.Horizontal)
+        self.columnSplitter.addWidget(self.leftColumn)
+        self.columnSplitter.addWidget(self.rightColumn)
+        self.columnSplitter.setStretchFactor(0, 2)
+        self.columnSplitter.setStretchFactor(1, 1)
+
+        for splitter in (self.leftColumn, self.rightColumn, self.columnSplitter):
+            # A little wider than the style's default, because these handles are
+            # the whole point of the layout and the default is a few pixels of
+            # gap between two group box frames -- easy to miss and easy to miss
+            # with the mouse.
+            splitter.setHandleWidth(8)
 
         outer = Qt.QHBoxLayout()
-        outer.addWidget(leftCol, 2)
-        outer.addWidget(rightColWidget, 1)
+        outer.addWidget(self.columnSplitter)
         self.setLayout(outer)
 
         if protocolDir is None:
@@ -92,7 +167,7 @@ class AutopatchWindow(Qt.QWidget):
         # picker below lists its contents.
         install_example_protocols(protocolDir)
         self.protocolPanel = ProtocolPanel(protocolDir=protocolDir)
-        self.area4Box.layout().addWidget(self.protocolPanel)
+        self.area4Layout.addWidget(self.protocolPanel)
 
         self.pipetteSelector = (
             pipetteSelector
@@ -102,11 +177,11 @@ class AutopatchWindow(Qt.QWidget):
         self.cameraSelector = (
             cameraSelector if cameraSelector is not None else InterfaceCombo(types=["camera"])
         )
-        self.area4Box.layout().addWidget(self.pipetteSelector)
-        self.area4Box.layout().addWidget(self.cameraSelector)
+        self.area4Layout.addWidget(self.pipetteSelector)
+        self.area4Layout.addWidget(self.cameraSelector)
 
         self.statusPanel = StatusPanel()
-        self.area3Box.layout().addWidget(self.statusPanel)
+        self.area3Layout.addWidget(self.statusPanel)
 
         self.newSliceBtn = Qt.QPushButton("New slice")
         self.newSliceBtn.setToolTip(
@@ -114,8 +189,8 @@ class AutopatchWindow(Qt.QWidget):
             "cells -- and start a fresh one for newly mounted tissue."
         )
         self.regionPanel = RegionPanel()
-        self.area1Box.layout().addWidget(self.newSliceBtn)
-        self.area1Box.layout().addWidget(self.regionPanel)
+        self.area1Layout.addWidget(self.newSliceBtn)
+        self.area1Layout.addWidget(self.regionPanel)
 
         self._pinnedFrameMirror = PinnedFrameMirror(self.regionPanel.view)
         # parent=self so the clear prompt is owned by this window: a parentless
@@ -158,13 +233,13 @@ class AutopatchWindow(Qt.QWidget):
         self._positionConnected: dict[int, object] = {}
 
         self.searchPanel = SearchPanel()
-        self.area2Box.layout().addWidget(self.searchPanel)
+        self.area2Layout.addWidget(self.searchPanel)
 
         self.cellPanel = CellPanel(
             pipetteGetter=self.pipetteSelector.getSelectedObj,
             cameraGetter=self.cameraSelector.getSelectedObj,
         )
-        self.area5Box.layout().addWidget(self.cellPanel)
+        self.area5Layout.addWidget(self.cellPanel)
 
         self.orchestrator = None
         # The pipette resolved from self.pipetteSelector at the moment Start was
@@ -241,6 +316,157 @@ class AutopatchWindow(Qt.QWidget):
         # rather than leaving it empty until the first cell or colour-source
         # change calls _refreshProgress() on its own.
         self._refreshProgress()
+        # Last, once every panel above is built and filled: what the areas ask
+        # for is read off their content, and this is the point at which that
+        # content is all there.
+        self._settleAreaSizes()
+        self._seedOpeningSplit()
+        # And then, if the operator left one behind, their own division of the
+        # window over the opening arrangement just seeded.
+        self._restoreLayout()
+
+    def _makeArea(self, title: str) -> tuple[Qt.QGroupBox, Qt.QVBoxLayout]:
+        """A titled area, and the layout its content goes into.
+
+        The content is put inside a scrolling viewport rather than into the
+        group box directly, which is what makes the split the operator drags the
+        split they get. A QSplitter refuses to shrink a child below its
+        minimumSizeHint, and a group box holding a panel directly takes on that
+        panel's: Area 1's slice view alone asks for a few hundred pixels square,
+        and Area 5's button row plus two lists plus a log plus a details widget
+        for a good deal more. Those hints would clamp the handle, so the areas
+        would spring back to what their contents preferred. With a viewport in
+        between -- one that insists on no minimum of its own, see _AreaViewport
+        -- the handle moves anywhere, and content that genuinely cannot fit
+        scrolls instead of refusing.
+
+        `widgetResizable`, so the content tracks the viewport and only scrolls
+        once it truly has no room, rather than sitting at its sizeHint with
+        scrollbars up from the start. `NoFrame`, because the group box already
+        draws a border around exactly this rectangle.
+        """
+        content = Qt.QWidget()
+        contentLayout = Qt.QVBoxLayout()
+        # No margins of its own: the group box and the viewport each already
+        # inset what they hold, and a third inset inside an area the operator
+        # may have deliberately squeezed is room taken from the content they
+        # chose to keep.
+        contentLayout.setContentsMargins(0, 0, 0, 0)
+        content.setLayout(contentLayout)
+
+        scroll = _AreaViewport()
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(Qt.QFrame.NoFrame)
+        scroll.setWidget(content)
+
+        box = Qt.QGroupBox(title)
+        # The group box's own layout keeps its default margins: its top margin
+        # is what keeps the content clear of the title drawn into its frame.
+        box.setLayout(Qt.QVBoxLayout())
+        box.layout().addWidget(scroll)
+        self._areaViewports.append(scroll)
+        return box, contentLayout
+
+    def _settleAreaSizes(self) -> None:
+        """Let the size the areas ask for catch up with the content now in them.
+
+        Filling a viewport's content widget invalidates the layouts *inside* that
+        widget; the group box layout holding the viewport is outside it and never
+        hears, so it goes on offering the splitters the hint it computed while
+        every area was still empty -- which opens the window a couple of hundred
+        pixels across with all five panels already scrolled. updateGeometry() is
+        what invalidates that outer chain.
+
+        Once, at the end of construction, rather than on every later change to a
+        panel's content: from here on the areas are sized by the splitters, which
+        hold explicit sizes and consult a hint only for their opening
+        arrangement.
+        """
+        for viewport in self._areaViewports:
+            viewport.updateGeometry()
+
+    def _seedOpeningSplit(self) -> None:
+        """Divide each splitter in proportion to what the areas in it ask for.
+
+        The stretch factors alone are not that: they describe how room *beyond*
+        what the content wants is shared as the window grows, and applied to a
+        window only just big enough for its content they hand one area room
+        another needed. A bare 2:1 between the columns is what puts Area 5's
+        button row behind a horizontal scrollbar at the size the window first
+        opens, while the slice view sits on space it was not asking for.
+
+        An opening arrangement only, in both senses: a saved layout is restored
+        straight over it (see _restoreLayout), and from the operator's first drag
+        onwards the splitter's own explicit sizes are what count. QSplitter
+        scales what it is handed to whatever room it actually has, so these are
+        read as proportions rather than as pixels.
+        """
+        for splitter in self._splitters().values():
+            horizontal = splitter.orientation() == Qt.Qt.Horizontal
+            hints = [splitter.widget(i).sizeHint() for i in range(splitter.count())]
+            splitter.setSizes([h.width() if horizontal else h.height() for h in hints])
+
+    def _splitters(self) -> dict:
+        """The window's splitters, by the name their state is saved under."""
+        return {
+            "columns": self.columnSplitter,
+            "leftColumn": self.leftColumn,
+            "rightColumn": self.rightColumn,
+        }
+
+    def _saveLayout(self) -> None:
+        """Write the operator's division of the window to the module's state file.
+
+        Every handle in the window, and the window's own geometry: what they
+        dragged the areas to is a working preference like any other, and having
+        to rebuild it at the start of each session is what makes an adjustable
+        layout not worth adjusting.
+
+        Percent-encoded QSplitter blobs and geometry as four plain numbers, so
+        this file stays readable text through configfile -- the same shape the
+        Camera, Manager and Console modules already keep their window state in.
+        """
+        if self._stateFile is None or self.manager is None:
+            return
+        geometry = self.geometry()
+        self.manager.writeConfigFile(
+            {
+                "geometry": [
+                    geometry.x(),
+                    geometry.y(),
+                    geometry.width(),
+                    geometry.height(),
+                ],
+                "splitters": {
+                    name: bytes(splitter.saveState().toPercentEncoding()).decode()
+                    for name, splitter in self._splitters().items()
+                },
+            },
+            self._stateFile,
+        )
+
+    def _restoreLayout(self) -> None:
+        """Put the window back the way the operator last left it.
+
+        Anything the saved state does not describe is left at the arrangement
+        __init__ just built, and a blob Qt refuses is dropped for the same
+        reason: a state file written by an older version of this window, or one
+        that has been hand-edited, must cost the operator their layout at worst
+        -- never the window itself. `restoreState` reports that refusal by
+        returning False rather than by raising, and a state naming a splitter
+        this window no longer has is simply not looked up.
+        """
+        if self._stateFile is None or self.manager is None:
+            return
+        state = self.manager.readConfigFile(self._stateFile)
+        geometry = state.get("geometry")
+        if geometry is not None:
+            self.setGeometry(Qt.QRect(*geometry))
+        splitters = self._splitters()
+        for name, blob in state.get("splitters", {}).items():
+            splitter = splitters.get(name)
+            if splitter is not None:
+                splitter.restoreState(Qt.QByteArray.fromPercentEncoding(blob.encode()))
 
     @staticmethod
     def _cameraModuleWindow(manager):
@@ -1001,11 +1227,25 @@ class AutopatchWindow(Qt.QWidget):
 
         Idempotent: safe to call more than once (e.g. once explicitly from
         Autopatch.quit() and again via closeEvent() when the operator closes
-        the window directly).
+        the window directly). Saving the layout rides on that: both routes out
+        of the window pass through here, and only the first one saves, so what
+        gets written is the window as the operator last had it rather than
+        whatever a second pass would read off a window already coming apart.
         """
         if self._tornDown:
             return
         self._tornDown = True
+        try:
+            # First, while the window is still up and its geometry is still
+            # what the operator left it at.
+            self._saveLayout()
+        except Exception:
+            # A layout is a convenience; everything below is not. A config
+            # directory that cannot be written must not cost this window its
+            # deterministic teardown -- see above for what is at stake when
+            # that is skipped -- so this is reported and stepped over rather
+            # than allowed to propagate.
+            logger.exception("Could not save the Autopatch window layout")
         try:
             if self.orchestrator is not None:
                 self._stopAndReleaseOrchestrator(self.orchestrator)

--- a/acq4/modules/Autopatch/region_panel.py
+++ b/acq4/modules/Autopatch/region_panel.py
@@ -27,7 +27,9 @@ def roiForRegion(region: SearchRegion) -> pg.ROI:
     box region carries an angle, and a polygon's vertices are read back through
     the ROI's own transform, which a rotation is part of. The stock
     `pg.EllipseROI` is used as it ships, rotate handle and all, since that handle
-    now does what it looks like it does.
+    now does what it looks like it does. `pg.RectROI` ships a scale handle alone,
+    so a rotate handle is added to it below -- both box shapes turn, and the
+    handle is what tells the operator so.
 
     Sized from `box()` rather than `bounds()`: those differ once there is an
     angle, and it is the box the operator sized -- not the larger axis-aligned
@@ -50,6 +52,16 @@ def roiForRegion(region: SearchRegion) -> pg.ROI:
     roi = roiClass(
         (x0, y0), (x1 - x0, y1 - y0), pen=REGION_PEN, removable=True, rotatable=True
     )
+    if not isinstance(roi, pg.EllipseROI):
+        # Where pg.EllipseROI puts its own (see EllipseROI._addHandles): the
+        # middle of the right edge, turning about the centre of the box. Same
+        # place on both shapes, so switching the shape selector does not move the
+        # controls; clear of pg.RectROI's scale handle on the corner; and turning
+        # about the centre keeps the tissue under the region while it is aimed.
+        # The centre is only the *gesture's* pivot -- the region reads its angle
+        # and its corner back off the finished transform (see regionForRoi), so
+        # this choice does not touch what a rotated region means.
+        roi.addRotateHandle([1.0, 0.5], [0.5, 0.5])
     if region.angle:
         roi.setAngle(region.angle)
     return roi

--- a/acq4/modules/Autopatch/region_panel.py
+++ b/acq4/modules/Autopatch/region_panel.py
@@ -147,7 +147,14 @@ class RegionPanel(Qt.QWidget):
         self.graphicsView.setSizePolicy(
             Qt.QSizePolicy.Expanding, Qt.QSizePolicy.Expanding
         )
-        self.graphicsView.setMinimumSize(300, 300)
+        # A floor, not a working size: how much room this view gets is the
+        # operator's decision, made by dragging the splitter handles around the
+        # area it sits in, and a floor of the size one actually draws at would
+        # take that decision away -- the area would scroll a viewport over the
+        # view instead of handing it the smaller rectangle it was given. Kept
+        # above zero only so that squeezing the area does not leave the controls
+        # above with a sliver of view underneath.
+        self.graphicsView.setMinimumSize(120, 120)
 
         # Item data, not display text, is what regionShape() returns: the window
         # maps it to a region class, and a label is a label.

--- a/acq4/modules/Autopatch/tests/test_layout_persistence.py
+++ b/acq4/modules/Autopatch/tests/test_layout_persistence.py
@@ -1,0 +1,173 @@
+"""Tests that the split the operator drags the window into, and the window's own
+geometry, survive closing it -- through the same manager config file the Camera
+and Manager modules keep their window state in."""
+from types import SimpleNamespace
+
+import pytest
+
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+class _FakeDeviceSelector(Qt.QWidget):
+    def getSelectedObj(self):
+        return None
+
+
+class _FakeManager:
+    """Manager's config-file pair, backed by a dict rather than the config
+    directory: a window built by these tests must not write into the real rig's
+    configuration, and what is being tested is the round trip, not configfile's
+    own serialisation."""
+
+    def __init__(self, files=None):
+        self.files = {} if files is None else files
+
+    def readConfigFile(self, fileName, missingOk=True):
+        if fileName not in self.files and not missingOk:
+            raise FileNotFoundError(fileName)
+        return self.files.get(fileName, {})
+
+    def writeConfigFile(self, data, fileName):
+        self.files[fileName] = data
+
+
+def _makeWindow(tmp_path, manager, moduleName="Autopatch"):
+    from acq4.modules.Autopatch.Autopatch import AutopatchWindow
+
+    return AutopatchWindow(
+        module=SimpleNamespace(manager=manager, name=moduleName),
+        protocolDir=str(tmp_path),
+        pipetteSelector=_FakeDeviceSelector(),
+        cameraSelector=_FakeDeviceSelector(),
+    )
+
+
+def test_the_layout_is_written_to_the_modules_state_file_on_teardown(qapp, tmp_path):
+    """Same place, and same shape, as every other module's window state: a
+    ``modules/<module name>_ui.cfg`` under the config directory, holding the
+    geometry as four numbers and each Qt state blob percent-encoded."""
+    manager = _FakeManager()
+    win = _makeWindow(tmp_path, manager)
+    win.teardown()
+
+    assert list(manager.files) == ["modules/Autopatch_ui.cfg"]
+    state = manager.files["modules/Autopatch_ui.cfg"]
+    assert len(state["geometry"]) == 4
+    assert set(state["splitters"]) == {"columns", "leftColumn", "rightColumn"}
+    for blob in state["splitters"].values():
+        assert isinstance(blob, str) and blob
+
+
+def test_a_saved_split_is_what_the_next_window_opens_with(qapp, tmp_path):
+    """The point of saving it: an operator who has given the slice view most of
+    the window, or squeezed the status area down to a strip, finds it that way
+    tomorrow rather than back at this constructor's opening arrangement."""
+    manager = _FakeManager()
+    first = _makeWindow(tmp_path, manager)
+    first.resize(1000, 800)
+    first.show()
+    qapp.processEvents()
+    first.columnSplitter.setSizes([300, 700])
+    first.rightColumn.setSizes([40, 260, 460])
+    qapp.processEvents()
+    saved = (first.columnSplitter.sizes(), first.rightColumn.sizes())
+    first.teardown()
+    first.close()
+
+    second = _makeWindow(tmp_path, manager)
+    second.show()
+    qapp.processEvents()
+    try:
+        assert second.columnSplitter.sizes() == saved[0]
+        assert second.rightColumn.sizes() == saved[1]
+    finally:
+        second.teardown()
+        second.close()
+
+
+def test_a_saved_geometry_is_what_the_next_window_opens_at(qapp, tmp_path):
+    manager = _FakeManager()
+    first = _makeWindow(tmp_path, manager)
+    first.setGeometry(120, 140, 1020, 760)
+    first.teardown()
+
+    second = _makeWindow(tmp_path, manager)
+    try:
+        assert second.geometry().width() == 1020
+        assert second.geometry().height() == 760
+    finally:
+        second.teardown()
+
+
+def test_each_module_instance_keeps_its_own_layout(qapp, tmp_path):
+    """The file is named for the module, as every other module's is, so two
+    Autopatch modules configured on one rig do not overwrite each other."""
+    manager = _FakeManager()
+    win = _makeWindow(tmp_path, manager, moduleName="Autopatch2")
+    win.teardown()
+
+    assert list(manager.files) == ["modules/Autopatch2_ui.cfg"]
+
+
+def test_a_window_with_no_module_neither_saves_nor_restores(qapp, tmp_path):
+    """module=None is a supported mode (headless, and every test that builds
+    this window without a Manager to stand in for), and there is no config
+    directory to keep a layout in there. Teardown must still be quiet."""
+    from acq4.modules.Autopatch.Autopatch import AutopatchWindow
+
+    win = AutopatchWindow(
+        module=None,
+        protocolDir=str(tmp_path),
+        pipetteSelector=_FakeDeviceSelector(),
+        cameraSelector=_FakeDeviceSelector(),
+    )
+    win.teardown()  # must not raise
+
+
+def test_a_layout_saved_by_a_different_window_size_is_ignored_not_crashed_on(
+    qapp, tmp_path
+):
+    """A state file is on disk from a previous version of this window, or was
+    hand-edited: a splitter blob Qt refuses is dropped and the window opens at
+    its own arrangement, rather than failing to open at all."""
+    manager = _FakeManager(
+        {
+            "modules/Autopatch_ui.cfg": {
+                "geometry": [10, 10, 900, 700],
+                "splitters": {"columns": "not-a-splitter-state"},
+            }
+        }
+    )
+    win = _makeWindow(tmp_path, manager)
+    try:
+        assert win.columnSplitter.count() == 2
+        assert win.geometry().width() == 900
+    finally:
+        win.teardown()
+
+
+def test_a_layout_that_cannot_be_written_does_not_cost_the_window_its_teardown(
+    qapp, tmp_path, caplog
+):
+    """A read-only or missing config directory is a lost preference, nothing
+    more. Teardown is what stops the orchestrator and hands the Camera module's
+    graphics back, and skipping it is the crash-on-exit this window's
+    deterministic teardown exists to prevent -- so the failure is reported and
+    stepped over, not propagated."""
+
+    class _UnwritableManager(_FakeManager):
+        def writeConfigFile(self, data, fileName):
+            raise OSError("read-only config directory")
+
+    win = _makeWindow(tmp_path, _UnwritableManager())
+    with caplog.at_level("ERROR", logger="acq4.modules.Autopatch.Autopatch"):
+        win.teardown()
+
+    assert win.orchestrator is None
+    assert win._referenceImagery is None
+    assert "read-only config directory" in caplog.text

--- a/acq4/modules/Autopatch/tests/test_region_adapters.py
+++ b/acq4/modules/Autopatch/tests/test_region_adapters.py
@@ -111,14 +111,17 @@ def test_a_rect_and_an_ellipse_map_to_different_roi_types(qapp):
     assert not isinstance(roiForRegion(RECT), pg.EllipseROI)
 
 
-def test_an_ellipse_roi_has_a_rotate_handle(qapp):
-    # pg.EllipseROI ships one, and now that a region can record an angle it
-    # tells the truth: grabbing it turns the ellipse and the turn reaches the
-    # slice. The rectangle offers the same gesture through an Alt-drag of its
-    # body, which needs no handle.
+@pytest.mark.parametrize("region", [RECT, ELLIPSE])
+def test_a_box_roi_has_a_rotate_handle(qapp, region):
+    # Both box shapes, and in the same place on each: a region records an angle,
+    # so the turn is an ordinary edit, and an affordance the operator can see is
+    # how they find out. pg.EllipseROI ships one; pg.RectROI ships a scale handle
+    # alone, so the rectangle's is added where the ellipse has it. The Alt-drag
+    # of the ROI body turns either shape too, but a modifier-plus-drag on a
+    # region with no handle to suggest it is not a discoverable gesture.
     from acq4.modules.Autopatch.region_panel import roiForRegion
 
-    handles = roiForRegion(ELLIPSE).handles
+    handles = roiForRegion(region).handles
     assert any(h["type"] == "r" for h in handles)
 
 
@@ -274,6 +277,50 @@ def test_the_rotated_roi_is_drawn_where_the_region_says(qapp, region):
         for cx, cy in ((x0, y0), (x1, y0), (x1, y1), (x0, y1))
     )
     assert roiCorners(roiForRegion(region)) == pytest.approx(expected)
+
+
+def dragRotateHandle(roi, deg):
+    """Turn `roi` by `deg` the way the operator does: by its rotate handle.
+
+    The path a real drag takes, minus the mouse: pg's Handle.mouseDragEvent hands
+    the handle's new position to ROI.movePoint, and that is what reads the "r"
+    type and turns the shape. Driving movePoint directly is what keeps this about
+    the handle rather than about setAngle.
+    """
+    handle = next(h for h in roi.handles if h["type"] == "r")
+    size = roi.size()
+    local = Qt.QPointF(handle["pos"][0] * size.x(), handle["pos"][1] * size.y())
+    start = roi.mapToParent(local)
+    centre = roi.mapToParent(Qt.QPointF(size.x() / 2, size.y() / 2))
+    x, y = turned(centre.x(), centre.y(), start.x(), start.y(), deg)
+    roi.movePoint(handle["item"], Qt.QPointF(x, y), coords="parent")
+
+
+@pytest.mark.parametrize("region", [RECT, ELLIPSE])
+def test_a_turn_by_the_rotate_handle_reaches_the_region(qapp, region):
+    # The handle turns about the centre of the box while the region's own pivot
+    # is its (x0, y0) corner, so this is where those two conventions meet: the
+    # region has to come back describing the shape now on screen, in its own
+    # terms, with the box the operator sized left alone.
+    from acq4.modules.Autopatch.region_panel import regionForRoi, roiForRegion
+
+    roi = roiForRegion(region)
+    before = region.box()
+
+    dragRotateHandle(roi, 30.0)
+    turnedRegion = regionForRoi(roi)
+
+    assert turnedRegion.angle == pytest.approx(30.0)
+    # A turn, not a resize: same box, somewhere else, at an angle.
+    x0, y0, x1, y1 = turnedRegion.box()
+    assert (x1 - x0, y1 - y0) == pytest.approx(
+        (before[2] - before[0], before[3] - before[1])
+    )
+    # And what the region describes is what is drawn: rebuilt from it, the ROI
+    # lands on the same four corners the handle just put it on.
+    assert sorted(roiCorners(roiForRegion(turnedRegion))) == pytest.approx(
+        sorted(roiCorners(roi))
+    )
 
 
 def test_a_rotated_roi_dragged_past_its_own_origin_still_describes_its_shape(qapp):

--- a/acq4/modules/Autopatch/tests/test_region_panel.py
+++ b/acq4/modules/Autopatch/tests/test_region_panel.py
@@ -648,3 +648,17 @@ def test_legend_swatch_shows_the_brush_colour(qapp):
     assert len(swatches) == 2
     assert swatches[0].palette().color(swatches[0].backgroundRole()) == firstBrush.color()
     assert swatches[1].palette().color(swatches[1].backgroundRole()) == secondBrush.color()
+
+
+def test_the_slice_view_shrinks_with_the_panel_rather_than_holding_a_floor(qapp):
+    """The window puts this panel in an area whose size the operator sets, and
+    the view is what should give when they make it small: a slice view that
+    refuses to go under a few hundred pixels square gets scrolled inside that
+    area instead, which is a viewport dragged over a picture rather than a
+    smaller picture. Small enough to still be a view, and no larger.
+    """
+    panel = makePanel()
+
+    minimum = panel.graphicsView.minimumSize()
+    assert minimum.width() <= 150, minimum.width()
+    assert minimum.height() <= 150, minimum.height()

--- a/acq4/modules/Autopatch/tests/test_teardown.py
+++ b/acq4/modules/Autopatch/tests/test_teardown.py
@@ -213,7 +213,7 @@ def test_teardown_frees_the_slice_producer_and_cells_by_refcounting(qapp, tmp_pa
     gc.disable()
     try:
         win = AutopatchWindow(
-            module=SimpleNamespace(manager=_FakeManager(storageRoot)),
+            module=SimpleNamespace(manager=_FakeManager(storageRoot), name="Autopatch"),
             protocolDir=str(tmp_path),
             pipetteSelector=_FakePipetteSelector(target=(1e-3, 2e-3, 3e-3)),
             cameraSelector=_FakeCameraWithDevice(),
@@ -485,7 +485,7 @@ def test_teardown_releases_the_reference_imagery(qapp, tmp_path):
     storageRoot = dm.getDirHandle(str(tmp_path / "storage"), create=True)
 
     win = AutopatchWindow(
-        module=SimpleNamespace(manager=_FakeManager(storageRoot)),
+        module=SimpleNamespace(manager=_FakeManager(storageRoot), name="Autopatch"),
         protocolDir=str(tmp_path),
         pipetteSelector=_FakePipetteSelector(target=(1e-3, 2e-3, 3e-3)),
         cameraSelector=_FakeCameraWithDevice(),

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -199,6 +199,11 @@ class _FakeManager(Qt.QObject):
     A QObject carrying sigModulesChanged, because the real Manager is one.
     Nothing in Autopatch listens to that signal, so the fake's implementation
     is inert; it exists to match the interface of the thing it stands in for.
+
+    The config-file pair is backed by a dict rather than by files under a config
+    directory: the window saves its layout through it when it is torn down, and
+    a test must not write into the real rig's configuration to do that. See
+    test_layout_persistence for the tests that are actually about this pair.
     """
 
     sigModulesChanged = Qt.Signal()
@@ -206,6 +211,7 @@ class _FakeManager(Qt.QObject):
     def __init__(self, root_dir):
         super().__init__()
         self._current_dir = root_dir
+        self.configFiles = {}
         self.drawn = []
         self.pinnedFrameSource = _FakePinnedFrameSource()
         self.cameraWindow = SimpleNamespace(
@@ -233,6 +239,14 @@ class _FakeManager(Qt.QObject):
     def folderTypesConfig(self):
         return _FOLDER_TYPES
 
+    def readConfigFile(self, fileName, missingOk=True):
+        if fileName not in self.configFiles and not missingOk:
+            raise FileNotFoundError(fileName)
+        return self.configFiles.get(fileName, {})
+
+    def writeConfigFile(self, data, fileName):
+        self.configFiles[fileName] = data
+
 
 def _makeWindow(tmp_path, cameraSelector=None):
     """An AutopatchWindow with a loaded no-op protocol and a camera-backed
@@ -250,7 +264,7 @@ def _makeWindow(tmp_path, cameraSelector=None):
     _write_protocol(tmp_path, "demo.py", _NOOP_PROTOCOL)
     storageRoot = dm.getDirHandle(str(tmp_path / "storage"), create=True)
     win = AutopatchWindow(
-        module=SimpleNamespace(manager=_FakeManager(storageRoot)),
+        module=SimpleNamespace(manager=_FakeManager(storageRoot), name="Autopatch"),
         protocolDir=str(tmp_path),
         pipetteSelector=_FakePipetteSelector(),
         cameraSelector=cameraSelector,

--- a/acq4/modules/Autopatch/tests/test_window_skeleton.py
+++ b/acq4/modules/Autopatch/tests/test_window_skeleton.py
@@ -1,5 +1,5 @@
 """Tests that AutopatchWindow constructs and exposes the five design-doc areas
-as labeled placeholder group boxes."""
+as labeled group boxes the operator can resize freely against each other."""
 import pytest
 
 from acq4.util import Qt
@@ -50,6 +50,18 @@ def test_area_titles_name_their_design_doc_role(qapp, tmp_path):
     assert "cell" in win.area5Box.title().lower()
 
 
+def test_area_titles_name_their_content_not_their_internal_number(qapp, tmp_path):
+    """"Area 3" is how this module's code and design doc refer to the
+    status/actions box; it tells an operator nothing about what is in it. The
+    titles they read name the content alone."""
+    win = _makeWindow(tmp_path)
+
+    for box in (win.area1Box, win.area2Box, win.area3Box, win.area4Box, win.area5Box):
+        title = box.title()
+        assert "area" not in title.lower(), title
+        assert not any(ch.isdigit() for ch in title), title
+
+
 def test_window_has_a_title(qapp, tmp_path):
     win = _makeWindow(tmp_path)
     assert win.windowTitle() == "Autopatch"
@@ -92,29 +104,144 @@ def test_default_pipette_selector_is_built_for_the_patchpipette_interface(qapp, 
     assert captured["types"] == ["patchpipette"]
 
 
-def test_areas_are_arranged_in_two_columns(qapp, tmp_path):
+def test_areas_are_arranged_in_two_columns_of_splitters(qapp, tmp_path):
     """Left column (top->bottom): Area 1, Area 2. Right column (top->bottom):
     Area 3, Area 4, Area 5.
 
-    The left column is a splitter rather than a plain box layout, so that the
-    operator can give Area 1's view of the slice as much of the window as
-    drawing a region over tissue needs.
+    Every boundary between areas is a splitter handle -- the one between the
+    columns and the ones between the areas stacked inside each column -- so the
+    operator, not this constructor, decides how the window is divided.
     """
     win = _makeWindow(tmp_path)
 
     outer = win.layout()
     assert isinstance(outer, Qt.QHBoxLayout)
-    assert outer.count() == 2
+    assert outer.count() == 1
 
-    leftCol = outer.itemAt(0).widget()
-    rightCol = outer.itemAt(1).widget().layout()
+    columns = outer.itemAt(0).widget()
+    assert isinstance(columns, Qt.QSplitter)
+    assert columns.orientation() == Qt.Qt.Horizontal
+    assert columns.count() == 2
 
+    leftCol, rightCol = columns.widget(0), columns.widget(1)
     assert isinstance(leftCol, Qt.QSplitter)
-    assert leftCol.count() == 2
-    assert leftCol.widget(0) is win.area1Box
-    assert leftCol.widget(1) is win.area2Box
+    assert isinstance(rightCol, Qt.QSplitter)
+    assert leftCol.orientation() == Qt.Qt.Vertical
+    assert rightCol.orientation() == Qt.Qt.Vertical
 
-    assert rightCol.count() == 3
-    assert rightCol.itemAt(0).widget() is win.area3Box
-    assert rightCol.itemAt(1).widget() is win.area4Box
-    assert rightCol.itemAt(2).widget() is win.area5Box
+    assert [leftCol.widget(i) for i in range(leftCol.count())] == [
+        win.area1Box,
+        win.area2Box,
+    ]
+    assert [rightCol.widget(i) for i in range(rightCol.count())] == [
+        win.area3Box,
+        win.area4Box,
+        win.area5Box,
+    ]
+
+
+def test_each_area_holds_its_content_in_a_scroll_area(qapp, tmp_path):
+    """The panels live inside scrolling viewports, which is what lets an area be
+    given less room than its content wants: the content scrolls instead of
+    refusing to shrink."""
+    win = _makeWindow(tmp_path)
+
+    for box, panel in (
+        (win.area1Box, win.regionPanel),
+        (win.area2Box, win.searchPanel),
+        (win.area3Box, win.statusPanel),
+        (win.area4Box, win.protocolPanel),
+        (win.area5Box, win.cellPanel),
+    ):
+        scrolls = box.findChildren(Qt.QScrollArea)
+        assert len(scrolls) == 1, (box.title(), scrolls)
+        scroll = scrolls[0]
+        assert scroll.widgetResizable(), box.title()
+        assert scroll.isAncestorOf(panel), box.title()
+
+
+def test_an_area_can_be_squeezed_below_what_its_content_asks_for(qapp, tmp_path):
+    """A QSplitter will not drag a child below its minimumSizeHint, so an area
+    that inherits its panel's hint -- Area 1's slice view alone asks for a
+    square of a few hundred pixels, Area 5's button row plus two lists plus a
+    log for far more -- would refuse the size the operator chose. Wrapped, each
+    area's hint is a viewport's, and the handle keeps moving."""
+    win = _makeWindow(tmp_path)
+
+    for box in (win.area1Box, win.area2Box, win.area3Box, win.area4Box, win.area5Box):
+        hint = box.minimumSizeHint()
+        assert hint.height() <= 100, (box.title(), hint.height())
+        assert hint.width() <= 250, (box.title(), hint.width())
+
+
+def test_the_operator_chosen_split_is_what_the_areas_actually_get(qapp, tmp_path):
+    """The end-to-end version of the check above, driven through the splitters
+    the operator drags: sizes asked for are sizes honoured, not clamped back up
+    to what the content inside would prefer."""
+    win = _makeWindow(tmp_path)
+    win.resize(900, 700)
+    win.show()
+    try:
+        qapp.processEvents()
+        columns = win.layout().itemAt(0).widget()
+        leftCol, rightCol = columns.widget(0), columns.widget(1)
+
+        # A narrow left column and a right column dominated by one area: both
+        # squeeze several panels well under their natural size.
+        columns.setSizes([200, 700])
+        leftCol.setSizes([500, 100])
+        rightCol.setSizes([60, 60, 500])
+        qapp.processEvents()
+
+        assert win.area1Box.width() <= 220
+        assert win.area2Box.height() <= 150
+        assert win.area3Box.height() <= 110
+        assert win.area4Box.height() <= 110
+    finally:
+        win.close()
+
+
+def test_an_area_asks_for_room_enough_for_the_content_it_holds(qapp, tmp_path):
+    """The other half of squeezing: the wrapping must not shrink what an area
+    asks for before the operator has touched a handle.
+
+    QScrollArea computes its sizeHint from the widget it was handed and then
+    caches it forever -- a cache only setWidget() clears -- and this window hands
+    those widgets over empty and fills them afterwards. Left to that cache every
+    area's hint is the empty one, which opens the whole window a couple of
+    hundred pixels across with all five areas already scrolled.
+    """
+    win = _makeWindow(tmp_path)
+
+    for box, panel in (
+        (win.area1Box, win.regionPanel),
+        (win.area2Box, win.searchPanel),
+        (win.area3Box, win.statusPanel),
+        (win.area4Box, win.protocolPanel),
+        (win.area5Box, win.cellPanel),
+    ):
+        hint, wanted = box.sizeHint(), panel.sizeHint()
+        assert hint.width() >= wanted.width(), (box.title(), hint, wanted)
+        assert hint.height() >= wanted.height(), (box.title(), hint, wanted)
+
+
+def test_the_window_opens_with_each_column_wide_enough_for_its_content(qapp, tmp_path):
+    """The opening arrangement is seeded from what the areas ask for, not from
+    the stretch factors alone: those describe how *extra* room is shared as the
+    window grows, and a bare 2:1 of a window that is only just big enough hands
+    the left column room the right column needed -- so an operator's first sight
+    of the window is Area 5's buttons behind a horizontal scrollbar, with the
+    slice view sitting on space it was not asking for.
+    """
+    win = _makeWindow(tmp_path)
+    wanted = [win.leftColumn.sizeHint().width(), win.rightColumn.sizeHint().width()]
+    # Comfortably more than both columns together, so nothing here is about what
+    # gives when there genuinely is not enough room.
+    win.resize(sum(wanted) + 200, 800)
+    win.show()
+    try:
+        qapp.processEvents()
+        for got, asked in zip(win.columnSplitter.sizes(), wanted):
+            assert got >= asked, (win.columnSplitter.sizes(), wanted)
+    finally:
+        win.close()


### PR DESCRIPTION
## What

Autopatch's five areas were divided by a fixed box layout with one splitter. Now every boundary between them is a handle the operator can drag, the areas fit whatever size they are dragged to, and the division is kept between sessions.

Also in here: the area titles stop saying "Area N" to the operator, and rectangle regions get the rotate handle they already supported.

Two commits, reviewable separately.

## Why

Which area deserves the room depends on what is being done at the time -- outlining a region over a whole slice, then watching one cell's timeline -- and that is not a judgement the constructor can make for a whole session.

## How

**Splitters all the way down.** A horizontal splitter between the columns, a vertical one inside each. The stretch factors now decide only which area grows as the *window* does; where the handles start is seeded from what the content asks for, and where they end up is the operator's.

**Content forced to fit.** Each area holds its panel in a scrolling viewport. Qt fights this in two directions, and `_AreaViewport` answers both:

- `QAbstractScrollArea.minimumSizeHint` is a ~68px floor, and a group box holding a panel directly inherits *the panel's* minimum -- the slice view alone asked for 300x300, Area 5's stack for far more. A QSplitter will not drag a child below that, so handles sprang back.
- `QScrollArea` caches its preferred size from the widget it was handed, and this window hands them over empty and fills them afterwards -- a cache only `setWidget()` clears. Left to it, every area opened at its title bar with the whole window at 283x162.

The slice view's own minimum drops to a 120px floor for the same reason: a view whose job is to fit the room available should shrink with its area rather than have a viewport scrolled over it.

**Persistence** follows the house idiom exactly -- `modules/<module name>_ui.cfg` via `manager.readConfigFile`/`writeConfigFile`, geometry as four numbers plus percent-encoded splitter states, the same shape and place `CameraWindow` and the Manager and Console modules use. Saved on teardown (both the close-the-window and quit routes pass through it), restored in the constructor.

**Rotate handle** on `pg.RectROI`, which ships a scale handle only -- `rotatable=True` merely permits rotation (it gates the Alt-drag body gesture) without creating anything to grab. Placed where pyqtgraph puts the ellipse's, so the shape selector does not move the controls.

## Notes for review

- **A write that fails is logged, not raised.** `teardown()` is what stops the orchestrator and hands the Camera module's graphics back; skipping it is the crash-on-exit that deterministic teardown exists to prevent. A read-only config directory must cost a layout preference, nothing more. Pinned by a test.
- **A saved layout Qt refuses is dropped**, and the window opens at its own arrangement -- an older or hand-edited state file must not cost the operator the window itself.
- **The rotate handle's pivot is the box centre while a region's angle pivots about its `(x0, y0)` corner.** These do not conflict: `regionForRoi` re-derives the corner from the finished transform. A test drags the handle through the real path (`ROI.movePoint`, what `Handle.mouseDragEvent` calls) and asserts the angle arrives, the box keeps its size, and an ROI rebuilt from the region lands on the same four corners.
- **Test fakes changed:** `_FakeManager` in the integration/teardown tests grows the config-file pair, and the fake modules grow a `name`, since the window now uses both.
- `test_an_ellipse_roi_has_a_rotate_handle` had a comment stating the rectangle deliberately had none. It is now parametrized over both box shapes with the reasoning rewritten -- Alt-drag still turns either shape, but a modifier-plus-drag with no visible handle is not discoverable.
- Polygons are untouched: pyqtgraph ships no rotate handle for `PolyLineROI`, and their vertices are individually draggable.

## Testing

- 594 Autopatch tests pass; 1068 with `acq4/experiment`. 20 new (layout structure, squeeze, opening size, `test_layout_persistence.py`, and the handle-drag rotation).
- Verified a real round trip of the saved layout through pyqtgraph's `configfile`, not just the dict-backed test fake.
- Rendered the window at its opening split and at a deliberately squeezed one, and the three region shapes including one already rotated 30 degrees, to confirm on screen.
- Unrelated pre-existing failure: `acq4/modules/DataManager/tests/test_file_data_view_acqtrack.py` fails in a full-suite run from cross-test interference. Confirmed it fails identically with these changes stashed.

🧙 Built with [WOZCODE](https://wozcode.com)