### PR TITLE
fix(autopatch): eleven operator-reported tweaks and bugfixes

### DIFF
--- a/acq4/experiment/actions/device.py
+++ b/acq4/experiment/actions/device.py
@@ -153,6 +153,26 @@ def _trackerStack(cell):
         return None
 
 
+def _attachStackDetails(action_entry, cell, title: str) -> None:
+    """Attach the cell tracker's stack to `action_entry` as image_stack details,
+    if the tracker exposes one. Shared by cellfie's success and tracking-lost
+    paths so a recorded stack is always shown, whichever one runs."""
+    stack = _trackerStack(cell)
+    if stack is not None:
+        action_entry.set_details(
+            "image_stack",
+            {
+                "stack": stack,
+                "center_index": (
+                    stack.shape[0] // 2
+                    if stack.ndim >= 3 and stack.shape[0] > 1
+                    else None
+                ),
+                "title": title,
+            },
+        )
+
+
 def cellfie(ctx, height: float = 30e-6, step: float = 1e-6) -> None:
     """Capture the cell "cellfie": focus on the target, save a z-stack into the
     current storage directory, and initialize the cell tracker's reference.
@@ -197,28 +217,20 @@ def cellfie(ctx, height: float = 30e-6, step: float = 1e-6) -> None:
             )
         except CellTrackingLost as exc:
             # The tracker could not re-find this cell against its own reference
-            # stacks, so the stacks are useless: the cell has drifted out of
-            # reach or died. That is a question about the tissue, not about this
-            # action, and the window is what can answer it. Never returns, so
-            # there is no stack to retain for the pane.
+            # stacks, so the stacks are useless for tracking: the cell has
+            # drifted out of reach or died. That is a question about the
+            # tissue, not about this action, and the window is what can answer
+            # it. A stack was still recorded above (a fresh reference, or the
+            # prior pass's reference on a re-verify) -- attach it before
+            # tissue_moved raises, so the operator sees what was captured
+            # instead of nothing, distinctly titled so they aren't misled into
+            # thinking the reference verified.
+            _attachStackDetails(action_entry, ctx.cell, "Cellfie (reference did not match)")
             ctx.tissue_moved(exc.reason or str(exc))
         # Retained for Area 5: the cube around the cell, which is what an
         # operator reads to judge a cellfie. The full acquired z-stack stays on
         # disk in the cellfie/ directory saved above.
-        stack = _trackerStack(ctx.cell)
-        if stack is not None:
-            action_entry.set_details(
-                "image_stack",
-                {
-                    "stack": stack,
-                    "center_index": (
-                        stack.shape[0] // 2
-                        if stack.ndim >= 3 and stack.shape[0] > 1
-                        else None
-                    ),
-                    "title": "Cellfie",
-                },
-            )
+        _attachStackDetails(action_entry, ctx.cell, "Cellfie")
 
 
 def load_preset(ctx, preset: str | None = None) -> None:

--- a/acq4/experiment/orchestrator.py
+++ b/acq4/experiment/orchestrator.py
@@ -399,6 +399,21 @@ class Orchestrator(Qt.QObject):
         # session, so one more reference here retains nothing that was going to
         # be freed anyway.
         self._savedTracking = (None, None, 0)
+        # The managed Cell directory already made for a given cell, keyed by
+        # id(cell) rather than held on the cell itself: cells reaching this
+        # engine are only ever duck-typed (a bare str stands in for one in most
+        # of this module's own tests), so nothing guarantees a cell can carry an
+        # attribute. Each entry keeps a strong reference to the cell alongside
+        # its directory -- with the cell kept alive by this dict, id(cell)
+        # cannot be recycled onto a different object for as long as its entry
+        # survives, which is what makes id() safe to key on here. Read by
+        # _makeCellDataDir so a cell CellPanel re-enqueues after it reaches a
+        # terminal disposition (see CellPanel._onReuseCheckedCells) re-enters
+        # the directory it already has on its next pass instead of a sibling.
+        # Never emptied: a cell keeps its entry for the life of the
+        # orchestrator, the same trade its pipette already makes by never
+        # releasing a cell from previousCells.
+        self._cellDataDirs = {}
 
     # ---- queue / context ----
     def enqueue(self, cell):
@@ -837,10 +852,10 @@ class Orchestrator(Qt.QObject):
             return
         self.sigCellFinished.emit(cell, status)
 
-    @staticmethod
-    def _makeCellDataDir(ctx, cell):
+    def _makeCellDataDir(self, ctx, cell):
         """Create the managed "Cell" directory this cell's data is saved into,
-        and make it the current one.
+        and make it the current one -- or, if this cell already has one from an
+        earlier pass, re-enter that directory instead.
 
         Everything a run writes -- the cellfie stack, the patch log, a
         TaskRunner sequence -- lands under the manager's current directory, so
@@ -854,16 +869,36 @@ class Orchestrator(Qt.QObject):
         Before the target rather than after, so an operator who has not chosen a
         storage directory finds out before the pipette has been pointed anywhere.
 
-        Nothing to create it under is not a failure -- a headless run has no
-        manager -- but a manager that cannot make the directory halts the run:
-        the alternative is patching cell after cell into a directory that names
-        another cell.
+        A cell CellPanel re-enqueues once it reaches a terminal disposition (see
+        CellPanel._onReuseCheckedCells) is the same Cell object, tracker
+        included, arriving at a second _processCell pass -- minting it a fresh
+        sibling directory here would split one physical cell's data across two
+        folders, with the tracker's cumulative history landing in whichever
+        directory the last pass made and the folder actually named after the
+        cell holding only whatever an earlier pass wrote before that. See
+        self._cellDataDirs for how this tells that case apart from a genuinely
+        new cell.
 
-        The cell's metadata is written into it as soon as it exists, rather than
-        alongside the tracking history at close-out. Everything in that file is
-        already settled by now -- it is what the detector found -- and writing
-        it here is what makes it survive a protocol that dies on its first move,
-        which is the pass whose inputs an operator most wants to read.
+        A directory recorded for this cell that has since stopped existing (a
+        storage-dir change mid-run, most plausibly) halts the run rather than
+        falling back to a new sibling: a silent fallback would reproduce the
+        very split this reuse exists to prevent, only now by this method's own
+        choice instead of by the oversight that caused it in the first place.
+
+        Nothing to create it under is not a failure -- a headless run has no
+        manager -- but a manager that cannot make (or re-enter) the directory
+        halts the run: the alternative is patching cell after cell into a
+        directory that names another cell.
+
+        The cell's metadata is (re)written into it as soon as it is current,
+        rather than alongside the tracking history at close-out. Everything in
+        that file is already settled by now -- it is what the detector found --
+        and writing it here is what makes it survive a protocol that dies on its
+        first move, which is the pass whose inputs an operator most wants to
+        read. Rewriting it on a reused directory is harmless rather than a
+        second, competing observation: it is the same cell's own settled facts,
+        recomputed from the same attributes, so the second write is either
+        identical to the first or a strict update of it.
 
         Returns the directory (None when there was no manager to make one), which
         _closeCellDataDir needs: by the time the pass ends the protocol may have
@@ -872,6 +907,24 @@ class Orchestrator(Qt.QObject):
         manager = getattr(ctx, "manager", None) if ctx is not None else None
         if manager is None:
             return None
+        reused = self._cellDataDirs.get(id(cell))
+        if reused is not None:
+            _, savedDir = reused
+            if not savedDir.exists():
+                raise OrchestrationError(
+                    f"the data directory previously made for cell {cell!r} no "
+                    f"longer exists: {savedDir.name()}"
+                )
+            try:
+                manager.setCurrentDir(savedDir)
+            except (Stopped, FlowSignal):
+                raise
+            except Exception as exc:
+                raise OrchestrationError(
+                    f"could not re-enter the data directory for cell {cell!r}: {exc}"
+                ) from exc
+            _saveCellMetadata(cell, savedDir)
+            return savedDir
         try:
             # Through the protocol-facing action rather than create_data_dir, for
             # its log_action entry: the operator has to be able to find a cell's
@@ -888,6 +941,7 @@ class Orchestrator(Qt.QObject):
         # made halts the run, and a metadata file that could not be written must
         # not be mistaken for one. _saveCellMetadata swallows its own.
         _saveCellMetadata(cell, cellDir)
+        self._cellDataDirs[id(cell)] = (cell, cellDir)
         return cellDir
 
     @staticmethod

--- a/acq4/experiment/slice.py
+++ b/acq4/experiment/slice.py
@@ -403,6 +403,107 @@ class Slice:
         return fov_w * fov_h * self._constraints.z_span()
 
     # ---- the record on disk ----
+    def snapshotState(self) -> dict | None:
+        """Capture everything saveState() would write, as one plain-data dict
+        with no reference back into this Slice.
+
+        The split from writeSnapshot() below exists for a caller that must not
+        read this Slice from anywhere but the thread it is being mutated on --
+        AutopatchWindow._flushSliceState captures a snapshot here on the GUI
+        thread and hands it to a worker thread to write, so the worker never
+        touches self._regions/self._covered/self._constraints, only the plain
+        data already pulled out of them. Every region is already to_dict()'d
+        and every coordinate already float()'d for exactly that reason: a
+        setRegions() or markCovered() landing on the GUI thread after this
+        returns must not be able to reach into a snapshot already handed off.
+
+        Returns None for a slice with no directory, matching saveState()'s own
+        no-op in that case -- there is nothing for writeSnapshot() to do with a
+        directory-less snapshot, so there is no reason to build one.
+        """
+        dirHandle = self.dirHandle
+        if dirHandle is None:
+            return None
+        # Bound once each, and everything below derived from these bindings:
+        # the GUI thread can swap the whole region list while the worker thread
+        # is covering tiles, and a record whose outlines and whose tile counts
+        # came from two different readings describes a slice that never
+        # existed. The same discipline setRegions() and tileGrid() keep.
+        regions = self._regions
+        covered = list(self._covered)
+        constraints = self._constraints
+        total, nCovered, percent = self._surveyStatsFor(regions, covered)
+        # float()/bool() throughout, because these coordinates arrive from a
+        # camera's boundary and a numpy-backed tiler, and a numpy scalar left
+        # in the payload is written as a tagged Python object that no plain
+        # YAML reader can load back. The conversion is exact.
+        return {
+            "dirHandle": dirHandle,
+            "regions": [region.to_dict() for region in regions],
+            "state": {
+                "fov": [float(v) for v in self._fov],
+                "overlap": float(self._overlap),
+                "constraints": {
+                    "depth_range": [float(v) for v in constraints.depth_range],
+                    "min_health": float(constraints.min_health),
+                    "max_cell_density": float(constraints.max_cell_density),
+                    "rescans_allowed": bool(constraints.rescans_allowed),
+                },
+                "covered": [[float(x), float(y)] for x, y in covered],
+                "survey": {
+                    "total_tiles": int(total),
+                    "covered_tiles": int(nCovered),
+                    "percent_covered": float(percent),
+                },
+            },
+            "info": {
+                "n_regions": len(regions),
+                "percent_covered": float(percent),
+                "min_health": float(constraints.min_health),
+                "depth_range": [float(v) for v in constraints.depth_range],
+            },
+        }
+
+    @staticmethod
+    def writeSnapshot(snapshot: dict) -> None:
+        """Write a snapshot captured by snapshotState() into its directory.
+
+        A staticmethod, not an instance method: it must not touch a live
+        Slice at all, only the plain data already sitting in `snapshot` and
+        the DirHandle inside it (DirHandle's own writes are safe to call from
+        any thread, the same way the orchestrator already calls them from its
+        worker thread to save cell data). That is what lets a caller build the
+        snapshot on the GUI thread and have this run -- possibly later,
+        possibly on another thread entirely -- without a second thread ever
+        touching this Slice's mutable state.
+
+        Nothing raises out of here. Every caller is either a GUI slot that has
+        already committed the operator's edit by the time it asks for a save,
+        a worker thread writing a snapshot handed to it, or New slice partway
+        through discarding the slice being saved -- and in all three, a raise
+        costs far more than the file it failed to write. The two halves are
+        guarded separately so that a failure specific to one does not take the
+        other with it, and the regions go first because they are the
+        irreplaceable half: coverage and constraints can be re-derived from a
+        rerun, while an outline traced around a piece of tissue cannot.
+
+        The summary put on the directory index rides with the search state
+        rather than being guarded on its own, because it is the same numbers
+        said twice: small scalars only, since the index is written with repr()
+        and read back with eval() (a region or an array put there would be
+        written and never read).
+        """
+        dirHandle = snapshot["dirHandle"]
+        try:
+            dirHandle.writeFile(snapshot["regions"], REGIONS_FILE, fileType="YamlFile")
+        except Exception:
+            logger.exception("Could not write this slice's search regions")
+        try:
+            dirHandle.writeFile(snapshot["state"], SEARCH_STATE_FILE, fileType="YamlFile")
+            dirHandle.setInfo(**snapshot["info"])
+        except Exception:
+            logger.exception("Could not write this slice's search state")
+
     def saveState(self) -> None:
         """Write this slice's search state into its own data directory.
 
@@ -419,74 +520,15 @@ class Slice:
         a region rather than by way of New slice (see `dirHandle`), and it
         honestly has nowhere to write.
 
-        Nothing raises out of here. Every caller is either a GUI slot that has
-        already committed the operator's edit by the time it asks for a save,
-        or New slice partway through discarding the slice being saved -- and in
-        both, a raise costs far more than the file it failed to write. The two
-        halves are guarded separately so that a failure specific to one does
-        not take the other with it, and the regions go first because they are
-        the irreplaceable half: coverage and constraints can be re-derived from
-        a rerun, while an outline traced around a piece of tissue cannot.
-
-        The summary put on the directory index rides with the search state
-        rather than being guarded on its own, because it is the same numbers
-        said twice: small scalars only, since the index is written with repr()
-        and read back with eval() (a region or an array put there would be
-        written and never read).
+        snapshotState() immediately followed by writeSnapshot() -- see either
+        for the split's own reason. This is the synchronous, same-thread
+        convenience the rest of this Slice's callers use; a caller that must
+        write off-thread (see AutopatchWindow._flushSliceState) calls the two
+        halves itself instead.
         """
-        dirHandle = self.dirHandle
-        if dirHandle is None:
-            return
-        # Bound once each, and everything below derived from these bindings:
-        # the GUI thread can swap the whole region list while the worker thread
-        # is covering tiles, and a record whose outlines and whose tile counts
-        # came from two different readings describes a slice that never
-        # existed. The same discipline setRegions() and tileGrid() keep.
-        regions = self._regions
-        covered = list(self._covered)
-        constraints = self._constraints
-        try:
-            dirHandle.writeFile(
-                [region.to_dict() for region in regions],
-                REGIONS_FILE,
-                fileType="YamlFile",
-            )
-        except Exception:
-            logger.exception("Could not write this slice's search regions")
-        try:
-            total, nCovered, percent = self._surveyStatsFor(regions, covered)
-            # float()/bool() throughout, because these coordinates arrive from
-            # a camera's boundary and a numpy-backed tiler, and a numpy scalar
-            # left in the payload is written as a tagged Python object that no
-            # plain YAML reader can load back. The conversion is exact.
-            dirHandle.writeFile(
-                {
-                    "fov": [float(v) for v in self._fov],
-                    "overlap": float(self._overlap),
-                    "constraints": {
-                        "depth_range": [float(v) for v in constraints.depth_range],
-                        "min_health": float(constraints.min_health),
-                        "max_cell_density": float(constraints.max_cell_density),
-                        "rescans_allowed": bool(constraints.rescans_allowed),
-                    },
-                    "covered": [[float(x), float(y)] for x, y in covered],
-                    "survey": {
-                        "total_tiles": int(total),
-                        "covered_tiles": int(nCovered),
-                        "percent_covered": float(percent),
-                    },
-                },
-                SEARCH_STATE_FILE,
-                fileType="YamlFile",
-            )
-            dirHandle.setInfo(
-                n_regions=len(regions),
-                percent_covered=float(percent),
-                min_health=float(constraints.min_health),
-                depth_range=[float(v) for v in constraints.depth_range],
-            )
-        except Exception:
-            logger.exception("Could not write this slice's search state")
+        snapshot = self.snapshotState()
+        if snapshot is not None:
+            Slice.writeSnapshot(snapshot)
 
     def loadState(self) -> bool:
         """Restore the search state saved into this slice's data directory.

--- a/acq4/experiment/slice.py
+++ b/acq4/experiment/slice.py
@@ -55,6 +55,13 @@ class SearchConstraints:
     metre, above which a tile counts as already crowded and is skipped rather
     than having more targets packed into it. `rescans_allowed` permits
     re-imaging tiles that have already been covered.
+
+    `min_volume_m3` and `step_z` parameterise the tile detector rather than
+    the search itself: a volume floor below which a detected blob is not a
+    cell, and the z step its detection stack is acquired at. They live here
+    (rather than as a separate, unpersisted rig setting) so an operator's
+    choice for one slice is exactly as reproducible as the health cutoff or
+    the density cap.
     """
 
     depth_range: tuple[float, float] = (-20e-6, -60e-6)
@@ -63,6 +70,8 @@ class SearchConstraints:
     # default cap only rejects genuinely crowded tissue.
     max_cell_density: float = 5e12
     rescans_allowed: bool = False
+    min_volume_m3: float = 0.0
+    step_z: float = 1e-6
 
     def __post_init__(self):
         near, far = self.depth_range
@@ -81,6 +90,12 @@ class SearchConstraints:
         if self.max_cell_density <= 0:
             raise ValueError(
                 f"max_cell_density must be positive, got {self.max_cell_density}"
+            )
+        if self.step_z <= 0:
+            raise ValueError(f"step_z must be positive, got {self.step_z}")
+        if self.min_volume_m3 < 0:
+            raise ValueError(
+                f"min_volume_m3 must be non-negative, got {self.min_volume_m3}"
             )
 
     def z_span(self) -> float:
@@ -448,6 +463,8 @@ class Slice:
                     "min_health": float(constraints.min_health),
                     "max_cell_density": float(constraints.max_cell_density),
                     "rescans_allowed": bool(constraints.rescans_allowed),
