### PR TITLE
fix(seal): gate spontaneous break-in on resistance floor

### DIFF
--- a/acq4/devices/PatchPipette/states/seal.py
+++ b/acq4/devices/PatchPipette/states/seal.py
@@ -33,7 +33,7 @@ class SealAnalysis(SteadyStateAnalysisBase):
         break_in_resistance_ceiling,
         break_in_resistance_floor,
     ):
-        return {'Ω': [
+        return {'Ω': [
             pg.InfiniteLine(movable=False, pos=success_at, angle=0, pen=pg.mkPen('g')),
             pg.InfiniteLine(movable=False, pos=hold_at, angle=0, pen=pg.mkPen('w')),
         ]}
@@ -274,7 +274,7 @@ class SealState(PatchPipetteState):
         capacitance. A cell that has barely started sealing can show a spurious capacitance
         transient; this keeps that from being mistaken for a whole-cell rupture. Once resistance
         has crossed this floor, break-in detection stays armed for the rest of the seal attempt.
-        Default 500MΩ.
+        Default 500MΩ.
     breakInMonitorTau : float
         Time constant (seconds) for exponential averaging of capacitance measurements when
         determining whether the cell has spontaneously broken in. Test pulses report NaN
@@ -336,7 +336,7 @@ class SealState(PatchPipetteState):
         'holdingPotential': {'type': 'float', 'default': -70e-3, 'suffix': 'V'},
         'sealThreshold': {'type': 'float', 'default': 1e9, 'suffix': 'Ω'},
         'breakInThreshold': {'type': 'float', 'default': 10e-12, 'suffix': 'F'},
-        'breakInResistanceFloor': {'type': 'float', 'default': 500e6, 'suffix': 'Ω'},
+        'breakInResistanceFloor': {'type': 'float', 'default': 500e6, 'suffix': 'Ω'},
         'failureResistanceThreshold': {'type': 'float', 'default': 50e6, 'suffix': 'Ω'},
         'failureDRDTThreshold': {'type': 'float', 'default': 1e6, 'suffix': 'Ω/s'},
         'autoSealTimeout': {'type': 'float', 'default': 30.0, 'suffix': 's'},

--- a/acq4/devices/PatchPipette/states/seal.py
+++ b/acq4/devices/PatchPipette/states/seal.py
@@ -31,8 +31,9 @@ class SealAnalysis(SteadyStateAnalysisBase):
         break_in_tau,
         break_in_capacitance_threshold,
         break_in_resistance_ceiling,
+        break_in_resistance_floor,
     ):
-        return {'Ω': [
+        return {'Ω': [
             pg.InfiniteLine(movable=False, pos=success_at, angle=0, pen=pg.mkPen('g')),
             pg.InfiniteLine(movable=False, pos=hold_at, angle=0, pen=pg.mkPen('w')),
         ]}
@@ -90,6 +91,7 @@ class SealAnalysis(SteadyStateAnalysisBase):
         break_in_tau,
         break_in_capacitance_threshold,
         break_in_resistance_ceiling,
+        break_in_resistance_floor,
     ):
         super().__init__()
         self._success_tau = success_tau
@@ -102,6 +104,11 @@ class SealAnalysis(SteadyStateAnalysisBase):
         self._break_in_tau = break_in_tau
         self._break_in_capacitance_threshold = break_in_capacitance_threshold
         self._break_in_resistance_ceiling = break_in_resistance_ceiling
+        self._break_in_resistance_floor = break_in_resistance_floor
+        # Spontaneous break-in is only plausible once the seal has gotten well underway; below
+        # the floor a rising capacitance reading is noise, not a ruptured membrane. This latches
+        # once crossed so a later dip back below the floor doesn't re-disarm the check.
+        self._break_in_floor_reached = False
 
     def process_test_pulses(self, tps) -> np.ndarray:
         # The base implementation reads resistance only; break-in detection also needs the
@@ -167,11 +174,16 @@ class SealAnalysis(SteadyStateAnalysisBase):
                 resistance_avg_for_failure < self._failure_resistance_threshold
                 and dRdt_for_failure < self._failure_dRdt_threshold
             )
+            if resistance_avg_for_success >= self._break_in_resistance_floor:
+                self._break_in_floor_reached = True
             # Membrane capacitance sustained while the resistance sits below a sealed pipette's
             # means the cell ruptured into whole-cell on its own. Above the ceiling the pipette
-            # is sealed rather than broken in, and *success* is the right answer instead.
+            # is sealed rather than broken in, and *success* is the right answer instead. Gated
+            # behind the floor latch: below it, a capacitance blip is measurement noise, not a
+            # real membrane rupture, and would otherwise fire before the seal has gotten anywhere.
             break_in = (
-                capacitance_avg_for_break_in > self._break_in_capacitance_threshold
+                self._break_in_floor_reached
+                and capacitance_avg_for_break_in > self._break_in_capacitance_threshold
                 and resistance < self._break_in_resistance_ceiling
             )
             ret_array[i] = (
@@ -256,7 +268,13 @@ class SealState(PatchPipetteState):
         Capacitance (Farads) above which the pipette is considered to be whole-cell and
         transitions to *spontaneousBreakInState* (in case of partial break-in, we don't want to
         transition directly to 'whole cell' state). Only applies while the resistance is below
-        *sealThreshold*; above that the pipette is sealed rather than broken in. Default 10pF.
+        *sealThreshold* and above *breakInResistanceFloor*. Default 10pF.
+    breakInResistanceFloor : float
+        Seal resistance (ohms) below which spontaneous break-in is never reported, regardless of
+        capacitance. A cell that has barely started sealing can show a spurious capacitance
+        transient; this keeps that from being mistaken for a whole-cell rupture. Once resistance
+        has crossed this floor, break-in detection stays armed for the rest of the seal attempt.
+        Default 500MΩ.
     breakInMonitorTau : float
         Time constant (seconds) for exponential averaging of capacitance measurements when
         determining whether the cell has spontaneously broken in. Test pulses report NaN
@@ -318,6 +336,7 @@ class SealState(PatchPipetteState):
         'holdingPotential': {'type': 'float', 'default': -70e-3, 'suffix': 'V'},
         'sealThreshold': {'type': 'float', 'default': 1e9, 'suffix': 'Ω'},
         'breakInThreshold': {'type': 'float', 'default': 10e-12, 'suffix': 'F'},
+        'breakInResistanceFloor': {'type': 'float', 'default': 500e6, 'suffix': 'Ω'},
         'failureResistanceThreshold': {'type': 'float', 'default': 50e6, 'suffix': 'Ω'},
         'failureDRDTThreshold': {'type': 'float', 'default': 1e6, 'suffix': 'Ω/s'},
         'autoSealTimeout': {'type': 'float', 'default': 30.0, 'suffix': 's'},
@@ -351,6 +370,7 @@ class SealState(PatchPipetteState):
             break_in_tau=config['breakInMonitorTau'],
             break_in_capacitance_threshold=config['breakInThreshold'],
             break_in_resistance_ceiling=config['sealThreshold'],
+            break_in_resistance_floor=config['breakInResistanceFloor'],
         )
         self._initialized = False
         self._patchrec = dev.patchRecord()

--- a/acq4/devices/PatchPipette/tests/test_seal_analysis.py
+++ b/acq4/devices/PatchPipette/tests/test_seal_analysis.py
@@ -39,6 +39,9 @@ def _analysis(**overrides):
         break_in_tau=3.0,
         break_in_capacitance_threshold=10e-12,
         break_in_resistance_ceiling=1e9,
+        # Disabled by default so tests that aren't about the floor itself don't need to stage a
+        # climb above it first; the floor-specific tests below override this explicitly.
+        break_in_resistance_floor=0.0,
     )
     kwargs.update(overrides)
     return SealAnalysis(**kwargs)
