### PR TITLE
feat(datamanager): render yaml files as a tree in the Data tab

### DIFF
--- a/acq4/modules/DataManager/FileDataView.py
+++ b/acq4/modules/DataManager/FileDataView.py
@@ -1,4 +1,6 @@
+import time
 import traceback
+from collections import OrderedDict
 from typing import Optional
 
 import pyqtgraph as pg
@@ -11,6 +13,32 @@ from acq4.util.DictView import DictView
 from acq4.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+
+def _orderedCopy(data):
+    """Rebuild nested containers with OrderedDict so keys stay in document order.
+
+    pyqtgraph's DataTreeWidget sorts the keys of a plain dict; a yaml document
+    reads better in the order it was written.
+    """
+    if isinstance(data, dict):
+        return OrderedDict((k, _orderedCopy(v)) for k, v in data.items())
+    if isinstance(data, (list, tuple)):
+        return type(data)(_orderedCopy(v) for v in data)
+    return data
+
+
+class YamlTreeWidget(pg.DataTreeWidget):
+    """DataTreeWidget that reads yaml documents: plain mappings and dated timestamps."""
+
+    def parse(self, data):
+        typeStr, desc, childs, widget = super().parse(data)
+        if isinstance(data, OrderedDict):
+            # only ordered because we made it so; the document just has a mapping here
+            typeStr = 'dict'
+        if isinstance(data, (int, float)) and not isinstance(data, bool) and 1e9 < data < 2e9:
+            desc = f"{desc}   ({time.strftime('%Y.%m.%d %H:%M:%S', time.localtime(data))})"
+        return typeStr, desc, childs, widget
 
 
 class FileDataView(Qt.QSplitter):
@@ -64,6 +92,8 @@ class FileDataView(Qt.QSplitter):
                         else:
                             self.displayDataAsPlot(data)
                         self.displayMetaInfoForData(data)
+                    elif typ == 'YamlFile':
+                        self.displayYaml(data)
                     else:
                         self.displayMessage(f"No data view available for file type {typ!r}.")
         except Exception:
@@ -136,6 +166,16 @@ class FileDataView(Qt.QSplitter):
         self._cursorText.setPos(pos.x() + 12, pos.y())
         pos = view.mapSceneToView(pos)
         self._cursorText.setText(f'({int(pos.x())}, {int(pos.y())})', color='y')
+
+    def displayYaml(self, data):
+        """Show a parsed yaml document as a browsable tree of mappings, lists and values."""
+        self.clear()
+        w = YamlTreeWidget(self)
+        # A mapping or list at the top level has nothing useful to say about itself,
+        # so drop that row and show its contents directly.
+        w.setData(_orderedCopy(data), hideRoot=isinstance(data, (dict, list, tuple)))
+        self.addWidget(w)
+        self._widgets.append(w)
 
     def displayAcqTrack(self, fh):
         """Offer to open a cell tracking history in the tracking visualizer."""