+                    "min_volume_m3": float(constraints.min_volume_m3),
+                    "step_z": float(constraints.step_z),
                 },
                 "covered": [[float(x), float(y)] for x, y in covered],
                 "survey": {
@@ -573,6 +590,12 @@ class Slice:
                 min_health=constraints["min_health"],
                 max_cell_density=constraints["max_cell_density"],
                 rescans_allowed=constraints["rescans_allowed"],
+                # .get() with the library defaults, not a migration: a record
+                # written before these existed simply lacks the keys, and a
+                # slice loaded from one gets the same defaults it would have
+                # gotten unconfigured.
+                min_volume_m3=constraints.get("min_volume_m3", 0.0),
+                step_z=constraints.get("step_z", 1e-6),
             )
             # Rebound rather than mutated, and as tuples, so the restored
             # coverage is indistinguishable from coverage markCovered() built.

--- a/acq4/experiment/tests/test_actions_device.py
+++ b/acq4/experiment/tests/test_actions_device.py
@@ -222,10 +222,14 @@ class FakeCell:
         # Recorded before the error path, so a test asserting on a lost cell can
         # still see what the call was made with.
         self.tracker_kwargs.append(tracker_kwargs)
-        if self.tracker_error is not None:
-            raise self.tracker_error
+        # Mirrors the real Cell.initializeTracker: a freshly-built tracker is
+        # assigned to _tracker before verify_reference() can raise
+        # CellTrackingLost, so a reference that fails to verify still leaves a
+        # tracker (and its stack) behind for the caller to read.
         if self.tracker_stack is not None:
             self._tracker = _FakeTracker(self.tracker_stack)
+        if self.tracker_error is not None:
+            raise self.tracker_error
 
 
 @pytest.fixture
@@ -664,9 +668,44 @@ def test_cellfie_sets_no_payload_when_the_tracker_exposes_no_stack(ctx, pip, mon
     assert details == []
 
 
-def test_cellfie_sets_no_payload_when_the_cell_is_lost(monkeypatch, tmp_path):
-    # tissue_moved never returns, so there is nothing to retain -- the accepted
-    # gap in the spec's §8.
+def test_cellfie_retains_the_stack_when_the_cell_is_lost(monkeypatch, tmp_path):
+    # A stack was genuinely recorded before verify_reference rejected it, so the
+    # operator must still see it even though tissue_moved never returns. Not
+    # showing it would misrepresent a stack that exists as a stack that doesn't.
+    pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
+    import numpy as np
+    from acq4_automation.feature_tracking import CellTrackingLost
+
+    def hook(c, reason):
+        raise AdvanceToNextCell(reason)
+
+    ctx = _cellfie_context(monkeypatch, tmp_path, tissue_moved_hook=hook)
+    ctx.cell.tracker_error = CellTrackingLost("gone")
+    ctx.cell.tracker_stack = np.arange(5 * 4 * 3, dtype=float).reshape(5, 4, 3)
+    details = []
+    ctx.on_log_action = lambda e: setattr(
+        e, "on_details", lambda entry, kind, payload: details.append((kind, payload))
+    )
+
+    with pytest.raises(AdvanceToNextCell):
+        cellfie(ctx)
+
+    assert len(details) == 1
+    kind, payload = details[0]
+    assert kind == "image_stack"
+    assert payload["stack"].shape == (5, 3, 4)
+    assert payload["center_index"] == 2
+    # Titled distinctly from the success path so the operator isn't misled into
+    # thinking this cellfie's reference actually verified.
+    assert payload["title"] == "Cellfie (reference did not match)"
+
+
+def test_cellfie_sets_no_payload_when_the_cell_is_lost_with_no_tracker_at_all(
+    monkeypatch, tmp_path
+):
+    # initializeTracker can fail before a tracker ever gets built (e.g. the
+    # tracker constructor itself raises CellTrackingLost). No tracker means no
+    # stack to show, and that must not crash the details attachment.
     pytest.importorskip("acq4_automation", reason=_CELLFIE_SKIP_REASON)
     from acq4_automation.feature_tracking import CellTrackingLost
 

--- a/acq4/experiment/tests/test_orchestrator_cell_setup.py
+++ b/acq4/experiment/tests/test_orchestrator_cell_setup.py
@@ -3,7 +3,9 @@ before it (the pipette's target and the managed Cell data directory, each done
 once per cell rather than once per attempt) and the close-out after it (the
 cell's .acqtrack tracking history, saved however the pass ended)."""
 import os
+import shutil
 
+import numpy as np
 import pytest
 
 import acq4.util.DataManager as dm
@@ -242,6 +244,151 @@ def _acqtrack_files(dir_handle):
     return sorted(
         f for f in os.listdir(dir_handle.name()) if f.endswith(".acqtrack")
     )
+
+
+# -- reusing a cell's directory across passes ----------------------------
+
+
+class FakeObjectStack:
+    """Stands in for the motion estimator's original reference cube: an array
+    plus the tolerance _referenceStack reads, .transform, which this leaves
+    unset the same way a cube with no transform yet does."""
+
+    def __init__(self, data):
+        self.data = data
+
+
+class FakeMotionEstimator:
+    def __init__(self, data):
+        self.original_object_stack = FakeObjectStack(data)
+
+
+class FakeTrackerWithReferenceStack(FakeTracker):
+    """A FakeTracker whose motion estimator also carries a reference cube, so
+    _saveReferenceStack has something to write -- what a cross-pass reuse test
+    needs in order to check that a first pass's cube survives a second pass
+    sharing its directory."""
+
+    def __init__(self, data):
+        FakeTracker.__init__(self)
+        self.motion_estimator = FakeMotionEstimator(data)
+
+
+def test_a_cell_reprocessed_on_a_later_pass_reuses_its_own_directory(
+    make_pf, root_dir
+):
+    # CellPanel._onReuseCheckedCells re-enqueues the very same Cell object once
+    # it reaches a terminal disposition, so this cell reaches _processCell a
+    # second time. Minting it a fresh sibling directory here is exactly the
+    # reported bug: one physical cell's data split across two Cell folders.
+    man = FakeManager(root_dir)
+    pf = make_pf()
+    seen = []
+    pf.run = lambda ctx, **kwargs: seen.append(ctx.manager.getCurrentDir())
+    orch = _dir_orch(pf, man)
+    cell = FakeTrackedCell("c1")
+    orch.run_sync_cell(cell)
+    orch.run_sync_cell(cell)
+    assert len(seen) == 2
+    assert seen[0].name() == seen[1].name()
+
+
+def test_two_different_cells_still_get_different_directories_on_the_reuse_path(
+    make_pf, root_dir
+):
+    # The guarantee test_each_cell_gets_its_own_managed_cell_directory already
+    # protects, checked again here against real (non-string) cell objects with
+    # the reuse bookkeeping in place: it is only the SAME cell across passes
+    # that must share a directory, never two distinct ones.
+    man = FakeManager(root_dir)
+    pf = make_pf()
+    seen = []
+    pf.run = lambda ctx, **kwargs: seen.append(ctx.manager.getCurrentDir())
+    orch = _dir_orch(pf, man)
+    first, second = FakeTrackedCell("c1"), FakeTrackedCell("c2")
+    orch.run_sync_cell(first)
+    orch.run_sync_cell(second)
+    assert seen[0].name() != seen[1].name()
+
+
+def test_a_reused_cells_earlier_artifacts_survive_a_second_pass(make_pf, root_dir):
+    # The second pass writes cell_metadata.yaml, reference_stack.ma and
+    # position_history.yaml into the SAME directory as the first. Overwriting
+    # them is the right call here (see orchestrator._makeCellDataDir's
+    # docstring): they describe this one cell's own settled facts, recomputed
+    # from the same tracker and the same growing _positions dict, not a
+    # competing pass's distinct observation -- so the point of this test is
+    # that the files are still there and still readable after pass two, not
+    # that their bytes are untouched.
+    man = FakeManager(root_dir)
+    pf = make_pf()
+    seen = []
+    pf.run = lambda ctx, **kwargs: seen.append(ctx.manager.getCurrentDir())
+    orch = _dir_orch(pf, man)
+    cell = FakeTrackedCell("c1")
+    cell._tracker = FakeTrackerWithReferenceStack(np.ones((2, 2)))
+    cell._positions = {0.0: (0.0, 0.0, 0.0)}
+
+    orch.run_sync_cell(cell)
+    cellDir = seen[0]
+    for fname in ("cell_metadata.yaml", "reference_stack.ma", "position_history.yaml"):
+        assert os.path.exists(os.path.join(cellDir.name(), fname)), fname
+
+    # Pass two: the tracker and position history both grew in the meantime.
+    cell._tracker.tracking_results.append(object())
+    cell._positions[1.0] = (1.0, 1.0, 1.0)
+    orch.run_sync_cell(cell)
+
+    assert seen[1].name() == cellDir.name()
+    for fname in ("cell_metadata.yaml", "reference_stack.ma", "position_history.yaml"):
+        assert os.path.exists(os.path.join(cellDir.name(), fname)), fname
+    # The tracking history is written into that one directory both times, not
+    # once there and once into a sibling.
+    assert cell._tracker.saved_to == [
+        os.path.join(cellDir.name(), "tracking_history.acqtrack"),
+        os.path.join(cellDir.name(), "tracking_history.acqtrack"),
+    ]
+
+
+def test_a_retry_inside_one_pass_still_reuses_its_directory(make_pf, root_dir):
+    # The in-place RetryCurrentCell loop is a different mechanism from the
+    # cross-pass reuse above (it never leaves _processCell, let alone
+    # _makeCellDataDir), and must keep behaving exactly as it did before.
+    man = FakeManager(root_dir)
+    pf = make_pf()
+    seen = []
+
+    def spy_run(ctx, **kwargs):
+        seen.append(ctx.manager.getCurrentDir())
+        if len(seen) == 1:
+            raise RetryCurrentCell("first attempt fails")
+
+    pf.run = spy_run
+    _dir_orch(pf, man).run_sync_cell("c1")
+    assert len(seen) == 2
+    assert seen[0].info().get("dirType") == "Cell"
+    assert seen[0].name() == seen[1].name()
+
+
+def test_a_vanished_cell_directory_halts_the_run_on_the_next_pass(make_pf, root_dir):
+    # A directory recorded for a cell can stop existing between passes -- a
+    # storage-dir change mid-run, most plausibly. Silently minting a new
+    # sibling here would reproduce the very split-history bug this reuse
+    # bookkeeping exists to prevent, so this halts instead.
+    man = FakeManager(root_dir)
+    pf = make_pf()
+    seen = []
+    pf.run = lambda ctx, **kwargs: seen.append(ctx.manager.getCurrentDir())
+    orch = _dir_orch(pf, man)
+    cell = FakeTrackedCell("c1")
+    orch.run_sync_cell(cell)
+    shutil.rmtree(seen[0].name())
+
+    errors = []
+    orch.sigRunError.connect(errors.append)
+    with pytest.raises(AbortExperiment):
+        orch.run_sync_cell(cell)
+    assert [r.exc_type for r in errors] == ["OrchestrationError"]
 
 
 def test_the_cells_tracking_history_is_saved_into_its_own_directory(make_pf, root_dir):

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -91,6 +91,25 @@ def test_max_cell_density_must_be_positive():
         SearchConstraints(max_cell_density=0.0)
 
 
+def test_detection_defaults_match_what_the_survey_used_before_these_were_settable():
+    c = SearchConstraints()
+    assert c.min_volume_m3 == 0.0
+    assert c.step_z == 1e-6
+
+
+def test_step_z_must_be_positive():
+    # A zero or negative z increment is nonsense for a detection z-stack.
+    with pytest.raises(ValueError, match="positive"):
+        SearchConstraints(step_z=0.0)
+    with pytest.raises(ValueError, match="positive"):
+        SearchConstraints(step_z=-1e-6)
+
+
+def test_min_volume_must_be_non_negative():
+    with pytest.raises(ValueError, match="non-negative"):
+        SearchConstraints(min_volume_m3=-1e-18)
+
+
 def test_constraints_are_frozen():
     c = SearchConstraints()
     with pytest.raises(Exception):
@@ -848,6 +867,8 @@ def _saved_slice(dirHandle, **kwargs):
             min_health=0.62,
             max_cell_density=3e12,
             rescans_allowed=True,
+            min_volume_m3=5e-17,
+            step_z=2e-6,
         ),
     )
     s = Slice(dirHandle=dirHandle, **kwargs)
@@ -912,6 +933,8 @@ def test_save_state_writes_the_search_parameters(slice_dir):
         "min_health": 0.62,
         "max_cell_density": 3e12,
         "rescans_allowed": True,
+        "min_volume_m3": 5e-17,
+        "step_z": 2e-6,
     }
 
 
@@ -1007,9 +1030,12 @@ def test_snapshot_state_is_plain_data_not_a_reference_into_the_slice(slice_dir):
     assert all(isinstance(d, dict) for d in snapshot["regions"])
     s.setRegions([RectRegion(0.0, 0.0, 1e-3, 1e-3)])
     s.markCovered((999.0, 999.0))
-    # The snapshot already taken must be untouched by the mutation above.
+    s.setConstraints(SearchConstraints(min_volume_m3=9e-17, step_z=9e-6))
+    # The snapshot already taken must be untouched by the mutations above.
     assert len(snapshot["regions"]) == 3
     assert (999.0, 999.0) not in [tuple(c) for c in snapshot["state"]["covered"]]
+    assert snapshot["state"]["constraints"]["min_volume_m3"] == 5e-17
+    assert snapshot["state"]["constraints"]["step_z"] == 2e-6
 
 
 def test_snapshot_state_returns_none_without_a_directory():
@@ -1140,6 +1166,23 @@ def test_load_state_leaves_the_field_of_view_alone(slice_dir):
     restored.loadState()
 
     assert restored.fov == (200e-6, 200e-6)
+
+
+def test_load_state_defaults_detection_settings_missing_from_an_older_record(slice_dir):
+    # A record written before min_volume_m3/step_z existed simply lacks those
+    # keys; loading it falls back to the library defaults rather than raising.
+    saved = _saved_slice(slice_dir)
+    saved.saveState()
+    state = slice_dir["search_state.yaml"].read()
+    del state["constraints"]["min_volume_m3"]
+    del state["constraints"]["step_z"]
+    slice_dir.writeFile(state, "search_state.yaml", fileType="YamlFile")
+
+    restored = Slice(fov=(100e-6, 50e-6), dirHandle=slice_dir)
+    assert restored.loadState() is True
+
+    assert restored.constraints.min_volume_m3 == 0.0
+    assert restored.constraints.step_z == 1e-6
 
 
 def test_load_state_finds_nothing_in_a_directory_with_no_record(slice_dir):

--- a/acq4/experiment/tests/test_slice.py
+++ b/acq4/experiment/tests/test_slice.py
@@ -974,6 +974,51 @@ def test_save_state_overwrites_the_previous_save(slice_dir):
     assert slice_dir.info()["n_regions"] == 1
 
 
+def test_snapshot_state_then_write_snapshot_writes_the_same_record_as_save_state(
+    slice_dir,
+):
+    # saveState() is snapshotState() immediately followed by writeSnapshot():
+    # a caller that must not read this Slice off the GUI thread (see
+    # AutopatchWindow._flushSliceState) captures the snapshot where saveState()
+    # would, and hands it to writeSnapshot() to do the actual writing --
+    # possibly later, possibly on another thread. Splitting them must not
+    # change what ends up on disk.
+    s = _saved_slice(slice_dir)
+
+    snapshot = s.snapshotState()
+    Slice.writeSnapshot(snapshot)
+
+    assert slice_dir["regions.yaml"].read() == [r.to_dict() for r in s.regions]
+    state = slice_dir["search_state.yaml"].read()
+    assert [tuple(t) for t in state["covered"]] == s.coveredTiles
+    assert slice_dir.info()["n_regions"] == 3
+
+
+def test_snapshot_state_is_plain_data_not_a_reference_into_the_slice(slice_dir):
+    # The whole point of splitting the snapshot out of saveState() is that a
+    # worker thread writing it later must never touch this Slice's own
+    # mutable state -- only regions.to_dict()'d already, coordinates already
+    # float()'d, nothing that setRegions()/markCovered() could still mutate
+    # out from under a write in progress.
+    s = _saved_slice(slice_dir)
+
+    snapshot = s.snapshotState()
+
+    assert all(isinstance(d, dict) for d in snapshot["regions"])
+    s.setRegions([RectRegion(0.0, 0.0, 1e-3, 1e-3)])
+    s.markCovered((999.0, 999.0))
+    # The snapshot already taken must be untouched by the mutation above.
+    assert len(snapshot["regions"]) == 3
+    assert (999.0, 999.0) not in [tuple(c) for c in snapshot["state"]["covered"]]
+
+
+def test_snapshot_state_returns_none_without_a_directory():
+    s = make_slice()
+    s.addRegion(RectRegion(0.0, 0.0, 30e-6, 30e-6))
+
+    assert s.snapshotState() is None
+
+
 class _RefusesToWrite:
     """A DirHandle whose every write fails -- a full disk, a storage directory
     that went away with a network mount, a permission that changed under a

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import os
+import time
 
 from acq4.experiment.actions.prompt import prompt
 from acq4.experiment.actions.storage import create_data_dir
@@ -80,6 +81,11 @@ class AutopatchWindow(Qt.QWidget):
     whatever size it is dragged to (see _makeArea and _AreaViewport), and the
     division is kept between sessions (see _saveLayout).
     """