@@ -82,6 +85,25 @@ def test_capacitance_above_ceiling_resistance_is_not_break_in():
     assert not analysis.break_in()
 
 
+def test_break_in_suppressed_below_resistance_floor():
+    """Sustained whole-cell capacitance at low resistance must not report a break-in if the seal
+    never climbed above the floor: the pipette never got anywhere near sealing, so there's no
+    seal to spontaneously rupture."""
+    analysis = _analysis(break_in_resistance_floor=500e6)
+    result = analysis.process_measurements(_steady(20.0, 100e6, 100e-12))
+    assert not result["break_in"].any()
+    assert not analysis.break_in()
+
+
+def test_break_in_armed_once_resistance_crosses_floor():
+    """Once resistance has climbed above the floor, a later rupture back down is still detected."""
+    analysis = _analysis(break_in_resistance_floor=500e6)
+    analysis.process_measurements(_steady(20.0, 600e6, np.nan))
+    result = analysis.process_measurements(_steady(20.0, 100e6, 100e-12, start=20.0))
+    assert result["break_in"][-1]
+    assert analysis.break_in()
+
+
 def test_isolated_capacitance_artifact_does_not_trip_detection():
     """A lone bad capacitance fit during sealing must not be mistaken for a break-in."""
     analysis = _analysis()