--- a/acq4/modules/DataManager/tests/test_file_data_view_yaml.py
+++ b/acq4/modules/DataManager/tests/test_file_data_view_yaml.py
@@ -1,0 +1,121 @@
+"""Tests that the Data tab renders a .yaml file as a browsable tree.
+
+Dicts, lists and scalars all have to show up; keys keep the order they appear in
+the document, and epoch timestamps are spelled out as dates.
+"""
+import time
+
+import pytest
+
+from acq4.filetypes.YamlFile import YamlFile
+from acq4.modules.DataManager.FileDataView import FileDataView, YamlTreeWidget
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+class _FakeFileHandle:
+    def __init__(self, path):
+        self._path = str(path)
+
+    def isDir(self):
+        return False
+
+    def fileType(self):
+        return "YamlFile"
+
+    def name(self, relativeTo=None):
+        return self._path
+
+    def read(self):
+        return YamlFile.read(self)
+
+
+def _yamlFile(tmp_path, text, name="data.yaml"):
+    path = tmp_path / name
+    path.write_text(text)
+    return _FakeFileHandle(path)
+
+
+def _tree(view):
+    trees = view.findChildren(YamlTreeWidget)
+    assert len(trees) == 1
+    return trees[0]
+
+
+def _rows(item):
+    """(key, type, value) for an item and everything under it, depth first."""
+    rows = []
+    for i in range(item.childCount()):
+        child = item.child(i)
+        rows.append((child.text(0), child.text(1), child.text(2)))
+        rows.extend(_rows(child))
+    return rows
+
+
+def test_mapping_is_shown_as_key_value_rows(qapp, tmp_path):
+    view = FileDataView(None)
+    fh = _yamlFile(tmp_path, "name: alpha\ncount: 3\n")
+
+    view.setCurrentFile(fh)
+
+    rows = _rows(_tree(view).invisibleRootItem())
+    assert ("name", "str", "alpha") in rows
+    assert ("count", "int", "3") in rows
+
+
+def test_keys_keep_document_order(qapp, tmp_path):
+    view = FileDataView(None)
+    fh = _yamlFile(tmp_path, "zebra: 1\nalpha: 2\nmiddle: 3\n")
+
+    view.setCurrentFile(fh)
+
+    assert [r[0] for r in _rows(_tree(view).invisibleRootItem())] == ["zebra", "alpha", "middle"]
+
+
+def test_list_of_scalars_gets_a_row_per_item(qapp, tmp_path):
+    view = FileDataView(None)
+    fh = _yamlFile(tmp_path, "pipettes:\n  - one\n  - two\n")
+
+    view.setCurrentFile(fh)
+
+    rows = _rows(_tree(view).invisibleRootItem())
+    assert ("pipettes", "list", "length=2") in rows
+    assert ("0", "str", "one") in rows
+    assert ("1", "str", "two") in rows
+
+
+def test_top_level_list_of_mappings_is_shown(qapp, tmp_path):
+    view = FileDataView(None)
+    fh = _yamlFile(tmp_path, "- cell: 1\n  ok: true\n- cell: 2\n  ok: false\n")
+
+    view.setCurrentFile(fh)
+
+    rows = _rows(_tree(view).invisibleRootItem())
+    assert ("0", "dict", "length=2") in rows
+    assert ("cell", "int", "1") in rows
+    assert ("cell", "int", "2") in rows
+
+
+def test_epoch_timestamps_are_spelled_out(qapp, tmp_path):
+    stamp = 1700000000.5
+    view = FileDataView(None)
+    fh = _yamlFile(tmp_path, f"startTime: {stamp}\n")
+
+    view.setCurrentFile(fh)
+
+    rows = _rows(_tree(view).invisibleRootItem())
+    expected = time.strftime("%Y.%m.%d %H:%M:%S", time.localtime(stamp))
+    assert any(r[0] == "startTime" and expected in r[2] for r in rows)
+
+
+def test_switching_away_from_yaml_clears_the_panel(qapp, tmp_path):
+    view = FileDataView(None)
+    view.setCurrentFile(_yamlFile(tmp_path, "name: alpha\n"))
+
+    view.setCurrentFile(None)
+
+    assert view.findChildren(YamlTreeWidget) == []


### PR DESCRIPTION
## What

Selecting a `.yaml`/`.yml` file in the Data Manager left the Data tab blank — `FileDataView` had no branch for `YamlFile`, so it fell through to "No data view available". Now it splats the parsed document into a browsable tree.

## How

`YamlTreeWidget` subclasses `pg.DataTreeWidget`, which already walks nested dicts, lists and scalars and gives `key / type / value` columns — so lists of things come free, each element on its own indexed row. Two readability tweaks on top:

- epoch floats in the 1e9–2e9 window get a spelled-out local date appended, the same heuristic `FileInfoView` uses
- keys keep document order (`DataTreeWidget` sorts plain-dict keys, so the document is rebuilt with `OrderedDict`; `parse` reports those back as plain `dict`)

The root row is hidden when the top level is a mapping or list, since it has nothing useful to say about itself.

```
protocol       str      whole cell
startTime      float    1755500000.25   (2025.08.17 23:53:20)
pipettes       list     length=2
  0              dict     length=2
    name           str      PatchPipette1
    attempts       list     length=2
      0              dict     length=3
        cell           int      3
```

## Tests

Six new tests in `acq4/modules/DataManager/tests/test_file_data_view_yaml.py` covering mappings, key order, lists of scalars, a top-level list of mappings, timestamp formatting, and clearing the panel. Written before the implementation; all 8 tests in that directory pass.

🤖 Generated with [Claude Code](https://claude.ai/code)