+
+    # Minimum spacing between periodic slice-state saves driven by a run's
+    # "surveying" status; see _flushSliceState for the durability tradeoff
+    # this bounds.
+    _SLICE_SAVE_MIN_INTERVAL = 2.0
 
     def __init__(
         self,
@@ -257,6 +263,13 @@ class AutopatchWindow(Qt.QWidget):
         # on the orchestrator's worker thread and must not read a selector.
         self._cachedCamera = None
         self._cachedScope = None
+        # Wall-clock source for _flushSliceState's throttle. An attribute
+        # rather than a bare time.monotonic() call so a test can swap in a
+        # fake clock instead of driving the throttle with real sleeps.
+        self._sliceSaveClock = time.monotonic
+        # Clock reading at the last periodic slice-state save, or None before
+        # the first one; see _flushSliceState.
+        self._lastSliceSaveTime = None
         self._tornDown = False
         self.protocolPanel.sigProtocolLoaded.connect(self._onProtocolLoaded)
         # Area 4 (the protocol picker/Reload) must not be usable while a
@@ -1064,11 +1077,40 @@ class AutopatchWindow(Qt.QWidget):
             self._refreshProgress()
             # The one point where coverage accumulated on the worker thread is
             # observed from the GUI thread, so it is where the record of it can
-            # be written without reading the slice off-thread. A survey
-            # interrupted between two of these has lost at most the tiles since
-            # the last one.
+            # be written without reading the slice off-thread. "surveying" fires
+            # once per queue refill -- in an interleaved survey+patch run that
+            # is effectively once per cell -- so the save itself is throttled;
+            # "waiting" fires once, at the run's end, and always forces a write.
             if self.slice is not None:
-                self.slice.saveState()
+                self._flushSliceState(force=(status == "waiting"))
+
+    def _flushSliceState(self, *, force: bool) -> None:
+        """Write self.slice's search state to disk, throttled unless `force`.
+
+        Durability contract: while a run is in progress, at most the coverage
+        gained in the last _SLICE_SAVE_MIN_INTERVAL seconds can be lost to a
+        crash or power loss -- the same tolerance wiring saveState() to the
+        "surveying" status was built to accept ("a survey interrupted between
+        two of these has lost at most the tiles since the last one"), now
+        bounded by wall-clock time rather than by how often the orchestrator
+        happens to refill its queue. That bound holds because every caller
+        that can end a run's ability to keep saving -- the run reaching
+        "waiting", a slice being replaced, and the window closing -- calls
+        this with force=True, which always writes regardless of the timer.
+
+        Never reads a state captured earlier: a throttled call writes nothing
+        and caches nothing, so the next write, forced or not, reads whatever
+        self.slice holds at that later moment -- never a stale snapshot from
+        whenever the throttle last let a save through.
+        """
+        if self.slice is None:
+            return
+        now = self._sliceSaveClock()
+        if not force and self._lastSliceSaveTime is not None:
+            if now - self._lastSliceSaveTime < self._SLICE_SAVE_MIN_INTERVAL:
+                return
+        self.slice.saveState()
+        self._lastSliceSaveTime = now
 
     def _onTissueMoved(self, cell, ctx, reason: str) -> None:
         """ExecutionContext.tissue_moved, cell-bound by the context factory.
@@ -1328,6 +1370,15 @@ class AutopatchWindow(Qt.QWidget):
             if self.orchestrator is not None:
                 self._stopAndReleaseOrchestrator(self.orchestrator)
         finally:
+            # Forced, in the finally, before anything else: the operator can
+            # close this window mid-survey, before a run ever reaches
+            # "waiting", and closing it must not itself become a way to lose
+            # whatever a throttled _flushSliceState call hasn't written yet
+            # (see that method's durability contract). Ahead of the releases
+            # below for the same reason they are in this finally at all -- a
+            # raise stopping the orchestrator must not cost the run's record.
+            if self.slice is not None:
+                self._flushSliceState(force=True)
             # In a finally because these are the releases that reach *outside*
             # this window: a raise while stopping the orchestrator would
             # otherwise leave the Camera module holding this session's outlines

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import os
+import threading
 import time
 
 from acq4.experiment.actions.prompt import prompt
@@ -17,6 +18,7 @@ from acq4.modules.Module import Module
 from acq4.util import Qt
 from acq4.util.HelpfulException import HelpfulException
 from acq4.util.InterfaceCombo import InterfaceCombo
+from acq4.util.task import WorkerThread
 
 from .cell_panel import CellPanel
 from .context_factory import make_context_factory
@@ -86,6 +88,10 @@ class AutopatchWindow(Qt.QWidget):
     # "surveying" status; see _flushSliceState for the durability tradeoff
     # this bounds.
     _SLICE_SAVE_MIN_INTERVAL = 2.0
+    # How long a forced flush (run end, slice replaced, window closing) waits
+    # for its write to land before giving up and logging instead of hanging;
+    # see _flushSliceState.
+    _SLICE_SAVE_FLUSH_TIMEOUT = 10.0
 
     def __init__(
         self,
@@ -270,6 +276,22 @@ class AutopatchWindow(Qt.QWidget):
         # Clock reading at the last periodic slice-state save, or None before
         # the first one; see _flushSliceState.
         self._lastSliceSaveTime = None
+        # Serialises this window's slice-state writes onto one dedicated
+        # thread, off the GUI thread the writes used to block -- see
+        # _flushSliceState/_dispatchSliceSave/_drainSliceWrites. One worker
+        # per window, stopped in teardown().
+        self._sliceSaveWorker = WorkerThread(name="Autopatch slice save")
+        # Guards the three attributes below, which the GUI thread (dispatching
+        # writes) and the slice-save worker thread (draining them) both touch.
+        self._sliceWriteLock = threading.Lock()
+        # The most recently dispatched snapshot not yet picked up by the
+        # worker's drain loop, or None. Replaced rather than queued when a
+        # write is already in flight -- see _dispatchSliceSave.
+        self._pendingSliceSnapshot = None
+        self._sliceWriteInFlight = False
+        # The task for whichever write is currently running (or about to
+        # run) on the worker; a forced flush waits on this.
+        self._sliceWriteTask = None
         self._tornDown = False
         self.protocolPanel.sigProtocolLoaded.connect(self._onProtocolLoaded)
         # Area 4 (the protocol picker/Reload) must not be usable while a
@@ -781,10 +803,16 @@ class AutopatchWindow(Qt.QWidget):
         # Captured before _startSlice replaces self.slice: the outgoing slice's
         # own record is written now, while it is still reachable, and its
         # directory is what its pinned frames are archived into further down.
+        # Forced (not a plain saveState()) so this waits for the write to
+        # actually land before self.slice is replaced below: a run may have
+        # left a periodic save still in flight on the slice-save worker for
+        # this very slice, and starting a fresh synchronous write on top of it
+        # would race that worker over the same directory with no guarantee
+        # which one lands last.
         outgoing = self.slice
         outgoingDir = outgoing.dirHandle if outgoing is not None else None
         if outgoing is not None:
-            outgoing.saveState()
+            self._flushSliceState(force=True)
         if not self._startSlice(dirHandle=dirHandle):
             return
         self.cellPanel.clearCells()
@@ -1085,7 +1113,8 @@ class AutopatchWindow(Qt.QWidget):
                 self._flushSliceState(force=(status == "waiting"))
 
     def _flushSliceState(self, *, force: bool) -> None:
-        """Write self.slice's search state to disk, throttled unless `force`.
+        """Dispatch self.slice's search state to be written, throttled unless
+        `force`, off the GUI thread.
 
         Durability contract: while a run is in progress, at most the coverage
         gained in the last _SLICE_SAVE_MIN_INTERVAL seconds can be lost to a
@@ -1093,15 +1122,25 @@ class AutopatchWindow(Qt.QWidget):
         "surveying" status was built to accept ("a survey interrupted between
         two of these has lost at most the tiles since the last one"), now
         bounded by wall-clock time rather than by how often the orchestrator
-        happens to refill its queue. That bound holds because every caller
-        that can end a run's ability to keep saving -- the run reaching
-        "waiting", a slice being replaced, and the window closing -- calls
-        this with force=True, which always writes regardless of the timer.
+        happens to refill its queue. `force=True` waits for the dispatched
+        write to actually land (up to _SLICE_SAVE_FLUSH_TIMEOUT) before
+        returning, rather than merely starting it: that is what lets the run
+        reaching "waiting", a slice being replaced, and the window closing
+        each promise nothing beyond the bound above is silently lost, instead
+        of "we started a write and hoped".
 
-        Never reads a state captured earlier: a throttled call writes nothing
-        and caches nothing, so the next write, forced or not, reads whatever
-        self.slice holds at that later moment -- never a stale snapshot from
-        whenever the throttle last let a save through.
+        The write itself never happens on the GUI thread, which is the actual
+        fix for the reported stall: two writeFile()s and a setInfo() each
+        drive DirHandle's synchronous, mutex-guarded full-directory .index
+        rewrite (see _dispatchSliceSave/_drainSliceWrites), and that cost used
+        to land on the thread painting the window. The snapshot handed to the
+        worker is captured right here, on the GUI thread, from self.slice's
+        live state -- never read by the worker itself, so a setRegions() or
+        markCovered() landing on the GUI thread after this returns can never
+        race the write. When a write is already running and a newer one is
+        dispatched before it finishes, the newer snapshot simply replaces
+        whatever was queued behind it (see _dispatchSliceSave): the LATEST
+        dispatched snapshot is what lands on disk, not every one dispatched.
         """
         if self.slice is None:
             return
@@ -1109,8 +1148,72 @@ class AutopatchWindow(Qt.QWidget):
         if not force and self._lastSliceSaveTime is not None:
             if now - self._lastSliceSaveTime < self._SLICE_SAVE_MIN_INTERVAL:
                 return
-        self.slice.saveState()
         self._lastSliceSaveTime = now
+        snapshot = self.slice.snapshotState()
+        if snapshot is None:
+            return
+        task = self._dispatchSliceSave(snapshot)
+        if force and task is not None:
+            try:
+                task.wait(timeout=self._SLICE_SAVE_FLUSH_TIMEOUT)
+            except Exception:
+                logger.exception(
+                    "Timed out waiting for this slice's search state to be written"
+                )
+
+    def _dispatchSliceSave(self, snapshot: dict):
+        """Queue `snapshot` for the slice-save worker thread to write,
+        coalescing with a write already in flight.
+
+        If nothing is currently running, this starts the worker on `snapshot`
+        directly. If a write is already running, `snapshot` replaces whatever
+        was waiting behind it instead of queuing a second job: a burst of
+        saves costs one write of the latest state once the worker gets to it,
+        not one write per save. Returns the task for the write that is now
+        running (or about to run), which is what `_flushSliceState`'s forced
+        path waits on -- or None if the worker has already been stopped (see
+        below), which a forced caller must not wait on.
+        """
+        with self._sliceWriteLock:
+            self._pendingSliceSnapshot = snapshot
+            if self._sliceWriteInFlight:
+                return self._sliceWriteTask
+            self._sliceWriteInFlight = True
+            try:
+                self._sliceWriteTask = self._sliceSaveWorker.submit(
+                    self._drainSliceWrites, name="Autopatch slice save"
+                )
+            except RuntimeError:
+                # teardown() already forced a flush and stopped the worker; a
+                # status change arriving after that (e.g. a Qt signal already
+                # queued when the window closed) has nothing left to write
+                # to. Not a raise this caller should see, for the same reason
+                # saveState() never raised: whatever asked for this save has
+                # already moved on.
+                self._sliceWriteInFlight = False
+                self._pendingSliceSnapshot = None
+                return None
+            return self._sliceWriteTask
+
+    def _drainSliceWrites(self) -> None:
+        """Worker-thread body: write the latest pending snapshot, then look
+        again in case a newer one was dispatched while writing, until none is
+        left.
+
+        Runs on the slice-save worker thread, never the GUI thread. Touches
+        only the lock and whatever snapshot it is handed -- plain data
+        _flushSliceState already captured from self.slice on the GUI thread
+        -- so this never reads the live Slice itself, which stays the GUI
+        thread's alone to mutate.
+        """
+        while True:
+            with self._sliceWriteLock:
+                snapshot = self._pendingSliceSnapshot
+                self._pendingSliceSnapshot = None
+                if snapshot is None:
+                    self._sliceWriteInFlight = False
+                    return
+            Slice.writeSnapshot(snapshot)
 
     def _onTissueMoved(self, cell, ctx, reason: str) -> None:
         """ExecutionContext.tissue_moved, cell-bound by the context factory.
@@ -1379,6 +1482,10 @@ class AutopatchWindow(Qt.QWidget):
             # raise stopping the orchestrator must not cost the run's record.
             if self.slice is not None:
                 self._flushSliceState(force=True)
+            # Stopped only after the forced flush above has returned, so the
+            # worker is never told to shut down while that flush is still
+            # waiting on it.
+            self._sliceSaveWorker.stop()
             # In a finally because these are the releases that reach *outside*
             # this window: a raise while stopping the orchestrator would
             # otherwise leave the Camera module holding this session's outlines

--- a/acq4/modules/Autopatch/Autopatch.py
+++ b/acq4/modules/Autopatch/Autopatch.py
@@ -244,7 +244,18 @@ class AutopatchWindow(Qt.QWidget):
         # these for the panel's life, so this adds no lifetime, only a handle.
         self._positionConnected: dict[int, object] = {}
 
-        self.searchPanel = SearchPanel()
+        # The rig's own `misc` configuration seeds Area 2's two detection
+        # controls with a starting point for a fresh slice; once the operator
+        # edits them, or a saved slice is loaded, their own values take over,
+        # the same as every other Area 2 control. Through getattr because a
+        # manager-less window (headless, or a test standing in for the
+        # Manager) has no configuration to read.
+        config = getattr(self.manager, "config", None) or {}
+        misc = config.get("misc") or {}
+        self.searchPanel = SearchPanel(
+            min_volume_m3=float(misc.get("minCellVolume", 0.0)),
+            step_z=float(misc.get("detectionStepZ", 1e-6)),
+        )
         self.area2Layout.addWidget(self.searchPanel)
 
         self.cellPanel = CellPanel(
@@ -1320,36 +1331,15 @@ class AutopatchWindow(Qt.QWidget):
             # one implicitly, without a directory -- which surveys exactly as
             # before and simply keeps no imagery.
             slice_dir=self.slice.dirHandle,
-            **self._surveyDetectionSettings(),
+            # The volume floor and z step Area 2's own controls set, same as
+            # every other SearchConstraints field: read here on the GUI thread
+            # alongside the camera and the scope, for the same reason those
+            # are -- the detector this feeds runs on the orchestrator's
+            # worker thread.
+            min_volume_m3=self.slice.constraints.min_volume_m3,
+            step_z=self.slice.constraints.step_z,
         )
         self.orchestrator.setCellProducer(self.slice.makeCellProducer(detector))
-
-    def _surveyDetectionSettings(self) -> dict:
-        """The two detection settings the survey does not get from Area 2.
-
-        AutomationDebug reads both off its own window: a minimum-volume spin box
-        beside its depth controls, and a z step its mock stacks can override.
-        Area 2 has neither control, so a survey that passed neither used the
-        library defaults -- no volume floor at all, and 1 um steps -- with no way
-        for a rig to say otherwise. Until Area 2 grows the controls, the rig's
-        own `misc` configuration is that way; the defaults here are exactly the
-        values the survey used when they were not settable, so a rig that
-        configures neither surveys precisely as it did before.
-
-        Read here on the GUI thread alongside the camera and the scope, for the
-        same reason those are: the detector this feeds runs on the
-        orchestrator's worker thread.
-
-        Through getattr because a manager-less window (headless, or a test
-        standing in for the Manager) has no configuration to read, and a survey
-        is not the place to discover that.
-        """
-        config = getattr(self.manager, "config", None) or {}
-        misc = config.get("misc") or {}
-        return {
-            "min_volume_m3": float(misc.get("minCellVolume", 0.0)),
-            "step_z": float(misc.get("detectionStepZ", 1e-6)),
-        }
 
     def _onProtocolLoaded(self, protocolFile) -> None:
         # Loading a second protocol must not abandon a still-live Orchestrator:

--- a/acq4/modules/Autopatch/cell_panel.py
+++ b/acq4/modules/Autopatch/cell_panel.py
@@ -8,6 +8,7 @@ import numpy as np
 from coorx import Point
 
 from acq4_automation.feature_tracking.cell import Cell
+from acq4.experiment.actions.device import _trackerStack
 from acq4.util import Qt
 
 from .details_renderers import buildDetailsWidget
@@ -35,6 +36,39 @@ COMPLETED = frozenset({"done"})
 # answer their question a few rows at a time, scrolling within themselves for
 # the rest.
 _VIEW_ROWS = 3
+
+# Row text for the synthetic timeline row _seedReferenceStackRow inserts at
+# index 0 for a cell whose tracker is already initialized when its (empty)
+# timeline is seeded. Plain and constant, unlike the "running"/outcome rows
+# _appendTimelineRow and _finishTimelineRow compose: nothing backs this row
+# with an ActionLogEntry to report a status or an outcome for.
+_REFERENCE_STACK_ROW_TEXT = "Tracker initialized"
+
+
+def _liveReferenceStackDetails(cell):
+    """("image_stack", payload) read directly off `cell`'s tracker, or None
+    if it has no reference stack to show.
+
+    Reads the same attribute chain acq4.experiment.actions.device._trackerStack
+    does (cell._tracker.motion_estimator.original_object_stack.data), and
+    shapes the payload the same way device._attachStackDetails does, so this
+    renders identically to a real Cellfie action's own image_stack details.
+    Callers, not this function, are responsible for only calling it where
+    that read is safe -- see _seedReferenceStackRow's docstring.
+    """
+    stack = _trackerStack(cell)
+    if stack is None:
+        return None
+    return (
+        "image_stack",
+        {
+            "stack": stack,
+            "center_index": (
+                stack.shape[0] // 2 if stack.ndim >= 3 and stack.shape[0] > 1 else None
+            ),
+            "title": _REFERENCE_STACK_ROW_TEXT,
+        },
+    )
 
 
 class _DetailsViewport(Qt.QScrollArea):
@@ -163,6 +197,18 @@ class CellPanel(Qt.QWidget):
         # still says what it was doing when it ended; a row absent from here
         # never reported a status.
         self._statuses: dict[tuple[int, int], str] = {}
+        # id(cell) -> the first ("image_stack", payload) pair any action ever
+        # retained for that cell, cached by _onActionEntry's "details" phase
+        # and reseeded into the synthetic "Tracker initialized" row (see
+        # _seedReferenceStackRow) whenever that cell's timeline starts empty.
+        # Deliberately NOT cleared by _dropDetailsFor: self._details is that
+        # pass's UI history and reuse's whole point is discarding it, but the
+        # reference stack this backs is the same cube across every pass (the
+        # tracker it lives on is the one thing reuse intentionally carries
+        # forward) -- so this is the one retained-payload store a reuse pass
+        # must not wipe. Holds only plain data, never a cell or a widget, for
+        # the same reference-cycle reasons self._details does.
+        self._referenceStacks: dict[int, tuple[str, object]] = {}
         # id(cell) -> (exc_type, exc_message, traceback_text) for the most
         # recent action of that cell's that failed. Ids and plain strings,
         # never the entry and never the exception: an ActionLogEntry's
@@ -446,6 +492,7 @@ class CellPanel(Qt.QWidget):
         self._logs.clear()
         self._details.clear()
         self._statuses.clear()
+        self._referenceStacks.clear()
         self.statusLabel.setText("")
         self._cellErrors.clear()
         self.cellList.clear()
@@ -505,6 +552,13 @@ class CellPanel(Qt.QWidget):
             self._logs.pop(cellId, None)
             self._cellErrors.pop(cellId, None)
             self._dropDetailsFor(cellId)
+            # Unlike _dropDetailsFor's targets, this cell is gone for good
+            # here (the reuse-and-restore branch above never reaches this
+            # line), so nothing is left to reseed a synthetic row from later
+            # -- and a stale id left behind could hand a future, unrelated
+            # cell at a reused memory address a reference stack that was
+            # never its own.
+            self._referenceStacks.pop(cellId, None)
         self._updateCheckAllButton()
         self._updateReuseButton()
         self.sigCellStateChanged.emit()
@@ -593,6 +647,7 @@ class CellPanel(Qt.QWidget):
         self.cellList.addItem(item)
         self._rows[id(cell)] = item
         self._timelines[id(cell)] = []
+        self._seedReferenceStackRow(cell)
         self._logs[id(cell)] = []
         # QListWidgetItem.setData() does not keep a strong Python reference to a
         # QObject-derived value (Cell is one): once the orchestrator's queue/worker
@@ -747,6 +802,10 @@ class CellPanel(Qt.QWidget):
             # Earlier-pass details are that pass's UI history, cleared with the
             # timeline and log for the same reason (design doc §7).
             self._dropDetailsFor(id(cell))
+            # After, not before: this seeds row 0 of the timeline just
+            # emptied above by writing into self._details itself, and
+            # _dropDetailsFor must not turn around and wipe that seed.
+            self._seedReferenceStackRow(cell)
             # A stored error describes the pass that just ended, not the one
             # about to start. errorText() reports it to anything that asks --
             # including a caller reading it after this row already reads
@@ -979,6 +1038,17 @@ class CellPanel(Qt.QWidget):
             loc = self._entryTimelineLoc.get(id(entry))
             if loc is not None:
                 self._details[loc] = (entry.details_kind, entry.details_payload)
+                if entry.details_kind == "image_stack":
+                    # The first reference stack any action retains for this
+                    # cell becomes the synthetic row's permanent backing (see
+                    # _seedReferenceStackRow) -- cached here, rather than read
+                    # back off the tracker later, because this payload just
+                    # arrived over sigActionEntry and so is already safely on
+                    # the GUI thread, the same way every other entry in
+                    # self._details is.
+                    self._referenceStacks.setdefault(
+                        id(cell), (entry.details_kind, entry.details_payload)
+                    )
                 # A payload is this action's final word for its row (see
                 # set_details' docstring: it must be called before the entry
                 # finishes), so it supersedes that same entry's live widget from
@@ -998,6 +1068,53 @@ class CellPanel(Qt.QWidget):
                 self._statuses[loc] = entry.status
                 if self._isSelectedRow(loc):
                     self.statusLabel.setText(entry.status)
+
+    def _seedReferenceStackRow(self, cell) -> None:
+        """Insert the synthetic "Tracker initialized" row at index 0 of
+        `cell`'s just-emptied timeline, if there is a reference stack to show
+        for it. A cell whose tracker was never initialized (Cell.isInitialized
+        False) gets no row at all, not an empty placeholder.
+
+        Callers must call this immediately after setting
+        self._timelines[id(cell)] = [] -- addCell() and _onReuseCheckedCells()
+        are the only two places a cell's timeline starts empty, and doing
+        this there means the synthetic row lands at index 0 with no other row
+        ever needing to move: every subsequent _appendTimelineRow call
+        computes its own index as len(rows), which already counts this one.
+
+        THREAD SAFETY: cell._tracker's reference stack is worker-thread-owned
+        data -- the same chain acq4.experiment.actions.device._trackerStack
+        reads, but from inside a running action, i.e. from that same worker
+        thread. Reading it directly here, on the GUI thread, is only safe for
+        a cell nothing has started running yet: a survey producer seeds a
+        freshly discovered cell's tracker with its reference cube once, on
+        its own worker thread, before ever announcing the cell, and nothing
+        touches that tracker again until the orchestrator marks the cell
+        attempted and starts running actions against it (_onCurrentCell and
+        _onCellFinished both record attempted before either could ever reach
+        this method for that cell, via their own addCell() fallback). Past
+        that point, a direct read races a worker thread that may still be
+        appending to the same tracker -- confirmed for exactly this situation
+        by 2794be759's finding that a detached FSM job can still be appending
+        to a cell's tracker after its pass is already closed out -- so once a
+        cell isAttempted(), this method reads only a payload already cached
+        in self._referenceStacks from an earlier action's set_details() call,
+        which arrived here over sigActionEntry and so was already safely on
+        the GUI thread; it is never read fresh off the tracker again.
+        """
+        if not getattr(cell, "isInitialized", False):
+            return
+        cellId = id(cell)
+        cached = self._referenceStacks.get(cellId)
+        if cached is None and not self.isAttempted(cell):
+            cached = _liveReferenceStackDetails(cell)
+            if cached is not None:
+                self._referenceStacks[cellId] = cached
+        if cached is None:
+            return
+        rows = self._timelines[cellId]
+        self._details[(cellId, len(rows))] = cached
+        rows.append(_REFERENCE_STACK_ROW_TEXT)
 
     def _appendTimelineRow(self, cell, entry) -> None:
         text = f"{entry.name} — ⏳ running"

--- a/acq4/modules/Autopatch/progress_overlay.py
+++ b/acq4/modules/Autopatch/progress_overlay.py
@@ -7,9 +7,18 @@ import pyqtgraph as pg
 
 from acq4.util import Qt
 
-# Under the region ROIs and over the mirrored pinned frames, so a marker never
-# hides the handle the operator needs to grab. PinnedFrameMirror preserves the
-# Camera module's own z-order, which is negative, so both layers sit above it.
+# Over a region ROI's own translatable body and under its handles (and a
+# polygon's edges), and over the mirrored pinned frames. Region_panel.py keeps
+# each ROI's own z a half-step below this layer (RegionPanel._REGION_ROI_Z)
+# so both halves of that hold: pg.ROI's hoverEvent claims every left-button
+# click across its body as soon as it is hovered (see HoverEvent.acceptClicks
+# in pyqtgraph's GraphicsScene), and once claimed, nothing drawn underneath --
+# a marker included -- is ever offered the click, so the marker layer has to
+# sit above the body for its own clicks to reach it; a handle sits one z
+# above its ROI (see pg.ROI.setZValue), which is what keeps it above the
+# marker layer in turn, so a marker still never hides one. PinnedFrameMirror
+# preserves the Camera module's own z-order, which is negative, so both
+# layers here still sit above it.
 _COVERAGE_Z = -50
 _MARKER_Z = -40
 
@@ -36,6 +45,28 @@ class Marker(NamedTuple):
     cellId: int
 
 
+class _MarkerScatter(pg.ScatterPlotItem):
+    """A scatter whose hoverEvent claims a left-button click for itself
+    whenever the cursor sits on one of its points.
+
+    The base ScatterPlotItem never makes that claim -- it only ever responds
+    to a click that nothing else has already claimed during hover (see
+    GraphicsScene.sendClickEvent's fallback search). A region ROI's own
+    hoverEvent, by contrast, claims every left-button click across its whole
+    translatable body unconditionally, so whichever of the two is asked
+    first wins every such click regardless of what is drawn where: z order
+    decides who is asked first, not who the cursor is actually over. This
+    override enters that same race, but only where a marker actually is, so
+    every other click -- including one that starts a drag on the ROI itself
+    -- is left for whatever would otherwise have claimed it.
+    """
+
+    def hoverEvent(self, ev) -> None:
+        super().hoverEvent(ev)
+        if not ev.isExit() and len(self.pointsAt(ev.pos())):
+            ev.acceptClicks(Qt.Qt.LeftButton)
+
+
 class ProgressOverlay(Qt.QObject):
     """Cell markers and to-do coverage in a ViewBox owned by someone else.
 
@@ -52,9 +83,7 @@ class ProgressOverlay(Qt.QObject):
         self._view = view
         self._coverageItems = []
 
-        self.scatter = pg.ScatterPlotItem(
-            pxMode=True, size=_MARKER_SIZE_PX, pen=pg.mkPen(0, 0, 0, 120)
-        )
+        self.scatter = _MarkerScatter(pxMode=True, size=_MARKER_SIZE_PX, pen=pg.mkPen(0, 0, 0, 120))
         # addItem() before setZValue(): ViewBox.addItem() raises an item's z to
         # view.zValue()+1 when it is lower, so setting z first collapses it.
         # The same ordering PinnedFrameMirror.refresh() documents.

--- a/acq4/modules/Autopatch/reference_imagery.py
+++ b/acq4/modules/Autopatch/reference_imagery.py
@@ -18,18 +18,21 @@ _CLEAR_PROMPT = (
 
 
 def _askToClear(text: str, parent=None) -> bool:
-    """Default prompt: an Ok/Cancel dialog asking to clear the pinned frames.
+    """Default prompt: a Yes/No dialog asking to clear the pinned frames.
 
     Its title and two-paragraph body are specific to a slice starting, not a
-    copy of ImagingCtrl's own Clear button confirmation -- only the button set
-    (Ok/Cancel) matches. `parent` places the dialog over the calling window
-    instead of centring it on the primary screen with no owner.
+    copy of ImagingCtrl's own Clear button confirmation. `parent` places the
+    dialog over the calling window instead of centring it on the primary
+    screen with no owner. Defaults to No so that an Enter or Escape typed
+    without reading the dialog leaves the pinned frames alone rather than
+    clearing them.
     """
     answer = Qt.QMessageBox.question(
         parent, "Clear pinned frames?", text,
-        Qt.QMessageBox.Ok | Qt.QMessageBox.Cancel,
+        Qt.QMessageBox.Yes | Qt.QMessageBox.No,
+        Qt.QMessageBox.No,
     )
-    return answer == Qt.QMessageBox.Ok
+    return answer == Qt.QMessageBox.Yes
 
 
 class ReferenceImagery(Qt.QObject):

--- a/acq4/modules/Autopatch/region_panel.py
+++ b/acq4/modules/Autopatch/region_panel.py
@@ -19,6 +19,22 @@ from .progress_colors import COLOR_SOURCES
 # draws, so the same shape reads the same way in either module.
 REGION_PEN = pg.mkPen("y", width=2)
 
+# A half-step below Area 1's marker layer (ProgressOverlay._MARKER_Z = -40 in
+# progress_overlay.py), rather than pg.ROI's own default of 10: this module
+# renders regions and does not import from a sibling overlay it does not know
+# exists, but the two constants still have to sit either side of the same
+# line for a marker's own click to ever reach it. pg.ROI's hoverEvent claims
+# every left-button click across its whole translatable body as soon as it is
+# hovered (see HoverEvent.acceptClicks in pyqtgraph's GraphicsScene), and once
+# claimed, the scene never offers that click to anything drawn underneath --
+# a marker included -- so the ROI's own body has to sit below the marker
+# layer for a marker's click to survive it. The half-step, rather than a
+# whole one, is what puts the handles back above: pg.ROI reparents every
+# handle to z+1 whenever setZValue() runs (see ROI.setZValue), so this same
+# gap lands the handles just above the marker layer again, and a marker still
+# never hides one.
+_REGION_ROI_Z = -40.5
+
 
 def roiForRegion(region: SearchRegion) -> pg.ROI:
     """The editable ROI that draws `region`.
@@ -247,6 +263,10 @@ class RegionPanel(Qt.QWidget):
     def _attachRoi(self, roi: pg.ROI) -> None:
         self._rois.append(roi)
         self.view.addItem(roi)
+        # addItem() before setZValue(): ViewBox.addItem() raises an item's z
+        # to view.zValue()+1 when it is lower, so setting z first collapses
+        # it. The same ordering ProgressOverlay.__init__ documents.
+        roi.setZValue(_REGION_ROI_Z)
         roi.sigRegionChangeFinished.connect(self._onRoiEdited)
         roi.sigRemoveRequested.connect(self._onRoiRemoved)
         self._applyRoiLock(roi)

--- a/acq4/modules/Autopatch/region_panel.py
+++ b/acq4/modules/Autopatch/region_panel.py
@@ -130,6 +130,28 @@ def regionForRoi(roi: pg.ROI) -> SearchRegion | None:
         return None
 
 
+def _isMirroredCameraItem(item) -> bool:
+    """Whether `item` is something drawn from the camera window's own
+    contents, as opposed to survey bookkeeping drawn over it.
+
+    Used by RegionPanel._mirroredImageryBounds() to decide what "fit to
+    regions" frames: the mirrored pinned frames (PinnedFrameMirror's
+    pg.ImageItem copies) and, elsewhere in that method, the region ROIs --
+    never the survey's coverage shading (ProgressOverlay.setCoverage()'s
+    plain Qt.QGraphicsRectItems), which marks ground the survey has not
+    imaged rather than anything the camera has shown.
+
+    Every item this panel's view has ever held that is not that coverage
+    shading is built through pyqtgraph -- PinnedFrameMirror's pg.ImageItem
+    copies, the region ROIs, ProgressOverlay's marker scatter -- so testing
+    for pyqtgraph's own GraphicsItem mixin is how that line is drawn today.
+    The mixin is a proxy for "camera-mirrored content" only because that
+    happens to coincide with "pyqtgraph built it" for every item this view
+    has ever held; it is the type being tested, not the question being asked.
+    """
+    return isinstance(item, pg.GraphicsItem)
+
+
 class RegionPanel(Qt.QWidget):
     """Area 1's view of the slice: the imagery to draw over, and the search
     regions drawn on it as ROIs the operator can move, resize, and delete.
@@ -432,14 +454,13 @@ class RegionPanel(Qt.QWidget):
         self._framingExclusions.append(item)
 
     def _mirroredImageryBounds(self) -> Qt.QRectF | None:
-        """The extent of everything in the view that is not a region ROI, or
-        None if there is nothing else there.
+        """The extent of everything in the view that mirrors what the camera
+        window would also show, or None if there is nothing else there.
 
-        In practice the mirrored pinned frames and the survey's coverage
-        shading. Read off the view rather than from PinnedFrameMirror: the
-        panel renders regions and knows nothing about what else is put in its
-        view, and a back-reference to the mirror would make the two mutually
-        dependent for a bounding box.
+        In practice the mirrored pinned frames. Read off the view rather than
+        from PinnedFrameMirror: the panel renders regions and knows nothing
+        about what else is put in its view, and a back-reference to the mirror
+        would make the two mutually dependent for a bounding box.
 
         Read off the view means exactly that, and nothing here may assume the
         items found there are pyqtgraph's. ProgressOverlay draws its coverage
@@ -452,11 +473,6 @@ class RegionPanel(Qt.QWidget):
         that child group, and the child group is also the parent
         `ViewBox.addItem` reparents every item it accepts onto -- so an item
         in `addedItems` is always somewhere below it.
-
-        The coverage shading is framed rather than skipped because it is drawn
-        content the operator can see, and because a tile is a whole field of
-        view: a region smaller than one field is surveyed well past its own
-        edges, and where the survey will actually image is worth framing.
 
         Region ROIs are skipped because their bounds come from `regions()`,
         which drops an ROI squashed to no extent. Framing one would re-centre
@@ -472,6 +488,14 @@ class RegionPanel(Qt.QWidget):
         by orders of magnitude, and unioning it would swamp the fit with a
         shape that describes the current zoom rather than anything drawn.
 
+        `_isMirroredCameraItem()` skips the survey's coverage shading next,
+        rather than framing it: this method answers "what would the camera
+        window also show", and a to-do tile is neither drawn from the camera
+        nor a region the operator drew, but ground the survey has not imaged
+        yet. Framing it would pull the view out to a whole field of view's
+        own size for a region far smaller than one, on the strength of tiles
+        that are not yet anything the operator can see.
+
         Finally, an item's mapped rect that comes back null or empty (a
         pinned frame not yet given any content, or the progress overlay's
         scatter before excludeFromFraming() reached it, previously) is treated
@@ -483,6 +507,8 @@ class RegionPanel(Qt.QWidget):
         childGroup = self.view.innerSceneItem()
         for item in self.view.addedItems:
             if item in self._rois or item in self._framingExclusions:
+                continue
+            if not _isMirroredCameraItem(item):
                 continue
             itemRect = item.mapRectToItem(childGroup, item.boundingRect()).normalized()
             if itemRect.isEmpty():

--- a/acq4/modules/Autopatch/search_panel.py
+++ b/acq4/modules/Autopatch/search_panel.py
@@ -20,7 +20,7 @@ _CELLS_PER_NL_TO_M3 = 1e12
 
 
 class SearchPanel(Qt.QWidget):
-    """The four Area 2 search constraints and a survey progress readout.
+    """The six Area 2 search constraints and a survey progress readout.
 
     Emits `sigConstraintsChanged` with a fresh SearchConstraints on every edit,
     or with None when the widget values do not describe a valid search (an
@@ -31,9 +31,17 @@ class SearchPanel(Qt.QWidget):
 
     sigConstraintsChanged = Qt.Signal(object)  # SearchConstraints, or None if invalid
 
-    def __init__(self):
+    def __init__(self, min_volume_m3: float = 0.0, step_z: float = 1e-6):
+        """`min_volume_m3` and `step_z` seed the two detection controls.
+
+        The owner (AutopatchWindow) is the one that can see the rig's `misc`
+        configuration; this panel takes the resulting numbers as plain floats
+        rather than reading that configuration itself, so a manager-less panel
+        (a test, a headless window) still has a sensible starting point --
+        the engine's own defaults, which is what leaving these unset gives.
+        """
         super().__init__()
-        defaults = SearchConstraints()
+        defaults = SearchConstraints(min_volume_m3=min_volume_m3, step_z=step_z)
         # The two independent things errorLabel can be showing, kept apart so
         # neither silently erases the other. The constraint message describes
         # the spin box values themselves and is rewritten (or cleared) by every
@@ -90,6 +98,28 @@ class SearchPanel(Qt.QWidget):
         self.rescansCheck = Qt.QCheckBox("Rescans allowed")
         self.rescansCheck.setChecked(defaults.rescans_allowed)
 
+        # A volume floor below which a detected blob is not a cell -- the same
+        # unit and step AutomationDebug's own minimum-volume spin box uses
+        # (acq4/modules/AutomationDebug/AutomationDebug.py).
+        self.minVolumeSpin = self._makeSpin(
+            defaults.min_volume_m3,
+            bounds=(0.0, None),
+            step=100e-18,
+            suffix="m³",
+            siPrefix=True,
+        )
+        # The z increment the detection stack is acquired at -- a distance,
+        # like the depth controls, so it takes the same units. Bounded above
+        # zero rather than at zero: a zero or negative step is not a smaller
+        # search, it is not a step at all, and SearchConstraints rejects it.
+        self.stepZSpin = self._makeSpin(
+            defaults.step_z,
+            bounds=(1e-9, None),
+            step=1e-7,
+            suffix="m",
+            siPrefix=True,
+        )
+
         self.surveyLabel = Qt.QLabel("no region")
         # A constraint error is a sentence ("depth_range must be ordered from
         # the surface downwards", and the like), and an unwrapped sentence is a
@@ -105,13 +135,15 @@ class SearchPanel(Qt.QWidget):
         form.addRow("Depth from surface, far", self.farDepthSpin)
         form.addRow("Minimum health", self.minHealthSpin)
         form.addRow("Maximum cell density", self.maxDensitySpin)
+        form.addRow("Minimum cell volume", self.minVolumeSpin)
+        form.addRow("Detection step, z", self.stepZSpin)
 
         layout = Qt.QVBoxLayout()
         layout.addLayout(form)
         layout.addWidget(self.rescansCheck)
         layout.addWidget(self.surveyLabel)
         layout.addWidget(self.errorLabel)
-        # Nothing above grows usefully -- four spin boxes, a checkbox and two
+        # Nothing above grows usefully -- six spin boxes, a checkbox and two
         # readouts are each one row of controls at any size -- so room beyond
         # what they need goes here rather than being shared out among them as
         # padding. Which matters in both directions: a widget allowed to grow is
@@ -124,6 +156,8 @@ class SearchPanel(Qt.QWidget):
             self.farDepthSpin,
             self.minHealthSpin,
             self.maxDensitySpin,
+            self.minVolumeSpin,
+            self.stepZSpin,
         ):
             spin.valueChanged.connect(self._onEdited)
         self.rescansCheck.toggled.connect(self._onEdited)
@@ -160,6 +194,8 @@ class SearchPanel(Qt.QWidget):
                 min_health=self.minHealthSpin.value(),
                 max_cell_density=self.maxDensitySpin.value() * _CELLS_PER_NL_TO_M3,
                 rescans_allowed=self.rescansCheck.isChecked(),
+                min_volume_m3=self.minVolumeSpin.value(),
+                step_z=self.stepZSpin.value(),
             )
         except ValueError as exc:
             self._constraintError = str(exc)
@@ -227,5 +263,7 @@ class SearchPanel(Qt.QWidget):
             self.minHealthSpin,
             self.maxDensitySpin,
             self.rescansCheck,
+            self.minVolumeSpin,
+            self.stepZSpin,
         ):
             w.setEnabled(not locked)

--- a/acq4/modules/Autopatch/status_panel.py
+++ b/acq4/modules/Autopatch/status_panel.py
@@ -44,6 +44,11 @@ class StatusPanel(Qt.QWidget):
         # None stands for "no status yet reported" -- same button gating as the
         # orchestrator's own post-run "waiting" (see _updateButtons()).
         self._currentStatus = None
+        # True from a Pause click until the orchestrator actually reports
+        # "paused" (or the request is withdrawn/superseded) -- pause is only
+        # honored between cells or retries, so without this the button would
+        # sit there still saying "Pause" for however long that takes.
+        self._pausePending = False
         # The RunErrorRecord for the failure that halted the last run, or None.
         # A run-level record rather than only the failing action's log entry: a
         # producer raising during a refill has no cell and opens no log_action,
@@ -119,6 +124,7 @@ class StatusPanel(Qt.QWidget):
         # A freshly bound orchestrator hasn't reported a status yet -- treat it
         # the same as "waiting" so Start is enabled and Stop/Pause/Next are not.
         self._currentStatus = None
+        self._pausePending = False
         self._lastError = None
         self._updateErrorBand()
         self.startBtn.clicked.connect(self._onStartClicked)
@@ -154,6 +160,7 @@ class StatusPanel(Qt.QWidget):
         self._entrySource = None
         self._onStart = None
         self._currentStatus = None
+        self._pausePending = False
         self._lastError = None
         self._updateErrorBand()
         self._updateButtons()
@@ -176,12 +183,19 @@ class StatusPanel(Qt.QWidget):
         self._orchestrator.stop("stopped by operator")
 
     def _onPauseClicked(self) -> None:
-        # Toggle: Pause while running, Resume while paused -- see _updateButtons()
-        # for the matching label swap.
+        # Three states cycle through this one button -- see _updateButtons()
+        # for the matching label: already paused, resume; a pause requested but
+        # not yet honored, withdraw it (resume before the orchestrator ever
+        # actually paused); otherwise, request a pause.
         if self._currentStatus == "paused":
             self._orchestrator.resume()
+        elif self._pausePending:
+            self._pausePending = False
+            self._orchestrator.resume()
         else:
+            self._pausePending = True
             self._orchestrator.pause()
+        self._updateButtons()
 
     def _onRunError(self, record) -> None:
         self._lastError = record
@@ -257,6 +271,12 @@ class StatusPanel(Qt.QWidget):
         # keyed on the status would be shown and hidden within the same run.
         # _onRunError drives it instead, and it clears when the next run starts.
         self._currentStatus = status
+        # A pending pause survives only through "surveying" -- the orchestrator
+        # hasn't reached a pause check yet, so the request still stands. Any
+        # other status means it either landed ("paused"), got superseded
+        # ("running"), or the run it was requested for is over ("waiting",
+        # "error") -- none of those should leave a stale pending label behind.
+        self._pausePending = self._pausePending and status == "surveying"
         self._updateButtons()
         self.sigInteractionLocked.emit(status in ("running", "surveying", "paused"))
         self.sigStatusChanged.emit(status)
@@ -287,7 +307,9 @@ class StatusPanel(Qt.QWidget):
         Stop/Pause but not Next, since a next-cell request during a refill is
         discarded (nothing is running and nothing is queued to advance past);
         "paused" enables Stop/Pause (relabeled "Resume") but not Next;
-        "error" enables only Stop.
+        "error" enables only Stop. Pause itself reads "Pausing at next
+        break..." (and stays enabled, to let the click be withdrawn) while a
+        pause has been requested but the orchestrator hasn't honored it yet.
         """
         hasProtocol = self._orchestrator is not None
         status = self._currentStatus
@@ -309,4 +331,10 @@ class StatusPanel(Qt.QWidget):
         self.stopBtn.setEnabled(stop)
         self.pauseBtn.setEnabled(pause)
         self.nextBtn.setEnabled(next_)
-        self.pauseBtn.setText("Resume" if status == "paused" else "Pause")
+        if status == "paused":
+            pauseText = "Resume"
+        elif self._pausePending:
+            pauseText = "Pausing at next break..."
+        else:
+            pauseText = "Pause"
+        self.pauseBtn.setText(pauseText)

--- a/acq4/modules/Autopatch/tests/test_cell_panel.py
+++ b/acq4/modules/Autopatch/tests/test_cell_panel.py
@@ -1971,3 +1971,223 @@ def test_a_mounted_details_widget_is_given_room_to_show(qapp):
         assert panel.minimumSizeHint().height() <= _panelFloor(panel)
     finally:
         panel.close()
+
+
+# --- synthetic "Tracker initialized" row (the reference-stack backfill) ---
+#
+# A cell with an initialized tracker always has a reference stack
+# (Cell.isInitialized reports self._tracker is not None), but nothing showed
+# it anywhere -- most visibly after a reuse pass, which wipes a cell's
+# timeline for its next pass while the tracker (and the reference stack it
+# holds) lives on unchanged on the Cell object itself. These tests cover the
+# synthetic row cell_panel.py seeds at index 0 of a cell's timeline to
+# surface that stack through the existing details pane, with no new UI and
+# no invented details kind.
+
+
+def _cellWithReferenceStack(stack=None):
+    """A real Cell (not a plain object()) with a stubbed-in tracker whose
+    reference-stack chain matches the one cell_panel.py and
+    acq4.experiment.actions.device._trackerStack both read:
+    cell._tracker.motion_estimator.original_object_stack.data.
+
+    A real Cell rather than a fake is used because isInitialized is a Cell
+    property (self._tracker is not None), and stubbing a whole fake class
+    just to reproduce that one property would be more code than reusing the
+    real thing.
+    """
+    import types
+
+    from acq4_automation.feature_tracking.cell import Cell
+    from coorx import Point
+
+    cell = Cell(Point((0.0, 0.0, 0.0), "global"))
+    if stack is None:
+        stack = np.arange(2 * 3 * 3, dtype=float).reshape(2, 3, 3)
+    cell._tracker = types.SimpleNamespace(
+        motion_estimator=types.SimpleNamespace(
+            original_object_stack=types.SimpleNamespace(data=stack)
+        )
+    )
+    return cell
+
+
+def test_a_cell_with_an_initialized_tracker_gets_a_synthetic_reference_row(qapp):
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    # A cellfie's own reference-stack payload transposes the last two axes
+    # (see acq4.experiment.actions.device._trackerStack); an all-equal stack
+    # sidesteps needing to reproduce that transform just to assert on it.
+    stack = np.full((2, 3, 3), 7.0)
+    cell = _cellWithReferenceStack(stack)
+
+    panel.addCell(cell)
+
+    assert panel._timelines[id(cell)] == ["Tracker initialized"]
+    kind, payload = panel.detailsFor(cell, 0)
+    assert kind == "image_stack"
+    assert np.array_equal(np.asarray(payload["stack"]), stack)
+
+
+def test_a_cell_with_no_tracker_gets_no_synthetic_row(qapp):
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+    from acq4_automation.feature_tracking.cell import Cell
+    from coorx import Point
+
+    panel = CellPanel()
+    cell = Cell(Point((0.0, 0.0, 0.0), "global"))  # _tracker is None -> not initialized
+    assert cell.isInitialized is False
+
+    panel.addCell(cell)
+
+    assert panel._timelines[id(cell)] == []
+    assert panel.detailsFor(cell, 0) is None
+
+
+def test_real_actions_after_the_synthetic_row_land_at_index_one_with_no_reindexing(qapp):
+    from acq4.experiment.log_entry import ActionLogEntry
+
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    cell = _cellWithReferenceStack()
+    panel.addCell(cell)
+    panel.cellList.setCurrentItem(panel._rows[id(cell)])
+
+    entry = ActionLogEntry("Pipette To Home")
+    panel.onLogAction(cell, entry)
+    entry.set_details("text", {"lines": ["pass 1"]})
+    entry._finish(None)
+
+    assert panel._timelines[id(cell)][0] == "Tracker initialized"
+    assert "Pipette To Home" in panel._timelines[id(cell)][1]
+    assert panel.detailsFor(cell, 0)[0] == "image_stack"
+    assert panel.detailsFor(cell, 1) == ("text", {"lines": ["pass 1"]})
+
+
+def test_after_a_reuse_pass_wipes_the_timeline_the_synthetic_row_reappears(qapp):
+    """The backfill this feature exists for: reuse wipes the timeline (and
+    self._details with it) while the cell's tracker -- and the reference
+    stack cached from its first real image_stack detail -- live on.
+
+    The cell has no tracker yet when addCell() runs (the common case for a
+    manually-added cell, or one a survey found before cellfie ever ran on
+    it), so the cache below can only have come from the real action's own
+    set_details() call, over sigActionEntry -- not from addCell()'s own
+    live-read fallback, which never had anything to read at that point.
+    """
+    from acq4.experiment.log_entry import ActionLogEntry
+    from acq4_automation.feature_tracking.cell import Cell
+    from coorx import Point
+
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    cell = Cell(Point((0.0, 0.0, 0.0), "global"))
+    panel.addCell(cell)  # no tracker yet -> nothing cached, no synthetic row
+    panel.cellList.setCurrentItem(panel._rows[id(cell)])
+    # Cellfie is what actually initializes the tracker in production
+    # (Cell.initializeTracker); a bare stand-in is enough here since this
+    # test cares only about the cache _onActionEntry populates from the
+    # entry's own set_details() payload below, not about a live tracker read.
+    cell._tracker = object()
+    entry = ActionLogEntry("Cellfie")
+    panel.onLogAction(cell, entry)
+    entry.set_details(
+        "image_stack", {"stack": np.ones((2, 2, 2)), "center_index": 0, "title": "Cellfie"}
+    )
+    entry._finish(None)
+    panel._onCellFinished(cell, "done")
+    panel.bindOrchestrator(_FakeOrchestrator())
+    panel._rows[id(cell)].setCheckState(Qt.Qt.Checked)
+
+    panel.reuseCheckedCellsBtn.click()
+
+    assert panel._timelines[id(cell)] == ["Tracker initialized"]
+    kind, payload = panel.detailsFor(cell, 0)
+    assert kind == "image_stack"
+    assert np.array_equal(payload["stack"], np.ones((2, 2, 2)))
+
+
+def test_reuse_never_reads_the_tracker_directly_when_nothing_was_ever_cached(qapp):
+    """The thread-safety guard: once a cell has been attempted, seeding the
+    synthetic row must come only from a payload this panel already cached off
+    sigActionEntry, never from a fresh read of cell._tracker -- reading that
+    on the GUI thread once a pass may still have a worker-thread job appending
+    to it (see 2794be759) is exactly the race this panel must not take. A cell
+    that finished a pass without ever attaching an image_stack detail (no
+    cache exists) must therefore get no synthetic row on reuse, even though
+    its tracker is still sitting right there with a stack to read.
+
+    The tracker is attached only after addCell() -- addCell() itself is a
+    provably quiet moment this panel does allow a live read from (see
+    _seedReferenceStackRow), and pre-seeding it before addCell() would let
+    that live read cache a stack of its own, which is exactly the confound
+    this test needs to avoid to isolate the "already attempted" guard.
+    """
+    from acq4_automation.feature_tracking.cell import Cell
+    from coorx import Point
+
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    cell = Cell(Point((0.0, 0.0, 0.0), "global"))
+    panel.addCell(cell)  # no tracker yet -> addCell()'s own live read finds nothing
+    cell._tracker = object()  # now initialized, but no action ever cached its stack
+    # First pass never attached an image_stack detail (e.g. every action
+    # logged something else), so nothing was ever cached for this cell.
+    panel._onCellFinished(cell, "done")
+    panel.bindOrchestrator(_FakeOrchestrator())
+    panel._rows[id(cell)].setCheckState(Qt.Qt.Checked)
+
+    panel.reuseCheckedCellsBtn.click()
+
+    assert panel._timelines[id(cell)] == []
+    assert panel.detailsFor(cell, 0) is None
+
+
+def test_auto_select_row_does_not_select_the_synthetic_row_when_real_actions_exist(qapp):
+    from acq4.experiment.log_entry import ActionLogEntry
+
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    cell = _cellWithReferenceStack()
+    panel.addCell(cell)
+    entry = ActionLogEntry("Pipette To Home")
+    panel.onLogAction(cell, entry)
+    entry._finish(None)
+
+    panel.cellList.setCurrentItem(panel._rows[id(cell)])
+
+    assert panel.timelineList.count() == 2
+    assert panel.timelineList.currentRow() == 1
+
+
+def test_auto_select_row_picks_the_synthetic_row_when_it_is_the_only_one(qapp):
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    cell = _cellWithReferenceStack()
+    panel.addCell(cell)
+
+    panel.cellList.setCurrentItem(panel._rows[id(cell)])
+
+    assert panel.timelineList.count() == 1
+    assert panel.timelineList.currentRow() == 0
+
+
+def test_selecting_the_synthetic_row_mounts_the_reference_stack_widget(qapp):
+    import pyqtgraph as pg
+
+    from acq4.modules.Autopatch.cell_panel import CellPanel
+
+    panel = CellPanel()
+    cell = _cellWithReferenceStack(np.zeros((2, 3, 3)))
+    panel.addCell(cell)
+    panel.cellList.setCurrentItem(panel._rows[id(cell)])
+
+    panel.timelineList.setCurrentRow(0)
+
+    assert panel.showContainer.findChild(pg.ImageView) is not None

--- a/acq4/modules/Autopatch/tests/test_progress_overlay.py
+++ b/acq4/modules/Autopatch/tests/test_progress_overlay.py
@@ -26,6 +26,31 @@ def makeOverlay():
     return ProgressOverlay(view), view
 
 
+def makeShownOverlay():
+    """Like makeOverlay(), but the ViewBox sits in an actual shown
+    GraphicsView with a real range.
+
+    A bare, unparented pg.ViewBox() has no device transform, so a pxMode
+    scatter's pixelVectors() -- what its hoverEvent needs to know how big a
+    marker is in local units -- comes back as an unresolved 1-unit-per-pixel
+    placeholder until an actual paint has happened, at which point every
+    point everywhere reads as "under the cursor". processEvents() alone does
+    not force that first paint; only running the event loop for a moment
+    (qWait) does. Only the hover-claim tests need a real paint for that
+    reason; every other test above hits none of this machinery.
+    """
+    from acq4.modules.Autopatch.progress_overlay import ProgressOverlay
+
+    graphicsView = pg.GraphicsView()
+    view = pg.ViewBox()
+    graphicsView.setCentralItem(view)
+    graphicsView.resize(400, 400)
+    graphicsView.show()
+    view.setRange(xRange=(0.9e-3, 1.5e-3), yRange=(1.9e-3, 2.2e-3), padding=0)
+    Qt.QTest.qWait(30)
+    return ProgressOverlay(view), view, graphicsView
+
+
 def test_markers_are_drawn_at_their_positions(qapp):
     from acq4.modules.Autopatch.progress_overlay import Marker
 
@@ -129,3 +154,64 @@ def test_clicking_a_marker_reports_its_cell_id(qapp):
     overlay.scatter.sigClicked.emit(overlay.scatter, [overlay.scatter.points()[0]], None)
 
     assert seen == [111]
+
+
+class _FakeHoverEvent:
+    """Stands in for pyqtgraph's real HoverEvent, which cannot be built
+    outside a live scene: only the two calls ScatterPlotItem.hoverEvent and
+    this module's override actually make on it.
+    """
+
+    def __init__(self, pos, exit=False):
+        self._pos = pos
+        self._exit = exit
+        self.claimedClicks = []
+
+    def isExit(self):
+        return self._exit
+
+    def pos(self):
+        return self._pos
+
+    def acceptClicks(self, button):
+        self.claimedClicks.append(button)
+        return True
+
+
+def test_hovering_a_marker_claims_the_left_button_click(qapp):
+    """A region ROI claims every left-button click across its whole
+    translatable body as soon as it is hovered (pg.ROI.hoverEvent calls
+    HoverEvent.acceptClicks unconditionally); once claimed, nothing drawn
+    underneath -- a cell marker included -- is ever offered that click. The
+    scatter has to make the same claim itself, right where a marker actually
+    sits, or it can never win that race.
+    """
+    from acq4.modules.Autopatch.progress_overlay import Marker
+
+    overlay, _view, graphicsView = makeShownOverlay()
+    overlay.setMarkers([Marker(POS_A[0], POS_A[1], pg.mkBrush(0, 180, 0), 111)])
+    Qt.QTest.qWait(30)
+
+    ev = _FakeHoverEvent(Qt.QPointF(POS_A[0], POS_A[1]))
+    overlay.scatter.hoverEvent(ev)
+    graphicsView.close()
+
+    assert ev.claimedClicks == [Qt.Qt.LeftButton]
+
+
+def test_hovering_empty_space_claims_nothing(qapp):
+    """Away from every marker, the scatter must stay out of the race
+    entirely -- claiming the click there too would take left-button clicks
+    away from a region ROI that has nothing to do with any marker.
+    """
+    from acq4.modules.Autopatch.progress_overlay import Marker
+
+    overlay, _view, graphicsView = makeShownOverlay()
+    overlay.setMarkers([Marker(POS_A[0], POS_A[1], pg.mkBrush(0, 180, 0), 111)])
+    Qt.QTest.qWait(30)
+
+    ev = _FakeHoverEvent(Qt.QPointF(POS_B[0], POS_B[1]))
+    overlay.scatter.hoverEvent(ev)
+    graphicsView.close()
+
+    assert ev.claimedClicks == []

--- a/acq4/modules/Autopatch/tests/test_reference_imagery.py
+++ b/acq4/modules/Autopatch/tests/test_reference_imagery.py
@@ -1,6 +1,8 @@
 """Tests for ReferenceImagery: the pinned-frames workflow that starts a slice."""
 from __future__ import annotations
 
+from unittest import mock
+
 import pytest
 
 from acq4.util import Qt
@@ -52,6 +54,29 @@ def _imagery(source, answer=True):
         return answer
 
     return ReferenceImagery(lambda: source, prompt=prompt), asked
+
+
+def test_ask_to_clear_offers_yes_no_and_defaults_to_no(qapp):
+    """The dialog is a yes/no question, and Enter/Escape must not clear."""
+    from acq4.modules.Autopatch.reference_imagery import _askToClear
+
+    with mock.patch.object(Qt.QMessageBox, "question", return_value=Qt.QMessageBox.No) as question:
+        _askToClear("some text")
+
+    args, kwargs = question.call_args
+    buttons = kwargs.get("buttons", args[3] if len(args) > 3 else None)
+    assert buttons == Qt.QMessageBox.Yes | Qt.QMessageBox.No
+    defaultButton = kwargs.get("defaultButton", args[4] if len(args) > 4 else None)
+    assert defaultButton == Qt.QMessageBox.No
+
+
+def test_ask_to_clear_returns_true_only_for_yes(qapp):
+    from acq4.modules.Autopatch.reference_imagery import _askToClear
+
+    with mock.patch.object(Qt.QMessageBox, "question", return_value=Qt.QMessageBox.No):
+        assert _askToClear("some text") is False
+    with mock.patch.object(Qt.QMessageBox, "question", return_value=Qt.QMessageBox.Yes):
+        assert _askToClear("some text") is True
 
 
 def test_nothing_pinned_means_no_prompt(qapp):

--- a/acq4/modules/Autopatch/tests/test_region_panel.py
+++ b/acq4/modules/Autopatch/tests/test_region_panel.py
@@ -284,11 +284,11 @@ def test_fit_to_regions_frames_the_regions_and_the_pinned_frames_together(qapp):
     assert vy0 <= 1.0e-3 and vy1 >= 2.1e-3
 
 
-# A region smaller than one field of view, and the single tile that surveys it.
-# Chosen that way so the shading reaches a long way past the region it came
-# from: fitToRegions() pads by a tenth of what it frames, and an overhang
-# smaller than that padding would land inside the padding either way and so
-# would not say which of the two was framed.
+# A region smaller than one field of view, and the single tile that surveys
+# it, sized so the tile reaches well past the region on every side:
+# fitToRegions() pads by a tenth of what it frames, and an overhang smaller
+# than that padding would land inside the padding either way, leaving "the
+# tile was framed" indistinguishable from "only the region was".
 SMALL = RectRegion(1.0e-3, 2.0e-3, 1.06e-3, 2.03e-3)
 COVERAGE_FOV = (200e-6, 100e-6)
 COVERAGE_TILE = (1.03e-3, 2.015e-3)
@@ -308,22 +308,14 @@ def makeOverlay(panel):
     return overlay
 
 
-def test_fit_to_regions_frames_the_survey_coverage_shading(qapp):
-    """Measured on a rig: pressing Fit on a slice with a region and tiles still
-    to survey raised AttributeError out of the button's slot, because the
-    shading ProgressOverlay.setCoverage() draws is plain Qt.QGraphicsRectItems
-    -- the only things put in this view that are not pyqtgraph items, and so
-    the only ones with no mapRectToView() to map their bounds through.
-
-    The shading is framed rather than skipped, which is what the overhang
-    asserted below pins down: a tile is a whole field of view, so a region
-    smaller than one is surveyed well past its own edges, and what the survey
-    will image is worth seeing.
-
-    x is the axis to assert an overhang on. The view is aspect-locked, so
-    whichever axis does not match the widget's shape is widened past what was
-    asked for -- the union here is twice as wide as it is tall, so y is the
-    widened one and only x reports the range this actually chose.
+def test_fit_to_regions_excludes_the_survey_coverage_shading(qapp):
+    """Fit shows what the camera window would also show -- the mirrored
+    pinned frames and the region ROIs -- not where the survey has yet to
+    look. A region smaller than one field of view, with a to-do tile drawn
+    well past it on every side (see SMALL/COVERAGE_FOV/COVERAGE_TILE above),
+    must fit tight to the region: the tile pulling the view out to a whole
+    field of view's own size would be this same panel answering a different
+    question than the one the button is for.
     """
     panel = makePanel()
     overlay = makeOverlay(panel)
@@ -334,9 +326,29 @@ def test_fit_to_regions_frames_the_survey_coverage_shading(qapp):
 
     (vx0, vx1), (vy0, vy1) = panel.view.viewRange()
     fovW, fovH = COVERAGE_FOV
-    cx, cy = COVERAGE_TILE
-    assert vx0 <= cx - fovW / 2 and vx1 >= cx + fovW / 2
-    assert vy0 <= cy - fovH / 2 and vy1 >= cy + fovH / 2
+    assert (vx1 - vx0) < fovW
+    assert (vy1 - vy0) < fovH
+    x0, y0, x1, y1 = SMALL.bounds()
+    assert vx0 <= x0 and vx1 >= x1
+    assert vy0 <= y0 and vy1 >= y1
+
+
+def test_fit_to_regions_does_not_crash_on_a_plain_qgraphicsrectitem(qapp):
+    """A plain Qt.QGraphicsRectItem -- what ProgressOverlay draws its coverage
+    shading with -- carries none of pyqtgraph's GraphicsItem mixin, and so has
+    no mapRectToView() of its own. Excluding such an item from the framed
+    union must not mean choking on it first: Fit has to run to completion
+    whether or not it is a ProgressOverlay that put one in this view.
+    """
+    panel = makePanel()
+    panel.setRegions([RECT])
+    panel.view.addItem(Qt.QGraphicsRectItem(0, 0, 1.0e-3, 1.0e-3))
+
+    panel.fitToRegions()
+
+    (vx0, vx1), (vy0, vy1) = panel.view.viewRange()
+    assert vx0 <= 1.0e-3 and vx1 >= 1.4e-3
+    assert vy0 <= 2.0e-3 and vy1 >= 2.1e-3
 
 
 def test_a_panel_with_no_slice_cannot_be_drawn_on(qapp):

--- a/acq4/modules/Autopatch/tests/test_region_panel.py
+++ b/acq4/modules/Autopatch/tests/test_region_panel.py
@@ -3,6 +3,7 @@ operator edits a region, and what it lets them touch."""
 
 import pytest
 
+import pyqtgraph as pg
 from acq4.experiment.search_region import EllipseRegion, PolygonRegion, RectRegion
 from acq4.util import Qt
 
@@ -703,6 +704,65 @@ def test_legend_swatch_shows_the_brush_colour(qapp):
     assert len(swatches) == 2
     assert swatches[0].palette().color(swatches[0].backgroundRole()) == firstBrush.color()
     assert swatches[1].palette().color(swatches[1].backgroundRole()) == secondBrush.color()
+
+
+def test_a_marker_inside_an_editable_region_still_wins_its_click(qapp):
+    """A cell marker drawn inside a region's interior has to win the click
+    over the region ROI stacked there too: pg.ROI's hoverEvent claims every
+    left-button click across its whole translatable body as soon as it is
+    hovered (see HoverEvent.acceptClicks in pyqtgraph's GraphicsScene), and
+    once claimed, the scene never offers that click to anything else -- a
+    marker included. Driven through real QMouseEvents rather than by calling
+    ProgressOverlay._onScatterClicked or roi.hoverEvent directly, because the
+    bug lives in which of the two ever gets asked, not in what either one
+    does once asked.
+    """
+    from acq4.modules.Autopatch.progress_overlay import Marker, ProgressOverlay
+
+    panel = makePanel()
+    panel.resize(400, 400)
+    panel.show()
+    Qt.QApplication.processEvents()
+    panel.setSliceReady(True)
+    panel.setRegions([RECT])
+    panel.view.setRange(xRange=(0.9e-3, 1.5e-3), yRange=(1.9e-3, 2.2e-3), padding=0)
+    Qt.QApplication.processEvents()
+    roi = panel._rois[0]
+
+    overlay = ProgressOverlay(panel.view)
+    markerPos = (1.2e-3, 2.05e-3)  # inside RECT's box
+    overlay.setMarkers([Marker(markerPos[0], markerPos[1], pg.mkBrush(0, 180, 0), 111)])
+    seen = []
+    overlay.sigMarkerClicked.connect(seen.append)
+
+    scenePos = panel.view.mapViewToScene(Qt.QPointF(*markerPos))
+    viewport = panel.graphicsView.viewport()
+    localPos = Qt.QPointF(panel.graphicsView.mapFromScene(scenePos))
+    globalPos = Qt.QPointF(viewport.mapToGlobal(localPos.toPoint()))
+
+    def send(kind, button, buttons):
+        ev = Qt.QMouseEvent(kind, localPos, globalPos, button, buttons, Qt.Qt.NoModifier)
+        Qt.QCoreApplication.sendEvent(viewport, ev)
+
+    # Hover the marker first, the way an operator's cursor always does before
+    # a click actually lands -- sendClickEvent() below reads this scene's
+    # lastHoverEvent, not anything freshly computed at click time.
+    send(Qt.QEvent.MouseMove, Qt.Qt.NoButton, Qt.Qt.NoButton)
+    Qt.QApplication.processEvents()
+    hover = panel.graphicsView.scene().lastHoverEvent
+    assert hover.clickItems().get(Qt.Qt.LeftButton) is overlay.scatter
+    # The ROI must still be the one dragging would move: acceptClicks and
+    # acceptDrags are separate claims, so a marker winning the click must not
+    # cost the region its own drag.
+    assert hover.dragItems().get(Qt.Qt.LeftButton) is roi
+
+    send(Qt.QEvent.MouseButtonPress, Qt.Qt.LeftButton, Qt.Qt.LeftButton)
+    Qt.QApplication.processEvents()
+    send(Qt.QEvent.MouseButtonRelease, Qt.Qt.LeftButton, Qt.Qt.NoButton)
+    Qt.QApplication.processEvents()
+
+    panel.close()
+    assert seen == [111]
 
 
 def test_the_slice_view_shrinks_with_the_panel_rather_than_holding_a_floor(qapp):

--- a/acq4/modules/Autopatch/tests/test_search_panel.py
+++ b/acq4/modules/Autopatch/tests/test_search_panel.py
@@ -12,10 +12,10 @@ def qapp():
     return Qt.QApplication.instance() or Qt.QApplication([])
 
 
-def makePanel():
+def makePanel(**kwargs):
     from acq4.modules.Autopatch.search_panel import SearchPanel
 
-    return SearchPanel()
+    return SearchPanel(**kwargs)
 
 
 def test_defaults_match_the_engines_defaults(qapp):
@@ -41,6 +41,38 @@ def test_the_density_control_reads_in_cells_per_nanolitre(qapp):
     # since a typical z-stack field of view is a couple of nanolitres.
     panel = makePanel()
     assert panel.maxDensitySpin.text() == "5 cells/nL"
+
+
+def test_the_detection_step_reads_in_si_units(qapp):
+    # step_z is a z distance, the same unit family as the depth controls, so
+    # it reads the same way: "2 µm" rather than "0.0000020 m".
+    panel = makePanel(step_z=2e-6)
+    assert panel.stepZSpin.text() == "2 µm"
+
+
+def test_the_min_volume_control_reads_in_si_cubic_metres(qapp):
+    # Mirrors AutomationDebug's own minimum-volume spin box (m³, SI-prefixed):
+    # a volume floor is small enough that a raw m^3 number is unreadable
+    # without prefixing.
+    panel = makePanel(min_volume_m3=5e-17)
+    assert panel.minVolumeSpin.text() == "50 am³"
+
+
+def test_the_detection_controls_are_seeded_from_the_constructor_defaults(qapp):
+    # Area 2 has no idea what a rig's `misc` config says; its owner reads
+    # that and passes it in here, so an operator opening Area 2 for the first
+    # time sees the rig's own starting point, not a hard-coded one.
+    panel = makePanel(min_volume_m3=5e-17, step_z=2e-6)
+    assert panel.minVolumeSpin.value() == pytest.approx(5e-17)
+    assert panel.stepZSpin.value() == pytest.approx(2e-6)
+
+
+def test_the_detection_controls_default_to_the_engines_defaults(qapp):
+    # An owner that passes nothing (a manager-less window, say) must not end
+    # up with a search Area 2 itself disagrees with.
+    panel = makePanel()
+    assert panel.minVolumeSpin.value() == pytest.approx(SearchConstraints().min_volume_m3)
+    assert panel.stepZSpin.value() == pytest.approx(SearchConstraints().step_z)
 
 
 def test_editing_the_depth_range_is_reflected_in_the_constraints(qapp):
@@ -82,6 +114,28 @@ def test_editing_the_max_cell_density_is_reflected_in_the_constraints(qapp):
     assert panel.constraints().max_cell_density == pytest.approx(2e12)
 
 
+def test_editing_the_min_volume_is_reflected_in_the_constraints(qapp):
+    panel = makePanel()
+    panel.minVolumeSpin.setValue(5e-17)
+    assert panel.constraints().min_volume_m3 == pytest.approx(5e-17)
+
+
+def test_editing_the_detection_step_is_reflected_in_the_constraints(qapp):
+    panel = makePanel()
+    panel.stepZSpin.setValue(2e-6)
+    assert panel.constraints().step_z == pytest.approx(2e-6)
+
+
+def test_the_detection_step_cannot_be_driven_to_zero_or_below(qapp):
+    # step_z is a z increment for a detection stack; SearchConstraints rejects
+    # a non-positive one, but the widget's own lower bound is what stops the
+    # operator getting there at all, the same discipline the depth controls
+    # use for their own single-field bound.
+    panel = makePanel()
+    panel.stepZSpin.setValue(-1e-6)
+    assert panel.stepZSpin.value() > 0.0
+
+
 def test_editing_rescans_is_reflected_in_the_constraints(qapp):
     panel = makePanel()
     panel.rescansCheck.setChecked(True)
@@ -112,8 +166,26 @@ def test_editing_rescans_is_reflected_in_the_constraints(qapp):
             pytest.approx(2e12),
         ),
         (lambda panel: panel.rescansCheck.setChecked(True), "rescans_allowed", True),
+        (
+            lambda panel: panel.minVolumeSpin.setValue(5e-17),
+            "min_volume_m3",
+            pytest.approx(5e-17),
+        ),
+        (
+            lambda panel: panel.stepZSpin.setValue(2e-6),
+            "step_z",
+            pytest.approx(2e-6),
+        ),
     ],
-    ids=["near_depth", "far_depth", "min_health", "max_density", "rescans"],
+    ids=[
+        "near_depth",
+        "far_depth",
+        "min_health",
+        "max_density",
+        "rescans",
+        "min_volume",
+        "step_z",
+    ],
 )
 def test_an_edit_emits_the_new_constraints(qapp, edit, attr, expected):
     # Each control is wired to _onEdited independently; the window listens on