@@ -122,7 +144,7 @@ def test_recorded_spontaneous_break_in_is_detected():
     holding suction on an established whole-cell until its timeout.
     """
     data = np.load(DATA_DIR / "spontaneous_break_in_seal.npy")
-    analysis = _analysis()
+    analysis = _analysis(break_in_resistance_floor=500e6)
     result = analysis.process_measurements(data)
 
     assert result["break_in"].any(), "the recorded break-in went undetected"
@@ -134,7 +156,7 @@ def test_recorded_spontaneous_break_in_is_detected():
 def test_recorded_failed_seal_never_reports_break_in():
     """Replay of a real seal that never broke in must stay silent (negative control)."""
     data = np.load(DATA_DIR / "failed_seal_no_break_in.npy")
-    analysis = _analysis()
+    analysis = _analysis(break_in_resistance_floor=500e6)
     result = analysis.process_measurements(data)
     assert not result["break_in"].any()
     assert not analysis.break_in()

--- a/acq4/devices/PatchPipette/tests/test_seal_state.py
+++ b/acq4/devices/PatchPipette/tests/test_seal_state.py
@@ -122,16 +122,28 @@ def _sealState(dev, resistance, capacitance, **config):
 
 def test_seal_goes_to_break_in_when_the_cell_ruptures(dev):
     """Sustained membrane capacitance with the seal gone must hand off to 'break in'."""
-    state = _sealState(dev, resistance=100e6, capacitance=100e-12)
+    # breakInResistanceFloor disabled: this test is about the break-in -> state hand-off, not
+    # about gating on how high the resistance climbed first (see test_seal_analysis.py for that).
+    state = _sealState(dev, resistance=100e6, capacitance=100e-12, breakInResistanceFloor=0)
     result = state.run()
     assert result == {"state": "break in"}
     assert dev.patchRecord()['spontaneousBreakin'] is True
 
 
+def test_break_in_is_suppressed_below_the_resistance_floor(dev):
+    """The default *breakInResistanceFloor* must reach the analyzer: a resistance that never
+    climbs anywhere near a seal must not be mistaken for a ruptured one."""
+    state = _sealState(dev, resistance=100e6, capacitance=100e-12)
+    assert state.config['breakInResistanceFloor'] == pytest.approx(500e6)
+    assert state._analysis._break_in_resistance_floor == pytest.approx(500e6)
+    state.processAtLeastOneTestPulse()
+    assert not state._analysis.break_in()
+
+
 def test_spontaneous_break_in_state_is_configurable(dev):
     """Like cell attached, the destination state can be redirected."""
     state = _sealState(dev, resistance=100e6, capacitance=100e-12,
-                       spontaneousBreakInState='whole cell')
+                       spontaneousBreakInState='whole cell', breakInResistanceFloor=0)
     assert state.run() == {"state": "whole cell"}
 
 

--- a/acq4/filetypes/MultiPatchLog.py
+++ b/acq4/filetypes/MultiPatchLog.py
@@ -863,6 +863,7 @@ class MultiPatchLogWidget(Qt.QWidget):
             break_in_tau=config['breakInMonitorTau'],
             break_in_capacitance_threshold=config['breakInThreshold'],
             break_in_resistance_ceiling=config['sealThreshold'],
+            break_in_resistance_floor=config['breakInResistanceFloor'],
         )
 
     def _toggleResealAnalysis(self, state: bool):


### PR DESCRIPTION
## Problem
Spontaneous break-in detection in `SealState`/`SealAnalysis` could fire on sustained capacitance alone, even when the pipette resistance never made meaningful sealing progress. A low-resistance capacitance blip near baseline could be mistaken for a whole-cell rupture.

## Fix
Add a `breakInResistanceFloor` parameter (default 500MΩ — halfway to the default 1GΩ `sealThreshold`). Break-in detection now latches "armed" only after the resistance has climbed above this floor at least once, and stays armed for the rest of the seal attempt (so a real rupture back down is still caught).

## Changes
- `acq4/devices/PatchPipette/states/seal.py`: new `breakInResistanceFloor` config param, threaded into `SealAnalysis`; gate added in `process_measurements`.
- `acq4/filetypes/MultiPatchLog.py`: forward the new param when replaying seal analysis in `MultiPatchLog` viewer.
- Tests: new unit tests for the floor gate and latch behavior in `test_seal_analysis.py` (using disabled-floor default for existing capacitance-only tests, and the real 500MΩ default for the recorded-data regression tests); new/updated integration tests in `test_seal_state.py`.

## Verification
`python -m pytest acq4/devices/PatchPipette/tests/ -q` → 65 passed.