@@ -160,6 +232,26 @@ def test_recovering_from_an_invalid_range_clears_the_error(qapp):
     panel.farDepthSpin.setValue(-70e-6)
     assert panel.constraints() is not None
     assert panel.errorLabel.text() == ""
+
+
+def test_the_min_volume_cannot_be_driven_negative(qapp):
+    # min_volume_m3 must be non-negative; the widget's own lower bound is what
+    # stops the operator getting there, so constraints() never sees a
+    # negative value to raise over.
+    panel = makePanel()
+    panel.minVolumeSpin.setValue(-5e-17)
+    assert panel.minVolumeSpin.value() >= 0.0
+    assert panel.constraints() is not None
+
+
+def test_dragging_the_detection_step_through_its_lower_bound_does_not_raise(qapp):
+    # An operator dragging stepZSpin down passes through values pyqtgraph
+    # clamps at the widget's own bound; that must never reach constraints()
+    # as a raw ValueError out of the GUI thread.
+    panel = makePanel()
+    for value in (5e-6, 1e-6, 1e-9, -1e-6, 0.0):
+        panel.stepZSpin.setValue(value)
+        assert panel.constraints() is not None
 
 
 def test_an_externally_set_error_is_shown(qapp):
@@ -226,6 +318,8 @@ def test_survey_stats_with_no_region_read_as_no_region(qapp):
         "minHealthSpin",
         "maxDensitySpin",
         "rescansCheck",
+        "minVolumeSpin",
+        "stepZSpin",
     ],
 )
 def test_locking_disables_editing_but_not_the_readout(qapp, widgetName):
@@ -254,6 +348,8 @@ def _controls(panel):
         panel.minHealthSpin,
         panel.maxDensitySpin,
         panel.rescansCheck,
+        panel.minVolumeSpin,
+        panel.stepZSpin,
     )
 
 

--- a/acq4/modules/Autopatch/tests/test_status_panel.py
+++ b/acq4/modules/Autopatch/tests/test_status_panel.py
@@ -104,6 +104,86 @@ def test_pause_button_toggles_to_resume_while_paused(qapp):
     assert orch.resumed == 1
 
 
+def test_clicking_pause_while_running_shows_pending_and_requests_pause(qapp):
+    # A paused status can be a long time coming -- the orchestrator only
+    # checks for it between cells or retries. The operator needs to see the
+    # click landed well before that, so the button must not just sit there
+    # still saying "Pause".
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("running")
+
+    panel.pauseBtn.click()
+
+    assert orch.paused == 1
+    assert orch.resumed == 0
+    assert panel.pauseBtn.text() == "Pausing at next break..."
+    assert panel.pauseBtn.isEnabled()
+
+
+def test_clicking_pause_again_while_pending_cancels_the_request(qapp):
+    # A second click before the pause has actually landed reads as "never
+    # mind" -- it should withdraw the request (by re-arming the orchestrator's
+    # pause event) rather than compound into some other state.
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("running")
+    panel.pauseBtn.click()
+
+    panel.pauseBtn.click()
+
+    assert orch.resumed == 1
+    assert panel.pauseBtn.text() == "Pause"
+    assert panel.pauseBtn.isEnabled()
+
+
+def test_sigstatus_paused_while_pending_shows_resume(qapp):
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("running")
+    panel.pauseBtn.click()
+
+    orch.sigStatus.emit("paused")
+
+    assert panel.pauseBtn.text() == "Resume"
+
+
+def test_sigstatus_running_while_pending_clears_pending_and_shows_pause(qapp):
+    # A pause request can be superseded without ever becoming an actual pause
+    # -- resumed from elsewhere, or the run loop simply reports "running"
+    # again on its own. Either way the pending label must not linger once the
+    # orchestrator itself says it is running.
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("running")
+    panel.pauseBtn.click()
+    assert panel.pauseBtn.text() == "Pausing at next break..."
+
+    orch.sigStatus.emit("running")
+
+    assert panel.pauseBtn.text() == "Pause"
+    # Clicking now must request a fresh pause, not cancel a stale one.
+    panel.pauseBtn.click()
+    assert orch.paused == 2
+    assert orch.resumed == 0
+
+
+def test_pending_does_not_survive_the_run_finishing(qapp):
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("running")
+    panel.pauseBtn.click()
+
+    orch.sigStatus.emit("waiting")  # the run loop's finally, run over
+
+    assert panel.pauseBtn.text() == "Pause"
+
+
+def test_pending_does_not_survive_an_error(qapp):
+    panel, orch = _boundPanel()
+    orch.sigStatus.emit("running")
+    panel.pauseBtn.click()
+
+    orch.sigStatus.emit("error")
+
+    assert panel.pauseBtn.text() == "Pause"
+
+
 def test_status_signal_updates_label(qapp):
     from acq4.modules.Autopatch.status_panel import StatusPanel
 

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -227,14 +227,15 @@ class _FakeManager(Qt.QObject):
 
     sigModulesChanged = Qt.Signal()
 
-    def __init__(self, root_dir):
+    def __init__(self, root_dir, config=None):
         super().__init__()
         self._current_dir = root_dir
         self.configFiles = {}
-        # The rig's own configuration, which is where the survey reads the two
-        # detection settings Area 2 has no control for. Empty by default, so
-        # every other test sees the defaults a stock rig would.
-        self.config = {}
+        # The rig's own configuration. `misc.minCellVolume`/`misc.detectionStepZ`
+        # seed Area 2's detection controls with a starting point for a fresh
+        # slice. Empty by default, so every other test sees the engine's own
+        # defaults, the way an unconfigured rig would.
+        self.config = config if config is not None else {}
         self.drawn = []
         self.pinnedFrameSource = _FakePinnedFrameSource()
         self.cameraWindow = SimpleNamespace(
@@ -271,7 +272,7 @@ class _FakeManager(Qt.QObject):
         self.configFiles[fileName] = data
 
 
-def _makeWindow(tmp_path, cameraSelector=None, pipetteSelector=None):
+def _makeWindow(tmp_path, cameraSelector=None, pipetteSelector=None, managerConfig=None):
     """An AutopatchWindow with a loaded no-op protocol and a camera-backed
     selector, for tests that don't care about protocol content but do need a
     working camera to seed a slice or region.
@@ -282,7 +283,12 @@ def _makeWindow(tmp_path, cameraSelector=None, pipetteSelector=None):
     Also wires up a manager backed by a real (temporary) managed directory, so
     newSlice()'s create_data_dir call has somewhere real to write -- kept in a
     subdirectory of tmp_path separate from the protocol files written directly
-    into tmp_path above."""
+    into tmp_path above.
+
+    `managerConfig`, when given, becomes the manager's `.config` before the
+    window (and thus SearchPanel) is constructed -- SearchPanel reads Area 2's
+    detection defaults from it once, at construction, so a test about that
+    seeding has to set it before the window exists rather than on the fly."""
     from acq4.modules.Autopatch.Autopatch import AutopatchWindow
 
     if cameraSelector is None:
@@ -292,7 +298,9 @@ def _makeWindow(tmp_path, cameraSelector=None, pipetteSelector=None):
     _write_protocol(tmp_path, "demo.py", _NOOP_PROTOCOL)
     storageRoot = dm.getDirHandle(str(tmp_path / "storage"), create=True)
     win = AutopatchWindow(
-        module=SimpleNamespace(manager=_FakeManager(storageRoot), name="Autopatch"),
+        module=SimpleNamespace(
+            manager=_FakeManager(storageRoot, config=managerConfig), name="Autopatch"
+        ),
         protocolDir=str(tmp_path),
         pipetteSelector=pipetteSelector,
         cameraSelector=cameraSelector,
@@ -1393,28 +1401,32 @@ def test_a_slice_with_no_directory_hands_the_survey_nowhere_to_save(
     assert win.orchestrator._cellProducer is not None
 
 
-def test_the_detection_settings_come_from_the_rigs_configuration(
+def test_the_detection_settings_reach_the_survey_from_the_slices_constraints(
     qapp, tmp_path, monkeypatch
 ):
-    """AutomationDebug reads a minimum volume off a spin box on its own window
-    and a step from its acquisition; the survey has neither, so until Area 2
-    grows the controls the rig's `misc` configuration is where they can be set.
+    """min_volume_m3 and step_z are SearchConstraints fields now, so the survey
+    reads them off the live slice, the same path the health cutoff and the
+    density cap already take -- not a separate rig-configuration read.
     Non-default values, so a hard-coded 0.0 or 1 um is caught."""
     calls = _captureDetectorArgs(monkeypatch)
     win = _makeWindow(tmp_path)
-    win.manager.config = {"misc": {"minCellVolume": 5e-17, "detectionStepZ": 2e-6}}
     win.newSlice()
     win.addRegionHere()
+    win.searchPanel.minVolumeSpin.setValue(5e-17)
+    win.searchPanel.stepZSpin.setValue(2e-6)
 
     win._onStartRun()
 
     assert calls[0]["min_volume_m3"] == pytest.approx(5e-17)
     assert calls[0]["step_z"] == pytest.approx(2e-6)
+    assert win.slice.constraints.min_volume_m3 == pytest.approx(5e-17)
+    assert win.slice.constraints.step_z == pytest.approx(2e-6)
 
 
 def test_an_unconfigured_rig_surveys_the_way_it_always_did(qapp, tmp_path, monkeypatch):
-    # The defaults are the values the survey used when neither was settable at
-    # all, so configuring nothing changes nothing.
+    # The library defaults are the values the survey used before these were
+    # settable at all, so an operator who touches neither Area 2 control nor
+    # a rig's `misc` config gets the same search.
     calls = _captureDetectorArgs(monkeypatch)
     win = _makeWindow(tmp_path)
     win.newSlice()
@@ -1424,6 +1436,48 @@ def test_an_unconfigured_rig_surveys_the_way_it_always_did(qapp, tmp_path, monke
 
     assert calls[0]["min_volume_m3"] == pytest.approx(0.0)
     assert calls[0]["step_z"] == pytest.approx(1e-6)
+
+
+def test_the_rigs_misc_config_seeds_area_2s_detection_defaults(qapp, tmp_path, monkeypatch):
+    """A rig that sets `misc.minCellVolume`/`misc.detectionStepZ` gets those as
+    Area 2's starting point for a fresh slice, without the operator typing
+    them in -- the panel's own hard-coded defaults are only for a rig that
+    configures neither."""
+    calls = _captureDetectorArgs(monkeypatch)
+    win = _makeWindow(
+        tmp_path,
+        managerConfig={"misc": {"minCellVolume": 5e-17, "detectionStepZ": 2e-6}},
+    )
+    assert win.searchPanel.minVolumeSpin.value() == pytest.approx(5e-17)
+    assert win.searchPanel.stepZSpin.value() == pytest.approx(2e-6)
+
+    win.newSlice()
+    win.addRegionHere()
+    win._onStartRun()
+
+    assert calls[0]["min_volume_m3"] == pytest.approx(5e-17)
+    assert calls[0]["step_z"] == pytest.approx(2e-6)
+
+
+def test_editing_detection_settings_after_the_config_seeded_them_overrides_them(
+    qapp, tmp_path, monkeypatch
+):
+    # Once a slice exists, an operator's own edit is the persisted value --
+    # the rig's `misc` config is only ever the starting point.
+    calls = _captureDetectorArgs(monkeypatch)
+    win = _makeWindow(
+        tmp_path,
+        managerConfig={"misc": {"minCellVolume": 5e-17, "detectionStepZ": 2e-6}},
+    )
+    win.newSlice()
+    win.addRegionHere()
+    win.searchPanel.minVolumeSpin.setValue(9e-17)
+    win.searchPanel.stepZSpin.setValue(4e-6)
+
+    win._onStartRun()
+
+    assert calls[0]["min_volume_m3"] == pytest.approx(9e-17)
+    assert calls[0]["step_z"] == pytest.approx(4e-6)
 
 
 def test_clicking_start_installs_a_producer(qapp, tmp_path):
@@ -1480,6 +1534,15 @@ def test_editing_the_constraints_reaches_the_live_slice(qapp, tmp_path):
     win.newSlice()
     win.searchPanel.minHealthSpin.setValue(0.85)
     assert win.slice.constraints.min_health == pytest.approx(0.85)
+
+
+def test_editing_the_detection_settings_reaches_the_live_slice(qapp, tmp_path):
+    win = _makeWindow(tmp_path)
+    win.newSlice()
+    win.searchPanel.minVolumeSpin.setValue(5e-17)
+    win.searchPanel.stepZSpin.setValue(2e-6)
+    assert win.slice.constraints.min_volume_m3 == pytest.approx(5e-17)
+    assert win.slice.constraints.step_z == pytest.approx(2e-6)
 
 
 def test_invalid_constraints_leave_the_slice_alone(qapp, tmp_path):

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -2913,6 +2913,133 @@ def test_coverage_draws_the_todo_tiles_not_the_covered_ones(qapp, win):
         assert ay == pytest.approx(ey)
 
 
+class _CountingDirHandle:
+    """Stands in for a slice's data directory, recording every write that
+    reaches it without touching disk.
+
+    Distinct from slice.py's own persistence tests, which use a real managed
+    directory because what they prove is the record on disk; what a throttle
+    test needs is only a count of how many times saveState() actually wrote,
+    which is what the real directory's full-index rewrite (the cost this
+    throttle exists to bound) would otherwise make these tests slow.
+    """
+
+    def __init__(self):
+        self.writes = []
+
+    def writeFile(self, obj, fileName, **kwargs):
+        self.writes.append((fileName, obj))
+
+    def setInfo(self, **kwargs):
+        self.writes.append(("setInfo", kwargs))
+
+
+def _sliceWithCountingDir(win):
+    """Install a Slice on `win` backed by a _CountingDirHandle, so a test can
+    assert on how many times saveState() actually wrote."""
+    handle = _CountingDirHandle()
+    slice_ = Slice(fov=(20e-6, 10e-6), dirHandle=handle)
+    slice_.addRegion(RectRegion(1e-3, 2e-3, 1e-3 + 60e-6, 2e-3 + 30e-6))
+    win.slice = slice_
+    return slice_, handle
+
+
+def _searchStateSaves(handle):
+    """The search_state.yaml writes recorded on `handle`, one per completed
+    saveState() call (each call also writes regions.yaml and setInfo, but
+    search_state.yaml alone is enough to count saves and read back the
+    covered list)."""
+    return [w for w in handle.writes if w[0] == "search_state.yaml"]
+
+
+def test_repeated_surveying_statuses_throttle_the_slice_save(win):
+    """An interleaved survey+patch run reports "surveying" once per queue
+    refill -- effectively once per cell -- and each one used to trigger a
+    full rewrite of the slice's directory index. A fixed fake clock stands in
+    for several such refills arriving faster than the throttle interval,
+    since driving this with a real sleep would make the test slow without
+    proving anything a fake clock doesn't."""
+    slice_, handle = _sliceWithCountingDir(win)
+    win._sliceSaveClock = lambda: 100.0
+
+    for _ in range(5):
+        win._onRunStatus("surveying")
+
+    assert len(_searchStateSaves(handle)) == 1
+
+
+def test_a_run_ending_forces_a_flush_even_when_throttled(win):
+    """"waiting" fires once, at the very end of a run. If the last periodic
+    save landed inside the throttle window, the tiles covered since then must
+    still reach disk right here -- otherwise a run that finishes between two
+    throttle windows silently loses its tail."""
+    slice_, handle = _sliceWithCountingDir(win)
+    win._sliceSaveClock = lambda: 100.0
+
+    win._onRunStatus("surveying")
+    win._onRunStatus("surveying")  # throttled: same fake instant
+    win._onRunStatus("waiting")  # must force, even though the clock hasn't moved
+
+    assert len(_searchStateSaves(handle)) == 2
+
+
+def test_the_forced_flush_writes_the_latest_coverage_not_a_stale_snapshot(win):
+    """A throttled call must never cache the state it declined to write and
+    play it back later: the eventual write -- forced or not -- has to read
+    whatever the slice holds at that moment, not a snapshot from whenever the
+    throttle last let a save through."""
+    slice_, handle = _sliceWithCountingDir(win)
+    win._sliceSaveClock = lambda: 100.0
+    tileA, tileB = slice_.tileGrid()[:2]
+    slice_.markCovered(tileA)
+
+    win._onRunStatus("surveying")  # writes with only tileA covered
+    slice_.markCovered(tileB)
+    win._onRunStatus("surveying")  # throttled: tileB not yet on disk
+    win._onRunStatus("waiting")  # forced: must catch tileB up
+
+    saves = _searchStateSaves(handle)
+    assert len(saves) == 2
+    latestCovered = {tuple(c) for c in saves[-1][1]["covered"]}
+    assert latestCovered == {tuple(tileA), tuple(tileB)}
+
+
+def test_slice_saves_resume_once_the_throttle_interval_elapses(win):
+    """The throttle bounds loss to a window of time, not forever: once that
+    window has passed, the next "surveying" status writes again on its own,
+    without waiting for the run to end."""
+    slice_, handle = _sliceWithCountingDir(win)
+    now = [100.0]
+    win._sliceSaveClock = lambda: now[0]
+
+    win._onRunStatus("surveying")
+    now[0] += win._SLICE_SAVE_MIN_INTERVAL + 0.001
+    win._onRunStatus("surveying")
+
+    assert len(_searchStateSaves(handle)) == 2
+
+
+def test_teardown_flushes_slice_state_even_without_a_waiting_status(win):
+    """The operator can close the window mid-survey, before a run ever
+    reaches "waiting". Closing the window must not itself become a way to
+    lose whatever a pending throttled save hasn't written yet."""
+    slice_, handle = _sliceWithCountingDir(win)
+    win._sliceSaveClock = lambda: 100.0
+    win._onRunStatus("surveying")
+    slice_.markCovered(slice_.tileGrid()[1])
+    win._onRunStatus("surveying")  # throttled: the new tile isn't on disk yet
+    # Confirms the second status really was throttled away, so the count after
+    # teardown below can only grow because teardown() itself forced a flush --
+    # not because the throttle never engaged in the first place.
+    assert len(_searchStateSaves(handle)) == 1
+
+    win.teardown()
+
+    saves = _searchStateSaves(handle)
+    assert len(saves) == 2
+    assert {tuple(c) for c in saves[-1][1]["covered"]} == set(slice_.coveredTiles)
+
+
 def test_a_tracked_cell_marker_follows_its_position_signal(qapp, win):
     cell = _makeCellAt(1.0e-3, 2.0e-3, -30e-6)
     win.cellPanel.addCell(cell)

--- a/acq4/modules/Autopatch/tests/test_window_integration.py
+++ b/acq4/modules/Autopatch/tests/test_window_integration.py
@@ -2,6 +2,8 @@
 to the window's StatusPanel/CellPanel, and a seeded cell runs end-to-end."""
 import importlib
 import os
+import threading
+import time
 from types import SimpleNamespace
 
 import numpy as np
@@ -2952,6 +2954,22 @@ def _searchStateSaves(handle):
     return [w for w in handle.writes if w[0] == "search_state.yaml"]
 
 
+def _waitForSliceWrite(win, timeout=2.0):
+    """Block until the slice-save worker's most recently dispatched write has
+    finished.
+
+    A save the window dispatches without forcing (an ordinary "surveying"
+    status) runs on a worker thread and returns to the caller immediately, so
+    a test that inspects the fake directory right after must synchronize on
+    it explicitly -- otherwise it is racing the worker thread, not testing
+    it. A forced flush (`_flushSliceState(force=True)`) already waits
+    internally and needs no help from this.
+    """
+    task = win._sliceWriteTask
+    if task is not None:
+        task.wait(timeout=timeout)
+
+
 def test_repeated_surveying_statuses_throttle_the_slice_save(win):
     """An interleaved survey+patch run reports "surveying" once per queue
     refill -- effectively once per cell -- and each one used to trigger a
@@ -2964,6 +2982,7 @@ def test_repeated_surveying_statuses_throttle_the_slice_save(win):
 
     for _ in range(5):
         win._onRunStatus("surveying")
+    _waitForSliceWrite(win)
 
     assert len(_searchStateSaves(handle)) == 1
 
@@ -3013,8 +3032,10 @@ def test_slice_saves_resume_once_the_throttle_interval_elapses(win):
     win._sliceSaveClock = lambda: now[0]
 
     win._onRunStatus("surveying")
+    _waitForSliceWrite(win)
     now[0] += win._SLICE_SAVE_MIN_INTERVAL + 0.001
     win._onRunStatus("surveying")
+    _waitForSliceWrite(win)
 
     assert len(_searchStateSaves(handle)) == 2
 
@@ -3026,8 +3047,10 @@ def test_teardown_flushes_slice_state_even_without_a_waiting_status(win):
     slice_, handle = _sliceWithCountingDir(win)
     win._sliceSaveClock = lambda: 100.0
     win._onRunStatus("surveying")
+    _waitForSliceWrite(win)
     slice_.markCovered(slice_.tileGrid()[1])
     win._onRunStatus("surveying")  # throttled: the new tile isn't on disk yet
+    _waitForSliceWrite(win)
     # Confirms the second status really was throttled away, so the count after
     # teardown below can only grow because teardown() itself forced a flush --
     # not because the throttle never engaged in the first place.
@@ -3038,6 +3061,154 @@ def test_teardown_flushes_slice_state_even_without_a_waiting_status(win):
     saves = _searchStateSaves(handle)
     assert len(saves) == 2
     assert {tuple(c) for c in saves[-1][1]["covered"]} == set(slice_.coveredTiles)
+
+
+def test_a_dispatched_save_does_not_write_on_the_calling_thread(win, monkeypatch):
+    """The whole point of moving this off the GUI thread: the write itself
+    -- the two writeFile()s and the setInfo(), each of which drives a
+    synchronous full-directory .index rewrite under DirHandle's own mutex --
+    must happen somewhere other than the thread _onRunStatus was called on."""
+    slice_, handle = _sliceWithCountingDir(win)
+    win._sliceSaveClock = lambda: 100.0
+    callingThread = threading.current_thread()
+    writerThreads = []
+    original = Slice.writeSnapshot
+
+    def _spy(snapshot):
+        writerThreads.append(threading.current_thread())
+        original(snapshot)
+
+    monkeypatch.setattr(Slice, "writeSnapshot", staticmethod(_spy))
+
+    win._onRunStatus("surveying")
+    _waitForSliceWrite(win)
+
+    assert writerThreads
+    assert writerThreads[0] is not callingThread
+
+
+class _BlockingDirHandle(_CountingDirHandle):
+    """A _CountingDirHandle whose search_state.yaml write blocks until the
+    test releases it -- what a coalescing test needs to force a write to
+    still be in flight when the next snapshot is dispatched, deterministically
+    rather than by racing real thread scheduling."""
+
+    def __init__(self):
+        super().__init__()
+        self.writeStarted = threading.Event()
+        self.releaseWrite = threading.Event()
+
+    def writeFile(self, obj, fileName, **kwargs):
+        if fileName == "search_state.yaml":
+            self.writeStarted.set()
+            self.releaseWrite.wait(timeout=2.0)
+        super().writeFile(obj, fileName, **kwargs)
+
+
+def _sliceWithBlockingDir(win):
+    handle = _BlockingDirHandle()
+    slice_ = Slice(fov=(20e-6, 10e-6), dirHandle=handle)
+    slice_.addRegion(RectRegion(1e-3, 2e-3, 1e-3 + 60e-6, 2e-3 + 30e-6))
+    win.slice = slice_
+    return slice_, handle
+
+
+def test_two_saves_dispatched_while_a_write_is_in_flight_coalesce_to_the_latest(win):
+    """Coalescing is what makes a single worker thread the right shape here:
+    if a second and third snapshot are dispatched while the worker is still
+    busy writing the first, the middle one must never reach disk at all --
+    only the latest state does, and it does so in one write, not two."""
+    slice_, handle = _sliceWithBlockingDir(win)
+    now = [100.0]
+    win._sliceSaveClock = lambda: now[0]
+
+    win._onRunStatus("surveying")  # dispatch A (covered=[]); worker blocks writing it
+    assert handle.writeStarted.wait(timeout=2.0)
+    handle.writeStarted.clear()
+
+    # Both land while A is still blocked mid-write, so the worker's drain
+    # loop has not yet had a chance to look for pending work.
+    now[0] += win._SLICE_SAVE_MIN_INTERVAL + 1
+    slice_.markCovered(slice_.tileGrid()[0])
+    win._onRunStatus("surveying")  # dispatch B: coalesced behind the in-flight write
+    now[0] += win._SLICE_SAVE_MIN_INTERVAL + 1
+    slice_.markCovered(slice_.tileGrid()[1])
+    win._onRunStatus("surveying")  # dispatch C: replaces B before it is ever written
+
+    handle.releaseWrite.set()  # let A's write complete
+    _waitForSliceWrite(win)  # wait for the drain loop to finish writing C
+
+    saves = _searchStateSaves(handle)
+    # A (already committed before B/C existed) and C (the last state
+    # standing once the worker looks again) -- B never appears.
+    assert len(saves) == 2
+    assert saves[0][1]["covered"] == []
+    latestCovered = {tuple(c) for c in saves[-1][1]["covered"]}
+    assert latestCovered == set(slice_.coveredTiles)
+
+
+class _SlowDirHandle(_CountingDirHandle):
+    """A _CountingDirHandle whose search_state.yaml write takes a small but
+    real amount of time -- long enough that a forced flush returning
+    immediately (rather than waiting on the write) would reliably be caught
+    checking the handle before the write lands."""
+
+    def __init__(self, delay=0.05):
+        super().__init__()
+        self._delay = delay
+
+    def writeFile(self, obj, fileName, **kwargs):
+        if fileName == "search_state.yaml":
+            time.sleep(self._delay)
+        super().writeFile(obj, fileName, **kwargs)
+
+
+def _sliceWithSlowDir(win):
+    handle = _SlowDirHandle()
+    slice_ = Slice(fov=(20e-6, 10e-6), dirHandle=handle)
+    slice_.addRegion(RectRegion(1e-3, 2e-3, 1e-3 + 60e-6, 2e-3 + 30e-6))
+    win.slice = slice_
+    return slice_, handle
+
+
+def test_a_forced_flush_waits_for_the_write_to_land_before_returning(win):
+    """"waiting" (run end) and teardown() both force a flush and both must be
+    able to promise the operator the state is actually on disk once they
+    return -- not merely that a write was started."""
+    slice_, handle = _sliceWithSlowDir(win)
+    win._sliceSaveClock = lambda: 100.0
+
+    win._onRunStatus("waiting")  # forced
+
+    assert len(_searchStateSaves(handle)) == 1
+
+
+def test_teardown_with_a_write_in_flight_still_lands_the_final_state(win):
+    """Closing the window while a periodic (non-forced) save is still running
+    on the worker thread must not race past it: teardown()'s own forced flush
+    has to join whatever is already in flight and end with the latest state
+    on disk, not whatever was there when the write started."""
+    slice_, handle = _sliceWithSlowDir(win)
+    win._sliceSaveClock = lambda: 100.0
+
+    win._onRunStatus("surveying")  # dispatched; the slow write is likely still running
+    win.teardown()  # must wait for it rather than returning past it
+
+    saves = _searchStateSaves(handle)
+    assert len(saves) == 1
+    assert {tuple(c) for c in saves[-1][1]["covered"]} == set(slice_.coveredTiles)
+
+
+def test_a_status_after_teardown_does_not_raise(win):
+    """teardown() stops the slice-save worker once its own forced flush has
+    landed. A status change delivered afterward -- a queued Qt signal from an
+    orchestrator that had already emitted before the window closed, say --
+    must find nothing left to write to rather than raising out of a slot."""
+    _sliceWithCountingDir(win)
+    win._sliceSaveClock = lambda: 100.0
+    win.teardown()
+
+    win._onRunStatus("surveying")  # must not raise
 
 
 def test_a_tracked_cell_marker_follows_its_position_signal(qapp, win):

--- a/acq4/modules/MultiPatch/pipetteControl.py
+++ b/acq4/modules/MultiPatch/pipetteControl.py
@@ -530,6 +530,11 @@ class PlotWidget(Qt.QWidget):
     def setMode(self, mode):
         if self.mode == mode:
             return
+        # Only the very first setMode() (self.mode still None, from __init__)
+        # counts as construction; a later switch into a resistance mode via the
+        # combo box should not re-seed the initial window, or every switch back
+        # into this mode would clobber whatever range autorange has since found.
+        firstMode = self.mode is None
         self.mode = mode
         with pg.SignalBlock(self.modeCombo.currentIndexChanged, self.modeComboChanged):
             self.modeCombo.setText(mode)
@@ -540,8 +545,13 @@ class PlotWidget(Qt.QWidget):
             self.tpLabel.setVisible(False)
         elif mode in ['ss resistance', 'peak resistance']:
             self.plot.setLogMode(y=True, x=False)
-            self.plot.enableAutoRange(True, False)
-            self.plot.setYRange(6, 10)
+            if firstMode:
+                # Sane pre-data window (1 MOhm..10 GOhm, log10 ohms) so the plot
+                # isn't a jarring default range before the first test pulse
+                # arrives. enableAutoRange below takes over from here, so this
+                # only ever runs once per widget.
+                self.plot.setYRange(6, 10)
+            self.plot.enableAutoRange(True, True)
             self.plot.setLabels(left=('Rss', u'Ω'))
         elif mode == 'holding current':
             self.plot.setLogMode(y=False, x=False)

--- a/acq4/modules/MultiPatch/tests/test_pipette_plot_autorange.py
+++ b/acq4/modules/MultiPatch/tests/test_pipette_plot_autorange.py
@@ -1,0 +1,89 @@
+"""Tests for PlotWidget's Y-axis autorange behaviour in the resistance modes,
+and a scope-creep guard for the modes deliberately left with a fixed range."""
+
+import numpy as np
+import pytest
+
+from acq4.filetypes.MultiPatchLog import TEST_PULSE_NUMPY_DTYPE
+from acq4.util import Qt
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    return Qt.QApplication.instance() or Qt.QApplication([])
+
+
+def _history(count=4):
+    """A structured test-pulse history array, shaped like the real thing
+    (see test_plot_widget_frozen.py's _history for the same convention)."""
+    history = np.zeros(count, dtype=TEST_PULSE_NUMPY_DTYPE)
+    history["event_time"] = np.arange(count, dtype=float)
+    history["steady_state_resistance"] = np.linspace(4e6, 7e6, count)
+    history["access_resistance"] = np.linspace(4e6, 7e6, count)
+    return history
+
+
+@pytest.mark.parametrize("mode", ["ss resistance", "peak resistance"])
+def test_resistance_mode_enables_y_autorange(qapp, mode):
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode=mode)
+
+    autoRange = widget.plot.getViewBox().state["autoRange"]
+    assert autoRange[1] is not False, f"Y autorange should be enabled for {mode!r}, got {autoRange}"
+
+
+@pytest.mark.parametrize("mode", ["ss resistance", "peak resistance"])
+def test_resistance_mode_keeps_y_autorange_after_data_arrives(qapp, mode):
+    """This is the reported bug: the plot loses its autorange once test-pulse
+    data starts coming in."""
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode=mode)
+
+    widget.newTestPulse(None, _history())
+
+    autoRange = widget.plot.getViewBox().state["autoRange"]
+    assert (
+        autoRange[1] is not False
+    ), f"Y autorange should still be enabled for {mode!r} after data, got {autoRange}"
+
+
+def test_time_constant_mode_keeps_its_fixed_y_range(qapp):
+    """Scope-creep guard: this task is resistance-only. time constant's mirror-
+    image issue (autorange on Y, fixed on X) is a noted follow-up, not fixed here."""
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode="time constant")
+
+    autoRange = widget.plot.getViewBox().state["autoRange"]
+    assert autoRange[1] is False
+    # setYRange pads its target range, so compare loosely rather than exactly.
+    lo, hi = widget.plot.getViewBox().viewRange()[1]
+    assert lo == pytest.approx(-5, abs=0.5)
+    assert hi == pytest.approx(-2, abs=0.5)
+
+
+def test_capacitance_mode_keeps_its_fixed_y_range(qapp):
+    """Scope-creep guard: capacitance's fixed Y range is untouched by this task."""
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode="capacitance")
+
+    autoRange = widget.plot.getViewBox().state["autoRange"]
+    assert autoRange[1] is False
+    # setYRange pads its target range, so compare loosely rather than exactly.
+    lo, hi = widget.plot.getViewBox().viewRange()[1]
+    assert lo == pytest.approx(0, abs=20e-12)
+    assert hi == pytest.approx(100e-12, abs=20e-12)
+
+
+def test_test_pulse_mode_keeps_full_autorange(qapp):
+    """Scope-creep guard: the raw test-pulse trace already autoranges both axes."""
+    from acq4.modules.MultiPatch.pipetteControl import PlotWidget
+
+    widget = PlotWidget(mode="test pulse")
+
+    autoRange = widget.plot.getViewBox().state["autoRange"]
+    assert autoRange[0] is not False
+    assert autoRange[1] is not False


### PR DESCRIPTION
Eleven operator-reported tweaks and bugfixes to the Autopatch module, each with tests.

## Bugfixes

**A reused cell's tracking history landed in a sibling directory.** `_makeCellDataDir` minted a fresh
`Cell_NNN` on every `_processCell` pass while the tracker persisted on the reused `Cell` object and kept
accumulating. So a cellfie pass wrote a one-frame history to `Cell_000` and the patch pass wrote the full
cumulative history to `Cell_001` next door. The orchestrator now remembers each cell's directory and
re-enters it, storing `(cell, dirHandle)` so the strong reference keeps the `id()` key from being recycled
onto a different object. A vanished directory halts the run rather than silently minting a sibling, since a
silent fallback would recreate the same split-history bug.

**Cell marker clicks were silently dropped inside editable regions.** `pg.ROI.hoverEvent` unconditionally
claims the left button across its whole translatable body, while `ScatterPlotItem` only ever receives a
click nothing else claimed during hover. Whichever is asked first wins, and z-order decides that — so an ROI
at pyqtgraph's default z always beat the marker layer. The marker scatter now enters the same claim race, but
only where a marker actually is. Region ROIs get an explicit z a half-step below the marker layer, because
`pg.ROI.setZValue` reparents handles to `z+1` and the half-step keeps handles above the markers, preserving
the existing "a marker never hides the handle" intent. `acceptDrags` and `acceptClicks` are separate claim
dictionaries, so region dragging is untouched.

**The GUI stalled between every cell.** `Slice.saveState()` was wired to the `"surveying"` status and ran
synchronously on the GUI thread on every queue refill — effectively once per cell — rewriting the whole
covered-tile list and triggering a full `.index` directory rewrite per call. `saveState()` is now split into
`snapshotState()` (plain-data capture on the GUI thread, reference-free) and a static `writeSnapshot()` that
runs on a worker. Saves coalesce, so a fresher snapshot replaces a pending one rather than queuing a second
write, and a forced flush waits for the write to actually land before returning. Run end, slice replacement
and window close each force a flush, so nothing is lost there; an unclean crash can lose at most the coverage
gained since the last periodic save.

**The cellfie action hid its stack whenever the reference failed to verify.** The z-stack is saved to disk
unconditionally, and the tracker is assigned before `verify_reference()` can raise — so the data existed but
`set_details` sat after the `try/except`, past a `tissue_moved()` that never returns. The stack is now
attached inside the `except CellTrackingLost` branch too, titled to distinguish it so a failed cellfie isn't
misread as a success.

**"Fit to regions" framed far too wide.** It now frames only what the camera window shows — pinned frame
mirrors and region ROIs — and no longer infers a frame from survey coverage, whose tiles are each a whole
field of view. The `mapRectToItem` mapping fix that stopped this slot crashing on plain `QGraphicsRectItem`s
is retained and now has its own regression guard, independent of the overlay that first triggered it.

**The live patch resistance plot never auto-fit in Y.** `enableAutoRange(True, False)` disabled Y autorange
and a hardcoded `setYRange(6, 10)` pinned it to 1 MΩ–10 GΩ in log space. Y autorange is now enabled for both
resistance modes, with the initial window applied once at construction so a mode switch back into resistance
cannot re-pin the axis.

## Tweaks

**The Pause button had no way to show a requested-but-not-yet-honored pause.** Pause is only checked at cell
and retry boundaries, never inside a protocol run, so the button sat reading "Pause" long after being
pressed. It now reads `Pausing at next break...` while pending, and a second press withdraws the request.

**The clear-pinned-frames prompt asked a yes/no question with Ok/Cancel buttons.** Now Yes/No, defaulting to
No so a stray Enter cannot discard the previous slice's reference imagery.

**Min cell volume and detection z-step are now Area 2 controls,** added to `SearchConstraints` and so
persisted with the slice alongside the other four, validated in `__post_init__` (positive step, non-negative
volume) with widget bounds that cannot reach a rejected value. `loadState()` reads them with a default, so a
record written before these fields existed loads rather than raising. The rig's `misc` config seeds Area 2
once at construction — the default for a fresh slice — and is not consulted again. Both controls lock during
a run like the others. `_surveyDetectionSettings()` is deleted; the survey reads `slice.constraints` directly.

**A cell's reference stack was invisible in the UI** unless a cellfie happened to run in the current pass —
and "Reuse checked cells" wipes the visible timeline while the tracker persists. Any cell with an initialized
tracker now shows a `Tracker initialized` row at the top of its action list, opening the same stack viewer
cellfie already produces. Seeding row 0 before any real action is logged means no reindexing of the existing
`(cell, index)`-keyed detail stores. The reference stack is read off the tracker only at survey-discovery,
before the cell is attempted; from then on the row is served from a GUI-thread-sourced cache, because a
detached FSM job can still be appending to an already-closed-out cell's tracker.

## Testing

Full sweep over `acq4/modules/Autopatch/tests acq4/experiment acq4/modules/AutomationDebug
acq4/modules/MultiPatch`. Every fix is covered by tests written before its implementation.

Pre-existing failures on `_reviewed`, none touched by this branch: four in `test_example_protocols.py`
(`ctx.pipette` is `None` in the fixture), two `test_open_in_editor_*` in `test_protocol_panel.py`, and
`test_acqtrack_file_gets_visualize_panel`, which fails only when the whole `acq4/modules` suite runs together
(a test-order Qt-teardown flake) and passes in isolation.

🤖 Generated with [Claude Code](https://claude.ai/code)

🧙 Built with [WOZCODE](https://wozcode.com)
